### PR TITLE
Add config pull command to fetch Platform API configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,14 @@
-# Override OAuth config for local development
+# ── OAuth ────────────────────────────────────────────────────────────────────
 # CLERK_OAUTH_CLIENT_ID=your_client_id
 # CLERK_OAUTH_BASE_URL=https://your-dev-instance.clerk.accounts.dev
 # CLERK_OAUTH_SCOPES=profile email
 
-# Override config/credential storage directory
+# ── Platform API ─────────────────────────────────────────────────────────────
+# CLERK_PLATFORM_API_KEY=your_platform_api_key
+# CLERK_PLATFORM_API_URL=https://api.clerk.com
+
+# ── Config / credentials storage ─────────────────────────────────────────────
 # CLERK_CONFIG_DIR=~/.clerk
 
-# Override auth callback timeout (milliseconds)
+# ── Auth callback ────────────────────────────────────────────────────────────
 # CLERK_AUTH_TIMEOUT_MS=120000

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { logout } from "./commands/auth/logout.js";
 import { whoami } from "./commands/whoami.js";
 import { pull } from "./commands/env/pull.js";
 import { deploy } from "./commands/deploy/index.js";
+import { configPull } from "./commands/config/pull.js";
 
 program
   .name("clerk")
@@ -61,6 +62,17 @@ env
   .command("pull")
   .description("Pull environment variables from Clerk to .env.local")
   .action(pull);
+
+const config = program
+  .command("config")
+  .description("Manage instance configuration");
+
+config
+  .command("pull")
+  .description("Pull instance configuration from Clerk")
+  .option("--instance <id>", "Instance to target (dev, prod, or a full instance ID)")
+  .option("--output <file>", "Write config to a file instead of stdout")
+  .action(configPull);
 
 program
   .command("deploy", { hidden: true })

--- a/src/commands/config/pull.test.ts
+++ b/src/commands/config/pull.test.ts
@@ -1,0 +1,198 @@
+import { test, expect, describe, beforeEach, afterEach, mock, spyOn } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { _setConfigDir, setProfile } from "../../lib/config";
+
+describe("config pull", () => {
+  const originalEnv = { ...process.env };
+  const originalFetch = globalThis.fetch;
+  let tempDir: string;
+  let logSpy: ReturnType<typeof spyOn>;
+  let errorSpy: ReturnType<typeof spyOn>;
+  let exitSpy: ReturnType<typeof spyOn>;
+
+  const mockConfig = {
+    session: { lifetime: 604800 },
+    sign_up: { mode: "public" },
+  };
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "clerk-config-pull-test-"));
+    _setConfigDir(tempDir);
+    process.env.CLERK_PLATFORM_API_KEY = "test_key";
+    process.env.CLERK_PLATFORM_API_URL = "https://test-api.clerk.com";
+
+    logSpy = spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify(mockConfig), { status: 200 });
+  });
+
+  afterEach(async () => {
+    _setConfigDir(undefined);
+    process.env = { ...originalEnv };
+    globalThis.fetch = originalFetch;
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  // Dynamically import to get fresh module state
+  async function runConfigPull(options: { instance?: string; output?: string } = {}) {
+    const { configPull } = await import("./pull");
+    return configPull(options);
+  }
+
+  test("errors when no profile is linked", async () => {
+    await expect(runConfigPull()).rejects.toThrow("process.exit");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("No Clerk project linked"),
+    );
+  });
+
+  test("errors when CLERK_PLATFORM_API_KEY is missing", async () => {
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+    delete process.env.CLERK_PLATFORM_API_KEY;
+
+    await expect(runConfigPull()).rejects.toThrow("process.exit");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("CLERK_PLATFORM_API_KEY"),
+    );
+  });
+
+  test("prints config JSON to stdout by default", async () => {
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigPull();
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(mockConfig, null, 2));
+  });
+
+  test("writes config to file with --output", async () => {
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+    const outFile = join(tempDir, "output.json");
+
+    await runConfigPull({ output: outFile });
+    const written = await Bun.file(outFile).json();
+    expect(written).toEqual(mockConfig);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("Config written to"));
+  });
+
+  test("shows which environment is being pulled", async () => {
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigPull();
+    expect(errorSpy).toHaveBeenCalledWith("Pulling config from development instance...");
+  });
+
+  test("shows production label when --instance prod", async () => {
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev", production: "ins_prod" },
+    });
+
+    await runConfigPull({ instance: "prod" });
+    expect(errorSpy).toHaveBeenCalledWith("Pulling config from production instance...");
+  });
+
+  test("uses development instance by default", async () => {
+    let requestedUrl = "";
+    globalThis.fetch = async (input: RequestInfo | URL) => {
+      requestedUrl = input.toString();
+      return new Response(JSON.stringify(mockConfig), { status: 200 });
+    };
+
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev", production: "ins_prod" },
+    });
+
+    await runConfigPull();
+    expect(requestedUrl).toContain("/instances/ins_dev/");
+  });
+
+  test("--instance prod targets production instance", async () => {
+    let requestedUrl = "";
+    globalThis.fetch = async (input: RequestInfo | URL) => {
+      requestedUrl = input.toString();
+      return new Response(JSON.stringify(mockConfig), { status: 200 });
+    };
+
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev", production: "ins_prod" },
+    });
+
+    await runConfigPull({ instance: "prod" });
+    expect(requestedUrl).toContain("/instances/ins_prod/");
+  });
+
+  test("--instance with literal ID passes through", async () => {
+    let requestedUrl = "";
+    globalThis.fetch = async (input: RequestInfo | URL) => {
+      requestedUrl = input.toString();
+      return new Response(JSON.stringify(mockConfig), { status: 200 });
+    };
+
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigPull({ instance: "ins_custom_123" });
+    expect(requestedUrl).toContain("/instances/ins_custom_123/");
+  });
+
+  test("errors when production instance not configured", async () => {
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await expect(runConfigPull({ instance: "prod" })).rejects.toThrow("process.exit");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("No production instance configured"),
+    );
+  });
+
+  test("handles API errors gracefully", async () => {
+    globalThis.fetch = async () => new Response("Unauthorized", { status: 401 });
+
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await expect(runConfigPull()).rejects.toThrow("process.exit");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to fetch config"),
+    );
+  });
+});

