### PR TITLE
Refactor init command to reuse env pull

### DIFF
--- a/src/commands/init/README.md
+++ b/src/commands/init/README.md
@@ -6,21 +6,14 @@ Initializes Clerk in a project by authenticating the user, linking a Clerk appli
 
 ```sh
 clerk init
-clerk init --prompt
 ```
-
-## Options
-
-| Flag | Description |
-|---|---|
-| `--prompt` | Output an AI agent prompt for integrating Clerk instead of running the interactive flow |
 
 ## Flow
 
 1. Authenticates the user via `clerk auth login` (see [auth/README.md](../auth/README.md) for APIs)
 2. Links the project to a Clerk application via `clerk link` (see [link/README.md](../link/README.md) for APIs)
 3. Detects the project's framework from `package.json` and installs the appropriate Clerk SDK (e.g. `@clerk/nextjs` for Next.js)
-4. Fetches the development instance API keys and writes them to `.env.local`
+4. Pulls development instance API keys via `clerk env pull` and writes them to `.env.local`
 
 ## Framework Detection
 
@@ -44,8 +37,4 @@ The package manager is detected from lock files (`bun.lockb` → bun, `yarn.lock
 
 ## API Endpoints
 
-| Method | Path | Description |
-|---|---|---|
-| GET | /v1/platform/applications/{appId} | Fetch application with instance keys (for env vars) |
-
-Also see [auth/README.md](../auth/README.md) and [link/README.md](../link/README.md) for the API endpoints used by steps 1 and 2.
+See [auth/README.md](../auth/README.md), [link/README.md](../link/README.md), and [env/README.md](../env/README.md) for the API endpoints used by each step.

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -1,10 +1,8 @@
 import { join } from "node:path";
 import { login } from "../auth/login.js";
 import { link } from "../link/index.js";
-import { resolveProfile } from "../../lib/config.js";
-import { fetchApplication, PlapiError } from "../../lib/plapi.js";
-import { detectFramework, detectPublishableKeyName } from "../../lib/framework.js";
-import { parseEnvFile, mergeEnvVars, serializeEnvFile } from "../../lib/dotenv.js";
+import { pull } from "../env/pull.js";
+import { detectFramework } from "../../lib/framework.js";
 import { isAgent } from "../../mode.js";
 
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
@@ -85,45 +83,6 @@ async function installSdk(cwd: string, sdk: string, frameworkName: string): Prom
   }
 }
 
-async function writeEnvVars(cwd: string): Promise<void> {
-  const resolved = await resolveProfile(cwd);
-  if (!resolved) return;
-
-  const { profile } = resolved;
-  const devInstanceId = profile.instances.development;
-
-  let app;
-  try {
-    app = await fetchApplication(profile.appId);
-  } catch (error) {
-    if (error instanceof PlapiError) {
-      console.error(`Failed to fetch API keys: ${error.message}`);
-    }
-    return;
-  }
-
-  const matched = app.instances.find((i) => i.instance_id === devInstanceId);
-  if (!matched) return;
-
-  const publishableKeyName = await detectPublishableKeyName(cwd);
-  const targetFile = join(cwd, ".env.local");
-  const file = Bun.file(targetFile);
-  const existingContent = (await file.exists()) ? await file.text() : "";
-
-  const lines = parseEnvFile(existingContent);
-  const vars: Record<string, string> = {
-    [publishableKeyName]: matched.publishable_key,
-  };
-  if (matched.secret_key) {
-    vars.CLERK_SECRET_KEY = matched.secret_key;
-  }
-  const merged = mergeEnvVars(lines, vars);
-  const output = serializeEnvFile(merged);
-
-  await Bun.write(targetFile, output);
-  console.log(`Environment variables written to ${dim(".env.local")}`);
-}
-
 export async function init() {
   if (isAgent()) {
     console.log(AGENT_PROMPT);
@@ -148,6 +107,6 @@ export async function init() {
     );
   }
 
-  // Step 4: Write environment variables
-  await writeEnvVars(cwd);
+  // Step 4: Pull environment variables
+  await pull({});
 }


### PR DESCRIPTION
## Summary
- Removes duplicated env var writing logic from init command
- Calls env pull to handle writing environment variables instead
- Eliminates ~40 lines of code, reducing maintenance surface
- Removes stale --prompt flag documentation from README

## Benefits
- Ensures init uses the same robust file handling as env pull (fallback to .env if .env.local doesn't exist)
- Single source of truth for env file parsing and merging logic
- Simpler init command that delegates to specialized commands for each concern

Generated with Claude Code