### PR TITLE
Add deploy command with API documentation

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,7 +63,7 @@ env
   .action(pull);
 
 program
-  .command("deploy")
+  .command("deploy", { hidden: true })
   .description("Deploy your Clerk application")
   .option("--debug", "Show debug output")
   .action(deploy);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { login } from "./commands/auth/login.js";
 import { logout } from "./commands/auth/logout.js";
 import { whoami } from "./commands/whoami.js";
 import { pull } from "./commands/env/pull.js";
+import { deploy } from "./commands/deploy/index.js";
 
 program
   .name("clerk")
@@ -60,5 +61,11 @@ env
   .command("pull")
   .description("Pull environment variables from Clerk to .env.local")
   .action(pull);
+
+program
+  .command("deploy")
+  .description("Deploy your Clerk application")
+  .option("--debug", "Show debug output")
+  .action(deploy);
 
 program.parse();

--- a/src/commands/deploy/README.md
+++ b/src/commands/deploy/README.md
@@ -1,0 +1,190 @@
+# Deploy Command
+
+Guides a user through deploying their Clerk application to production.
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant CLI as Clerk CLI
+    participant API as Clerk Platform API
+    participant DNS as DNS Provider
+    participant Browser
+
+    Note over CLI: clerk deploy
+
+    %% Auth & App Check
+    Note over CLI: Auth token from local config<br/>(stored during `clerk auth login`)
+    CLI->>API: GET /v1/platform/applications/{appID}
+    API-->>CLI: { application }
+
+    %% Production Instance Check
+    CLI->>API: GET /v1/platform/applications/{appID}/instances/production/config
+    alt 200 — production instance exists
+        API-->>CLI: { config }
+        CLI->>User: Production instance already exists
+        Note over CLI: Update flow — TBD
+    else 404 — no production instance
+        API-->>CLI: 404 Not Found
+    end
+
+    %% Read Dev Instance Config (features + social providers)
+    CLI->>API: GET /v1/platform/applications/{appID}/instances/development/config
+    API-->>CLI: { config_version, connection_oauth_google: {...}, ... }
+
+    %% Subscription Check
+    CLI->>API: GET /v1/platform/applications/{appID}/subscription
+    API-->>CLI: { id, stripe_subscription_id }
+    CLI->>CLI: Compare dev features vs plan features
+    alt Unsupported features found
+        CLI->>User: Upgrade plan to continue
+    end
+
+    %% Domain Selection
+    CLI->>User: How would you like to set up your production domain?
+    alt Custom domain
+        User->>CLI: "Use my own domain"
+        CLI->>User: Enter your domain:
+        User->>CLI: example.com
+    else Clerk subdomain
+        User->>CLI: "Use a Clerk-provided subdomain"
+    end
+
+    %% Create Production Instance
+    Note over CLI,API: No "add production instance" endpoint exists.<br/>Current API only creates instances at app creation.<br/>Needs a new endpoint or re-creation via<br/>POST /v1/platform/applications<br/>with environment_types: ["development","production"]
+    CLI->>API: POST /v1/platform/applications (TBD — needs new endpoint?)
+    API-->>CLI: { application, instances: [dev, prod] }
+
+    %% Domain Setup
+    opt Custom domain selected
+        CLI->>API: POST /v1/platform/applications/{appID}/domains
+        Note right of API: { name: "example.com",<br/>is_satellite: false }
+        API-->>CLI: { domain }
+
+        CLI->>DNS: Lookup NS records for domain
+        DNS-->>CLI: { provider, supportsDomainConnect }
+
+        alt Supports Domain Connect
+            CLI->>User: Open browser to configure DNS?
+            User->>CLI: Yes
+            CLI->>Browser: Open Domain Connect URL
+        else No Domain Connect
+            CLI->>User: Add these DNS records manually
+        end
+
+        CLI->>API: POST /v1/platform/applications/{appID}/domains/{domainID}/dns_check
+        API-->>CLI: { status }
+    end
+
+    %% Social Provider Credential Collection
+    Note over CLI: Dev config already fetched above —<br/>check for enabled connection_oauth_* keys
+
+    loop Each enabled social provider (e.g. google)
+        CLI->>User: Your app uses {Provider} OAuth. Have credentials?
+
+        alt Walk me through it
+            User->>CLI: "Walk me through setting it up"
+            CLI->>User: Use these values:<br/>  JS origins: https://example.com<br/>  Redirect URI: https://accounts.example.com/v1/oauth_callback
+            CLI->>Browser: Open Clerk docs for provider
+            CLI->>User: Enter credentials below:
+        else Already have credentials
+            User->>CLI: "I already have my credentials"
+        end
+
+        CLI->>User: Client ID:
+        User->>CLI: {client_id}
+        CLI->>User: Client Secret:
+        User->>CLI: {client_secret}
+
+        CLI->>API: PATCH /v1/platform/applications/{appID}/instances/production/config
+        Note right of API: { connection_oauth_google:<br/>{ enabled: true,<br/>client_id: "...",<br/>client_secret: "..." } }
+        API-->>CLI: { before, after, config_version }
+    end
+
+    %% Done
+    CLI->>User: Production ready at https://{domain}
+    CLI->>User: (Redeploy with updated secret keys if needed)
+```
+
+## API Endpoints
+
+All endpoints are on the **Platform API** (`/v1/platform/...`).
+
+| Step | Method | Endpoint | Notes |
+|---|---|---|---|
+| Auth | — | Local config | Token stored from `clerk auth login` |
+| Get application | `GET` | `/v1/platform/applications/{appID}` | |
+| Check prod instance | `GET` | `.../instances/production/config` | 404 if none exists |
+| Read dev config | `GET` | `.../instances/development/config` | Returns all settings including `connection_oauth_*` keys |
+| Subscription check | `GET` | `.../subscription` | Returns `{ id, stripe_subscription_id }` only — feature comparison is client-side |
+| Create prod instance | `POST` | `/v1/platform/applications` | **Gap: no endpoint to add a production instance to an existing app** |
+| Add domain | `POST` | `.../domains` | Body: `{ name, is_satellite }` |
+| DNS check | `POST` | `.../domains/{domainID}/dns_check` | Triggers async DNS verification |
+| Write OAuth creds | `PATCH` | `.../instances/production/config` | Body: `{ connection_oauth_{provider}: { enabled, client_id, client_secret } }` |
+
+## API Gaps
+
+### Creating a production instance for an existing app
+
+The current Platform API only creates instances during application creation via `POST /v1/platform/applications` with the `environment_types` parameter:
+
+```json
+POST /v1/platform/applications
+{
+  "name": "my-app",
+  "environment_types": ["development", "production"],
+  "domain": "example.com"
+}
+```
+
+There is **no endpoint** to add a production instance to an application that was originally created with only a development instance. This needs either:
+1. A new `POST /v1/platform/applications/{appID}/instances` endpoint
+2. Or a different approach (e.g., re-creating the application)
+
+### Subscription feature comparison
+
+`GET /v1/platform/applications/{appID}/subscription` returns only basic metadata (`id`, `stripe_subscription_id`), not feature lists. Feature detection is done server-side in `pkg/pricing/pricing.go` by inspecting instance config. The CLI would need either:
+1. A new endpoint that returns the feature comparison result
+2. Or access to plan feature lists to compare client-side
+
+## OAuth Provider Config Format
+
+Config keys follow the pattern `connection_oauth_{provider}`. When writing credentials to a production instance:
+
+```json
+PATCH /v1/platform/applications/{appID}/instances/production/config
+
+{
+  "connection_oauth_google": {
+    "enabled": true,
+    "client_id": "123456789-abc.apps.googleusercontent.com",
+    "client_secret": "GOCSPX-..."
+  }
+}
+```
+
+### Provider-specific required fields
+
+| Provider | Required Fields |
+|---|---|
+| Google | `client_id`, `client_secret` |
+| GitHub | `client_id`, `client_secret` |
+| Microsoft | `client_id`, `client_secret` |
+| Apple | `client_id`, `client_secret`, `key_id`, `team_id` |
+| Linear | `client_id`, `client_secret` |
+
+Production instances return `422` if you try to enable a provider without credentials.
+
+### Google OAuth `client_id` validation
+
+Google enforces a pattern: `^[0-9]+-[a-z0-9]+\.apps\.googleusercontent\.com$`
+
+## Helpful values for OAuth walkthrough
+
+When the user chooses the guided walkthrough, these values are derived from their domain:
+
+| Field | Value |
+|---|---|
+| Authorized JavaScript origins | `https://{domain}`, `https://www.{domain}` |
+| Authorized redirect URI | `https://accounts.{domain}/v1/oauth_callback` |

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -3,6 +3,8 @@ import { select, input, confirm, password } from "@inquirer/prompts";
 export async function deploy(options: { debug?: boolean }) {
   const debug = options.debug ? (...args: unknown[]) => console.log("[debug]", ...args) : () => {};
 
+  console.log("\x1b[33m[mock] This command uses mocked data and is not yet wired up to real APIs.\x1b[0m\n");
+
   debug("Checking for authenticated user and linked application...");
 
   // Mock state — will be replaced with real lookups

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -1,4 +1,4 @@
-import { select, input, confirm } from "@inquirer/prompts";
+import { select, input, confirm, password } from "@inquirer/prompts";
 
 export async function deploy(options: { debug?: boolean }) {
   const debug = options.debug ? (...args: unknown[]) => console.log("[debug]", ...args) : () => {};
@@ -137,7 +137,7 @@ export async function deploy(options: { debug?: boolean }) {
         message: `${displayName} OAuth Client ID:`,
       });
 
-      const clientSecret = await input({
+      const clientSecret = await password({
         message: `${displayName} OAuth Client Secret:`,
       });
 

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -1,0 +1,154 @@
+import { select, input, confirm } from "@inquirer/prompts";
+
+export async function deploy(options: { debug?: boolean }) {
+  const debug = options.debug ? (...args: unknown[]) => console.log("[debug]", ...args) : () => {};
+
+  debug("Checking for authenticated user and linked application...");
+
+  // Mock state — will be replaced with real lookups
+  const user = { id: "user_abc123", email: "kyle@clerk.dev" };
+  const application = { id: "app_xyz789", name: "my-saas-app" };
+
+  debug(`Found authenticated user: ${user.email} (${user.id})`);
+  debug(`Found linked application: ${application.name} (${application.id})`);
+
+  // Mock state — no production instance exists yet
+  debug("Checking for production instance...");
+  const productionInstance = null;
+
+  debug("No production instance found.");
+
+  // Mock state — check subscription vs dev instance features
+  debug("Checking development instance features against subscription...");
+  const devFeatures = ["email_auth", "social_oauth"];
+  const subscriptionFeatures = ["email_auth", "social_oauth"];
+  const unsupported = devFeatures.filter((f) => !subscriptionFeatures.includes(f));
+
+  if (unsupported.length > 0) {
+    debug(`Found features not covered by subscription: ${unsupported.join(", ")}`);
+    debug("User must upgrade their plan before deploying.");
+    return;
+  }
+
+  debug("All development features are covered by subscription.");
+
+  const domainChoice = await select({
+    message: "How would you like to set up your production domain?",
+    choices: [
+      {
+        name: "Use my own domain",
+        value: "custom-domain",
+      },
+      {
+        name: "Use a Clerk-provided subdomain",
+        value: "clerk-subdomain",
+      },
+    ],
+  });
+
+  let domain: string;
+
+  if (domainChoice === "custom-domain") {
+    domain = await input({
+      message: "Enter your domain:",
+    });
+    debug(`User provided custom domain: ${domain}`);
+  } else {
+    // Mock generated subdomain
+    const generatedSubdomain = "sincere-chinchilla-87.clerk.app";
+    domain = generatedSubdomain;
+    debug(`Using Clerk-provided subdomain: ${domain}`);
+  }
+
+  debug("Creating production instance...");
+  debug(`Production instance created with domain: ${domain}`);
+
+  // DNS setup for custom domains
+  if (domainChoice === "custom-domain") {
+    debug(`Looking up DNS provider for ${domain}...`);
+
+    // Mock state — DNS lookup and Domain Connect check
+    const dnsProvider = { name: "Cloudflare", supportsDomainConnect: true };
+    debug(`DNS hosted by: ${dnsProvider.name}`);
+    debug(`Checking Domain Connect support for ${dnsProvider.name}...`);
+    debug(`${dnsProvider.name} supports Domain Connect.`);
+
+    const domainConnectUrl = `https://domainconnect.${dnsProvider.name.toLowerCase()}.com/v2/domainTemplates/providers/clerk.com/services/clerk-production/apply?domain=${domain}`;
+    debug(`Composed Domain Connect URL: ${domainConnectUrl}`);
+
+    await confirm({
+      message: `We can automatically configure DNS for ${domain} via ${dnsProvider.name}. Open browser to continue?`,
+      default: true,
+    });
+
+    debug("Opening Domain Connect flow in browser...");
+  }
+
+  // Check dev instance settings that require production credentials
+  debug("Checking development instance settings for production requirements...");
+
+  // Mock state — dev instance has Google OAuth enabled
+  const devSettings = {
+    socialProviders: ["google"],
+  };
+
+  if (devSettings.socialProviders.length > 0) {
+    debug(`Found social providers requiring production credentials: ${devSettings.socialProviders.join(", ")}`);
+
+    for (const provider of devSettings.socialProviders) {
+      const displayName = provider.charAt(0).toUpperCase() + provider.slice(1);
+      const docsUrl = `https://clerk.com/docs/guides/configure/auth-strategies/social-connections/${provider}#configure-for-your-production-instance`;
+
+      const credentialChoice = await select({
+        message: `Your app uses ${displayName} OAuth. Do you have your production credentials?`,
+        choices: [
+          {
+            name: "Walk me through setting it up",
+            value: "walkthrough",
+          },
+          {
+            name: "I already have my credentials",
+            value: "have-credentials",
+          },
+        ],
+      });
+
+      if (credentialChoice === "walkthrough") {
+        const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
+        const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
+        const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;
+
+        console.log(`\n${bold(`When configuring your ${displayName} OAuth app, use these values:`)}\n`);
+        console.log(`  ${dim("Authorized JavaScript origins:")}`);
+        console.log(`    ${cyan(`https://${domain}`)}`);
+        console.log(`    ${cyan(`https://www.${domain}`)}`);
+        console.log(`\n  ${dim("Authorized redirect URI:")}`);
+        console.log(`    ${cyan(`https://accounts.${domain}/v1/oauth_callback`)}`);
+        console.log();
+
+        debug(`Opening ${displayName} OAuth setup guide in browser...`);
+        const proc = Bun.spawn(["open", docsUrl]);
+        await proc.exited;
+
+        console.log("Once you've created your credentials, enter them below:\n");
+      }
+
+      const clientId = await input({
+        message: `${displayName} OAuth Client ID:`,
+      });
+
+      const clientSecret = await input({
+        message: `${displayName} OAuth Client Secret:`,
+      });
+
+      debug(`Received ${displayName} credentials (client ID: ${clientId.slice(0, 8)}...)`);
+    }
+
+    debug("All social provider credentials collected.");
+  }
+
+  debug("Deploy complete.");
+
+  console.log(`\n\x1b[1m\x1b[32mYour production application is set up and ready at \x1b[34mhttps://${domain}\x1b[0m`);
+  console.log(`\x1b[2mIf your application is not loading correctly, you may need to redeploy with your updated Clerk secret keys.\x1b[0m`);
+}


### PR DESCRIPTION
## Summary

Adds the `clerk deploy` command and documents the full deployment flow with actual Clerk Platform API endpoint mappings.

> **Note:** The deploy command is currently a prototype — all state is mocked inline and nothing is hooked up to real APIs yet. This PR establishes the interactive flow and documents the API endpoints we'll need to integrate.

## Changes

- Moved `src/commands/deploy.ts` → `src/commands/deploy/index.ts` for better code organization
- Added `src/commands/deploy/README.md` with detailed API documentation and flow diagrams
- Registered the deploy command in `src/cli.ts` with `--debug` flag support

## Deploy Flow

The command walks users through deploying to production in this sequence:

1. **Auth & app check** — verify stored session token and linked application
2. **Production instance check** — see if one already exists
3. **Subscription check** — compare dev instance features against plan
4. **Domain selection** — custom domain or Clerk-provided subdomain
5. **Create production instance** — provision the prod environment
6. **DNS setup** (custom domains) — Domain Connect auto-config or manual instructions
7. **Social provider credentials** — guided walkthrough or direct input for OAuth credentials (e.g. Google)
8. **Done** — display production URL

## API Endpoints Identified

| Step | Method | Endpoint |
|---|---|---|
| Get application | `GET` | `/v1/platform/applications/{appID}` |
| Check prod instance | `GET` | `/v1/platform/applications/{appID}/instances/production/config` |
| Read dev config | `GET` | `/v1/platform/applications/{appID}/instances/development/config` |
| Subscription | `GET` | `/v1/platform/applications/{appID}/subscription` |
| Add domain | `POST` | `/v1/platform/applications/{appID}/domains` |
| DNS check | `POST` | `/v1/platform/applications/{appID}/domains/{domainID}/dns_check` |
| Write OAuth creds | `PATCH` | `/v1/platform/applications/{appID}/instances/production/config` |

## API Gaps

- **No endpoint to create a production instance for an existing app** — currently only possible at app creation time via `environment_types`
- **Subscription endpoint returns only metadata** (`id`, `stripe_subscription_id`) — feature comparison logic lives server-side in `pkg/pricing` with no CLI-facing equivalent

See [`src/commands/deploy/README.md`](src/commands/deploy/README.md) for the full sequence diagram and OAuth provider details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)