--- a/src/commands/config/pull.ts
+++ b/src/commands/config/pull.ts
@@ -1,0 +1,51 @@
+import { resolveProfile, resolveInstanceId } from "../../lib/config.ts";
+import { fetchInstanceConfig, PlapiError } from "../../lib/plapi.ts";
+
+interface ConfigPullOptions {
+  instance?: string;
+  output?: string;
+}
+
+export async function configPull(options: ConfigPullOptions): Promise<void> {
+  const resolved = await resolveProfile(process.cwd());
+  if (!resolved) {
+    console.error("No Clerk project linked to this directory. Run `clerk init` to set up.");
+    process.exit(1);
+  }
+
+  const { profile } = resolved;
+
+  let instance: { id: string; label: string };
+  try {
+    instance = resolveInstanceId(profile, options.instance);
+  } catch (error) {
+    console.error((error as Error).message);
+    process.exit(1);
+  }
+
+  console.error(`Pulling config from ${instance.label} instance...`);
+
+  let config: Record<string, unknown>;
+  try {
+    config = await fetchInstanceConfig(profile.appId, instance.id);
+  } catch (error) {
+    if (error instanceof PlapiError) {
+      console.error(`Failed to fetch config: ${error.message}`);
+      process.exit(1);
+    }
+    if (error instanceof Error) {
+      console.error(error.message);
+      process.exit(1);
+    }
+    throw error;
+  }
+
+  const json = JSON.stringify(config, null, 2);
+
+  if (options.output) {
+    await Bun.write(options.output, json + "\n");
+    console.error(`Config written to ${options.output}`);
+  } else {
+    console.log(json);
+  }
+}

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe, beforeEach, afterEach } from "bun:test";
-import { readConfig, writeConfig, getAuth, setAuth, clearAuth, getProfile, setProfile, listProfiles, resolveProfile, _setConfigDir } from "./config";
+import { readConfig, writeConfig, getAuth, setAuth, clearAuth, getProfile, setProfile, listProfiles, resolveProfile, resolveInstanceId, _setConfigDir, type Profile } from "./config";
 import { join } from "node:path";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -29,7 +29,7 @@ describe("config", () => {
         "/path/to/project": {
           workspaceId: "org_abc",
           appId: "app_def",
-          instanceId: "ins_ghi",
+          instances: { development: "ins_ghi" },
         },
       },
     };
