### PR TITLE
Add config push command to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Commands:
   whoami               Show the current logged-in user
   config               Manage instance configuration
     pull [options]     Pull instance configuration from Clerk
+    patch [options]    Partially update instance configuration (PATCH)
+    put [options]      Replace entire instance configuration (PUT)
   env                  Manage environment variables
     pull [options]     Pull environment variables from Clerk to .env.local
   deploy [options]     Deploy your Clerk application (hidden)
@@ -31,6 +33,20 @@ clerk init
 clerk config pull
   --instance <id>      Instance to target (dev, prod, or a full instance ID)
   --output <file>      Write config to a file instead of stdout
+
+clerk config patch
+  --instance <id>      Instance to target (dev, prod, or a full instance ID)
+  --file <path>        Read config JSON from a file
+  --json <string>      Pass config JSON inline
+  --dry-run            Show what would be sent without making the API call
+  --yes                Skip confirmation prompts
+
+clerk config put
+  --instance <id>      Instance to target (dev, prod, or a full instance ID)
+  --file <path>        Read config JSON from a file
+  --json <string>      Pass config JSON inline
+  --dry-run            Show what would be sent without making the API call
+  --yes                Skip confirmation prompts
 
 clerk env pull
   --instance <id>      Instance to target (dev, prod, or a full instance ID)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import { whoami } from "./commands/whoami/index.js";
 import { pull } from "./commands/env/pull.js";
 import { deploy } from "./commands/deploy/index.js";
 import { configPull } from "./commands/config/pull.js";
+import { configPatch, configPut } from "./commands/config/push.js";
 
 program
   .name("clerk")
@@ -75,6 +76,26 @@ config
   .option("--instance <id>", "Instance to target (dev, prod, or a full instance ID)")
   .option("--output <file>", "Write config to a file instead of stdout")
   .action(configPull);
+
+config
+  .command("patch")
+  .description("Partially update instance configuration (PATCH)")
+  .option("--instance <id>", "Instance to target (dev, prod, or a full instance ID)")
+  .option("--file <path>", "Read config JSON from a file")
+  .option("--json <string>", "Pass config JSON inline")
+  .option("--dry-run", "Show what would be sent without making the API call")
+  .option("--yes", "Skip confirmation prompts")
+  .action(configPatch);
+
+config
+  .command("put")
+  .description("Replace entire instance configuration (PUT)")
+  .option("--instance <id>", "Instance to target (dev, prod, or a full instance ID)")
+  .option("--file <path>", "Read config JSON from a file")
+  .option("--json <string>", "Pass config JSON inline")
+  .option("--dry-run", "Show what would be sent without making the API call")
+  .option("--yes", "Skip confirmation prompts")
+  .action(configPut);
 
 program
   .command("deploy", { hidden: true })

