### PR TITLE
Restructure commands into dedicated directories with documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,3 +109,18 @@ bun --hot ./index.ts
 ```
 
 For more information, read the Bun API docs in `node_modules/bun-types/docs/**.md`.
+
+## Commands
+
+Every CLI command lives in its own directory under `src/commands/<name>/`. Each directory must contain a `README.md` that documents:
+
+- What the command does
+- Usage and options
+- Clerk API endpoints the command calls (method, path, description)
+- Whether the command (or parts of it) is mocked/stubbed — call this out prominently with a blockquote at the top of the README if so
+
+When adding a new command, create its directory and README. When modifying a command's behavior, options, or API calls, update its README to match.
+
+### Root README
+
+`README.md` at the project root contains the CLI help output. When commands are added, removed, or their options change, update the help output in `README.md` to stay in sync. You can regenerate it by running `bun run src/cli.ts --help`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 import { program } from "commander";
 import { setMode, type Mode } from "./mode.js";
-import { init } from "./commands/init.js";
+import { init } from "./commands/init/index.js";
 import { login } from "./commands/auth/login.js";
 import { logout } from "./commands/auth/logout.js";
-import { whoami } from "./commands/whoami.js";
+import { whoami } from "./commands/whoami/index.js";
 import { pull } from "./commands/env/pull.js";
 import { deploy } from "./commands/deploy/index.js";
 import { configPull } from "./commands/config/pull.js";

--- a/src/commands/auth/README.md
+++ b/src/commands/auth/README.md
@@ -1,0 +1,31 @@
+# Auth Commands
+
+Manage authentication with Clerk.
+
+## Commands
+
+### `clerk auth login`
+
+Authenticates the user via an OAuth 2.0 PKCE flow.
+
+1. Checks for an existing valid token and skips login if found
+2. Generates PKCE parameters (code verifier, challenge, state)
+3. Starts a local HTTP callback server on `127.0.0.1`
+4. Opens the browser to the Clerk OAuth authorization URL
+5. Waits for the redirect callback with an authorization code
+6. Exchanges the code for an access token
+7. Stores the token and user info in local config
+
+#### API Endpoints
+
+All requests are made against the Clerk OAuth system instance (default `https://clerk.clerk.com`, overridable via `CLERK_OAUTH_BASE_URL`).
+
+| Step | Method | Endpoint | Description |
+|---|---|---|---|
+| Authorize | `GET` | `/oauth/authorize` | Browser redirect with PKCE `code_challenge`, `state`, `client_id`, `redirect_uri` |
+| Token exchange | `POST` | `/oauth/token` | Exchanges authorization code + `code_verifier` for an access token |
+| User info | `GET` | `/oauth/userinfo` | Fetches `sub` (user ID) and `email` using the access token |
+
+### `clerk auth logout`
+
+Removes the stored authentication token and clears auth info from local config. No API calls are made.

--- a/src/commands/config/README.md
+++ b/src/commands/config/README.md
@@ -1,0 +1,35 @@
+# Config Commands
+
+Manage Clerk instance configuration.
+
+## Commands
+
+### `clerk config pull`
+
+Fetches the instance configuration from the Clerk Platform API and outputs it as JSON.
+
+```sh
+clerk config pull
+clerk config pull --instance prod
+clerk config pull --output clerk-config.json
+```
+
+#### Options
+
+| Flag | Description |
+|---|---|
+| `--instance <id>` | Instance to target (`dev`, `prod`, or a full instance ID). Defaults to development. |
+| `--output <file>` | Write config to a file instead of stdout |
+
+#### Requirements
+
+- Must have a Clerk project linked to the current directory (via `clerk init`)
+- Requires the `CLERK_PLATFORM_API_KEY` environment variable
+
+#### API Endpoints
+
+All requests are made against the Clerk Platform API (default `https://api.clerk.com`, overridable via `CLERK_PLATFORM_API_URL`).
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `GET` | `/v1/platform/applications/{appID}/instances/{instanceID}/config` | Fetches the full instance configuration as JSON. Authenticated via `Bearer` token from `CLERK_PLATFORM_API_KEY`. |

--- a/src/commands/deploy/README.md
+++ b/src/commands/deploy/README.md
@@ -1,5 +1,7 @@
 # Deploy Command
 
+> **Fully mocked.** This command uses hardcoded test data and is not yet wired to real APIs. The interactive prompts are real, but all API calls (application lookup, instance creation, DNS, OAuth credential storage) are simulated.
+
 Guides a user through deploying their Clerk application to production.
 
 ## Sequence Diagram

--- a/src/commands/env/README.md
+++ b/src/commands/env/README.md
@@ -1,0 +1,15 @@
+# Env Commands
+
+> **Not yet implemented.** This command is a placeholder that prints "coming soon!". No API calls are made.
+
+Manage environment variables for Clerk.
+
+## Commands
+
+### `clerk env pull`
+
+Pull environment variables from Clerk to `.env.local`.
+
+## API Endpoints
+
+None yet. When implemented, this will likely call the Platform API to fetch API keys and environment-specific variables for the linked instance.

--- a/src/commands/init/README.md
+++ b/src/commands/init/README.md
@@ -1,0 +1,34 @@
+# Init Command
+
+> **Partially mocked.** The authentication step (`clerk auth login`) is real. Everything after login — app creation, app selection, and writing API keys to `.env` — is stubbed with debug log output only.
+
+Initializes Clerk in a project by authenticating the user and linking a Clerk application.
+
+## Usage
+
+```sh
+clerk init
+clerk init --prompt
+```
+
+## Options
+
+| Flag | Description |
+|---|---|
+| `--prompt` | Output an AI agent prompt for integrating Clerk instead of running the interactive flow |
+
+## Flow
+
+1. Authenticates the user via `clerk auth login` (see [auth/README.md](../auth/README.md) for APIs)
+2. **New users**: automatically creates a Clerk app and writes API keys (`NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`) to `.env`
+3. **Existing users**: opens the browser to pick or create an app, then writes API keys to `.env`
+
+## API Endpoints
+
+Steps 2 and 3 are not yet wired to real APIs. When implemented, they will likely use:
+
+| Step | Method | Endpoint | Status |
+|---|---|---|---|
+| Create application | `POST` | `/v1/platform/applications` | Not yet implemented |
+| List applications | `GET` | `/v1/platform/applications` | Not yet implemented |
+| Fetch API keys | `GET` | `/v1/platform/applications/{appID}/instances/{instanceID}/api_keys` | Not yet implemented |

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -1,4 +1,4 @@
-import { login } from "./auth/login.js";
+import { login } from "../auth/login.js";
 
 const AGENT_PROMPT = `You are integrating Clerk authentication into an existing project. Follow these steps:
 

--- a/src/commands/whoami/README.md
+++ b/src/commands/whoami/README.md
@@ -1,0 +1,22 @@
+# Whoami Command
+
+Displays the email address of the currently authenticated user.
+
+## Usage
+
+```sh
+clerk whoami
+```
+
+## Behavior
+
+- Reads the stored authentication token from the local credential store
+- Fetches user info from the Clerk API and prints the user's email
+- If no token exists, prints a message to run `clerk auth login`
+- If the token is expired or invalid, prints a session expired message
+
+## API Endpoints
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `GET` | `/oauth/userinfo` | Fetches the user's `email` and `sub` (user ID) using the stored access token. Base URL defaults to `https://clerk.clerk.com`. |

--- a/src/commands/whoami/index.test.ts
+++ b/src/commands/whoami/index.test.ts
@@ -3,15 +3,15 @@ import { test, expect, describe, afterEach, mock, spyOn } from "bun:test";
 const mockGetToken = mock();
 const mockFetchUserInfo = mock();
 
-mock.module("../lib/credential-store.ts", () => ({
+mock.module("../../lib/credential-store.ts", () => ({
   getToken: (...args: unknown[]) => mockGetToken(...args),
 }));
 
-mock.module("../lib/token-exchange.ts", () => ({
+mock.module("../../lib/token-exchange.ts", () => ({
   fetchUserInfo: (...args: unknown[]) => mockFetchUserInfo(...args),
 }));
 
-const { whoami } = await import("./whoami.ts");
+const { whoami } = await import("./index.ts");
 
 describe("whoami", () => {
   let consoleSpy: ReturnType<typeof spyOn>;

--- a/src/commands/whoami/index.ts
+++ b/src/commands/whoami/index.ts
@@ -1,5 +1,5 @@
-import { getToken } from "../lib/credential-store.ts";
-import { fetchUserInfo } from "../lib/token-exchange.ts";
+import { getToken } from "../../lib/credential-store.ts";
+import { fetchUserInfo } from "../../lib/token-exchange.ts";
 
 export async function whoami() {
   const token = await getToken();


### PR DESCRIPTION
## Summary

- Reorganize CLI commands (`init`, `whoami`) into their own subdirectories (`src/commands/<name>/index.ts`) instead of flat `.ts` files for better scalability and organization
- Add comprehensive README documentation for all command groups (`auth`, `config`, `env`, `init`, `whoami`) with usage examples, options, and API endpoints
- Update the deploy command README to clarify it currently uses mocked data
- All relative import paths updated to reflect new directory structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)