@@ -54,7 +54,7 @@ describe("config", () => {
     const profile = {
       workspaceId: "org_abc",
       appId: "app_def",
-      instanceId: "ins_ghi",
+      instances: { development: "ins_ghi" },
     };
     await setProfile("/projects/my-app", profile);
     expect(await getProfile("/projects/my-app")).toEqual(profile);
@@ -65,12 +65,12 @@ describe("config", () => {
     await setProfile("/projects/app-a", {
       workspaceId: "org_1",
       appId: "app_1",
-      instanceId: "ins_1",
+      instances: { development: "ins_1" },
     });
     await setProfile("/projects/app-b", {
       workspaceId: "org_2",
       appId: "app_2",
-      instanceId: "ins_2",
+      instances: { development: "ins_2" },
     });
     const profiles = await listProfiles();
     expect(Object.keys(profiles)).toEqual(["/projects/app-a", "/projects/app-b"]);
@@ -80,7 +80,7 @@ describe("config", () => {
     await setProfile("/projects/my-app", {
       workspaceId: "org_1",
       appId: "app_1",
-      instanceId: "ins_1",
+      instances: { development: "ins_1" },
     });
     const result = await resolveProfile("/projects/my-app");
     expect(result?.path).toBe("/projects/my-app");
@@ -91,7 +91,7 @@ describe("config", () => {
     await setProfile("/projects/my-app", {
       workspaceId: "org_1",
       appId: "app_1",
-      instanceId: "ins_1",
+      instances: { development: "ins_1" },
     });
     const result = await resolveProfile("/projects/my-app/src/components");
     expect(result?.path).toBe("/projects/my-app");
@@ -100,5 +100,48 @@ describe("config", () => {
   test("resolveProfile returns undefined when no match", async () => {
     const result = await resolveProfile("/some/random/path");
     expect(result).toBeUndefined();
+  });
+
+  describe("resolveInstanceId", () => {
+    const profile: Profile = {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev", production: "ins_prod" },
+    };
+
+    test("defaults to development when no flag", () => {
+      expect(resolveInstanceId(profile)).toEqual({ id: "ins_dev", label: "development" });
+    });
+
+    test("resolves dev alias", () => {
+      expect(resolveInstanceId(profile, "dev")).toEqual({ id: "ins_dev", label: "development" });
+    });
+
+    test("resolves development alias", () => {
+      expect(resolveInstanceId(profile, "development")).toEqual({ id: "ins_dev", label: "development" });
+    });
+
+    test("resolves prod alias", () => {
+      expect(resolveInstanceId(profile, "prod")).toEqual({ id: "ins_prod", label: "production" });
+    });
+
+    test("resolves production alias", () => {
+      expect(resolveInstanceId(profile, "production")).toEqual({ id: "ins_prod", label: "production" });
+    });
+
+    test("passes through literal instance ID", () => {
+      expect(resolveInstanceId(profile, "ins_custom")).toEqual({ id: "ins_custom", label: "ins_custom" });
+    });
+
+    test("throws when production not configured", () => {
+      const devOnly: Profile = {
+        workspaceId: "org_1",
+        appId: "app_1",
+        instances: { development: "ins_dev" },
+      };
+      expect(() => resolveInstanceId(devOnly, "prod")).toThrow(
+        "No production instance configured"
+      );
+    });
   });
 });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -25,7 +25,10 @@ interface Auth {
 interface Profile {
   workspaceId: string;
   appId: string;
-  instanceId: string;
+  instances: {
+    development: string;
+    production?: string;
+  };
 }
 
 interface ClerkConfig {
@@ -97,6 +100,28 @@ export async function resolveProfile(cwd: string): Promise<{ path: string; profi
     dir = parent;
   }
   return undefined;
+}
+
+const INSTANCE_ALIASES: Record<string, "development" | "production"> = {
+  dev: "development",
+  development: "development",
+  prod: "production",
+  production: "production",
+};
+
+export function resolveInstanceId(profile: Profile, flag?: string): { id: string; label: string } {
+  if (!flag) {
+    return { id: profile.instances.development, label: "development" };
+  }
+
+  const env = INSTANCE_ALIASES[flag];
+  if (!env) return { id: flag, label: flag }; // literal instance ID
+
+  const id = profile.instances[env];
+  if (!id) {
+    throw new Error(`No ${env} instance configured. Run \`clerk init\` to set one up.`);
+  }
+  return { id, label: env };
 }
 
 export type { Auth, Profile, ClerkConfig };

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -29,6 +29,10 @@ export const OAUTH = {
 export const CALLBACK_PATH = "/callback";
 export const AUTH_TIMEOUT_MS = Number(process.env.CLERK_AUTH_TIMEOUT_MS) || 2 * 60 * 1000;
 
+// ── Platform API ────────────────────────────────────────────────────────────
+
+export const PLAPI_BASE_URL = process.env.CLERK_PLATFORM_API_URL ?? "https://api.clerk.com";
+
 // ── Keychain ────────────────────────────────────────────────────────────────
 
 export const KEYCHAIN_SERVICE = "clerk-cli";

--- a/src/lib/plapi.test.ts
+++ b/src/lib/plapi.test.ts
@@ -1,0 +1,80 @@
+import { test, expect, describe, beforeEach, afterEach, mock } from "bun:test";
+import { fetchInstanceConfig, PlapiError } from "./plapi";
+
+describe("plapi", () => {
+  const originalEnv = { ...process.env };
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    process.env.CLERK_PLATFORM_API_KEY = "test_key_123";
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    globalThis.fetch = originalFetch;
+  });
+
+  test("throws when CLERK_PLATFORM_API_KEY is not set", async () => {
+    delete process.env.CLERK_PLATFORM_API_KEY;
+    await expect(fetchInstanceConfig("app_1", "ins_1")).rejects.toThrow(
+      "CLERK_PLATFORM_API_KEY environment variable is required",
+    );
+  });
+
+  test("constructs correct URL", async () => {
+    let requestedUrl = "";
+    globalThis.fetch = async (input: RequestInfo | URL) => {
+      requestedUrl = input.toString();
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+
+    await fetchInstanceConfig("app_abc", "ins_def");
+    expect(requestedUrl).toBe(
+      "https://api.clerk.com/v1/platform/applications/app_abc/instances/ins_def/config",
+    );
+  });
+
+  test("sends Bearer token in Authorization header", async () => {
+    let capturedHeaders: Headers | undefined;
+    globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+      capturedHeaders = new Headers(init?.headers);
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+
+    await fetchInstanceConfig("app_1", "ins_1");
+    expect(capturedHeaders?.get("Authorization")).toBe("Bearer test_key_123");
+    expect(capturedHeaders?.get("Accept")).toBe("application/json");
+  });
+
+  test("returns parsed JSON on success", async () => {
+    const mockConfig = { session: { lifetime: 604800 }, sign_up: { mode: "public" } };
+    globalThis.fetch = async () => new Response(JSON.stringify(mockConfig), { status: 200 });
+
+    const result = await fetchInstanceConfig("app_1", "ins_1");
+    expect(result).toEqual(mockConfig);
+  });
+
+  test("throws PlapiError on non-2xx response", async () => {
+    globalThis.fetch = async () => new Response("Not Found", { status: 404 });
+
+    try {
+      await fetchInstanceConfig("app_1", "ins_bad");
+      expect(true).toBe(false); // should not reach
+    } catch (error) {
+      expect(error).toBeInstanceOf(PlapiError);
+      expect((error as PlapiError).status).toBe(404);
+      expect((error as PlapiError).body).toBe("Not Found");
+    }
+  });
+
+  test("default base URL is api.clerk.com", async () => {
+    let requestedUrl = "";
+    globalThis.fetch = async (input: RequestInfo | URL) => {
+      requestedUrl = input.toString();
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+
+    await fetchInstanceConfig("app_1", "ins_1");
+    expect(requestedUrl).toStartWith("https://api.clerk.com/");
+  });
+});

--- a/src/lib/plapi.ts
+++ b/src/lib/plapi.ts
@@ -1,0 +1,47 @@
+/**
+ * Platform API (PLAPI) client.
+ * Thin HTTP wrapper for Clerk's Platform API endpoints.
+ */
+
+import { PLAPI_BASE_URL } from "./constants.ts";
+
+export class PlapiError extends Error {
+  constructor(
+    public status: number,
+    public body: string,
+  ) {
+    super(`Platform API error (${status}): ${body}`);
+    this.name = "PlapiError";
+  }
+}
+
+function getApiKey(): string {
+  // TODO: Support OAuth token from login flow long-term
+  const key = process.env.CLERK_PLATFORM_API_KEY;
+  if (!key) {
+    throw new Error(
+      "CLERK_PLATFORM_API_KEY environment variable is required.",
+    );
+  }
+  return key;
+}
+
+export async function fetchInstanceConfig(
+  applicationId: string,
+  instanceId: string,
+): Promise<Record<string, unknown>> {
+  const url = `${PLAPI_BASE_URL}/v1/platform/applications/${applicationId}/instances/${instanceId}/config`;
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${getApiKey()}`,
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new PlapiError(response.status, body);
+  }
+
+  return response.json() as Promise<Record<string, unknown>>;
+}


### PR DESCRIPTION
## Summary

Introduces a new `clerk config pull` subcommand that retrieves instance configuration from the Clerk Platform API. Updates the `Profile` type to support multiple environments (development and optional production instances) via an `instances` object, replacing the single `instanceId` field.

## Changes

- New `config pull` command with `--instance` and `--output` options
- Platform API client (`plapi.ts`) for fetching instance configuration
- `resolveInstanceId()` helper function for alias resolution (dev/development/prod/production)
- `Profile.instances` replaces `Profile.instanceId` to support multiple environments
- Comprehensive test coverage for the new command, API client, and configuration changes

Generated with Claude Code