--- a/src/commands/config/README.md
+++ b/src/commands/config/README.md
@@ -33,3 +33,75 @@ All requests are made against the Clerk Platform API (default `https://api.clerk
 | Method | Endpoint | Description |
 |---|---|---|
 | `GET` | `/v1/platform/applications/{appID}/instances/{instanceID}/config` | Fetches the full instance configuration as JSON. Authenticated via `Bearer` token from `CLERK_PLATFORM_API_KEY`. |
+
+---
+
+### `clerk config patch`
+
+Partially updates instance configuration using a PATCH request. Only the fields you include in the payload are modified; everything else remains unchanged.
+
+Input can be provided via `--json` (inline), `--file` (path to a JSON file), or piped to stdin. When running interactively, the command shows the payload and prompts for confirmation before sending.
+
+```sh
+clerk config patch --json '{"session":{"lifetime":3600}}'
+clerk config patch --file partial-config.json
+cat partial-config.json | clerk config patch
+clerk config patch --file partial-config.json --dry-run
+```
+
+#### Options
+
+| Flag | Description |
+|---|---|
+| `--instance <id>` | Instance to target (`dev`, `prod`, or a full instance ID). Defaults to development. |
+| `--file <path>` | Read config JSON from a file |
+| `--json <string>` | Pass config JSON inline (takes priority over `--file`) |
+| `--dry-run` | Show what would be sent without making the API call |
+| `--yes` | Skip confirmation prompts |
+
+#### Requirements
+
+- Must have a Clerk project linked to the current directory (via `clerk init`)
+- Requires the `CLERK_PLATFORM_API_KEY` environment variable
+
+#### API Endpoints
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `PATCH` | `/v1/platform/applications/{appID}/instances/{instanceID}/config` | Partially updates instance configuration. Authenticated via `Bearer` token from `CLERK_PLATFORM_API_KEY`. |
+
+---
+
+### `clerk config put`
+
+Replaces the entire instance configuration using a PUT request. The payload you send becomes the complete configuration, overwriting all existing values.
+
+Input can be provided via `--json` (inline), `--file` (path to a JSON file), or piped to stdin. When running interactively, the command shows a destructive-action warning and prompts for confirmation before sending.
+
+```sh
+clerk config put --file full-config.json
+clerk config put --json '{"session":{"lifetime":3600},"sign_in":{"enabled":true}}'
+cat full-config.json | clerk config put
+clerk config put --file full-config.json --dry-run
+```
+
+#### Options
+
+| Flag | Description |
+|---|---|
+| `--instance <id>` | Instance to target (`dev`, `prod`, or a full instance ID). Defaults to development. |
+| `--file <path>` | Read config JSON from a file |
+| `--json <string>` | Pass config JSON inline (takes priority over `--file`) |
+| `--dry-run` | Show what would be sent without making the API call |
+| `--yes` | Skip confirmation prompts |
+
+#### Requirements
+
+- Must have a Clerk project linked to the current directory (via `clerk init`)
+- Requires the `CLERK_PLATFORM_API_KEY` environment variable
+
+#### API Endpoints
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `PUT` | `/v1/platform/applications/{appID}/instances/{instanceID}/config` | Replaces the full instance configuration. Authenticated via `Bearer` token from `CLERK_PLATFORM_API_KEY`. |

--- a/src/commands/config/push.test.ts
+++ b/src/commands/config/push.test.ts
@@ -1,0 +1,366 @@
+import { test, expect, describe, beforeEach, afterEach, spyOn } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { _setConfigDir, setProfile } from "../../lib/config";
+
+describe("config push", () => {
+  const originalEnv = { ...process.env };
+  const originalFetch = globalThis.fetch;
+  let tempDir: string;
+  let logSpy: ReturnType<typeof spyOn>;
+  let errorSpy: ReturnType<typeof spyOn>;
+  let exitSpy: ReturnType<typeof spyOn>;
+
+  const mockResponse = {
+    session: { lifetime: 3600 },
+    sign_up: { mode: "public" },
+  };
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "clerk-config-push-test-"));
+    _setConfigDir(tempDir);
+    process.env.CLERK_PLATFORM_API_KEY = "test_key";
+    process.env.CLERK_PLATFORM_API_URL = "https://test-api.clerk.com";
+
+    logSpy = spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify(mockResponse), { status: 200 });
+  });
+
+  afterEach(async () => {
+    _setConfigDir(undefined);
+    process.env = { ...originalEnv };
+    globalThis.fetch = originalFetch;
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function runConfigPatch(options: { instance?: string; file?: string; json?: string; dryRun?: boolean; yes?: boolean } = {}) {
+    const { configPatch } = await import("./push");
+    return configPatch(options);
+  }
+
+  async function runConfigPut(options: { instance?: string; file?: string; json?: string; dryRun?: boolean; yes?: boolean } = {}) {
+    const { configPut } = await import("./push");
+    return configPut(options);
+  }
+
+  // --- Shared error cases ---
+
+  test("errors when no profile is linked", async () => {
+    await expect(runConfigPatch({ json: '{"a":1}' })).rejects.toThrow("process.exit");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("No Clerk project linked"),
+    );
+  });
+
+  test("errors when CLERK_PLATFORM_API_KEY is missing", async () => {
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+    delete process.env.CLERK_PLATFORM_API_KEY;
+
+    await expect(runConfigPatch({ json: '{"a":1}', yes: true })).rejects.toThrow("process.exit");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("CLERK_PLATFORM_API_KEY"),
+    );
+  });
+
+  test("errors when no input source is provided", async () => {
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    // Without --file or --json, falls through to stdin which yields empty input
+    await expect(runConfigPatch()).rejects.toThrow("process.exit");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("No input"),
+    );
+  });
+
+  test("errors on invalid JSON input", async () => {
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await expect(runConfigPatch({ json: "not-json" })).rejects.toThrow("process.exit");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid JSON"),
+    );
+  });
+
+  test("errors when JSON is an array", async () => {
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await expect(runConfigPatch({ json: "[1,2,3]" })).rejects.toThrow("process.exit");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Config must be a JSON object"),
+    );
+  });
+
+  test("errors when --file points to nonexistent file", async () => {
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await expect(runConfigPatch({ file: "/tmp/does-not-exist.json" })).rejects.toThrow("process.exit");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("File not found"),
+    );
+  });
+
+  // --- PATCH happy paths ---
+
+  test("patch sends PATCH method with --json input", async () => {
+    let capturedMethod = "";
+    let capturedBody = "";
+    globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+      capturedMethod = init?.method ?? "GET";
+      capturedBody = init?.body as string;
+      return new Response(JSON.stringify(mockResponse), { status: 200 });
+    };
+
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigPatch({ json: '{"session":{"lifetime":3600}}', yes: true });
+    expect(capturedMethod).toBe("PATCH");
+    expect(JSON.parse(capturedBody)).toEqual({ session: { lifetime: 3600 } });
+  });
+
+  test("patch reads config from --file", async () => {
+    let capturedBody = "";
+    globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+      capturedBody = init?.body as string;
+      return new Response(JSON.stringify(mockResponse), { status: 200 });
+    };
+
+    const configFile = join(tempDir, "input.json");
+    await Bun.write(configFile, JSON.stringify({ session: { lifetime: 7200 } }));
+
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigPatch({ file: configFile, yes: true });
+    expect(JSON.parse(capturedBody)).toEqual({ session: { lifetime: 7200 } });
+  });
+
+  test("patch prints returned config to stdout", async () => {
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigPatch({ json: '{"session":{"lifetime":3600}}', yes: true });
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(mockResponse, null, 2));
+  });
+
+  test("patch shows 'Updating' label", async () => {
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigPatch({ json: '{"session":{"lifetime":3600}}', yes: true });
+    expect(errorSpy).toHaveBeenCalledWith("Updating config on development instance...");
+  });
+
+  // --- PUT happy paths ---
+
+  test("put sends PUT method", async () => {
+    let capturedMethod = "";
+    globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+      capturedMethod = init?.method ?? "GET";
+      return new Response(JSON.stringify(mockResponse), { status: 200 });
+    };
+
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigPut({ json: '{"session":{"lifetime":3600}}', yes: true });
+    expect(capturedMethod).toBe("PUT");
+  });
+
+  test("put shows 'Replacing' label", async () => {
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigPut({ json: '{"session":{"lifetime":3600}}', yes: true });
+    expect(errorSpy).toHaveBeenCalledWith("Replacing config on development instance...");
+  });
+
+  // --- Instance targeting ---
+
+  test("targets development instance by default", async () => {
+    let requestedUrl = "";
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      requestedUrl = input.toString();
+      return new Response(JSON.stringify(mockResponse), { status: 200 });
+    };
+
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev", production: "ins_prod" },
+    });
+
+    await runConfigPatch({ json: '{"a":1}', yes: true });
+    expect(requestedUrl).toContain("/instances/ins_dev/");
+  });
+
+  test("--instance prod targets production instance", async () => {
+    let requestedUrl = "";
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      requestedUrl = input.toString();
+      return new Response(JSON.stringify(mockResponse), { status: 200 });
+    };
+
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev", production: "ins_prod" },
+    });
+
+    await runConfigPatch({ json: '{"a":1}', instance: "prod", yes: true });
+    expect(requestedUrl).toContain("/instances/ins_prod/");
+  });
+
+  test("--instance with literal ID passes through", async () => {
+    let requestedUrl = "";
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      requestedUrl = input.toString();
+      return new Response(JSON.stringify(mockResponse), { status: 200 });
+    };
+
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigPut({ json: '{"a":1}', instance: "ins_custom_123", yes: true });
+    expect(requestedUrl).toContain("/instances/ins_custom_123/");
+  });
+
+  // --- Dry run ---
+
+  test("dry-run prints payload without calling API", async () => {
+    let fetchCalled = false;
+    globalThis.fetch = async () => {
+      fetchCalled = true;
+      return new Response(JSON.stringify(mockResponse), { status: 200 });
+    };
+
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigPatch({ json: '{"session":{"lifetime":3600}}', dryRun: true });
+    expect(fetchCalled).toBe(false);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[dry-run]"),
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      JSON.stringify({ session: { lifetime: 3600 } }, null, 2),
+    );
+  });
+
+  test("dry-run for put shows PUT method", async () => {
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigPut({ json: '{"a":1}', dryRun: true });
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[dry-run] Would PUT"),
+    );
+  });
+
+  // --- API error handling ---
+
+  test("handles API errors gracefully", async () => {
+    globalThis.fetch = async () => new Response("Bad Request", { status: 400 });
+
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await expect(runConfigPatch({ json: '{"a":1}', yes: true })).rejects.toThrow("process.exit");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to push config"),
+    );
+  });
+
+  test("shows success message after push", async () => {
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigPatch({ json: '{"a":1}', yes: true });
+    expect(errorSpy).toHaveBeenCalledWith("Config pushed successfully.");
+  });
+
+  // --- --json takes priority over --file ---
+
+  test("--json takes priority over --file", async () => {
+    let capturedBody = "";
+    globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+      capturedBody = init?.body as string;
+      return new Response(JSON.stringify(mockResponse), { status: 200 });
+    };
+
+    const configFile = join(tempDir, "should-not-read.json");
+    await Bun.write(configFile, JSON.stringify({ from: "file" }));
+
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigPatch({ json: '{"from":"json"}', file: configFile, yes: true });
+    expect(JSON.parse(capturedBody)).toEqual({ from: "json" });
+  });
+});

--- a/src/commands/config/push.ts
+++ b/src/commands/config/push.ts
@@ -1,0 +1,149 @@
+import { confirm } from "@inquirer/prompts";
+import { resolveProfile, resolveInstanceId } from "../../lib/config.ts";
+import { putInstanceConfig, patchInstanceConfig, PlapiError } from "../../lib/plapi.ts";
+import { isHuman } from "../../mode.ts";
+
+interface ConfigPushOptions {
+  instance?: string;
+  file?: string;
+  json?: string;
+  dryRun?: boolean;
+  yes?: boolean;
+}
+
+type Operation = {
+  method: "PUT" | "PATCH";
+  verb: string;
+  warning?: string;
+  apiFn: (appId: string, instId: string, config: Record<string, unknown>) => Promise<Record<string, unknown>>;
+};
+
+const PUT_OP: Operation = {
+  method: "PUT",
+  verb: "Replacing",
+  warning: "This will overwrite the entire instance configuration.",
+  apiFn: putInstanceConfig,
+};
+
+const PATCH_OP: Operation = {
+  method: "PATCH",
+  verb: "Updating",
+  apiFn: patchInstanceConfig,
+};
+
+export async function configPut(options: ConfigPushOptions): Promise<void> {
+  return configPush(options, PUT_OP);
+}
+
+export async function configPatch(options: ConfigPushOptions): Promise<void> {
+  return configPush(options, PATCH_OP);
+}
+
+async function configPush(options: ConfigPushOptions, op: Operation): Promise<void> {
+  const resolved = await resolveProfile(process.cwd());
+  if (!resolved) {
+    console.error("No Clerk project linked to this directory. Run `clerk init` to set up.");
+    process.exit(1);
+  }
+
+  const { profile } = resolved;
+
+  let instance: { id: string; label: string };
+  try {
+    instance = resolveInstanceId(profile, options.instance);
+  } catch (error) {
+    console.error((error as Error).message);
+    process.exit(1);
+  }
+
+  let rawInput: string;
+  try {
+    rawInput = await readInput(options);
+  } catch (error) {
+    console.error((error as Error).message);
+    process.exit(1);
+  }
+
+  let configPayload: Record<string, unknown>;
+  try {
+    configPayload = JSON.parse(rawInput);
+  } catch {
+    console.error("Invalid JSON input. Please provide valid JSON.");
+    process.exit(1);
+  }
+
+  if (typeof configPayload !== "object" || configPayload === null || Array.isArray(configPayload)) {
+    console.error("Config must be a JSON object.");
+    process.exit(1);
+  }
+
+  if (options.dryRun) {
+    console.error(`[dry-run] Would ${op.method} config on ${instance.label} instance:`);
+    console.log(JSON.stringify(configPayload, null, 2));
+    return;
+  }
+
+  if (isHuman() && !options.yes) {
+    console.error(`\n${op.verb} config on ${instance.label} instance:`);
+    console.error(JSON.stringify(configPayload, null, 2));
+    if (op.warning) {
+      console.error(`\nWARNING: ${op.warning}`);
+    }
+    const ok = await confirm({ message: "Proceed?" });
+    if (!ok) {
+      console.error("Aborted.");
+      process.exit(0);
+    }
+  }
+
+  console.error(`${op.verb} config on ${instance.label} instance...`);
+
+  try {
+    const result = await op.apiFn(profile.appId, instance.id, configPayload);
+    console.log(JSON.stringify(result, null, 2));
+    console.error("Config pushed successfully.");
+  } catch (error) {
+    if (error instanceof PlapiError) {
+      console.error(`Failed to push config: ${error.message}`);
+      process.exit(1);
+    }
+    if (error instanceof Error) {
+      console.error(error.message);
+      process.exit(1);
+    }
+    throw error;
+  }
+}
+
+export async function readInput(options: { file?: string; json?: string }): Promise<string> {
+  if (options.json) {
+    return options.json;
+  }
+
+  if (options.file) {
+    const file = Bun.file(options.file);
+    if (!(await file.exists())) {
+      throw new Error(`File not found: ${options.file}`);
+    }
+    return file.text();
+  }
+
+  if (!process.stdin.isTTY) {
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) {
+      chunks.push(Buffer.from(chunk));
+    }
+    const text = Buffer.concat(chunks).toString("utf-8").trim();
+    if (!text) {
+      throw new Error("No input received from stdin.");
+    }
+    return text;
+  }
+
+  throw new Error(
+    "No input provided. Use --file <path>, --json <string>, or pipe JSON to stdin.\n" +
+    "  Example: clerk config patch --file config.json\n" +
+    "  Example: clerk config patch --json '{\"session\":{\"lifetime\":3600}}'\n" +
+    "  Example: cat config.json | clerk config patch",
+  );
+}

--- a/src/lib/plapi.test.ts
+++ b/src/lib/plapi.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe, beforeEach, afterEach, mock } from "bun:test";
-import { fetchInstanceConfig, PlapiError } from "./plapi";
+import { fetchInstanceConfig, putInstanceConfig, patchInstanceConfig, PlapiError } from "./plapi";
 
 describe("plapi", () => {
   const originalEnv = { ...process.env };
@@ -76,5 +76,130 @@ describe("plapi", () => {
 
     await fetchInstanceConfig("app_1", "ins_1");
     expect(requestedUrl).toStartWith("https://api.clerk.com/");
+  });
+
+  describe("putInstanceConfig", () => {
+    test("sends PUT method with correct URL", async () => {
+      let capturedMethod = "";
+      let capturedUrl = "";
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        capturedUrl = input.toString();
+        capturedMethod = init?.method ?? "GET";
+        return new Response(JSON.stringify({}), { status: 200 });
+      };
+
+      await putInstanceConfig("app_abc", "ins_def", { session: { lifetime: 3600 } });
+      expect(capturedMethod).toBe("PUT");
+      expect(capturedUrl).toBe(
+        "https://api.clerk.com/v1/platform/applications/app_abc/instances/ins_def/config",
+      );
+    });
+
+    test("sends Content-Type and Authorization headers", async () => {
+      let capturedHeaders: Headers | undefined;
+      globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedHeaders = new Headers(init?.headers);
+        return new Response(JSON.stringify({}), { status: 200 });
+      };
+
+      await putInstanceConfig("app_1", "ins_1", {});
+      expect(capturedHeaders?.get("Authorization")).toBe("Bearer test_key_123");
+      expect(capturedHeaders?.get("Content-Type")).toBe("application/json");
+      expect(capturedHeaders?.get("Accept")).toBe("application/json");
+    });
+
+    test("sends JSON body", async () => {
+      let capturedBody = "";
+      globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedBody = init?.body as string;
+        return new Response(JSON.stringify({}), { status: 200 });
+      };
+
+      const payload = { session: { lifetime: 3600 } };
+      await putInstanceConfig("app_1", "ins_1", payload);
+      expect(JSON.parse(capturedBody)).toEqual(payload);
+    });
+
+    test("returns parsed JSON on success", async () => {
+      const mockResult = { session: { lifetime: 3600 }, sign_up: { mode: "restricted" } };
+      globalThis.fetch = async () => new Response(JSON.stringify(mockResult), { status: 200 });
+
+      const result = await putInstanceConfig("app_1", "ins_1", { session: { lifetime: 3600 } });
+      expect(result).toEqual(mockResult);
+    });
+
+    test("throws PlapiError on non-2xx response", async () => {
+      globalThis.fetch = async () => new Response("Bad Request", { status: 400 });
+
+      try {
+        await putInstanceConfig("app_1", "ins_1", {});
+        expect(true).toBe(false);
+      } catch (error) {
+        expect(error).toBeInstanceOf(PlapiError);
+        expect((error as PlapiError).status).toBe(400);
+      }
+    });
+  });
+
+  describe("patchInstanceConfig", () => {
+    test("sends PATCH method with correct URL", async () => {
+      let capturedMethod = "";
+      let capturedUrl = "";
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        capturedUrl = input.toString();
+        capturedMethod = init?.method ?? "GET";
+        return new Response(JSON.stringify({}), { status: 200 });
+      };
+
+      await patchInstanceConfig("app_abc", "ins_def", { session: { lifetime: 3600 } });
+      expect(capturedMethod).toBe("PATCH");
+      expect(capturedUrl).toBe(
+        "https://api.clerk.com/v1/platform/applications/app_abc/instances/ins_def/config",
+      );
+    });
+
+    test("sends Content-Type and Authorization headers", async () => {
+      let capturedHeaders: Headers | undefined;
+      globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedHeaders = new Headers(init?.headers);
+        return new Response(JSON.stringify({}), { status: 200 });
+      };
+
+      await patchInstanceConfig("app_1", "ins_1", {});
+      expect(capturedHeaders?.get("Authorization")).toBe("Bearer test_key_123");
+      expect(capturedHeaders?.get("Content-Type")).toBe("application/json");
+    });
+
+    test("sends JSON body", async () => {
+      let capturedBody = "";
+      globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedBody = init?.body as string;
+        return new Response(JSON.stringify({}), { status: 200 });
+      };
+
+      const payload = { sign_up: { mode: "restricted" } };
+      await patchInstanceConfig("app_1", "ins_1", payload);
+      expect(JSON.parse(capturedBody)).toEqual(payload);
+    });
+
+    test("returns full config after merge", async () => {
+      const mockResult = { session: { lifetime: 3600 }, sign_up: { mode: "public" } };
+      globalThis.fetch = async () => new Response(JSON.stringify(mockResult), { status: 200 });
+
+      const result = await patchInstanceConfig("app_1", "ins_1", { session: { lifetime: 3600 } });
+      expect(result).toEqual(mockResult);
+    });
+
+    test("throws PlapiError on non-2xx response", async () => {
+      globalThis.fetch = async () => new Response("Unprocessable Entity", { status: 422 });
+
+      try {
+        await patchInstanceConfig("app_1", "ins_1", { bad: "config" });
+        expect(true).toBe(false);
+      } catch (error) {
+        expect(error).toBeInstanceOf(PlapiError);
+        expect((error as PlapiError).status).toBe(422);
+      }
+    });
   });
 });

--- a/src/lib/plapi.ts
+++ b/src/lib/plapi.ts
@@ -76,3 +76,40 @@ export async function fetchApplication(
 
   return response.json() as Promise<Application>;
 }
+
+async function sendInstanceConfig(
+  method: "PUT" | "PATCH",
+  applicationId: string,
+  instanceId: string,
+  config: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const url = `${PLAPI_BASE_URL}/v1/platform/applications/${applicationId}/instances/${instanceId}/config`;
+  const response = await fetch(url, {
+    method,
+    headers: {
+      Authorization: `Bearer ${getApiKey()}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(config),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new PlapiError(response.status, body);
+  }
+
+  return response.json() as Promise<Record<string, unknown>>;
+}
+
+export const putInstanceConfig = (
+  applicationId: string,
+  instanceId: string,
+  config: Record<string, unknown>,
+) => sendInstanceConfig("PUT", applicationId, instanceId, config);
+
+export const patchInstanceConfig = (
+  applicationId: string,
+  instanceId: string,
+  config: Record<string, unknown>,
+) => sendInstanceConfig("PATCH", applicationId, instanceId, config);

