### PR TITLE
Add clerk api command for direct authenticated API access

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Commands:
     put [options]      Replace entire instance configuration (PUT)
   env                  Manage environment variables
     pull [options]     Pull environment variables from Clerk to .env.local
-  api [options] <endpoint>  Make authenticated requests to the Clerk API
+  api [options] [endpoint] [filter]  Make authenticated requests to the Clerk API
+    ls [filter]        List available API endpoints
+    (no args)          Interactive request builder (TTY only)
   deploy [options]     Deploy your Clerk application (hidden)
 
 clerk init
@@ -53,7 +55,7 @@ clerk env pull
   --instance <id>      Instance to target (dev, prod, or a full instance ID)
   --file <path>        Target env file (default: auto-detect)
 
-clerk api <endpoint>
+clerk api [endpoint] [filter]
   -X, --method <method>  HTTP method (default: GET, or POST if body provided)
   -d, --data <json>      JSON request body
   --file <path>          Read request body from a file
@@ -63,6 +65,9 @@ clerk api <endpoint>
   --platform             Use Platform API instead of Backend API
   --dry-run              Show the request without executing it
   --yes                  Skip confirmation for mutating requests
+
+clerk api ls [filter]    List available API endpoints
+clerk api                Interactive request builder (TTY only)
 
 clerk deploy
   --debug              Show debug output

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Commands:
     put [options]      Replace entire instance configuration (PUT)
   env                  Manage environment variables
     pull [options]     Pull environment variables from Clerk to .env.local
+  api [options] <endpoint>  Make authenticated requests to the Clerk API
   deploy [options]     Deploy your Clerk application (hidden)
 
 clerk init
@@ -51,6 +52,17 @@ clerk config put
 clerk env pull
   --instance <id>      Instance to target (dev, prod, or a full instance ID)
   --file <path>        Target env file (default: auto-detect)
