### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - run: bun install --frozen-lockfile
+
+      - run: bun test


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow to automatically run tests on every pull request targeting main. The workflow uses Bun to set up the environment and run the test suite.

## Changes
- Created `.github/workflows/ci.yml` with a CI job that:
  - Checks out code
  - Installs Bun
  - Installs dependencies
  - Runs test suite (114 tests pass locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)