--- a/todos/plapi/config-push.md
+++ b/todos/plapi/config-push.md
@@ -1,0 +1,131 @@
+# PLAPI: Instance Config Push Endpoints
+
+Status: **Proposed** — no backend implementation yet. This documents the endpoints the CLI expects.
+
+## Resource
+
+```
+/v1/platform/applications/{applicationId}/instances/{instanceId}/config
+```
+
+This resource already supports `GET` (used by `clerk config pull`). We propose adding `PUT` and `PATCH`.
+
+## Authentication
+
+All requests require a Bearer token via the `Authorization` header:
+
+```
+Authorization: Bearer <CLERK_PLATFORM_API_KEY>
+```
+
+---
+
+## PUT — Replace Entire Config
+
+Replaces the full instance configuration. Any fields not present in the request body are removed.
+
+### Request
+
+```
+PUT /v1/platform/applications/{applicationId}/instances/{instanceId}/config
+Content-Type: application/json
+Authorization: Bearer <token>
+```
+
+```json
+{
+  "session": { "lifetime": 3600 },
+  "sign_up": { "mode": "restricted" }
+}
+```
+
+### Response — 200 OK
+
+Returns the full config as it exists after replacement.
+
+```json
+{
+  "session": { "lifetime": 3600 },
+  "sign_up": { "mode": "restricted" }
+}
+```
+
+---
+
+## PATCH — Partial Config Update
+
+Updates specific fields via deep merge. Fields not included in the request body are left unchanged. Nested objects are merged recursively — sending `{"session": {"lifetime": 3600}}` updates `session.lifetime` without touching other `session` fields or any other top-level keys.
+
+### Request
+
+```
+PATCH /v1/platform/applications/{applicationId}/instances/{instanceId}/config
+Content-Type: application/json
+Authorization: Bearer <token>
+```
+
+```json
+{
+  "session": { "lifetime": 3600 }
+}
+```
+
+### Response — 200 OK
+
+Returns the full config as it exists after the merge.
+
+```json
+{
+  "session": { "lifetime": 3600, "token_format": "jwt" },
+  "sign_up": { "mode": "public" }
+}
+```
+
+---
+
+## Error Responses
+
+All error responses use a consistent shape:
+
+```json
+{
+  "errors": [
+    {
+      "code": "invalid_config",
+      "message": "session.lifetime must be a positive integer"
+    }
+  ]
+}
+```
+
+### Status Codes
+
+| Status | Meaning |
+|--------|---------|
+| 200 | Success — config updated, full resulting config returned |
+| 400 | Invalid JSON or malformed request body |
+| 401 | Missing or invalid API key |
+| 404 | Application or instance not found |
+| 422 | Valid JSON but logically invalid config (e.g., incompatible settings, unknown keys) |
+
+---
+
+## Field Deletion (PATCH)
+
+To explicitly remove a field during a PATCH, set its value to `null`:
+
+```json
+{
+  "sign_up": null
+}
+```
+
+This removes the `sign_up` key entirely from the config. Omitting a key leaves it unchanged (the default PATCH behavior).
+
+---
+
+## Notes
+
+- Both PUT and PATCH return the full resulting config, so the CLI can display the final state to the user.
+- The config schema is not defined here — it varies by Clerk version and instance type. The API is responsible for schema validation and returns 422 for invalid configs.
+- Rate limiting and idempotency behavior should follow existing PLAPI conventions.


### PR DESCRIPTION
## Summary

Implements `config patch` and `config put` subcommands for pushing instance configuration changes to the Clerk Platform API. Patch performs partial updates via deep merge, while put replaces the entire config. Both commands support flexible input (inline JSON, file, or stdin), dry-run mode, and interactive confirmation when running in human mode. Includes comprehensive tests and documentation.

## What changed

- **CLI registration**: New `patch` and `put` subcommands under `config` group
- **Command implementation**: Full input validation, confirmation flow, and error handling
- **API client**: Added `putInstanceConfig` and `patchInstanceConfig` functions with proper authentication
- **Tests**: 366 lines covering both commands, including happy paths, error cases, and edge cases
- **Documentation**: Updated command README with usage, options, and API endpoint details; updated root README with help output

## Test plan

- [x] Run existing test suite to ensure no regressions
- [x] Manual testing of --json, --file, and stdin input modes
- [x] Verify --dry-run doesn't call the API
- [x] Confirm interactive prompts appear and work correctly
- [x] Test --yes flag to skip prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)