### PR TITLE
Add env pull command with .env file merging

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,6 +61,8 @@ const env = program
 env
   .command("pull")
   .description("Pull environment variables from Clerk to .env.local")
+  .option("--instance <id>", "Instance to target (dev, prod, or a full instance ID)")
+  .option("--file <path>", "Target env file (default: auto-detect)")
   .action(pull);
 
 const config = program

--- a/src/commands/env/README.md
+++ b/src/commands/env/README.md
@@ -1,0 +1,77 @@
+# Env Pull Command
+
+Pulls Clerk API keys for the linked instance and merges them into the project's `.env` file.
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant CLI as Clerk CLI
+    participant API as Clerk Platform API
+    participant FS as File System
+
+    Note over CLI: clerk env pull [--instance dev|prod] [--file .env]
+
+    %% Resolve project profile
+    CLI->>FS: Read ~/.clerk/config.json
+    FS-->>CLI: { appId, instances }
+
+    %% Fetch application with keys
+    CLI->>API: GET /v1/platform/applications/{appId}
+    API-->>CLI: { instances: [{ instance_id, publishable_key, secret_key }] }
+    CLI->>CLI: Find matching instance by instance_id
+
+    %% Detect framework
+    CLI->>FS: Read package.json
+    FS-->>CLI: { dependencies }
+    CLI->>CLI: Map framework → publishable key env var name
+
+    %% Resolve target file
+    alt --file flag provided
+        CLI->>CLI: Use specified file
+    else .env.local exists
+        CLI->>FS: Check .env.local
+        FS-->>CLI: exists
+    else .env exists
+        CLI->>FS: Check .env
+        FS-->>CLI: exists
+    else No env file
+        CLI->>CLI: Default to .env.local
+    end
+
+    %% Read, merge, write
+    CLI->>FS: Read target file (or empty)
+    CLI->>CLI: Parse → Merge (in-place update or append) → Serialize
+    CLI->>FS: Write updated file
+    CLI->>User: Environment variables written to .env.local
+```
+
+## API Endpoints
+
+| Step | Method | Endpoint | Notes |
+|---|---|---|---|
+| Auth | — | Local config | Token from `CLERK_PLATFORM_API_KEY` env var |
+| Fetch application | `GET` | `/v1/platform/applications/{appId}` | Returns all instances with keys |
+
+## Framework Detection
+
+Reads `package.json` dependencies to determine the correct publishable key env var name:
+
+| Framework dependency | Env var name |
+|---|---|
+| `next` | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` |
+| `expo` | `EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY` |
+| `astro` | `PUBLIC_CLERK_PUBLISHABLE_KEY` |
+| `nuxt` | `NUXT_PUBLIC_CLERK_PUBLISHABLE_KEY` |
+| `vite` | `VITE_CLERK_PUBLISHABLE_KEY` |
+| fallback | `CLERK_PUBLISHABLE_KEY` |
+
+Priority is top-to-bottom (e.g., a Next.js project that also has Vite will use `NEXT_PUBLIC_*`).
+
+## .env Merge Behavior
+
+- Existing Clerk keys are updated **in-place**, preserving their position in the file
+- New keys are appended at the end with a `# Clerk` section header
+- Comments, blank lines, and non-Clerk keys are preserved exactly as-is
+- File always ends with a trailing newline

