### PR TITLE
Add Open Questions section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,7 @@ clerk config pull
 clerk deploy
   --debug              Show debug output
 ```
+
+## Open Questions
+
+- How do we keep types in sync with PLAPI?


### PR DESCRIPTION
Added an "Open Questions" section to the README to document important questions about the project. Started with the question: "How do we keep types in sync with PLAPI?"

This allows the team to track architectural questions in the documentation.