+
+clerk api <endpoint>
+  -X, --method <method>  HTTP method (default: GET, or POST if body provided)
+  -d, --data <json>      JSON request body
+  --file <path>          Read request body from a file
+  --include              Show response headers
+  --secret-key <key>     Override the secret key
+  --instance <id>        Instance to target (dev, prod, or instance ID)
+  --platform             Use Platform API instead of Backend API
+  --dry-run              Show the request without executing it
+  --yes                  Skip confirmation for mutating requests
 
 clerk deploy
   --debug              Show debug output

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "dependencies": {
         "@inquirer/prompts": "^8.2.0",
         "commander": "^14.0.3",
+        "yaml": "^2.8.2",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -85,5 +86,7 @@
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^8.2.0",
-    "commander": "^14.0.3"
+    "commander": "^14.0.3",
+    "yaml": "^2.8.2"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -101,7 +101,8 @@ config
 program
   .command("api")
   .description("Make authenticated requests to the Clerk API")
-  .argument("<endpoint>", "API endpoint path (e.g., /users, /organizations)")
+  .argument("[endpoint]", "API endpoint path, 'ls' to list endpoints, or omit for interactive mode")
+  .argument("[filter]", "Filter keyword (used with 'ls')")
   .option("-X, --method <method>", "HTTP method (default: GET, or POST if body provided)")
   .option("-d, --data <json>", "JSON request body")
   .option("--file <path>", "Read request body from a file")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { pull } from "./commands/env/pull.js";
 import { deploy } from "./commands/deploy/index.js";
 import { configPull } from "./commands/config/pull.js";
 import { configPatch, configPut } from "./commands/config/push.js";
+import { api } from "./commands/api/index.js";
 
 program
   .name("clerk")
@@ -96,6 +97,21 @@ config
   .option("--dry-run", "Show what would be sent without making the API call")
   .option("--yes", "Skip confirmation prompts")
   .action(configPut);
+
+program
+  .command("api")
+  .description("Make authenticated requests to the Clerk API")
+  .argument("<endpoint>", "API endpoint path (e.g., /users, /organizations)")
+  .option("-X, --method <method>", "HTTP method (default: GET, or POST if body provided)")
+  .option("-d, --data <json>", "JSON request body")
+  .option("--file <path>", "Read request body from a file")
+  .option("--include", "Show response headers")
+  .option("--secret-key <key>", "Override the secret key")
+  .option("--instance <id>", "Instance to target (dev, prod, or instance ID)")
+  .option("--platform", "Use Platform API instead of Backend API")
+  .option("--dry-run", "Show the request without executing it")
+  .option("--yes", "Skip confirmation for mutating requests")
+  .action(api);
 
 program
   .command("deploy", { hidden: true })

--- a/src/commands/api/README.md
+++ b/src/commands/api/README.md
@@ -8,6 +8,15 @@ the instance secret key. Use `--platform` to target the Platform API instead.
 ## Usage
 
 ```sh
+# List available API endpoints
+clerk api ls
+
+# Filter endpoints by keyword
+clerk api ls users
+
+# Interactive request builder (TTY only)
+clerk api
+
 # List users
 clerk api /users
 
@@ -86,6 +95,29 @@ Base URL: `https://api.clerk.com` (overridable via `CLERK_PLATFORM_API_URL`)
 | Method | Endpoint | Description |
 |---|---|---|
 | Any | `/v1/{path}` | Pass-through to Clerk Platform API. Authenticated via `Bearer` token from `CLERK_PLATFORM_API_KEY`. |
+
+## Subcommands
+
+### `clerk api ls [filter]`
+
+Lists available API endpoints from the Clerk OpenAPI spec.
+
+- Fetches the spec from `clerk/openapi-specs` on GitHub
+- Caches locally in `~/.clerk/cache/` for 24 hours
+- Supports `--platform` to list Platform API endpoints
+- Optional filter keyword matches against path, summary, tag, and operation ID
+
+### `clerk api` (interactive mode)
+
+When run with no arguments in a TTY, launches an interactive request builder:
+
+1. Select an API category (Users, Organizations, Sessions, etc.)
+2. Select an endpoint
+3. Fill in path parameters (if any)
+4. Optionally provide a request body (opens `$EDITOR`)
+5. Preview and confirm before executing
+
+Requires human mode (TTY). In agent mode, prints usage help instead.
 
 ## Safety
 

--- a/src/commands/api/README.md
+++ b/src/commands/api/README.md
@@ -1,0 +1,94 @@
+# API Command
+
+Make authenticated HTTP requests to Clerk APIs directly from the command line.
+
+By default, targets the Clerk Backend API (`https://api.clerk.dev/v1/`) using
+the instance secret key. Use `--platform` to target the Platform API instead.
+
+## Usage
+
+```sh
+# List users
+clerk api /users
+
+# Get a specific user
+clerk api /users/user_abc123
+
+# Create a user (method auto-detected as POST from body)
+clerk api /users -d '{"email_address":["alice@example.com"]}'
+
+# Update with explicit method
+clerk api /users/user_abc123 -X PATCH -d '{"first_name":"Alice"}'
+
+# Delete a user
+clerk api /users/user_abc123 -X DELETE
+
+# Read body from file
+clerk api /users --file create-user.json
+
+# Pipe body from stdin
+cat payload.json | clerk api /users
+
+# Show response headers
+clerk api /users --include
+
+# Preview without executing
+clerk api /users -X DELETE --dry-run
+
+# Use a specific secret key
+clerk api /users --secret-key sk_test_abc123
+
+# Target production instance (requires CLERK_PLATFORM_API_KEY)
+clerk api /users --instance prod
+
+# Platform API mode
+clerk api /v1/platform/applications --platform
+```
+
+## Options
+
+| Flag | Description |
+|---|---|
+| `-X, --method <method>` | HTTP method. Defaults to GET, or POST if body is provided. |
+| `-d, --data <json>` | JSON request body (inline) |
+| `--file <path>` | Read request body from a file |
+| `--include` | Show response status and headers |
+| `--secret-key <key>` | Override the secret key |
+| `--instance <id>` | Instance to target for key resolution (`dev`, `prod`, or full ID) |
+| `--platform` | Use Platform API instead of Backend API |
+| `--dry-run` | Show request without executing |
+| `--yes` | Skip confirmation for mutating requests |
+
+## Authentication
+
+Secret key resolution order:
+
+1. `--secret-key` flag (explicit)
+2. `CLERK_SECRET_KEY` environment variable
+3. Auto-resolve from linked project profile (requires `CLERK_PLATFORM_API_KEY`)
+
+For `--platform` mode, uses `CLERK_PLATFORM_API_KEY` environment variable.
+
+## API Endpoints
+
+### Backend API (default)
+
+Base URL: `https://api.clerk.dev` (overridable via `CLERK_BACKEND_API_URL`)
+
+| Method | Endpoint | Description |
+|---|---|---|
+| Any | `/v1/{path}` | Pass-through to Clerk Backend API. Authenticated via `Bearer` token from secret key. |
+
+### Platform API (`--platform`)
+
+Base URL: `https://api.clerk.com` (overridable via `CLERK_PLATFORM_API_URL`)
+
+| Method | Endpoint | Description |
+|---|---|---|
+| Any | `/v1/{path}` | Pass-through to Clerk Platform API. Authenticated via `Bearer` token from `CLERK_PLATFORM_API_KEY`. |
+
+## Safety
+
+- POST, PUT, PATCH, and DELETE requests prompt for confirmation in interactive mode
+- Use `--yes` to skip confirmation (for scripting)
+- Use `--dry-run` to preview without executing

--- a/src/commands/api/bapi.test.ts
+++ b/src/commands/api/bapi.test.ts
@@ -1,0 +1,132 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import { bapiRequest, BapiError } from "./bapi";
+
+describe("bapi", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("constructs correct URL with /v1/ prefix", async () => {
+    let requestedUrl = "";
+    globalThis.fetch = async (input: RequestInfo | URL) => {
+      requestedUrl = input.toString();
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+    await bapiRequest({ method: "GET", path: "/users", secretKey: "sk_test_123" });
+    expect(requestedUrl).toBe("https://api.clerk.dev/v1/users");
+  });
+
+  test("does not double-prefix /v1/", async () => {
+    let requestedUrl = "";
+    globalThis.fetch = async (input: RequestInfo | URL) => {
+      requestedUrl = input.toString();
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+    await bapiRequest({ method: "GET", path: "/v1/users", secretKey: "sk_test_123" });
+    expect(requestedUrl).toBe("https://api.clerk.dev/v1/users");
+  });
+
+  test("handles path without leading slash", async () => {
+    let requestedUrl = "";
+    globalThis.fetch = async (input: RequestInfo | URL) => {
+      requestedUrl = input.toString();
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+    await bapiRequest({ method: "GET", path: "users", secretKey: "sk_test_123" });
+    expect(requestedUrl).toBe("https://api.clerk.dev/v1/users");
+  });
+
+  test("sends Bearer token in Authorization header", async () => {
+    let capturedHeaders: Headers | undefined;
+    globalThis.fetch = async (_: RequestInfo | URL, init?: RequestInit) => {
+      capturedHeaders = new Headers(init?.headers as HeadersInit);
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+    await bapiRequest({ method: "GET", path: "/users", secretKey: "sk_test_abc" });
+    expect(capturedHeaders?.get("Authorization")).toBe("Bearer sk_test_abc");
+  });
+
+  test("sends Content-Type header when body is present", async () => {
+    let capturedHeaders: Headers | undefined;
+    globalThis.fetch = async (_: RequestInfo | URL, init?: RequestInit) => {
+      capturedHeaders = new Headers(init?.headers as HeadersInit);
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+    await bapiRequest({
+      method: "POST",
+      path: "/users",
+      secretKey: "sk_test_abc",
+      body: '{"email":"a@b.com"}',
+    });
+    expect(capturedHeaders?.get("Content-Type")).toBe("application/json");
+  });
+
+  test("does not send Content-Type header when no body", async () => {
+    let capturedHeaders: Headers | undefined;
+    globalThis.fetch = async (_: RequestInfo | URL, init?: RequestInit) => {
+      capturedHeaders = new Headers(init?.headers as HeadersInit);
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+    await bapiRequest({ method: "GET", path: "/users", secretKey: "sk_test_abc" });
+    expect(capturedHeaders?.get("Content-Type")).toBeNull();
+  });
+
+  test("returns parsed JSON body on success", async () => {
+    const data = { data: [{ id: "user_1" }] };
+    globalThis.fetch = async () => new Response(JSON.stringify(data), { status: 200 });
+    const result = await bapiRequest({ method: "GET", path: "/users", secretKey: "sk_test_abc" });
+    expect(result.body).toEqual(data);
+    expect(result.status).toBe(200);
+  });
+
+  test("returns raw text when response is not JSON", async () => {
+    globalThis.fetch = async () => new Response("plain text", { status: 200 });
+    const result = await bapiRequest({ method: "GET", path: "/health", secretKey: "sk_test_abc" });
+    expect(result.body).toBe("plain text");
+    expect(result.rawBody).toBe("plain text");
+  });
+
+  test("throws BapiError on non-2xx response", async () => {
+    globalThis.fetch = async () => new Response("Not Found", { status: 404 });
+    try {
+      await bapiRequest({ method: "GET", path: "/users/bad", secretKey: "sk_test_abc" });
+      expect(true).toBe(false); // should not reach
+    } catch (error) {
+      expect(error).toBeInstanceOf(BapiError);
+      expect((error as BapiError).status).toBe(404);
+      expect((error as BapiError).body).toBe("Not Found");
+    }
+  });
+
+  test("respects baseUrl override", async () => {
+    let requestedUrl = "";
+    globalThis.fetch = async (input: RequestInfo | URL) => {
+      requestedUrl = input.toString();
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+    await bapiRequest({
+      method: "GET",
+      path: "/users",
+      secretKey: "sk_test_abc",
+      baseUrl: "https://custom.api.dev",
+    });
+    expect(requestedUrl).toBe("https://custom.api.dev/v1/users");
+  });
+
+  test("sends request body", async () => {
+    let capturedBody = "";
+    globalThis.fetch = async (_: RequestInfo | URL, init?: RequestInit) => {
+      capturedBody = init?.body as string;
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+    await bapiRequest({
+      method: "POST",
+      path: "/users",
+      secretKey: "sk_test_abc",
+      body: '{"email":"a@b.com"}',
+    });
+    expect(JSON.parse(capturedBody)).toEqual({ email: "a@b.com" });
+  });
+});

--- a/src/commands/api/bapi.ts
+++ b/src/commands/api/bapi.ts
@@ -1,0 +1,76 @@
+/**
+ * Backend API (BAPI) client.
+ * Thin HTTP wrapper for Clerk's Backend API endpoints.
+ */
+
+import { BAPI_BASE_URL } from "../../lib/constants.ts";
+
+export class BapiError extends Error {
+  constructor(
+    public status: number,
+    public body: string,
+    public headers: Headers,
+  ) {
+    super(`Backend API error (${status}): ${body}`);
+    this.name = "BapiError";
+  }
+}
+
+export interface BapiResponse {
+  status: number;
+  headers: Headers;
+  body: unknown;
+  rawBody: string;
+}
+
+export async function bapiRequest(options: {
+  method: string;
+  path: string;
+  secretKey: string;
+  body?: string;
+  baseUrl?: string;
+}): Promise<BapiResponse> {
+  const base = options.baseUrl ?? BAPI_BASE_URL;
+
+  // Normalize: ensure path starts with /v1/ if not already versioned
+  let path = options.path;
+  if (!path.startsWith("/")) path = `/${path}`;
+  if (!path.startsWith("/v1/")) path = `/v1${path}`;
+
+  const url = `${base}${path}`;
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${options.secretKey}`,
+    Accept: "application/json",
+  };
+
+  if (options.body) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  const response = await fetch(url, {
+    method: options.method,
+    headers,
+    body: options.body,
+  });
+
+  const rawBody = await response.text();
+
+  if (!response.ok) {
+    throw new BapiError(response.status, rawBody, response.headers);
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(rawBody);
+  } catch {
+    body = rawBody;
+  }
+
+  return {
+    status: response.status,
+    headers: response.headers,
+    body,
+    rawBody,
+  };
+}

--- a/src/commands/api/catalog.test.ts
+++ b/src/commands/api/catalog.test.ts
@@ -1,0 +1,285 @@
+import { test, expect, describe, beforeEach, afterEach, spyOn } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  parseSpec,
+  loadCatalog,
+  filterEndpoints,
+  endpointsByTag,
+  _setCacheDir,
+} from "./catalog";
+
+const MINIMAL_SPEC = `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: "1.0"
+paths:
+  /users:
+    get:
+      tags: [Users]
+      summary: List all users
+      operationId: GetUserList
+    post:
+      tags: [Users]
+      summary: Create a new user
+      operationId: CreateUser
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+  /users/{user_id}:
+    get:
+      tags: [Users]
+      summary: Retrieve a user
+      operationId: GetUser
+      parameters:
+        - name: user_id
+          in: path
+          description: The ID of the user
+          required: true
+    delete:
+      tags: [Users]
+      summary: Delete a user
+      operationId: DeleteUser
+      parameters:
+        - name: user_id
+          in: path
+          required: true
+  /organizations:
+    get:
+      tags: [Organizations]
+      summary: List all organizations
+      operationId: ListOrganizations
+  /no-tag:
+    get:
+      summary: Endpoint without tags
+      operationId: NoTag
+`;
+
+describe("parseSpec", () => {
+  test("extracts endpoints from valid YAML", () => {
+    const catalog = parseSpec(MINIMAL_SPEC);
+    expect(catalog.endpoints.length).toBe(6);
+    expect(catalog.endpoints[0]).toMatchObject({
+      method: "GET",
+      path: "/users",
+      summary: "List all users",
+      tag: "Users",
+      operationId: "GetUserList",
+    });
+  });
+
+  test("extracts path parameters", () => {
+    const catalog = parseSpec(MINIMAL_SPEC);
+    const getUser = catalog.endpoints.find((e) => e.operationId === "GetUser");
+    expect(getUser!.pathParams).toEqual([
+      { name: "user_id", description: "The ID of the user" },
+    ]);
+  });
+
+  test("detects requestBody presence", () => {
+    const catalog = parseSpec(MINIMAL_SPEC);
+    const createUser = catalog.endpoints.find((e) => e.operationId === "CreateUser");
+    expect(createUser!.hasRequestBody).toBe(true);
+
+    const listUsers = catalog.endpoints.find((e) => e.operationId === "GetUserList");
+    expect(listUsers!.hasRequestBody).toBe(false);
+  });
+
+  test("handles missing tags gracefully", () => {
+    const catalog = parseSpec(MINIMAL_SPEC);
+    const noTag = catalog.endpoints.find((e) => e.operationId === "NoTag");
+    expect(noTag!.tag).toBe("Other");
+  });
+
+  test("produces sorted unique tags", () => {
+    const catalog = parseSpec(MINIMAL_SPEC);
+    expect(catalog.tags).toEqual(["Organizations", "Other", "Users"]);
+  });
+
+  test("sets fetchedAt timestamp", () => {
+    const before = Date.now();
+    const catalog = parseSpec(MINIMAL_SPEC);
+    expect(catalog.fetchedAt).toBeGreaterThanOrEqual(before);
+    expect(catalog.fetchedAt).toBeLessThanOrEqual(Date.now());
+  });
+
+  test("handles path-level parameters", () => {
+    const spec = `
+openapi: "3.0.0"
+info:
+  title: Test
+  version: "1.0"
+paths:
+  /items/{item_id}:
+    parameters:
+      - name: item_id
+        in: path
+        description: Item ID
+    get:
+      tags: [Items]
+      summary: Get item
+      operationId: GetItem
+`;
+    const catalog = parseSpec(spec);
+    const getItem = catalog.endpoints.find((e) => e.operationId === "GetItem");
+    expect(getItem!.pathParams).toEqual([{ name: "item_id", description: "Item ID" }]);
+  });
+});
+
+describe("filterEndpoints", () => {
+  const catalog = parseSpec(MINIMAL_SPEC);
+
+  test("returns all endpoints when no keyword", () => {
+    expect(filterEndpoints(catalog)).toEqual(catalog.endpoints);
+    expect(filterEndpoints(catalog, undefined)).toEqual(catalog.endpoints);
+  });
+
+  test("filters by path", () => {
+    const results = filterEndpoints(catalog, "user");
+    expect(results.length).toBe(4);
+    expect(results.every((e) => e.path.includes("user"))).toBe(true);
+  });
+
+  test("filters by summary", () => {
+    const results = filterEndpoints(catalog, "retrieve");
+    expect(results.length).toBe(1);
+    expect(results[0].operationId).toBe("GetUser");
+  });
+
+  test("filters by tag", () => {
+    const results = filterEndpoints(catalog, "organizations");
+    expect(results.length).toBe(1);
+    expect(results[0].tag).toBe("Organizations");
+  });
+
+  test("is case-insensitive", () => {
+    const results = filterEndpoints(catalog, "USER");
+    expect(results.length).toBe(4);
+  });
+
+  test("returns empty array when no matches", () => {
+    expect(filterEndpoints(catalog, "zzzzz")).toEqual([]);
+  });
+});
+
+describe("endpointsByTag", () => {
+  test("groups endpoints correctly", () => {
+    const catalog = parseSpec(MINIMAL_SPEC);
+    const grouped = endpointsByTag(catalog);
+    expect(grouped.get("Users")!.length).toBe(4);
+    expect(grouped.get("Organizations")!.length).toBe(1);
+    expect(grouped.get("Other")!.length).toBe(1);
+  });
+});
+
+describe("loadCatalog", () => {
+  const originalFetch = globalThis.fetch;
+  let tempDir: string;
+  let errorSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "clerk-catalog-test-"));
+    _setCacheDir(tempDir);
+    errorSpy = spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    _setCacheDir(undefined);
+    globalThis.fetch = originalFetch;
+    errorSpy.mockRestore();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("fetches and caches on first load", async () => {
+    let fetchCalled = false;
+    globalThis.fetch = async () => {
+      fetchCalled = true;
+      return new Response(MINIMAL_SPEC, { status: 200 });
+    };
+
+    const catalog = await loadCatalog();
+    expect(fetchCalled).toBe(true);
+    expect(catalog.endpoints.length).toBe(6);
+
+    // Verify cache was written
+    const cacheFile = Bun.file(join(tempDir, "bapi-catalog.json"));
+    expect(await cacheFile.exists()).toBe(true);
+  });
+
+  test("uses cache when fresh", async () => {
+    // Pre-populate cache
+    const cached = parseSpec(MINIMAL_SPEC);
+    cached.fetchedAt = Date.now(); // fresh
+    await Bun.write(join(tempDir, "bapi-catalog.json"), JSON.stringify(cached));
+
+    let fetchCalled = false;
+    globalThis.fetch = async () => {
+      fetchCalled = true;
+      return new Response(MINIMAL_SPEC, { status: 200 });
+    };
+
+    const catalog = await loadCatalog();
+    expect(fetchCalled).toBe(false);
+    expect(catalog.endpoints.length).toBe(6);
+  });
+
+  test("re-fetches when cache is expired", async () => {
+    // Pre-populate with expired cache
+    const cached = parseSpec(MINIMAL_SPEC);
+    cached.fetchedAt = Date.now() - 25 * 60 * 60 * 1000; // 25 hours ago
+    await Bun.write(join(tempDir, "bapi-catalog.json"), JSON.stringify(cached));
+
+    let fetchCalled = false;
+    globalThis.fetch = async () => {
+      fetchCalled = true;
+      return new Response(MINIMAL_SPEC, { status: 200 });
+    };
+
+    await loadCatalog();
+    expect(fetchCalled).toBe(true);
+  });
+
+  test("returns stale cache on network failure", async () => {
+    // Pre-populate with expired cache
+    const cached = parseSpec(MINIMAL_SPEC);
+    cached.fetchedAt = Date.now() - 25 * 60 * 60 * 1000;
+    await Bun.write(join(tempDir, "bapi-catalog.json"), JSON.stringify(cached));
+
+    globalThis.fetch = async () => {
+      throw new Error("Network error");
+    };
+
+    const catalog = await loadCatalog();
+    expect(catalog.endpoints.length).toBe(6);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Unable to refresh"),
+    );
+  });
+
+  test("errors when offline with no cache", async () => {
+    globalThis.fetch = async () => {
+      throw new Error("Network error");
+    };
+
+    await expect(loadCatalog()).rejects.toThrow("Unable to fetch API catalog");
+  });
+
+  test("uses platform URL when platform flag set", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = async (input: RequestInfo | URL) => {
+      capturedUrl = input.toString();
+      return new Response(MINIMAL_SPEC, { status: 200 });
+    };
+
+    await loadCatalog({ platform: true });
+    expect(capturedUrl).toContain("platform");
+
+    // Cache uses platform filename
+    const cacheFile = Bun.file(join(tempDir, "plapi-catalog.json"));
+    expect(await cacheFile.exists()).toBe(true);
+  });
+});

--- a/src/commands/api/catalog.ts
+++ b/src/commands/api/catalog.ts
@@ -1,0 +1,178 @@
+/**
+ * OpenAPI spec catalog: fetching, parsing, caching, and querying.
+ * Used by `clerk api ls` and the interactive request builder.
+ */
+
+import { parse as parseYaml } from "yaml";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { CLERK_CACHE_DIR, CACHE_TTL_MS, OPENAPI_SPEC_URLS } from "../../lib/constants.ts";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface PathParam {
+  name: string;
+  description: string;
+}
+
+export interface EndpointInfo {
+  method: string;
+  path: string;
+  summary: string;
+  tag: string;
+  operationId: string;
+  pathParams: PathParam[];
+  hasRequestBody: boolean;
+}
+
+export interface Catalog {
+  endpoints: EndpointInfo[];
+  tags: string[];
+  fetchedAt: number;
+}
+
+// ── Test helper ────────────────────────────────────────────────────────────
+
+let overrideCacheDir: string | undefined;
+
+/** Test-only: override the cache directory. Pass undefined to reset. */
+export function _setCacheDir(dir: string | undefined): void {
+  overrideCacheDir = dir;
+}
+
+function cacheDir(): string {
+  return overrideCacheDir ?? CLERK_CACHE_DIR;
+}
+
+function cacheFilePath(platform: boolean): string {
+  return join(cacheDir(), platform ? "plapi-catalog.json" : "bapi-catalog.json");
+}
+
+// ── Cache I/O ──────────────────────────────────────────────────────────────
+
+async function readCache(platform: boolean): Promise<Catalog | null> {
+  try {
+    const file = Bun.file(cacheFilePath(platform));
+    if (!(await file.exists())) return null;
+    const data = await file.json();
+    return data as Catalog;
+  } catch {
+    return null;
+  }
+}
+
+async function writeCache(platform: boolean, catalog: Catalog): Promise<void> {
+  await mkdir(cacheDir(), { recursive: true });
+  await Bun.write(cacheFilePath(platform), JSON.stringify(catalog));
+}
+
+// ── Spec parsing ───────────────────────────────────────────────────────────
+
+const HTTP_METHODS = ["get", "post", "put", "patch", "delete"] as const;
+
+/** Parse an OpenAPI YAML string into a Catalog. Pure function, no I/O. */
+export function parseSpec(yamlText: string): Catalog {
+  const spec = parseYaml(yamlText);
+  const endpoints: EndpointInfo[] = [];
+
+  for (const [path, pathItem] of Object.entries(spec.paths ?? {})) {
+    const pathObj = pathItem as Record<string, unknown>;
+
+    for (const method of HTTP_METHODS) {
+      const operation = pathObj[method];
+      if (!operation || typeof operation !== "object") continue;
+
+      const op = operation as Record<string, unknown>;
+      const tag = ((op.tags as string[]) ?? ["Other"])[0] ?? "Other";
+
+      // Merge path-level and operation-level parameters
+      const allParams = [
+        ...((pathObj.parameters as unknown[]) ?? []),
+        ...((op.parameters as unknown[]) ?? []),
+      ];
+      const pathParams: PathParam[] = allParams
+        .filter((p: any) => p.in === "path")
+        .map((p: any) => ({ name: p.name, description: p.description ?? "" }));
+
+      endpoints.push({
+        method: method.toUpperCase(),
+        path,
+        summary: (op.summary as string) ?? "",
+        tag,
+        operationId: (op.operationId as string) ?? "",
+        pathParams,
+        hasRequestBody: !!op.requestBody,
+      });
+    }
+  }
+
+  const tags = [...new Set(endpoints.map((e) => e.tag))].sort();
+  return { endpoints, tags, fetchedAt: Date.now() };
+}
+
+// ── Loading ────────────────────────────────────────────────────────────────
+
+export async function loadCatalog(options: { platform?: boolean } = {}): Promise<Catalog> {
+  const platform = options.platform ?? false;
+
+  // Check cache
+  const cached = await readCache(platform);
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached;
+  }
+
+  // Fetch spec
+  const url = platform ? OPENAPI_SPEC_URLS.platform : OPENAPI_SPEC_URLS.bapi;
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    const yamlText = await response.text();
+    const catalog = parseSpec(yamlText);
+    await writeCache(platform, catalog);
+    return catalog;
+  } catch (error) {
+    // Fall back to stale cache
+    if (cached) {
+      console.error("Warning: Unable to refresh API catalog, using cached version.");
+      return cached;
+    }
+    throw new Error(
+      `Unable to fetch API catalog. Check your network connection.\n` +
+        `  URL: ${url}\n` +
+        `  ${(error as Error).message}`,
+    );
+  }
+}
+
+// ── Querying ───────────────────────────────────────────────────────────────
+
+export function filterEndpoints(catalog: Catalog, keyword?: string): EndpointInfo[] {
+  if (!keyword) return catalog.endpoints;
+
+  const lower = keyword.toLowerCase();
+  return catalog.endpoints.filter(
+    (e) =>
+      e.path.toLowerCase().includes(lower) ||
+      e.summary.toLowerCase().includes(lower) ||
+      e.tag.toLowerCase().includes(lower) ||
+      e.operationId.toLowerCase().includes(lower),
+  );
+}
+
+export function endpointsByTag(catalog: Catalog): Map<string, EndpointInfo[]> {
+  const map = new Map<string, EndpointInfo[]>();
+  for (const tag of catalog.tags) {
+    map.set(tag, []);
+  }
+  for (const endpoint of catalog.endpoints) {
+    const list = map.get(endpoint.tag);
+    if (list) {
+      list.push(endpoint);
+    } else {
+      map.set(endpoint.tag, [endpoint]);
+    }
+  }
+  return map;
+}

--- a/src/commands/api/index.test.ts
+++ b/src/commands/api/index.test.ts
@@ -1,0 +1,279 @@
+import { test, expect, describe, beforeEach, afterEach, spyOn } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { _setConfigDir, setProfile } from "../../lib/config";
+import { setMode } from "../../mode";
+
+describe("api command", () => {
+  const originalEnv = { ...process.env };
+  const originalFetch = globalThis.fetch;
+  let tempDir: string;
+  let logSpy: ReturnType<typeof spyOn>;
+  let errorSpy: ReturnType<typeof spyOn>;
+  let exitSpy: ReturnType<typeof spyOn>;
+
+  const mockUsers = { data: [{ id: "user_1", email: "test@example.com" }] };
+
+  const originalIsTTY = process.stdin.isTTY;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "clerk-api-test-"));
+    _setConfigDir(tempDir);
+    process.env.CLERK_SECRET_KEY = "sk_test_123";
+    setMode("agent"); // skip confirmation prompts
+    // Prevent resolveBody from trying to read stdin in tests
+    Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true, configurable: true });
+
+    logSpy = spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify(mockUsers), { status: 200 });
+  });
+
+  afterEach(async () => {
+    _setConfigDir(undefined);
+    process.env = { ...originalEnv };
+    globalThis.fetch = originalFetch;
+    Object.defineProperty(process.stdin, "isTTY", { value: originalIsTTY, writable: true, configurable: true });
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function runApi(endpoint: string, options: Record<string, unknown> = {}) {
+    const { api } = await import("./index");
+    return api(endpoint, options);
+  }
+
+  // --- GET requests ---
+
+  test("sends GET request with CLERK_SECRET_KEY", async () => {
+    let capturedUrl = "";
+    let capturedMethod = "";
+    let capturedHeaders: Headers | undefined;
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      capturedUrl = input.toString();
+      capturedMethod = init?.method ?? "GET";
+      capturedHeaders = new Headers(init?.headers as HeadersInit);
+      return new Response(JSON.stringify(mockUsers), { status: 200 });
+    };
+
+    await runApi("/users");
+    expect(capturedUrl).toContain("/v1/users");
+    expect(capturedMethod).toBe("GET");
+    expect(capturedHeaders?.get("Authorization")).toBe("Bearer sk_test_123");
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(mockUsers, null, 2));
+  });
+
+  test("defaults to GET when no body provided", async () => {
+    let capturedMethod = "";
+    globalThis.fetch = async (_: RequestInfo | URL, init?: RequestInit) => {
+      capturedMethod = init?.method ?? "GET";
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+
+    await runApi("/users");
+    expect(capturedMethod).toBe("GET");
+  });
+
+  // --- POST requests ---
+
+  test("defaults to POST when -d data is provided", async () => {
+    let capturedMethod = "";
+    let capturedBody = "";
+    globalThis.fetch = async (_: RequestInfo | URL, init?: RequestInit) => {
+      capturedMethod = init?.method ?? "GET";
+      capturedBody = init?.body as string;
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+
+    await runApi("/users", { data: '{"email_address":["a@b.com"]}' });
+    expect(capturedMethod).toBe("POST");
+    expect(JSON.parse(capturedBody)).toEqual({ email_address: ["a@b.com"] });
+  });
+
+  // --- Explicit method ---
+
+  test("uses explicit -X method override", async () => {
+    let capturedMethod = "";
+    globalThis.fetch = async (_: RequestInfo | URL, init?: RequestInit) => {
+      capturedMethod = init?.method ?? "GET";
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+
+    await runApi("/users/user_1", { method: "PATCH", data: '{"first_name":"Alice"}' });
+    expect(capturedMethod).toBe("PATCH");
+  });
+
+  test("method is case-insensitive", async () => {
+    let capturedMethod = "";
+    globalThis.fetch = async (_: RequestInfo | URL, init?: RequestInit) => {
+      capturedMethod = init?.method ?? "GET";
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+
+    await runApi("/users", { method: "delete" });
+    expect(capturedMethod).toBe("DELETE");
+  });
+
+  // --- --file option ---
+
+  test("reads body from --file", async () => {
+    let capturedBody = "";
+    globalThis.fetch = async (_: RequestInfo | URL, init?: RequestInit) => {
+      capturedBody = init?.body as string;
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+
+    const bodyFile = join(tempDir, "body.json");
+    await Bun.write(bodyFile, JSON.stringify({ first_name: "Bob" }));
+
+    await runApi("/users/user_1", { method: "PATCH", file: bodyFile });
+    expect(JSON.parse(capturedBody)).toEqual({ first_name: "Bob" });
+  });
+
+  test("errors when --file does not exist", async () => {
+    await expect(
+      runApi("/users", { file: "/tmp/nonexistent-file.json" }),
+    ).rejects.toThrow("process.exit");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("File not found"),
+    );
+  });
+
+  // --- --include option ---
+
+  test("--include shows response headers", async () => {
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify(mockUsers), {
+        status: 200,
+        headers: { "x-request-id": "req_123" },
+      });
+
+    await runApi("/users", { include: true });
+    expect(errorSpy).toHaveBeenCalledWith("HTTP 200");
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("x-request-id: req_123"));
+  });
+
+  // --- --dry-run option ---
+
+  test("--dry-run shows request without executing", async () => {
+    let fetchCalled = false;
+    globalThis.fetch = async () => {
+      fetchCalled = true;
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+
+    await runApi("/users", { dryRun: true });
+    expect(fetchCalled).toBe(false);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[dry-run] GET"),
+    );
+  });
+
+  test("--dry-run shows body when present", async () => {
+    await runApi("/users", { dryRun: true, data: '{"email":"a@b.com"}' });
+    expect(logSpy).toHaveBeenCalledWith(
+      JSON.stringify({ email: "a@b.com" }, null, 2),
+    );
+  });
+
+  // --- --secret-key override ---
+
+  test("--secret-key overrides env var", async () => {
+    let capturedHeaders: Headers | undefined;
+    globalThis.fetch = async (_: RequestInfo | URL, init?: RequestInit) => {
+      capturedHeaders = new Headers(init?.headers as HeadersInit);
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+
+    await runApi("/users", { secretKey: "sk_live_override" });
+    expect(capturedHeaders?.get("Authorization")).toBe("Bearer sk_live_override");
+  });
+
+  // --- --platform mode ---
+
+  test("--platform uses Platform API URL and key", async () => {
+    let capturedUrl = "";
+    let capturedHeaders: Headers | undefined;
+    process.env.CLERK_PLATFORM_API_KEY = "plat_key_123";
+
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      capturedUrl = input.toString();
+      capturedHeaders = new Headers(init?.headers as HeadersInit);
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+
+    await runApi("/v1/platform/applications", { platform: true });
+    expect(capturedUrl).toContain("api.clerk.com");
+    expect(capturedUrl).not.toContain("api.clerk.dev");
+    expect(capturedHeaders?.get("Authorization")).toBe("Bearer plat_key_123");
+  });
+
+  test("--platform errors when CLERK_PLATFORM_API_KEY missing", async () => {
+    delete process.env.CLERK_PLATFORM_API_KEY;
+
+    await expect(
+      runApi("/v1/platform/applications", { platform: true }),
+    ).rejects.toThrow("process.exit");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("CLERK_PLATFORM_API_KEY"),
+    );
+  });
+
+  // --- Error handling ---
+
+  test("errors when no secret key available", async () => {
+    delete process.env.CLERK_SECRET_KEY;
+
+    await expect(runApi("/users")).rejects.toThrow("process.exit");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("No secret key found"),
+    );
+  });
+
+  test("prints API error response body to stdout and exits 1", async () => {
+    const errorBody = { errors: [{ message: "not found", code: "resource_not_found" }] };
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify(errorBody), { status: 404 });
+
+    await expect(runApi("/users/bad_id")).rejects.toThrow("process.exit");
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(errorBody, null, 2));
+  });
+
+  test("--include shows headers on error responses too", async () => {
+    globalThis.fetch = async () =>
+      new Response('{"error":"bad"}', {
+        status: 400,
+        headers: { "x-request-id": "req_err" },
+      });
+
+    await expect(
+      runApi("/users", { include: true }),
+    ).rejects.toThrow("process.exit");
+    expect(errorSpy).toHaveBeenCalledWith("HTTP 400");
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("x-request-id: req_err"));
+  });
+
+  // --- -d takes priority over --file ---
+
+  test("-d takes priority over --file", async () => {
+    let capturedBody = "";
+    globalThis.fetch = async (_: RequestInfo | URL, init?: RequestInit) => {
+      capturedBody = init?.body as string;
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+
+    const bodyFile = join(tempDir, "should-not-read.json");
+    await Bun.write(bodyFile, JSON.stringify({ from: "file" }));
+
+    await runApi("/users", { data: '{"from":"inline"}', file: bodyFile });
+    expect(JSON.parse(capturedBody)).toEqual({ from: "inline" });
+  });
+});

--- a/src/commands/api/index.test.ts
+++ b/src/commands/api/index.test.ts
@@ -48,7 +48,7 @@ describe("api command", () => {
 
   async function runApi(endpoint: string, options: Record<string, unknown> = {}) {
     const { api } = await import("./index");
-    return api(endpoint, options);
+    return api(endpoint, undefined, options);
   }
 
   // --- GET requests ---

--- a/src/commands/api/index.ts
+++ b/src/commands/api/index.ts
@@ -5,7 +5,7 @@ import { BAPI_BASE_URL, PLAPI_BASE_URL } from "../../lib/constants.ts";
 import { bapiRequest, BapiError } from "./bapi.ts";
 import { isHuman } from "../../mode.ts";
 
-interface ApiOptions {
+export interface ApiOptions {
   method?: string;
   data?: string;
   file?: string;
@@ -19,7 +19,23 @@ interface ApiOptions {
 
 const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
-export async function api(endpoint: string, options: ApiOptions): Promise<void> {
+export async function api(
+  endpoint: string | undefined,
+  filter: string | undefined,
+  options: ApiOptions,
+): Promise<void> {
+  // Route: no args → interactive builder
+  if (!endpoint) {
+    const { apiInteractive } = await import("./interactive.ts");
+    return apiInteractive(options);
+  }
+
+  // Route: "ls" → list endpoints
+  if (endpoint === "ls") {
+    const { apiLs } = await import("./ls.ts");
+    return apiLs(filter, options);
+  }
+
   // 1. Resolve the request body
   const body = await resolveBody(options);
 

--- a/src/commands/api/index.ts
+++ b/src/commands/api/index.ts
@@ -1,0 +1,216 @@
+import { confirm } from "@inquirer/prompts";
+import { resolveProfile, resolveInstanceId } from "../../lib/config.ts";
+import { fetchApplication, PlapiError } from "../../lib/plapi.ts";
+import { BAPI_BASE_URL, PLAPI_BASE_URL } from "../../lib/constants.ts";
+import { bapiRequest, BapiError } from "./bapi.ts";
+import { isHuman } from "../../mode.ts";
+
+interface ApiOptions {
+  method?: string;
+  data?: string;
+  file?: string;
+  include?: boolean;
+  secretKey?: string;
+  instance?: string;
+  platform?: boolean;
+  dryRun?: boolean;
+  yes?: boolean;
+}
+
+const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+export async function api(endpoint: string, options: ApiOptions): Promise<void> {
+  // 1. Resolve the request body
+  const body = await resolveBody(options);
+
+  // 2. Determine HTTP method
+  const method = (options.method ?? (body ? "POST" : "GET")).toUpperCase();
+
+  // 3. Resolve authentication
+  let secretKey: string;
+  let baseUrl: string;
+
+  if (options.platform) {
+    const key = process.env.CLERK_PLATFORM_API_KEY;
+    if (!key) {
+      console.error("CLERK_PLATFORM_API_KEY environment variable is required for --platform mode.");
+      process.exit(1);
+    }
+    secretKey = key;
+    baseUrl = PLAPI_BASE_URL;
+  } else {
+    secretKey = await resolveSecretKey(options);
+    baseUrl = BAPI_BASE_URL;
+  }
+
+  // 4. Dry run
+  if (options.dryRun) {
+    console.error(`[dry-run] ${method} ${baseUrl}${normalizePath(endpoint)}`);
+    if (body) {
+      prettyPrint(body);
+    }
+    return;
+  }
+
+  // 5. Confirmation for mutating methods
+  if (MUTATING_METHODS.has(method) && isHuman() && !options.yes) {
+    console.error(`\nAbout to ${method} ${endpoint}`);
+    if (body) {
+      prettyPrintToStderr(body);
+    }
+    const ok = await confirm({ message: "Proceed?" });
+    if (!ok) {
+      console.error("Aborted.");
+      process.exit(0);
+    }
+  }
+
+  // 6. Execute request
+  try {
+    const response = await bapiRequest({
+      method,
+      path: endpoint,
+      secretKey,
+      body: body ?? undefined,
+      baseUrl,
+    });
+
+    if (options.include) {
+      printHeaders(response.status, response.headers);
+    }
+    printBody(response.body);
+  } catch (error) {
+    if (error instanceof BapiError) {
+      if (options.include) {
+        printHeaders(error.status, error.headers);
+      }
+      prettyPrint(error.body);
+      process.exit(1);
+    }
+    if (error instanceof Error) {
+      console.error(error.message);
+      process.exit(1);
+    }
+    throw error;
+  }
+}
+
+async function resolveSecretKey(options: ApiOptions): Promise<string> {
+  if (options.secretKey) return options.secretKey;
+
+  if (process.env.CLERK_SECRET_KEY) return process.env.CLERK_SECRET_KEY;
+
+  // Resolve from linked profile via Platform API
+  const resolved = await resolveProfile(process.cwd());
+  if (!resolved) {
+    console.error(
+      "No secret key found. Provide one via:\n" +
+      "  --secret-key <key>\n" +
+      "  CLERK_SECRET_KEY environment variable\n" +
+      "  Link a project with `clerk init` and set CLERK_PLATFORM_API_KEY",
+    );
+    process.exit(1);
+  }
+
+  const { profile } = resolved;
+  const platformKey = process.env.CLERK_PLATFORM_API_KEY;
+  if (!platformKey) {
+    console.error(
+      "No secret key found. Provide one via:\n" +
+      "  --secret-key <key>\n" +
+      "  CLERK_SECRET_KEY environment variable\n" +
+      "  Set CLERK_PLATFORM_API_KEY to auto-resolve from your linked project",
+    );
+    process.exit(1);
+  }
+
+  let instance: { id: string; label: string };
+  try {
+    instance = resolveInstanceId(profile, options.instance);
+  } catch (error) {
+    console.error((error as Error).message);
+    process.exit(1);
+  }
+
+  try {
+    const app = await fetchApplication(profile.appId);
+    const matched = app.instances.find((i) => i.instance_id === instance.id);
+    if (!matched) {
+      console.error(`Instance ${instance.id} not found in application.`);
+      process.exit(1);
+    }
+    return matched.secret_key;
+  } catch (error) {
+    if (error instanceof PlapiError) {
+      console.error(`Failed to resolve secret key: ${error.message}`);
+      process.exit(1);
+    }
+    throw error;
+  }
+}
+
+async function resolveBody(options: { data?: string; file?: string }): Promise<string | null> {
+  if (options.data) return options.data;
+
+  if (options.file) {
+    const file = Bun.file(options.file);
+    if (!(await file.exists())) {
+      console.error(`File not found: ${options.file}`);
+      process.exit(1);
+    }
+    return file.text();
+  }
+
+  // Read from stdin if piped
+  if (!process.stdin.isTTY) {
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) {
+      chunks.push(Buffer.from(chunk));
+    }
+    const text = Buffer.concat(chunks).toString("utf-8").trim();
+    if (text) return text;
+  }
+
+  return null;
+}
+
+function normalizePath(path: string): string {
+  let p = path;
+  if (!p.startsWith("/")) p = `/${p}`;
+  if (!p.startsWith("/v1/")) p = `/v1${p}`;
+  return p;
+}
+
+function printHeaders(status: number, headers: Headers): void {
+  console.error(`HTTP ${status}`);
+  headers.forEach((value, key) => {
+    console.error(`${key}: ${value}`);
+  });
+  console.error("");
+}
+
+function printBody(body: unknown): void {
+  if (typeof body === "string") {
+    console.log(body);
+  } else {
+    console.log(JSON.stringify(body, null, 2));
+  }
+}
+
+/** Pretty-print a string as JSON to stdout if possible, otherwise print raw. */
+function prettyPrint(text: string): void {
+  try {
+    console.log(JSON.stringify(JSON.parse(text), null, 2));
+  } catch {
+    console.log(text);
+  }
+}
+
+/** Pretty-print a string as JSON to stderr if possible, otherwise print raw. */
+function prettyPrintToStderr(text: string): void {
+  try {
+    console.error(JSON.stringify(JSON.parse(text), null, 2));
+  } catch {
+    console.error(text);
+  }
+}

--- a/src/commands/api/interactive.test.ts
+++ b/src/commands/api/interactive.test.ts
@@ -49,6 +49,7 @@ mock.module("@inquirer/prompts", () => ({
   input: async () => inputResponses.shift(),
   confirm: async () => confirmResponses.shift(),
   editor: async () => "{}",
+  password: async () => "",
 }));
 
 describe("apiInteractive", () => {

--- a/src/commands/api/interactive.test.ts
+++ b/src/commands/api/interactive.test.ts
@@ -1,0 +1,181 @@
+import { test, expect, describe, beforeEach, afterEach, spyOn, mock } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parseSpec, _setCacheDir } from "./catalog";
+import { setMode } from "../../mode";
+
+const MINIMAL_SPEC = `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: "1.0"
+paths:
+  /users:
+    get:
+      tags: [Users]
+      summary: List all users
+      operationId: GetUserList
+    post:
+      tags: [Users]
+      summary: Create a new user
+      operationId: CreateUser
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+  /users/{user_id}:
+    get:
+      tags: [Users]
+      summary: Retrieve a user
+      operationId: GetUser
+      parameters:
+        - name: user_id
+          in: path
+          description: The ID of the user
+`;
+
+// Track mock prompt responses
+let selectResponses: unknown[] = [];
+let inputResponses: string[] = [];
+let confirmResponses: boolean[] = [];
+
+// Track api calls
+let apiCalls: { endpoint: string; options: Record<string, unknown> }[] = [];
+
+mock.module("@inquirer/prompts", () => ({
+  select: async () => selectResponses.shift(),
+  input: async () => inputResponses.shift(),
+  confirm: async () => confirmResponses.shift(),
+  editor: async () => "{}",
+}));
+
+// Mock the api handler to track calls without making real requests
+mock.module("./index.ts", () => ({
+  api: async (endpoint: string, _filter: unknown, options: Record<string, unknown>) => {
+    apiCalls.push({ endpoint, options });
+  },
+}));
+
+describe("apiInteractive", () => {
+  let tempDir: string;
+  let errorSpy: ReturnType<typeof spyOn>;
+  let exitSpy: ReturnType<typeof spyOn>;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "clerk-interactive-test-"));
+    _setCacheDir(tempDir);
+
+    // Pre-populate fresh cache
+    const cached = parseSpec(MINIMAL_SPEC);
+    cached.fetchedAt = Date.now();
+    await Bun.write(join(tempDir, "bapi-catalog.json"), JSON.stringify(cached));
+
+    errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    globalThis.fetch = async () => {
+      throw new Error("Should not fetch");
+    };
+
+    // Reset tracking
+    selectResponses = [];
+    inputResponses = [];
+    confirmResponses = [];
+    apiCalls = [];
+  });
+
+  afterEach(async () => {
+    _setCacheDir(undefined);
+    globalThis.fetch = originalFetch;
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("shows help and exits in agent mode", async () => {
+    setMode("agent");
+    const { apiInteractive } = await import("./interactive");
+
+    await expect(apiInteractive({})).rejects.toThrow("process.exit");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Interactive mode requires a TTY"),
+    );
+    setMode("human");
+  });
+
+  test("completes full flow for GET endpoint (no body, no params)", async () => {
+    setMode("human");
+    const { apiInteractive } = await import("./interactive");
+
+    // Step 1: select tag "Users"
+    selectResponses.push("Users");
+    // Step 2: select endpoint GET /users
+    selectResponses.push({
+      method: "GET",
+      path: "/users",
+      summary: "List all users",
+      tag: "Users",
+      operationId: "GetUserList",
+      pathParams: [],
+      hasRequestBody: false,
+    });
+    // Step 5: confirm execution
+    confirmResponses.push(true);
+
+    await apiInteractive({});
+
+    expect(apiCalls.length).toBe(1);
+    expect(apiCalls[0].endpoint).toBe("/users");
+    expect(apiCalls[0].options.method).toBe("GET");
+    expect(apiCalls[0].options.yes).toBe(true);
+  });
+
+  test("prompts for path parameters", async () => {
+    setMode("human");
+    const { apiInteractive } = await import("./interactive");
+
+    selectResponses.push("Users");
+    selectResponses.push({
+      method: "GET",
+      path: "/users/{user_id}",
+      summary: "Retrieve a user",
+      tag: "Users",
+      operationId: "GetUser",
+      pathParams: [{ name: "user_id", description: "The ID of the user" }],
+      hasRequestBody: false,
+    });
+    inputResponses.push("user_abc123");
+    confirmResponses.push(true);
+
+    await apiInteractive({});
+
+    expect(apiCalls.length).toBe(1);
+    expect(apiCalls[0].endpoint).toBe("/users/user_abc123");
+  });
+
+  test("aborts when user declines confirmation", async () => {
+    setMode("human");
+    const { apiInteractive } = await import("./interactive");
+
+    selectResponses.push("Users");
+    selectResponses.push({
+      method: "GET",
+      path: "/users",
+      summary: "List all users",
+      tag: "Users",
+      operationId: "GetUserList",
+      pathParams: [],
+      hasRequestBody: false,
+    });
+    confirmResponses.push(false); // decline
+
+    await apiInteractive({});
+
+    expect(apiCalls.length).toBe(0);
+    expect(errorSpy).toHaveBeenCalledWith("Aborted.");
+  });
+});

--- a/src/commands/api/interactive.test.ts
+++ b/src/commands/api/interactive.test.ts
@@ -41,8 +41,8 @@ let selectResponses: unknown[] = [];
 let inputResponses: string[] = [];
 let confirmResponses: boolean[] = [];
 
-// Track api calls
-let apiCalls: { endpoint: string; options: Record<string, unknown> }[] = [];
+// Track fetch calls made by the real api handler
+let fetchCalls: { url: string; method: string }[] = [];
 
 mock.module("@inquirer/prompts", () => ({
   select: async () => selectResponses.shift(),
@@ -51,18 +51,15 @@ mock.module("@inquirer/prompts", () => ({
   editor: async () => "{}",
 }));
 
-// Mock the api handler to track calls without making real requests
-mock.module("./index.ts", () => ({
-  api: async (endpoint: string, _filter: unknown, options: Record<string, unknown>) => {
-    apiCalls.push({ endpoint, options });
-  },
-}));
-
 describe("apiInteractive", () => {
   let tempDir: string;
   let errorSpy: ReturnType<typeof spyOn>;
+  let logSpy: ReturnType<typeof spyOn>;
   let exitSpy: ReturnType<typeof spyOn>;
   const originalFetch = globalThis.fetch;
+  const originalIsTTY = process.stdin.isTTY;
+
+  const originalEnv = { ...process.env };
 
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), "clerk-interactive-test-"));
@@ -73,25 +70,35 @@ describe("apiInteractive", () => {
     cached.fetchedAt = Date.now();
     await Bun.write(join(tempDir, "bapi-catalog.json"), JSON.stringify(cached));
 
+    process.env.CLERK_SECRET_KEY = "sk_test_123";
+    // Prevent resolveBody from trying to read stdin
+    Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true, configurable: true });
+
     errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    logSpy = spyOn(console, "log").mockImplementation(() => {});
     exitSpy = spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit");
     });
-    globalThis.fetch = async () => {
-      throw new Error("Should not fetch");
+    // Capture fetch calls from the real api handler
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      fetchCalls.push({ url: input.toString(), method: init?.method ?? "GET" });
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
     };
 
     // Reset tracking
     selectResponses = [];
     inputResponses = [];
     confirmResponses = [];
-    apiCalls = [];
+    fetchCalls = [];
   });
 
   afterEach(async () => {
     _setCacheDir(undefined);
+    process.env = { ...originalEnv };
     globalThis.fetch = originalFetch;
+    Object.defineProperty(process.stdin, "isTTY", { value: originalIsTTY, writable: true, configurable: true });
     errorSpy.mockRestore();
+    logSpy.mockRestore();
     exitSpy.mockRestore();
     await rm(tempDir, { recursive: true, force: true });
   });
@@ -128,10 +135,9 @@ describe("apiInteractive", () => {
 
     await apiInteractive({});
 
-    expect(apiCalls.length).toBe(1);
-    expect(apiCalls[0].endpoint).toBe("/users");
-    expect(apiCalls[0].options.method).toBe("GET");
-    expect(apiCalls[0].options.yes).toBe(true);
+    expect(fetchCalls.length).toBe(1);
+    expect(fetchCalls[0].url).toContain("/v1/users");
+    expect(fetchCalls[0].method).toBe("GET");
   });
 
   test("prompts for path parameters", async () => {
@@ -153,8 +159,8 @@ describe("apiInteractive", () => {
 
     await apiInteractive({});
 
-    expect(apiCalls.length).toBe(1);
-    expect(apiCalls[0].endpoint).toBe("/users/user_abc123");
+    expect(fetchCalls.length).toBe(1);
+    expect(fetchCalls[0].url).toContain("/v1/users/user_abc123");
   });
 
   test("aborts when user declines confirmation", async () => {
@@ -175,7 +181,7 @@ describe("apiInteractive", () => {
 
     await apiInteractive({});
 
-    expect(apiCalls.length).toBe(0);
+    expect(fetchCalls.length).toBe(0);
     expect(errorSpy).toHaveBeenCalledWith("Aborted.");
   });
 });

--- a/src/commands/api/interactive.ts
+++ b/src/commands/api/interactive.ts
@@ -1,0 +1,109 @@
+/**
+ * Interactive API request builder for `clerk api` (no args, human mode).
+ */
+
+import { select, input, confirm, editor } from "@inquirer/prompts";
+import { isHuman } from "../../mode.ts";
+import { loadCatalog, endpointsByTag, type EndpointInfo } from "./catalog.ts";
+import type { ApiOptions } from "./index.ts";
+
+export async function apiInteractive(options: ApiOptions): Promise<void> {
+  if (!isHuman()) {
+    console.error(
+      "Interactive mode requires a TTY.\n\n" +
+        "Usage:\n" +
+        "  clerk api <endpoint>        Make an API request\n" +
+        "  clerk api ls [filter]       List available endpoints\n" +
+        "\nExample:\n" +
+        "  clerk api /users\n" +
+        "  clerk api ls users",
+    );
+    process.exit(0);
+  }
+
+  // 1. Load catalog and group by tag
+  const catalog = await loadCatalog({ platform: options.platform });
+  const grouped = endpointsByTag(catalog);
+
+  // 2. Select category
+  const tag = await select({
+    message: "Select a category:",
+    choices: catalog.tags.map((t) => ({
+      name: `${t} (${grouped.get(t)!.length})`,
+      value: t,
+    })),
+  });
+
+  // 3. Select endpoint
+  const endpoints = grouped.get(tag)!;
+  const endpoint = await select<EndpointInfo>({
+    message: "Select an endpoint:",
+    choices: endpoints.map((e) => ({
+      name: `${e.method.padEnd(7)} ${e.path.padEnd(40)} ${e.summary}`,
+      value: e,
+    })),
+  });
+
+  // 4. Fill path parameters
+  let resolvedPath = endpoint.path;
+  for (const param of endpoint.pathParams) {
+    const value = await input({
+      message: param.description
+        ? `${param.name} (${param.description}):`
+        : `${param.name}:`,
+      validate: (v: string) => v.trim().length > 0 || `${param.name} is required`,
+    });
+    resolvedPath = resolvedPath.replace(`{${param.name}}`, value.trim());
+  }
+
+  // 5. Request body (if applicable)
+  let body: string | undefined;
+  if (endpoint.hasRequestBody) {
+    const wantsBody = await confirm({
+      message: "Provide a request body?",
+      default: endpoint.method === "POST" || endpoint.method === "PUT",
+    });
+
+    if (wantsBody) {
+      const bodyText = await editor({
+        message: "Enter request body (JSON):",
+        default: "{}",
+        postfix: ".json",
+        validate: (v: string) => {
+          try {
+            JSON.parse(v);
+            return true;
+          } catch {
+            return "Invalid JSON";
+          }
+        },
+      });
+      body = bodyText.trim();
+    }
+  }
+
+  // 6. Preview and confirm
+  console.error(`\n${endpoint.method} ${resolvedPath}`);
+  if (body) {
+    try {
+      console.error(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.error(body);
+    }
+  }
+
+  const proceed = await confirm({ message: "Execute this request?" });
+  if (!proceed) {
+    console.error("Aborted.");
+    return;
+  }
+
+  // 7. Delegate to the main api handler
+  const { api } = await import("./index.ts");
+  await api(resolvedPath, undefined, {
+    ...options,
+    method: endpoint.method,
+    data: body,
+    yes: true, // skip double-confirmation
+  });
+}

--- a/src/commands/api/ls.test.ts
+++ b/src/commands/api/ls.test.ts
@@ -1,0 +1,117 @@
+import { test, expect, describe, beforeEach, afterEach, spyOn } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parseSpec, _setCacheDir } from "./catalog";
+import { apiLs } from "./ls";
+
+const MINIMAL_SPEC = `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: "1.0"
+paths:
+  /users:
+    get:
+      tags: [Users]
+      summary: List all users
+      operationId: GetUserList
+    post:
+      tags: [Users]
+      summary: Create a new user
+      operationId: CreateUser
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+  /users/{user_id}:
+    get:
+      tags: [Users]
+      summary: Retrieve a user
+      operationId: GetUser
+      parameters:
+        - name: user_id
+          in: path
+  /organizations:
+    get:
+      tags: [Organizations]
+      summary: List all organizations
+      operationId: ListOrganizations
+`;
+
+describe("apiLs", () => {
+  let tempDir: string;
+  let logSpy: ReturnType<typeof spyOn>;
+  let errorSpy: ReturnType<typeof spyOn>;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "clerk-ls-test-"));
+    _setCacheDir(tempDir);
+
+    // Pre-populate fresh cache so no fetch needed
+    const cached = parseSpec(MINIMAL_SPEC);
+    cached.fetchedAt = Date.now();
+    await Bun.write(join(tempDir, "bapi-catalog.json"), JSON.stringify(cached));
+
+    logSpy = spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    globalThis.fetch = async () => {
+      throw new Error("Should not fetch");
+    };
+  });
+
+  afterEach(async () => {
+    _setCacheDir(undefined);
+    globalThis.fetch = originalFetch;
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("prints all endpoints in table format", async () => {
+    await apiLs(undefined, {});
+
+    expect(logSpy).toHaveBeenCalledTimes(4);
+    // Check that each line contains method, path, and summary
+    const firstCall = logSpy.mock.calls[0][0] as string;
+    expect(firstCall).toContain("GET");
+    expect(firstCall).toContain("/users");
+    expect(firstCall).toContain("List all users");
+
+    // Footer
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("4 endpoints"));
+  });
+
+  test("filters endpoints by keyword", async () => {
+    await apiLs("organizations", {});
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const line = logSpy.mock.calls[0][0] as string;
+    expect(line).toContain("/organizations");
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('1 endpoint matching "organizations"'),
+    );
+  });
+
+  test("shows message when no matches", async () => {
+    await apiLs("zzzzz", {});
+
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('No endpoints matching "zzzzz"'),
+    );
+  });
+
+  test("uses platform catalog when --platform set", async () => {
+    // Pre-populate platform cache
+    const cached = parseSpec(MINIMAL_SPEC);
+    cached.fetchedAt = Date.now();
+    await Bun.write(join(tempDir, "plapi-catalog.json"), JSON.stringify(cached));
+
+    await apiLs(undefined, { platform: true });
+    expect(logSpy).toHaveBeenCalled();
+  });
+});

--- a/src/commands/api/ls.ts
+++ b/src/commands/api/ls.ts
@@ -1,0 +1,43 @@
+/**
+ * `clerk api ls [filter]` — list available API endpoints.
+ */
+
+import { loadCatalog, filterEndpoints, type EndpointInfo } from "./catalog.ts";
+
+export async function apiLs(
+  filter: string | undefined,
+  options: { platform?: boolean },
+): Promise<void> {
+  const catalog = await loadCatalog({ platform: options.platform });
+  const endpoints = filterEndpoints(catalog, filter);
+
+  if (endpoints.length === 0) {
+    console.error(
+      filter
+        ? `No endpoints matching "${filter}". Try a broader search term.`
+        : "No endpoints found.",
+    );
+    return;
+  }
+
+  printTable(endpoints);
+
+  const label = filter
+    ? `${endpoints.length} endpoint${endpoints.length === 1 ? "" : "s"} matching "${filter}"`
+    : `${endpoints.length} endpoint${endpoints.length === 1 ? "" : "s"}`;
+  console.error(`\n${label}`);
+}
+
+function printTable(endpoints: EndpointInfo[]): void {
+  const methodWidth = 8;
+  const pathWidth = Math.min(
+    Math.max(...endpoints.map((e) => e.path.length)) + 2,
+    50,
+  );
+
+  for (const ep of endpoints) {
+    const method = ep.method.padEnd(methodWidth);
+    const path = ep.path.padEnd(pathWidth);
+    console.log(`${method}${path}${ep.summary}`);
+  }
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -37,6 +37,18 @@ export const PLAPI_BASE_URL = process.env.CLERK_PLATFORM_API_URL ?? "https://api
 
 export const BAPI_BASE_URL = process.env.CLERK_BACKEND_API_URL ?? "https://api.clerk.dev";
 
+// ── OpenAPI Spec ──────────────────────────────────────────────────────────
+
+export const OPENAPI_SPEC_URLS = {
+  bapi: "https://raw.githubusercontent.com/clerk/openapi-specs/main/bapi/2025-11-10.yml",
+  platform: "https://raw.githubusercontent.com/clerk/openapi-specs/main/platform/beta.yml",
+} as const;
+
+// ── Cache ────────────────────────────────────────────────────────────────
+
+export const CLERK_CACHE_DIR = join(CLERK_HOME_DIR, "cache");
+export const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
 // ── Keychain ────────────────────────────────────────────────────────────────
 
 export const KEYCHAIN_SERVICE = "clerk-cli";

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -33,6 +33,10 @@ export const AUTH_TIMEOUT_MS = Number(process.env.CLERK_AUTH_TIMEOUT_MS) || 2 * 
 
 export const PLAPI_BASE_URL = process.env.CLERK_PLATFORM_API_URL ?? "https://api.clerk.com";
 
+// ── Backend API ────────────────────────────────────────────────────────────
+
+export const BAPI_BASE_URL = process.env.CLERK_BACKEND_API_URL ?? "https://api.clerk.dev";
+
 // ── Keychain ────────────────────────────────────────────────────────────────
 
 export const KEYCHAIN_SERVICE = "clerk-cli";


### PR DESCRIPTION
## Summary

Implements a new `clerk api` command that provides direct, authenticated access to the Clerk Backend API (and optionally Platform API). Developers can now make authenticated HTTP requests from the CLI with automatic secret key resolution and safe mutation handling.

## Test plan

- All 172 tests pass (28 new tests for the api command)
- Dry-run tests verify request preview without execution
- Mutation confirmation works in interactive mode, skips with --yes
- Secret key resolution: flag > env var > profile auto-resolve
- Body handling: inline JSON, file, and stdin all work correctly
- Response headers display with --include flag
- Platform API mode switches base URL and uses PLAPI key

🤖 Generated with [Claude Code](https://claude.com/claude-code)