--- a/src/commands/env/pull.test.ts
+++ b/src/commands/env/pull.test.ts
@@ -1,0 +1,255 @@
+import { test, expect, describe, beforeEach, afterEach, spyOn } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { _setConfigDir, setProfile } from "../../lib/config";
+
+describe("env pull", () => {
+  const originalEnv = { ...process.env };
+  const originalFetch = globalThis.fetch;
+  const originalCwd = process.cwd;
+  let tempDir: string;
+  let errorSpy: ReturnType<typeof spyOn>;
+  let exitSpy: ReturnType<typeof spyOn>;
+
+  const mockApplication = {
+    application_id: "app_1",
+    instances: [
+      {
+        instance_id: "ins_dev",
+        environment_type: "development",
+        publishable_key: "pk_test_abc123",
+        secret_key: "sk_test_xyz789",
+      },
+      {
+        instance_id: "ins_prod",
+        environment_type: "production",
+        publishable_key: "pk_live_abc123",
+        secret_key: "sk_live_xyz789",
+      },
+    ],
+  };
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "clerk-env-pull-test-"));
+    _setConfigDir(tempDir);
+    process.env.CLERK_PLATFORM_API_KEY = "test_key";
+    process.env.CLERK_PLATFORM_API_URL = "https://test-api.clerk.com";
+
+    // Write a package.json so framework detection works (fallback)
+    await Bun.write(
+      join(tempDir, "package.json"),
+      JSON.stringify({ dependencies: { express: "4.0.0" } }),
+    );
+
+    // Mock cwd to tempDir so file resolution works
+    process.cwd = () => tempDir;
+
+    errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify(mockApplication), { status: 200 });
+  });
+
+  afterEach(async () => {
+    _setConfigDir(undefined);
+    process.env = { ...originalEnv };
+    process.cwd = originalCwd;
+    globalThis.fetch = originalFetch;
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function runEnvPull(options: { instance?: string; file?: string } = {}) {
+    const { pull } = await import("./pull");
+    return pull(options);
+  }
+
+  test("errors when no profile is linked", async () => {
+    await expect(runEnvPull()).rejects.toThrow("process.exit");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("No Clerk project linked"),
+    );
+  });
+
+  test("errors when CLERK_PLATFORM_API_KEY is missing", async () => {
+    await setProfile(tempDir, {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+    delete process.env.CLERK_PLATFORM_API_KEY;
+
+    await expect(runEnvPull()).rejects.toThrow("process.exit");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("CLERK_PLATFORM_API_KEY"),
+    );
+  });
+
+  test("creates .env.local with keys when no env file exists", async () => {
+    await setProfile(tempDir, {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runEnvPull();
+
+    const content = await Bun.file(join(tempDir, ".env.local")).text();
+    expect(content).toContain("CLERK_PUBLISHABLE_KEY=pk_test_abc123");
+    expect(content).toContain("CLERK_SECRET_KEY=sk_test_xyz789");
+  });
+
+  test("updates existing .env.local preserving other vars", async () => {
+    await setProfile(tempDir, {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+    await Bun.write(join(tempDir, ".env.local"), "DB_URL=postgres://localhost\nAPP_NAME=myapp\n");
+
+    await runEnvPull();
+
+    const content = await Bun.file(join(tempDir, ".env.local")).text();
+    expect(content).toContain("DB_URL=postgres://localhost");
+    expect(content).toContain("APP_NAME=myapp");
+    expect(content).toContain("CLERK_PUBLISHABLE_KEY=pk_test_abc123");
+    expect(content).toContain("CLERK_SECRET_KEY=sk_test_xyz789");
+  });
+
+  test("updates existing Clerk keys in-place", async () => {
+    await setProfile(tempDir, {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+    await Bun.write(
+      join(tempDir, ".env.local"),
+      "CLERK_PUBLISHABLE_KEY=old_pk\nOTHER=val\nCLERK_SECRET_KEY=old_sk\n",
+    );
+
+    await runEnvPull();
+
+    const content = await Bun.file(join(tempDir, ".env.local")).text();
+    expect(content).toBe(
+      "CLERK_PUBLISHABLE_KEY=pk_test_abc123\nOTHER=val\nCLERK_SECRET_KEY=sk_test_xyz789\n",
+    );
+  });
+
+  test("falls back to .env when .env.local does not exist", async () => {
+    await setProfile(tempDir, {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+    await Bun.write(join(tempDir, ".env"), "EXISTING=value\n");
+
+    await runEnvPull();
+
+    const content = await Bun.file(join(tempDir, ".env")).text();
+    expect(content).toContain("EXISTING=value");
+    expect(content).toContain("CLERK_SECRET_KEY=sk_test_xyz789");
+    // Should not have created .env.local
+    expect(await Bun.file(join(tempDir, ".env.local")).exists()).toBe(false);
+  });
+
+  test("uses --file flag to target specific file", async () => {
+    await setProfile(tempDir, {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runEnvPull({ file: ".env.development" });
+
+    const content = await Bun.file(join(tempDir, ".env.development")).text();
+    expect(content).toContain("CLERK_SECRET_KEY=sk_test_xyz789");
+  });
+
+  test("uses --instance prod to target production", async () => {
+    await setProfile(tempDir, {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev", production: "ins_prod" },
+    });
+
+    await runEnvPull({ instance: "prod" });
+
+    const content = await Bun.file(join(tempDir, ".env.local")).text();
+    expect(content).toContain("CLERK_PUBLISHABLE_KEY=pk_live_abc123");
+    expect(content).toContain("CLERK_SECRET_KEY=sk_live_xyz789");
+  });
+
+  test("shows instance label in status message", async () => {
+    await setProfile(tempDir, {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runEnvPull();
+    expect(errorSpy).toHaveBeenCalledWith("Pulling env vars from development instance...");
+  });
+
+  test("shows written file in status message", async () => {
+    await setProfile(tempDir, {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runEnvPull();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Environment variables written to"),
+    );
+  });
+
+  test("errors when instance not found in API response", async () => {
+    await setProfile(tempDir, {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_unknown" },
+    });
+
+    await expect(runEnvPull()).rejects.toThrow("process.exit");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Instance ins_unknown not found"),
+    );
+  });
+
+  test("handles API errors gracefully", async () => {
+    globalThis.fetch = async () => new Response("Unauthorized", { status: 401 });
+
+    await setProfile(tempDir, {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await expect(runEnvPull()).rejects.toThrow("process.exit");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to fetch API keys"),
+    );
+  });
+
+  test("detects Next.js and uses NEXT_PUBLIC_* key name", async () => {
+    await setProfile(tempDir, {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+    await Bun.write(
+      join(tempDir, "package.json"),
+      JSON.stringify({ dependencies: { next: "14.0.0" } }),
+    );
+
+    await runEnvPull();
+
+    const content = await Bun.file(join(tempDir, ".env.local")).text();
+    expect(content).toContain("NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_abc123");
+  });
+});

--- a/src/commands/env/pull.ts
+++ b/src/commands/env/pull.ts
@@ -1,3 +1,81 @@
-export function pull() {
-  console.log("clerk env pull - coming soon!");
+import { join } from "node:path";
+import { resolveProfile, resolveInstanceId } from "../../lib/config.ts";
+import { fetchApplication, PlapiError } from "../../lib/plapi.ts";
+import { parseEnvFile, mergeEnvVars, serializeEnvFile } from "../../lib/dotenv.ts";
+import { detectPublishableKeyName } from "../../lib/framework.ts";
+
+interface EnvPullOptions {
+  instance?: string;
+  file?: string;
+}
+
+async function resolveTargetFile(cwd: string, flag?: string): Promise<string> {
+  if (flag) return join(cwd, flag);
+
+  const envLocal = Bun.file(join(cwd, ".env.local"));
+  if (await envLocal.exists()) return join(cwd, ".env.local");
+
+  const envFile = Bun.file(join(cwd, ".env"));
+  if (await envFile.exists()) return join(cwd, ".env");
+
+  return join(cwd, ".env.local");
+}
+
+export async function pull(options: EnvPullOptions): Promise<void> {
+  const resolved = await resolveProfile(process.cwd());
+  if (!resolved) {
+    console.error("No Clerk project linked to this directory. Run `clerk init` to set up.");
+    process.exit(1);
+  }
+
+  const { profile } = resolved;
+
+  let instance: { id: string; label: string };
+  try {
+    instance = resolveInstanceId(profile, options.instance);
+  } catch (error) {
+    console.error((error as Error).message);
+    process.exit(1);
+  }
+
+  console.error(`Pulling env vars from ${instance.label} instance...`);
+
+  let app;
+  try {
+    app = await fetchApplication(profile.appId);
+  } catch (error) {
+    if (error instanceof PlapiError) {
+      console.error(`Failed to fetch API keys: ${error.message}`);
+      process.exit(1);
+    }
+    if (error instanceof Error) {
+      console.error(error.message);
+      process.exit(1);
+    }
+    throw error;
+  }
+
+  const matched = app.instances.find((i) => i.instance_id === instance.id);
+  if (!matched) {
+    console.error(`Instance ${instance.id} not found in application response.`);
+    process.exit(1);
+  }
+
+  const publishableKeyName = await detectPublishableKeyName(process.cwd());
+  const targetFile = await resolveTargetFile(process.cwd(), options.file);
+
+  const file = Bun.file(targetFile);
+  const existingContent = (await file.exists()) ? await file.text() : "";
+
+  const lines = parseEnvFile(existingContent);
+  const merged = mergeEnvVars(lines, {
+    [publishableKeyName]: matched.publishable_key,
+    CLERK_SECRET_KEY: matched.secret_key,
+  });
+  const output = serializeEnvFile(merged);
+
+  await Bun.write(targetFile, output);
+
+  const displayPath = options.file ?? targetFile.split("/").pop()!;
+  console.error(`Environment variables written to ${displayPath}`);
 }

--- a/src/lib/dotenv.test.ts
+++ b/src/lib/dotenv.test.ts
@@ -1,0 +1,147 @@
+import { test, expect, describe } from "bun:test";
+import { parseEnvFile, mergeEnvVars, serializeEnvFile } from "./dotenv";
+
+describe("parseEnvFile", () => {
+  test("returns empty array for empty string", () => {
+    expect(parseEnvFile("")).toEqual([]);
+  });
+
+  test("parses KEY=VALUE entries", () => {
+    const lines = parseEnvFile("FOO=bar\nBAZ=qux\n");
+    expect(lines).toEqual([
+      { type: "entry", key: "FOO", value: "bar", raw: "FOO=bar" },
+      { type: "entry", key: "BAZ", value: "qux", raw: "BAZ=qux" },
+    ]);
+  });
+
+  test("strips double quotes from values", () => {
+    const lines = parseEnvFile('FOO="hello world"\n');
+    expect(lines[0]).toEqual({
+      type: "entry",
+      key: "FOO",
+      value: "hello world",
+      raw: 'FOO="hello world"',
+    });
+  });
+
+  test("strips single quotes from values", () => {
+    const lines = parseEnvFile("FOO='hello world'\n");
+    expect(lines[0]).toEqual({
+      type: "entry",
+      key: "FOO",
+      value: "hello world",
+      raw: "FOO='hello world'",
+    });
+  });
+
+  test("preserves comments", () => {
+    const lines = parseEnvFile("# This is a comment\nFOO=bar\n");
+    expect(lines[0]).toEqual({ type: "comment", raw: "# This is a comment" });
+  });
+
+  test("preserves blank lines", () => {
+    const lines = parseEnvFile("FOO=bar\n\nBAZ=qux\n");
+    expect(lines).toEqual([
+      { type: "entry", key: "FOO", value: "bar", raw: "FOO=bar" },
+      { type: "blank" },
+      { type: "entry", key: "BAZ", value: "qux", raw: "BAZ=qux" },
+    ]);
+  });
+
+  test("handles export prefix", () => {
+    const lines = parseEnvFile("export FOO=bar\n");
+    expect(lines[0]).toEqual({
+      type: "entry",
+      key: "FOO",
+      value: "bar",
+      raw: "export FOO=bar",
+    });
+  });
+
+  test("handles empty values", () => {
+    const lines = parseEnvFile("FOO=\n");
+    expect(lines[0]).toEqual({ type: "entry", key: "FOO", value: "", raw: "FOO=" });
+  });
+
+  test("handles values with equals signs", () => {
+    const lines = parseEnvFile("FOO=bar=baz\n");
+    expect(lines[0]).toEqual({
+      type: "entry",
+      key: "FOO",
+      value: "bar=baz",
+      raw: "FOO=bar=baz",
+    });
+  });
+});
+
+describe("mergeEnvVars", () => {
+  test("updates existing key in-place", () => {
+    const lines = parseEnvFile("A=1\nCLERK_SECRET_KEY=old\nB=2\n");
+    const merged = mergeEnvVars(lines, { CLERK_SECRET_KEY: "new" });
+    const output = serializeEnvFile(merged);
+    expect(output).toBe("A=1\nCLERK_SECRET_KEY=new\nB=2\n");
+  });
+
+  test("appends new keys with section header", () => {
+    const lines = parseEnvFile("DB_URL=postgres://localhost\n");
+    const merged = mergeEnvVars(lines, {
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: "pk_test_xxx",
+      CLERK_SECRET_KEY: "sk_test_yyy",
+    });
+    const output = serializeEnvFile(merged);
+    expect(output).toBe(
+      "DB_URL=postgres://localhost\n\n# Clerk\nNEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_xxx\nCLERK_SECRET_KEY=sk_test_yyy\n",
+    );
+  });
+
+  test("does not add section header when updating existing keys", () => {
+    const lines = parseEnvFile("CLERK_SECRET_KEY=old\n");
+    const merged = mergeEnvVars(lines, { CLERK_SECRET_KEY: "new" });
+    const output = serializeEnvFile(merged);
+    expect(output).toBe("CLERK_SECRET_KEY=new\n");
+    expect(output).not.toContain("# Clerk");
+  });
+
+  test("preserves comments and blank lines during merge", () => {
+    const input = "# Database\nDB_URL=postgres://localhost\n\n# App\nAPP_NAME=foo\n";
+    const lines = parseEnvFile(input);
+    const merged = mergeEnvVars(lines, { CLERK_SECRET_KEY: "sk_test" });
+    const output = serializeEnvFile(merged);
+    expect(output).toContain("# Database\n");
+    expect(output).toContain("# App\n");
+    expect(output).toContain("DB_URL=postgres://localhost\n");
+  });
+
+  test("handles empty file", () => {
+    const lines = parseEnvFile("");
+    const merged = mergeEnvVars(lines, { CLERK_SECRET_KEY: "sk_test" });
+    const output = serializeEnvFile(merged);
+    expect(output).toBe("CLERK_SECRET_KEY=sk_test\n");
+  });
+
+  test("updates one key and appends another", () => {
+    const lines = parseEnvFile("CLERK_SECRET_KEY=old\n");
+    const merged = mergeEnvVars(lines, {
+      CLERK_SECRET_KEY: "new",
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: "pk_test",
+    });
+    const output = serializeEnvFile(merged);
+    expect(output).toContain("CLERK_SECRET_KEY=new\n");
+    expect(output).toContain("NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test\n");
+    // Should not add header since a Clerk key already existed
+    expect(output).not.toContain("# Clerk");
+  });
+});
+
+describe("serializeEnvFile", () => {
+  test("ends with trailing newline", () => {
+    const lines = parseEnvFile("FOO=bar\n");
+    expect(serializeEnvFile(lines)).toBe("FOO=bar\n");
+  });
+
+  test("round-trips without modification", () => {
+    const input = "# Header\nFOO=bar\n\nBAZ=qux\n";
+    const lines = parseEnvFile(input);
+    expect(serializeEnvFile(lines)).toBe(input);
+  });
+});

--- a/src/lib/dotenv.ts
+++ b/src/lib/dotenv.ts
@@ -1,0 +1,73 @@
+/**
+ * Minimal .env file parser and merger.
+ * Preserves comments, blank lines, and key ordering when merging new values.
+ */
+
+export type EnvLine =
+  | { type: "comment"; raw: string }
+  | { type: "blank" }
+  | { type: "entry"; key: string; value: string; raw: string };
+
+const ENTRY_RE = /^(export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/;
+
+export function parseEnvFile(content: string): EnvLine[] {
+  if (!content) return [];
+  const raw = content.endsWith("\n") ? content.slice(0, -1) : content;
+  return raw.split("\n").map((line): EnvLine => {
+    if (line.trim() === "") return { type: "blank" };
+    const match = line.match(ENTRY_RE);
+    if (!match) return { type: "comment", raw: line };
+    const key = match[2];
+    let value = match[3];
+    // Strip surrounding quotes
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    return { type: "entry", key, value, raw: line };
+  });
+}
+
+export function mergeEnvVars(
+  lines: EnvLine[],
+  vars: Record<string, string>,
+): EnvLine[] {
+  const remaining = { ...vars };
+  const result = lines.map((line): EnvLine => {
+    if (line.type !== "entry" || !(line.key in remaining)) return line;
+    const value = remaining[line.key];
+    delete remaining[line.key];
+    return { type: "entry", key: line.key, value, raw: `${line.key}=${value}` };
+  });
+
+  const toAppend = Object.entries(remaining);
+  if (toAppend.length === 0) return result;
+
+  // Add a Clerk section header if no Clerk keys existed in the original file
+  const hadClerkKey = lines.some(
+    (l) => l.type === "entry" && l.key in vars,
+  );
+  if (!hadClerkKey && result.length > 0) {
+    result.push({ type: "blank" });
+    result.push({ type: "comment", raw: "# Clerk" });
+  }
+
+  for (const [key, value] of toAppend) {
+    result.push({ type: "entry", key, value, raw: `${key}=${value}` });
+  }
+
+  return result;
+}
+
+export function serializeEnvFile(lines: EnvLine[]): string {
+  const out = lines
+    .map((line) => {
+      if (line.type === "blank") return "";
+      if (line.type === "comment") return line.raw;
+      return line.raw;
+    })
+    .join("\n");
+  return out + "\n";
+}

--- a/src/lib/framework.test.ts
+++ b/src/lib/framework.test.ts
@@ -1,0 +1,103 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { detectPublishableKeyName } from "./framework";
+
+describe("detectPublishableKeyName", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "clerk-framework-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("returns NEXT_PUBLIC_* for Next.js projects", async () => {
+    await Bun.write(
+      join(tempDir, "package.json"),
+      JSON.stringify({ dependencies: { next: "14.0.0" } }),
+    );
+    expect(await detectPublishableKeyName(tempDir)).toBe(
+      "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+    );
+  });
+
+  test("returns VITE_* for Vite projects", async () => {
+    await Bun.write(
+      join(tempDir, "package.json"),
+      JSON.stringify({ devDependencies: { vite: "5.0.0" } }),
+    );
+    expect(await detectPublishableKeyName(tempDir)).toBe(
+      "VITE_CLERK_PUBLISHABLE_KEY",
+    );
+  });
+
+  test("returns PUBLIC_* for Astro projects", async () => {
+    await Bun.write(
+      join(tempDir, "package.json"),
+      JSON.stringify({ dependencies: { astro: "4.0.0" } }),
+    );
+    expect(await detectPublishableKeyName(tempDir)).toBe(
+      "PUBLIC_CLERK_PUBLISHABLE_KEY",
+    );
+  });
+
+  test("returns EXPO_PUBLIC_* for Expo projects", async () => {
+    await Bun.write(
+      join(tempDir, "package.json"),
+      JSON.stringify({ dependencies: { expo: "50.0.0" } }),
+    );
+    expect(await detectPublishableKeyName(tempDir)).toBe(
+      "EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY",
+    );
+  });
+
+  test("returns NUXT_PUBLIC_* for Nuxt projects", async () => {
+    await Bun.write(
+      join(tempDir, "package.json"),
+      JSON.stringify({ dependencies: { nuxt: "3.0.0" } }),
+    );
+    expect(await detectPublishableKeyName(tempDir)).toBe(
+      "NUXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+    );
+  });
+
+  test("prefers Next.js over Vite when both present", async () => {
+    await Bun.write(
+      join(tempDir, "package.json"),
+      JSON.stringify({
+        dependencies: { next: "14.0.0" },
+        devDependencies: { vite: "5.0.0" },
+      }),
+    );
+    expect(await detectPublishableKeyName(tempDir)).toBe(
+      "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+    );
+  });
+
+  test("returns fallback when no framework detected", async () => {
+    await Bun.write(
+      join(tempDir, "package.json"),
+      JSON.stringify({ dependencies: { express: "4.0.0" } }),
+    );
+    expect(await detectPublishableKeyName(tempDir)).toBe(
+      "CLERK_PUBLISHABLE_KEY",
+    );
+  });
+
+  test("returns fallback when no package.json exists", async () => {
+    expect(await detectPublishableKeyName(tempDir)).toBe(
+      "CLERK_PUBLISHABLE_KEY",
+    );
+  });
+
+  test("returns fallback for malformed package.json", async () => {
+    await Bun.write(join(tempDir, "package.json"), "not json");
+    expect(await detectPublishableKeyName(tempDir)).toBe(
+      "CLERK_PUBLISHABLE_KEY",
+    );
+  });
+});

--- a/src/lib/framework.ts
+++ b/src/lib/framework.ts
@@ -1,0 +1,39 @@
+/**
+ * Framework detection for determining the correct publishable key env var name.
+ * Reads package.json to identify the project's framework.
+ */
+
+import { join } from "node:path";
+
+const FRAMEWORK_MAP: Array<{ dep: string; envVar: string }> = [
+  { dep: "next", envVar: "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY" },
+  { dep: "expo", envVar: "EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY" },
+  { dep: "astro", envVar: "PUBLIC_CLERK_PUBLISHABLE_KEY" },
+  { dep: "nuxt", envVar: "NUXT_PUBLIC_CLERK_PUBLISHABLE_KEY" },
+  { dep: "vite", envVar: "VITE_CLERK_PUBLISHABLE_KEY" },
+];
+
+const FALLBACK_KEY = "CLERK_PUBLISHABLE_KEY";
+
+export async function detectPublishableKeyName(cwd: string): Promise<string> {
+  const file = Bun.file(join(cwd, "package.json"));
+  if (!(await file.exists())) return FALLBACK_KEY;
+
+  let pkg: Record<string, Record<string, string>>;
+  try {
+    pkg = await file.json();
+  } catch {
+    return FALLBACK_KEY;
+  }
+
+  const allDeps = {
+    ...pkg.dependencies,
+    ...pkg.devDependencies,
+  };
+
+  for (const { dep, envVar } of FRAMEWORK_MAP) {
+    if (dep in allDeps) return envVar;
+  }
+
+  return FALLBACK_KEY;
+}

--- a/src/lib/plapi.ts
+++ b/src/lib/plapi.ts
@@ -45,3 +45,34 @@ export async function fetchInstanceConfig(
 
   return response.json() as Promise<Record<string, unknown>>;
 }
+
+export interface ApplicationInstance {
+  instance_id: string;
+  environment_type: string;
+  secret_key: string;
+  publishable_key: string;
+}
+
+export interface Application {
+  application_id: string;
+  instances: ApplicationInstance[];
+}
+
+export async function fetchApplication(
+  applicationId: string,
+): Promise<Application> {
+  const url = `${PLAPI_BASE_URL}/v1/platform/applications/${applicationId}`;
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${getApiKey()}`,
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new PlapiError(response.status, body);
+  }
+
+  return response.json() as Promise<Application>;
+}


### PR DESCRIPTION
## Summary

Implements the `clerk env pull` command to fetch Clerk API keys from the Platform API and merge them into local `.env` files with framework detection and comment preservation.

- Fetches publishable and secret keys from Clerk Platform API
- Auto-detects framework (Next.js, Vite, Astro, Expo, Nuxt) to choose correct env var prefix
- Preserves existing comments, blank lines, and non-Clerk variables when merging
- Supports `--instance` flag to target dev/prod and `--file` flag for custom paths
- Comprehensive unit and integration tests with full .env parsing coverage

## Test Plan

- [x] Creates .env.local from scratch with Clerk keys
- [x] Updates existing .env.local preserving other variables
- [x] Updates existing Clerk keys in-place
- [x] Falls back to .env when .env.local absent
- [x] Respects --file flag for custom paths
- [x] Supports --instance prod targeting production
- [x] Shows appropriate status messages
- [x] Handles errors gracefully (missing profile, API errors, instance not found)
- [x] Detects frameworks and uses correct env var names
- [x] Preserves comments and formatting in .env files

🤖 Generated with [Claude Code](https://claude.com/claude-code)