### PR TITLE
Add agent mode support to deploy command

### DIFF
--- a/src/commands/deploy/README.md
+++ b/src/commands/deploy/README.md
@@ -4,6 +4,31 @@
 
 Guides a user through deploying their Clerk application to production.
 
+## Usage
+
+```sh
+clerk deploy              # Interactive wizard (human mode)
+clerk deploy --debug      # With debug output
+clerk deploy --mode agent # Output agent prompt instead of interactive flow
+```
+
+## Agent Mode
+
+> **TODO:** The `DEPLOY_PROMPT` string is hardcoded. It should probably fetch from the quickstart prompt in the Clerk docs instead.
+
+When running in agent mode (`--mode agent`, `CLERK_MODE=agent`, or non-TTY context), this command outputs a structured prompt describing the full deployment flow instead of running the interactive wizard. The prompt includes:
+
+- Prerequisites and pre-flight checks
+- Domain selection options (custom vs. Clerk subdomain)
+- Production instance creation steps
+- OAuth credential collection for social providers
+- All relevant Platform API endpoints
+
+Agent mode is detected via the mode system (`src/mode.ts`), which checks in priority order:
+1. `--mode` CLI flag
+2. `CLERK_MODE` environment variable
+3. TTY detection (`process.stdout.isTTY`)
+
 ## Sequence Diagram
 
 ```mermaid

--- a/src/commands/deploy/index.test.ts
+++ b/src/commands/deploy/index.test.ts
@@ -1,0 +1,129 @@
+import { test, expect, describe, afterEach, mock, spyOn } from "bun:test";
+
+const mockIsAgent = mock();
+
+mock.module("../../mode.ts", () => ({
+  isAgent: (...args: unknown[]) => mockIsAgent(...args),
+}));
+
+// Mock inquirer prompts so human-mode tests don't hang
+const mockSelect = mock();
+const mockInput = mock();
+const mockConfirm = mock();
+const mockPassword = mock();
+
+mock.module("@inquirer/prompts", () => ({
+  select: (...args: unknown[]) => mockSelect(...args),
+  input: (...args: unknown[]) => mockInput(...args),
+  confirm: (...args: unknown[]) => mockConfirm(...args),
+  password: (...args: unknown[]) => mockPassword(...args),
+}));
+
+const { deploy } = await import("./index.ts");
+
+describe("deploy", () => {
+  let consoleSpy: ReturnType<typeof spyOn>;
+
+  afterEach(() => {
+    mockIsAgent.mockReset();
+    mockSelect.mockReset();
+    mockInput.mockReset();
+    mockConfirm.mockReset();
+    mockPassword.mockReset();
+    consoleSpy?.mockRestore();
+  });
+
+  describe("agent mode", () => {
+    test("outputs deploy prompt and returns", async () => {
+      mockIsAgent.mockReturnValue(true);
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await deploy({});
+
+      expect(consoleSpy).toHaveBeenCalledTimes(1);
+      const output = consoleSpy.mock.calls[0][0] as string;
+      expect(output).toContain("deploying a Clerk application to production");
+    });
+
+    test("prompt includes all deployment steps", async () => {
+      mockIsAgent.mockReturnValue(true);
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await deploy({});
+
+      const output = consoleSpy.mock.calls[0][0] as string;
+      expect(output).toContain("Prerequisites");
+      expect(output).toContain("Verify Subscription Compatibility");
+      expect(output).toContain("Choose a Production Domain");
+      expect(output).toContain("Create the Production Instance");
+      expect(output).toContain("Configure Social OAuth Providers");
+      expect(output).toContain("Finalize");
+    });
+
+    test("prompt includes API reference", async () => {
+      mockIsAgent.mockReturnValue(true);
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await deploy({});
+
+      const output = consoleSpy.mock.calls[0][0] as string;
+      expect(output).toContain("/v1/platform/applications");
+      expect(output).toContain("instances/production/config");
+      expect(output).toContain("instances/development/config");
+    });
+
+    test("prompt includes OAuth redirect URI pattern", async () => {
+      mockIsAgent.mockReturnValue(true);
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await deploy({});
+
+      const output = consoleSpy.mock.calls[0][0] as string;
+      expect(output).toContain("accounts.{domain}/v1/oauth_callback");
+    });
+
+    test("does not trigger interactive prompts", async () => {
+      mockIsAgent.mockReturnValue(true);
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await deploy({ debug: true });
+
+      expect(mockSelect).not.toHaveBeenCalled();
+      expect(mockInput).not.toHaveBeenCalled();
+      expect(mockConfirm).not.toHaveBeenCalled();
+      expect(mockPassword).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("human mode", () => {
+    function mockHumanFlow() {
+      mockIsAgent.mockReturnValue(false);
+      // Domain selection → OAuth credential choice
+      mockSelect.mockResolvedValueOnce("clerk-subdomain").mockResolvedValueOnce("have-credentials");
+      mockInput.mockResolvedValueOnce("fake-client-id-12345");
+      mockPassword.mockResolvedValueOnce("fake-secret");
+    }
+
+    test("does not print deploy prompt", async () => {
+      mockHumanFlow();
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await deploy({});
+
+      const allOutput = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+      expect(allOutput).not.toContain(
+        "deploying a Clerk application to production"
+      );
+    });
+
+    test("shows mock banner", async () => {
+      mockHumanFlow();
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await deploy({});
+
+      const allOutput = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+      expect(allOutput).toContain("[mock]");
+    });
+  });
+});

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -1,6 +1,91 @@
 import { select, input, confirm, password } from "@inquirer/prompts";
+import { isAgent } from "../../mode.js";
+
+const DEPLOY_PROMPT = `You are deploying a Clerk application to production. Follow these steps:
+
+## Prerequisites
+
+Ensure the following before starting:
+- The user is authenticated (\`clerk auth login\` has been run)
+- A Clerk application is linked to the project (\`clerk init\` has been run)
+- The project has a development instance with a working configuration
+
+## Step 1: Verify Subscription Compatibility
+
+Check that the development instance's features are covered by the application's subscription plan.
+
+- Fetch the development config: \`GET /v1/platform/applications/{appID}/instances/development/config\`
+- Fetch the subscription: \`GET /v1/platform/applications/{appID}/subscription\`
+- If any development features are not covered by the plan, the user must upgrade before deploying.
+
+## Step 2: Choose a Production Domain
+
+Ask the user which domain setup they prefer:
+
+**Option A: Custom domain**
+- The user provides their own domain (e.g., example.com)
+- DNS must be configured to point to Clerk. Check if the DNS provider supports Domain Connect for automatic setup.
+- If Domain Connect is available, direct the user to the Domain Connect URL to authorize DNS changes.
+- If not, provide the DNS records the user must add manually.
+- Verify DNS propagation: \`POST /v1/platform/applications/{appID}/domains/{domainID}/dns_check\`
+
+**Option B: Clerk-provided subdomain**
+- A subdomain like \`{adjective}-{animal}-{number}.clerk.app\` is automatically assigned.
+- No DNS configuration is needed.
+
+## Step 3: Create the Production Instance
+
+Create or configure the production instance for the application.
+- Add the domain: \`POST /v1/platform/applications/{appID}/domains\` with body \`{ "name": "<domain>", "is_satellite": false }\`
+- Note: There is currently no dedicated endpoint to add a production instance to an existing app. This may require \`POST /v1/platform/applications\` with \`environment_types: ["development", "production"]\`.
+
+## Step 4: Configure Social OAuth Providers
+
+For each social provider enabled in the development instance (e.g., Google, GitHub, Apple), production OAuth credentials are required.
+
+Check the dev config for \`connection_oauth_*\` keys. For each enabled provider:
+
+1. Collect the required credentials from the user:
+   - Most providers: \`client_id\` and \`client_secret\`
+   - Apple: also requires \`key_id\` and \`team_id\`
+
+2. When helping the user create OAuth credentials, provide these values:
+   - Authorized JavaScript origins: \`https://{domain}\` and \`https://www.{domain}\`
+   - Authorized redirect URI: \`https://accounts.{domain}/v1/oauth_callback\`
+
+3. Write credentials to production config:
+   \`PATCH /v1/platform/applications/{appID}/instances/production/config\`
+   Body: \`{ "connection_oauth_{provider}": { "enabled": true, "client_id": "...", "client_secret": "..." } }\`
+
+Provider-specific documentation: https://clerk.com/docs/guides/configure/auth-strategies/social-connections/{provider}
+
+## Step 5: Finalize
+
+After all configuration is complete:
+- Inform the user their production application is ready at \`https://{domain}\`
+- Remind them to redeploy their application with the updated Clerk production secret keys
+- They can pull production keys with: \`clerk env pull --instance prod\`
+
+## API Reference
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| GET | /v1/platform/applications/{appID} | Fetch application details |
+| GET | .../instances/development/config | Read dev instance config and enabled features |
+| GET | .../instances/production/config | Check if production instance exists (404 if not) |
+| GET | .../subscription | Check subscription plan |
+| POST | /v1/platform/applications | Create application with production instance |
+| POST | .../domains | Add a custom domain |
+| POST | .../domains/{domainID}/dns_check | Trigger DNS verification |
+| PATCH | .../instances/production/config | Write OAuth credentials to production |
+
+Refer to the Clerk Platform API docs for detailed request/response schemas.`;
 
 export async function deploy(options: { debug?: boolean }) {
+  if (isAgent()) {
+    console.log(DEPLOY_PROMPT);
+    return;
+  }
   const debug = options.debug ? (...args: unknown[]) => console.log("[debug]", ...args) : () => {};
 
   console.log("\x1b[33m[mock] This command uses mocked data and is not yet wired up to real APIs.\x1b[0m\n");


### PR DESCRIPTION
## Summary

Adds agent mode support to the deploy command. When running in non-interactive context (via `--mode agent`, `CLERK_MODE=agent`, or non-TTY), the command outputs a comprehensive structured prompt describing the full deployment workflow instead of running the interactive wizard.

The prompt includes all deployment steps (prerequisites, subscription verification, domain setup, OAuth configuration), relevant Platform API endpoints, and deployment sequence. Includes comprehensive tests for both agent and human mode paths with proper mocking to prevent hanging on interactive prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)