### PR TITLE
Key link profiles by git remote URL for cross-clone sharing

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "build": "bun build ./src/cli.ts --outfile ./dist/cli.js --target node",
-    "dev": "bun run ./src/cli.ts"
+    "dev": "bun run ./src/cli.ts",
+    "test": "bun test"
   },
   "devDependencies": {
     "@types/bun": "latest"

--- a/src/commands/api/bapi.test.ts
+++ b/src/commands/api/bapi.test.ts
@@ -1,4 +1,5 @@
 import { test, expect, describe, afterEach } from "bun:test";
+import { stubFetch } from "../../test/stubs.ts";
 import { bapiRequest, BapiError } from "./bapi";
 
 describe("bapi", () => {
@@ -10,50 +11,50 @@ describe("bapi", () => {
 
   test("constructs correct URL with /v1/ prefix", async () => {
     let requestedUrl = "";
-    globalThis.fetch = async (input: RequestInfo | URL) => {
+    stubFetch(async (input) => {
       requestedUrl = input.toString();
       return new Response(JSON.stringify({}), { status: 200 });
-    };
+    });
     await bapiRequest({ method: "GET", path: "/users", secretKey: "sk_test_123" });
     expect(requestedUrl).toBe("https://api.clerk.dev/v1/users");
   });
 
   test("does not double-prefix /v1/", async () => {
     let requestedUrl = "";
-    globalThis.fetch = async (input: RequestInfo | URL) => {
+    stubFetch(async (input) => {
       requestedUrl = input.toString();
       return new Response(JSON.stringify({}), { status: 200 });
-    };
+    });
     await bapiRequest({ method: "GET", path: "/v1/users", secretKey: "sk_test_123" });
     expect(requestedUrl).toBe("https://api.clerk.dev/v1/users");
   });
 
   test("handles path without leading slash", async () => {
     let requestedUrl = "";
-    globalThis.fetch = async (input: RequestInfo | URL) => {
+    stubFetch(async (input) => {
       requestedUrl = input.toString();
       return new Response(JSON.stringify({}), { status: 200 });
-    };
+    });
     await bapiRequest({ method: "GET", path: "users", secretKey: "sk_test_123" });
     expect(requestedUrl).toBe("https://api.clerk.dev/v1/users");
   });
 
   test("sends Bearer token in Authorization header", async () => {
     let capturedHeaders: Headers | undefined;
-    globalThis.fetch = async (_: RequestInfo | URL, init?: RequestInit) => {
-      capturedHeaders = new Headers(init?.headers as HeadersInit);
+    stubFetch(async (_input, init) => {
+      capturedHeaders = new Headers(init?.headers);
       return new Response(JSON.stringify({}), { status: 200 });
-    };
+    });
     await bapiRequest({ method: "GET", path: "/users", secretKey: "sk_test_abc" });
     expect(capturedHeaders?.get("Authorization")).toBe("Bearer sk_test_abc");
   });
 
   test("sends Content-Type header when body is present", async () => {
     let capturedHeaders: Headers | undefined;
-    globalThis.fetch = async (_: RequestInfo | URL, init?: RequestInit) => {
-      capturedHeaders = new Headers(init?.headers as HeadersInit);
+    stubFetch(async (_input, init) => {
+      capturedHeaders = new Headers(init?.headers);
       return new Response(JSON.stringify({}), { status: 200 });
-    };
+    });
     await bapiRequest({
       method: "POST",
       path: "/users",
@@ -65,31 +66,31 @@ describe("bapi", () => {
 
   test("does not send Content-Type header when no body", async () => {
     let capturedHeaders: Headers | undefined;
-    globalThis.fetch = async (_: RequestInfo | URL, init?: RequestInit) => {
-      capturedHeaders = new Headers(init?.headers as HeadersInit);
+    stubFetch(async (_input, init) => {
+      capturedHeaders = new Headers(init?.headers);
       return new Response(JSON.stringify({}), { status: 200 });
-    };
+    });
     await bapiRequest({ method: "GET", path: "/users", secretKey: "sk_test_abc" });
     expect(capturedHeaders?.get("Content-Type")).toBeNull();
   });
 
   test("returns parsed JSON body on success", async () => {
     const data = { data: [{ id: "user_1" }] };
-    globalThis.fetch = async () => new Response(JSON.stringify(data), { status: 200 });
+    stubFetch(async () => new Response(JSON.stringify(data), { status: 200 }));
     const result = await bapiRequest({ method: "GET", path: "/users", secretKey: "sk_test_abc" });
     expect(result.body).toEqual(data);
     expect(result.status).toBe(200);
   });
 
   test("returns raw text when response is not JSON", async () => {
-    globalThis.fetch = async () => new Response("plain text", { status: 200 });
+    stubFetch(async () => new Response("plain text", { status: 200 }));
     const result = await bapiRequest({ method: "GET", path: "/health", secretKey: "sk_test_abc" });
     expect(result.body).toBe("plain text");
     expect(result.rawBody).toBe("plain text");
   });
 
   test("throws BapiError on non-2xx response", async () => {
-    globalThis.fetch = async () => new Response("Not Found", { status: 404 });
+    stubFetch(async () => new Response("Not Found", { status: 404 }));
     try {
       await bapiRequest({ method: "GET", path: "/users/bad", secretKey: "sk_test_abc" });
       expect(true).toBe(false); // should not reach
@@ -102,10 +103,10 @@ describe("bapi", () => {
 
   test("respects baseUrl override", async () => {
     let requestedUrl = "";
-    globalThis.fetch = async (input: RequestInfo | URL) => {
+    stubFetch(async (input) => {
       requestedUrl = input.toString();
       return new Response(JSON.stringify({}), { status: 200 });
-    };
+    });
     await bapiRequest({
       method: "GET",
       path: "/users",
@@ -117,10 +118,10 @@ describe("bapi", () => {
 
   test("sends request body", async () => {
     let capturedBody = "";
-    globalThis.fetch = async (_: RequestInfo | URL, init?: RequestInit) => {
+    stubFetch(async (_input, init) => {
       capturedBody = init?.body as string;
       return new Response(JSON.stringify({}), { status: 200 });
-    };
+    });
     await bapiRequest({
       method: "POST",
       path: "/users",

--- a/src/commands/api/catalog.test.ts
+++ b/src/commands/api/catalog.test.ts
@@ -1,4 +1,5 @@
 import { test, expect, describe, beforeEach, afterEach, spyOn } from "bun:test";
+import { stubFetch } from "../../test/stubs.ts";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -196,10 +197,10 @@ describe("loadCatalog", () => {
 
   test("fetches and caches on first load", async () => {
     let fetchCalled = false;
-    globalThis.fetch = async () => {
+    stubFetch(async () => {
       fetchCalled = true;
       return new Response(MINIMAL_SPEC, { status: 200 });
-    };
+    });
 
     const catalog = await loadCatalog();
     expect(fetchCalled).toBe(true);
@@ -217,10 +218,10 @@ describe("loadCatalog", () => {
     await Bun.write(join(tempDir, "bapi-catalog.json"), JSON.stringify(cached));
 
     let fetchCalled = false;
-    globalThis.fetch = async () => {
+    stubFetch(async () => {
       fetchCalled = true;
       return new Response(MINIMAL_SPEC, { status: 200 });
-    };
+    });
 
     const catalog = await loadCatalog();
     expect(fetchCalled).toBe(false);
@@ -234,10 +235,10 @@ describe("loadCatalog", () => {
     await Bun.write(join(tempDir, "bapi-catalog.json"), JSON.stringify(cached));
 
     let fetchCalled = false;
-    globalThis.fetch = async () => {
+    stubFetch(async () => {
       fetchCalled = true;
       return new Response(MINIMAL_SPEC, { status: 200 });
-    };
+    });
 
     await loadCatalog();
     expect(fetchCalled).toBe(true);
@@ -249,9 +250,9 @@ describe("loadCatalog", () => {
     cached.fetchedAt = Date.now() - 25 * 60 * 60 * 1000;
     await Bun.write(join(tempDir, "bapi-catalog.json"), JSON.stringify(cached));
 
-    globalThis.fetch = async () => {
+    stubFetch(async () => {
       throw new Error("Network error");
-    };
+    });
 
     const catalog = await loadCatalog();
     expect(catalog.endpoints.length).toBe(6);
@@ -261,19 +262,19 @@ describe("loadCatalog", () => {
   });
 
   test("errors when offline with no cache", async () => {
-    globalThis.fetch = async () => {
+    stubFetch(async () => {
       throw new Error("Network error");
-    };
+    });
 
     await expect(loadCatalog()).rejects.toThrow("Unable to fetch API catalog");
   });
 
   test("uses platform URL when platform flag set", async () => {
     let capturedUrl = "";
-    globalThis.fetch = async (input: RequestInfo | URL) => {
+    stubFetch(async (input) => {
       capturedUrl = input.toString();
       return new Response(MINIMAL_SPEC, { status: 200 });
-    };
+    });
 
     await loadCatalog({ platform: true });
     expect(capturedUrl).toContain("platform");

--- a/src/commands/api/index.test.ts
+++ b/src/commands/api/index.test.ts
@@ -1,9 +1,44 @@
-import { test, expect, describe, beforeEach, afterEach, spyOn } from "bun:test";
+import { test, expect, describe, beforeEach, afterEach, spyOn, mock } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { _setConfigDir, setProfile } from "../../lib/config";
-import { setMode } from "../../mode";
+import { credentialStoreStubs, gitStubs, configStubs, promptsStubs, stubFetch } from "../../test/stubs.ts";
+
+mock.module("../../lib/credential-store.ts", () => credentialStoreStubs);
+mock.module("../../lib/git.ts", () => gitStubs);
+
+let _mode = "human";
+mock.module("../../mode.ts", () => ({
+  setMode: (m: string) => { _mode = m; },
+  getMode: () => _mode,
+  isAgent: () => _mode === "agent",
+  isHuman: () => _mode !== "agent",
+}));
+
+type Profile = { workspaceId: string; appId: string; instances: Record<string, string> };
+const _profiles: Record<string, Profile> = {};
+mock.module("../../lib/config.ts", () => ({
+  ...configStubs,
+  setProfile: async (path: string, profile: Profile) => { _profiles[path] = profile; },
+  resolveProfile: async (cwd: string) => {
+    if (_profiles[cwd]) return { path: cwd, profile: _profiles[cwd], resolvedVia: "directory" as const };
+    return undefined;
+  },
+  resolveInstanceId: (profile: Profile, flag?: string) => {
+    const aliases: Record<string, string> = { dev: "development", development: "development", prod: "production", production: "production" };
+    if (!flag) return { id: profile.instances.development, label: "development" };
+    const env = aliases[flag];
+    if (!env) return { id: flag, label: flag };
+    const id = profile.instances[env];
+    if (!id) throw new Error(`No ${env} instance configured.`);
+    return { id, label: env };
+  },
+}));
+
+mock.module("@inquirer/prompts", () => promptsStubs);
+
+const { _setConfigDir } = await import("../../lib/config") as any;
+const { setMode } = await import("../../mode") as any;
 
 describe("api command", () => {
   const originalEnv = { ...process.env };
@@ -18,11 +53,12 @@ describe("api command", () => {
   const originalIsTTY = process.stdin.isTTY;
 
   beforeEach(async () => {
+    Object.keys(_profiles).forEach(k => delete _profiles[k]);
+    _mode = "human";
     tempDir = await mkdtemp(join(tmpdir(), "clerk-api-test-"));
     _setConfigDir(tempDir);
     process.env.CLERK_SECRET_KEY = "sk_test_123";
     setMode("agent"); // skip confirmation prompts
-    // Prevent resolveBody from trying to read stdin in tests
     Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true, configurable: true });
 
     logSpy = spyOn(console, "log").mockImplementation(() => {});
@@ -31,8 +67,7 @@ describe("api command", () => {
       throw new Error("process.exit");
     });
 
-    globalThis.fetch = async () =>
-      new Response(JSON.stringify(mockUsers), { status: 200 });
+    stubFetch(async () => new Response(JSON.stringify(mockUsers), { status: 200 }));
   });
 
   afterEach(async () => {
@@ -57,12 +92,12 @@ describe("api command", () => {
     let capturedUrl = "";
     let capturedMethod = "";
     let capturedHeaders: Headers | undefined;
-    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    stubFetch(async (input, init) => {
       capturedUrl = input.toString();
       capturedMethod = init?.method ?? "GET";
-      capturedHeaders = new Headers(init?.headers as HeadersInit);
+      capturedHeaders = new Headers(init?.headers);
       return new Response(JSON.stringify(mockUsers), { status: 200 });
-    };
+    });
 
     await runApi("/users");
     expect(capturedUrl).toContain("/v1/users");
@@ -73,10 +108,10 @@ describe("api command", () => {
 
   test("defaults to GET when no body provided", async () => {
     let capturedMethod = "";
-    globalThis.fetch = async (_: RequestInfo | URL, init?: RequestInit) => {
+    stubFetch(async (_input, init) => {
       capturedMethod = init?.method ?? "GET";
       return new Response(JSON.stringify({}), { status: 200 });
-    };
+    });
 
     await runApi("/users");
     expect(capturedMethod).toBe("GET");
@@ -87,11 +122,11 @@ describe("api command", () => {
   test("defaults to POST when -d data is provided", async () => {
     let capturedMethod = "";
     let capturedBody = "";
-    globalThis.fetch = async (_: RequestInfo | URL, init?: RequestInit) => {
+    stubFetch(async (_input, init) => {
       capturedMethod = init?.method ?? "GET";
       capturedBody = init?.body as string;
       return new Response(JSON.stringify({}), { status: 200 });
-    };
+    });
 
     await runApi("/users", { data: '{"email_address":["a@b.com"]}' });
     expect(capturedMethod).toBe("POST");
@@ -102,10 +137,10 @@ describe("api command", () => {
 
   test("uses explicit -X method override", async () => {
     let capturedMethod = "";
-    globalThis.fetch = async (_: RequestInfo | URL, init?: RequestInit) => {
+    stubFetch(async (_input, init) => {
       capturedMethod = init?.method ?? "GET";
       return new Response(JSON.stringify({}), { status: 200 });
-    };
+    });
 
     await runApi("/users/user_1", { method: "PATCH", data: '{"first_name":"Alice"}' });
     expect(capturedMethod).toBe("PATCH");
@@ -113,10 +148,10 @@ describe("api command", () => {
 
   test("method is case-insensitive", async () => {
     let capturedMethod = "";
-    globalThis.fetch = async (_: RequestInfo | URL, init?: RequestInit) => {
+    stubFetch(async (_input, init) => {
       capturedMethod = init?.method ?? "GET";
       return new Response(JSON.stringify({}), { status: 200 });
-    };
+    });
 
     await runApi("/users", { method: "delete" });
     expect(capturedMethod).toBe("DELETE");
@@ -126,10 +161,10 @@ describe("api command", () => {
 
   test("reads body from --file", async () => {
     let capturedBody = "";
-    globalThis.fetch = async (_: RequestInfo | URL, init?: RequestInit) => {
+    stubFetch(async (_input, init) => {
       capturedBody = init?.body as string;
       return new Response(JSON.stringify({}), { status: 200 });
-    };
+    });
 
     const bodyFile = join(tempDir, "body.json");
     await Bun.write(bodyFile, JSON.stringify({ first_name: "Bob" }));
@@ -150,11 +185,12 @@ describe("api command", () => {
   // --- --include option ---
 
   test("--include shows response headers", async () => {
-    globalThis.fetch = async () =>
+    stubFetch(async () =>
       new Response(JSON.stringify(mockUsers), {
         status: 200,
         headers: { "x-request-id": "req_123" },
-      });
+      }),
+    );
 
     await runApi("/users", { include: true });
     expect(errorSpy).toHaveBeenCalledWith("HTTP 200");
@@ -165,10 +201,10 @@ describe("api command", () => {
 
   test("--dry-run shows request without executing", async () => {
     let fetchCalled = false;
-    globalThis.fetch = async () => {
+    stubFetch(async () => {
       fetchCalled = true;
       return new Response(JSON.stringify({}), { status: 200 });
-    };
+    });
 
     await runApi("/users", { dryRun: true });
     expect(fetchCalled).toBe(false);
@@ -188,10 +224,10 @@ describe("api command", () => {
 
   test("--secret-key overrides env var", async () => {
     let capturedHeaders: Headers | undefined;
-    globalThis.fetch = async (_: RequestInfo | URL, init?: RequestInit) => {
-      capturedHeaders = new Headers(init?.headers as HeadersInit);
+    stubFetch(async (_input, init) => {
+      capturedHeaders = new Headers(init?.headers);
       return new Response(JSON.stringify({}), { status: 200 });
-    };
+    });
 
     await runApi("/users", { secretKey: "sk_live_override" });
     expect(capturedHeaders?.get("Authorization")).toBe("Bearer sk_live_override");
@@ -204,11 +240,11 @@ describe("api command", () => {
     let capturedHeaders: Headers | undefined;
     process.env.CLERK_PLATFORM_API_KEY = "plat_key_123";
 
-    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    stubFetch(async (input, init) => {
       capturedUrl = input.toString();
-      capturedHeaders = new Headers(init?.headers as HeadersInit);
+      capturedHeaders = new Headers(init?.headers);
       return new Response(JSON.stringify({}), { status: 200 });
-    };
+    });
 
     await runApi("/v1/platform/applications", { platform: true });
     expect(capturedUrl).toContain("api.clerk.com");
@@ -240,19 +276,19 @@ describe("api command", () => {
 
   test("prints API error response body to stdout and exits 1", async () => {
     const errorBody = { errors: [{ message: "not found", code: "resource_not_found" }] };
-    globalThis.fetch = async () =>
-      new Response(JSON.stringify(errorBody), { status: 404 });
+    stubFetch(async () => new Response(JSON.stringify(errorBody), { status: 404 }));
 
     await expect(runApi("/users/bad_id")).rejects.toThrow("process.exit");
     expect(logSpy).toHaveBeenCalledWith(JSON.stringify(errorBody, null, 2));
   });
 
   test("--include shows headers on error responses too", async () => {
-    globalThis.fetch = async () =>
+    stubFetch(async () =>
       new Response('{"error":"bad"}', {
         status: 400,
         headers: { "x-request-id": "req_err" },
-      });
+      }),
+    );
 
     await expect(
       runApi("/users", { include: true }),
@@ -265,10 +301,10 @@ describe("api command", () => {
 
   test("-d takes priority over --file", async () => {
     let capturedBody = "";
-    globalThis.fetch = async (_: RequestInfo | URL, init?: RequestInit) => {
+    stubFetch(async (_input, init) => {
       capturedBody = init?.body as string;
       return new Response(JSON.stringify({}), { status: 200 });
-    };
+    });
 
     const bodyFile = join(tempDir, "should-not-read.json");
     await Bun.write(bodyFile, JSON.stringify({ from: "file" }));

--- a/src/commands/api/interactive.test.ts
+++ b/src/commands/api/interactive.test.ts
@@ -2,8 +2,18 @@ import { test, expect, describe, beforeEach, afterEach, spyOn, mock } from "bun:
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { parseSpec, _setCacheDir } from "./catalog";
-import { setMode } from "../../mode";
+import { promptsStubs, stubFetch } from "../../test/stubs.ts";
+
+let _mode = "human";
+mock.module("../../mode.ts", () => ({
+  setMode: (m: string) => { _mode = m; },
+  getMode: () => _mode,
+  isAgent: () => _mode === "agent",
+  isHuman: () => _mode !== "agent",
+}));
+
+const { parseSpec, _setCacheDir } = await import("./catalog") as any;
+const { setMode } = await import("../../mode") as any;
 
 const MINIMAL_SPEC = `
 openapi: "3.0.0"
@@ -45,11 +55,10 @@ let confirmResponses: boolean[] = [];
 let fetchCalls: { url: string; method: string }[] = [];
 
 mock.module("@inquirer/prompts", () => ({
+  ...promptsStubs,
   select: async () => selectResponses.shift(),
   input: async () => inputResponses.shift(),
   confirm: async () => confirmResponses.shift(),
-  editor: async () => "{}",
-  password: async () => "",
 }));
 
 describe("apiInteractive", () => {
@@ -81,10 +90,10 @@ describe("apiInteractive", () => {
       throw new Error("process.exit");
     });
     // Capture fetch calls from the real api handler
-    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    stubFetch(async (input, init) => {
       fetchCalls.push({ url: input.toString(), method: init?.method ?? "GET" });
       return new Response(JSON.stringify({ data: [] }), { status: 200 });
-    };
+    });
 
     // Reset tracking
     selectResponses = [];

--- a/src/commands/api/ls.test.ts
+++ b/src/commands/api/ls.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { parseSpec, _setCacheDir } from "./catalog";
+import { stubFetch } from "../../test/stubs.ts";
 import { apiLs } from "./ls";
 
 const MINIMAL_SPEC = `
@@ -57,9 +58,9 @@ describe("apiLs", () => {
 
     logSpy = spyOn(console, "log").mockImplementation(() => {});
     errorSpy = spyOn(console, "error").mockImplementation(() => {});
-    globalThis.fetch = async () => {
+    stubFetch(async () => {
       throw new Error("Should not fetch");
-    };
+    });
   });
 
   afterEach(async () => {

--- a/src/commands/auth/login.test.ts
+++ b/src/commands/auth/login.test.ts
@@ -1,4 +1,5 @@
 import { test, expect, describe, afterEach, mock, spyOn } from "bun:test";
+import { credentialStoreStubs, configStubs } from "../../test/stubs.ts";
 
 const mockGetToken = mock();
 const mockStoreToken = mock();
@@ -9,11 +10,13 @@ const mockFetchUserInfo = mock();
 const mockStartAuthServer = mock();
 
 mock.module("../../lib/credential-store.ts", () => ({
+  ...credentialStoreStubs,
   getToken: (...args: unknown[]) => mockGetToken(...args),
   storeToken: (...args: unknown[]) => mockStoreToken(...args),
 }));
 
 mock.module("../../lib/config.ts", () => ({
+  ...configStubs,
   getAuth: (...args: unknown[]) => mockGetAuth(...args),
   setAuth: (...args: unknown[]) => mockSetAuth(...args),
 }));

--- a/src/commands/auth/logout.test.ts
+++ b/src/commands/auth/logout.test.ts
@@ -1,13 +1,16 @@
 import { test, expect, describe, afterEach, mock, spyOn } from "bun:test";
+import { credentialStoreStubs, configStubs } from "../../test/stubs.ts";
 
 const mockDeleteToken = mock();
 const mockClearAuth = mock();
 
 mock.module("../../lib/credential-store.ts", () => ({
+  ...credentialStoreStubs,
   deleteToken: (...args: unknown[]) => mockDeleteToken(...args),
 }));
 
 mock.module("../../lib/config.ts", () => ({
+  ...configStubs,
   clearAuth: (...args: unknown[]) => mockClearAuth(...args),
 }));
 

--- a/src/commands/config/pull.test.ts
+++ b/src/commands/config/pull.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { _setConfigDir, setProfile } from "../../lib/config";
+import { stubFetch } from "../../test/stubs.ts";
 
 describe("config pull", () => {
   const originalEnv = { ...process.env };
@@ -29,8 +30,8 @@ describe("config pull", () => {
       throw new Error("process.exit");
     });
 
-    globalThis.fetch = async () =>
-      new Response(JSON.stringify(mockConfig), { status: 200 });
+    stubFetch(async () =>
+      new Response(JSON.stringify(mockConfig), { status: 200 }));
   });
 
   afterEach(async () => {
@@ -119,10 +120,10 @@ describe("config pull", () => {
 
   test("uses development instance by default", async () => {
     let requestedUrl = "";
-    globalThis.fetch = async (input: RequestInfo | URL) => {
+    stubFetch(async (input) => {
       requestedUrl = input.toString();
       return new Response(JSON.stringify(mockConfig), { status: 200 });
-    };
+    });
 
     await setProfile(process.cwd(), {
       workspaceId: "org_1",
@@ -136,10 +137,10 @@ describe("config pull", () => {
 
   test("--instance prod targets production instance", async () => {
     let requestedUrl = "";
-    globalThis.fetch = async (input: RequestInfo | URL) => {
+    stubFetch(async (input) => {
       requestedUrl = input.toString();
       return new Response(JSON.stringify(mockConfig), { status: 200 });
-    };
+    });
 
     await setProfile(process.cwd(), {
       workspaceId: "org_1",
@@ -153,10 +154,10 @@ describe("config pull", () => {
 
   test("--instance with literal ID passes through", async () => {
     let requestedUrl = "";
-    globalThis.fetch = async (input: RequestInfo | URL) => {
+    stubFetch(async (input) => {
       requestedUrl = input.toString();
       return new Response(JSON.stringify(mockConfig), { status: 200 });
-    };
+    });
 
     await setProfile(process.cwd(), {
       workspaceId: "org_1",
@@ -182,7 +183,7 @@ describe("config pull", () => {
   });
 
   test("handles API errors gracefully", async () => {
-    globalThis.fetch = async () => new Response("Unauthorized", { status: 401 });
+    stubFetch(async () => new Response("Unauthorized", { status: 401 }));
 
     await setProfile(process.cwd(), {
       workspaceId: "org_1",

--- a/src/commands/config/push.test.ts
+++ b/src/commands/config/push.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { _setConfigDir, setProfile } from "../../lib/config";
+import { stubFetch } from "../../test/stubs.ts";
 
 describe("config push", () => {
   const originalEnv = { ...process.env };
@@ -29,8 +30,8 @@ describe("config push", () => {
       throw new Error("process.exit");
     });
 
-    globalThis.fetch = async () =>
-      new Response(JSON.stringify(mockResponse), { status: 200 });
+    stubFetch(async () =>
+      new Response(JSON.stringify(mockResponse), { status: 200 }));
   });
 
   afterEach(async () => {
@@ -134,11 +135,11 @@ describe("config push", () => {
   test("patch sends PATCH method with --json input", async () => {
     let capturedMethod = "";
     let capturedBody = "";
-    globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+    stubFetch(async (_input, init) => {
       capturedMethod = init?.method ?? "GET";
       capturedBody = init?.body as string;
       return new Response(JSON.stringify(mockResponse), { status: 200 });
-    };
+    });
 
     await setProfile(process.cwd(), {
       workspaceId: "org_1",
@@ -153,10 +154,10 @@ describe("config push", () => {
 
   test("patch reads config from --file", async () => {
     let capturedBody = "";
-    globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+    stubFetch(async (_input, init) => {
       capturedBody = init?.body as string;
       return new Response(JSON.stringify(mockResponse), { status: 200 });
-    };
+    });
 
     const configFile = join(tempDir, "input.json");
     await Bun.write(configFile, JSON.stringify({ session: { lifetime: 7200 } }));
@@ -197,10 +198,10 @@ describe("config push", () => {
 
   test("put sends PUT method", async () => {
     let capturedMethod = "";
-    globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+    stubFetch(async (_input, init) => {
       capturedMethod = init?.method ?? "GET";
       return new Response(JSON.stringify(mockResponse), { status: 200 });
-    };
+    });
 
     await setProfile(process.cwd(), {
       workspaceId: "org_1",
@@ -227,10 +228,10 @@ describe("config push", () => {
 
   test("targets development instance by default", async () => {
     let requestedUrl = "";
-    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    stubFetch(async (input) => {
       requestedUrl = input.toString();
       return new Response(JSON.stringify(mockResponse), { status: 200 });
-    };
+    });
 
     await setProfile(process.cwd(), {
       workspaceId: "org_1",
@@ -244,10 +245,10 @@ describe("config push", () => {
 
   test("--instance prod targets production instance", async () => {
     let requestedUrl = "";
-    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    stubFetch(async (input) => {
       requestedUrl = input.toString();
       return new Response(JSON.stringify(mockResponse), { status: 200 });
-    };
+    });
 
     await setProfile(process.cwd(), {
       workspaceId: "org_1",
@@ -261,10 +262,10 @@ describe("config push", () => {
 
   test("--instance with literal ID passes through", async () => {
     let requestedUrl = "";
-    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    stubFetch(async (input) => {
       requestedUrl = input.toString();
       return new Response(JSON.stringify(mockResponse), { status: 200 });
-    };
+    });
 
     await setProfile(process.cwd(), {
       workspaceId: "org_1",
@@ -280,10 +281,10 @@ describe("config push", () => {
 
   test("dry-run prints payload without calling API", async () => {
     let fetchCalled = false;
-    globalThis.fetch = async () => {
+    stubFetch(async () => {
       fetchCalled = true;
       return new Response(JSON.stringify(mockResponse), { status: 200 });
-    };
+    });
 
     await setProfile(process.cwd(), {
       workspaceId: "org_1",
@@ -317,7 +318,7 @@ describe("config push", () => {
   // --- API error handling ---
 
   test("handles API errors gracefully", async () => {
-    globalThis.fetch = async () => new Response("Bad Request", { status: 400 });
+    stubFetch(async () => new Response("Bad Request", { status: 400 }));
 
     await setProfile(process.cwd(), {
       workspaceId: "org_1",
@@ -346,10 +347,10 @@ describe("config push", () => {
 
   test("--json takes priority over --file", async () => {
     let capturedBody = "";
-    globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+    stubFetch(async (_input, init) => {
       capturedBody = init?.body as string;
       return new Response(JSON.stringify(mockResponse), { status: 200 });
-    };
+    });
 
     const configFile = join(tempDir, "should-not-read.json");
     await Bun.write(configFile, JSON.stringify({ from: "file" }));

--- a/src/commands/deploy/index.test.ts
+++ b/src/commands/deploy/index.test.ts
@@ -1,18 +1,23 @@
 import { test, expect, describe, afterEach, mock, spyOn } from "bun:test";
+import { capturedOutput, promptsStubs } from "../../test/stubs.ts";
 
 const mockIsAgent = mock();
+let _modeOverride: string | undefined;
 
 mock.module("../../mode.ts", () => ({
-  isAgent: (...args: unknown[]) => mockIsAgent(...args),
+  isAgent: (...args: unknown[]) => _modeOverride !== undefined ? _modeOverride === "agent" : mockIsAgent(...args),
+  isHuman: (...args: unknown[]) => _modeOverride !== undefined ? _modeOverride !== "agent" : !mockIsAgent(...args),
+  setMode: (m: string) => { _modeOverride = m; },
+  getMode: () => _modeOverride ?? "human",
 }));
 
-// Mock inquirer prompts so human-mode tests don't hang
 const mockSelect = mock();
 const mockInput = mock();
 const mockConfirm = mock();
 const mockPassword = mock();
 
 mock.module("@inquirer/prompts", () => ({
+  ...promptsStubs,
   select: (...args: unknown[]) => mockSelect(...args),
   input: (...args: unknown[]) => mockInput(...args),
   confirm: (...args: unknown[]) => mockConfirm(...args),
@@ -21,14 +26,11 @@ mock.module("@inquirer/prompts", () => ({
 
 const { deploy } = await import("./index.ts");
 
-function capturedOutput(spy: ReturnType<typeof spyOn>): string {
-  return spy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
-}
-
 describe("deploy", () => {
   let consoleSpy: ReturnType<typeof spyOn>;
 
   afterEach(() => {
+    _modeOverride = undefined;
     mockIsAgent.mockReset();
     mockSelect.mockReset();
     mockInput.mockReset();

--- a/src/commands/deploy/index.test.ts
+++ b/src/commands/deploy/index.test.ts
@@ -21,6 +21,10 @@ mock.module("@inquirer/prompts", () => ({
 
 const { deploy } = await import("./index.ts");
 
+function capturedOutput(spy: ReturnType<typeof spyOn>): string {
+  return spy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+}
+
 describe("deploy", () => {
   let consoleSpy: ReturnType<typeof spyOn>;
 
@@ -110,7 +114,7 @@ describe("deploy", () => {
 
       await deploy({});
 
-      const allOutput = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+      const allOutput = capturedOutput(consoleSpy);
       expect(allOutput).not.toContain(
         "deploying a Clerk application to production"
       );
@@ -122,7 +126,7 @@ describe("deploy", () => {
 
       await deploy({});
 
-      const allOutput = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+      const allOutput = capturedOutput(consoleSpy);
       expect(allOutput).toContain("[mock]");
     });
   });

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -1,5 +1,6 @@
 import { select, input, confirm, password } from "@inquirer/prompts";
 import { isAgent } from "../../mode.js";
+import { dim, bold, cyan, green, blue, yellow } from "../../lib/color.js";
 
 const DEPLOY_PROMPT = `You are deploying a Clerk application to production. Follow these steps:
 
@@ -88,7 +89,7 @@ export async function deploy(options: { debug?: boolean }) {
   }
   const debug = options.debug ? (...args: unknown[]) => console.log("[debug]", ...args) : () => {};
 
-  console.log("\x1b[33m[mock] This command uses mocked data and is not yet wired up to real APIs.\x1b[0m\n");
+  console.log(yellow("[mock] This command uses mocked data and is not yet wired up to real APIs.") + "\n");
 
   debug("Checking for authenticated user and linked application...");
 
@@ -201,9 +202,6 @@ export async function deploy(options: { debug?: boolean }) {
       });
 
       if (credentialChoice === "walkthrough") {
-        const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
-        const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
-        const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;
 
         console.log(`\n${bold(`When configuring your ${displayName} OAuth app, use these values:`)}\n`);
         console.log(`  ${dim("Authorized JavaScript origins:")}`);
@@ -236,6 +234,6 @@ export async function deploy(options: { debug?: boolean }) {
 
   debug("Deploy complete.");
 
-  console.log(`\n\x1b[1m\x1b[32mYour production application is set up and ready at \x1b[34mhttps://${domain}\x1b[0m`);
-  console.log(`\x1b[2mIf your application is not loading correctly, you may need to redeploy with your updated Clerk secret keys.\x1b[0m`);
+  console.log(`\n${bold(green(`Your production application is set up and ready at ${blue(`https://${domain}`)}`))}`)
+  console.log(dim("If your application is not loading correctly, you may need to redeploy with your updated Clerk secret keys."));
 }

--- a/src/commands/env/pull.test.ts
+++ b/src/commands/env/pull.test.ts
@@ -1,8 +1,37 @@
-import { test, expect, describe, beforeEach, afterEach, spyOn } from "bun:test";
+import { test, expect, describe, beforeEach, afterEach, spyOn, mock } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { _setConfigDir, setProfile } from "../../lib/config";
+import { credentialStoreStubs, gitStubs, configStubs, stubFetch } from "../../test/stubs.ts";
+
+mock.module("../../lib/credential-store.ts", () => credentialStoreStubs);
+mock.module("../../lib/git.ts", () => gitStubs);
+
+type Profile = { workspaceId: string; appId: string; instances: Record<string, string> };
+const _profiles: Record<string, Profile> = {};
+const INSTANCE_ALIASES: Record<string, string> = {
+  dev: "development", development: "development",
+  prod: "production", production: "production",
+};
+
+mock.module("../../lib/config.ts", () => ({
+  ...configStubs,
+  setProfile: async (path: string, profile: Profile) => { _profiles[path] = profile; },
+  resolveProfile: async (cwd: string) => {
+    if (_profiles[cwd]) return { path: cwd, profile: _profiles[cwd], resolvedVia: "directory" as const };
+    return undefined;
+  },
+  resolveInstanceId: (profile: Profile, flag?: string) => {
+    if (!flag) return { id: profile.instances.development, label: "development" };
+    const env = INSTANCE_ALIASES[flag];
+    if (!env) return { id: flag, label: flag };
+    const id = profile.instances[env];
+    if (!id) throw new Error(`No ${env} instance configured. Run \`clerk init\` to set one up.`);
+    return { id, label: env };
+  },
+}));
+
+const { _setConfigDir, setProfile } = await import("../../lib/config") as any;
 
 describe("env pull", () => {
   const originalEnv = { ...process.env };
@@ -31,6 +60,7 @@ describe("env pull", () => {
   };
 
   beforeEach(async () => {
+    Object.keys(_profiles).forEach(k => delete _profiles[k]);
     tempDir = await mkdtemp(join(tmpdir(), "clerk-env-pull-test-"));
     _setConfigDir(tempDir);
     process.env.CLERK_PLATFORM_API_KEY = "test_key";
@@ -50,8 +80,8 @@ describe("env pull", () => {
       throw new Error("process.exit");
     });
 
-    globalThis.fetch = async () =>
-      new Response(JSON.stringify(mockApplication), { status: 200 });
+    stubFetch(async () =>
+      new Response(JSON.stringify(mockApplication), { status: 200 }));
   });
 
   afterEach(async () => {
@@ -222,7 +252,7 @@ describe("env pull", () => {
   });
 
   test("handles API errors gracefully", async () => {
-    globalThis.fetch = async () => new Response("Unauthorized", { status: 401 });
+    stubFetch(async () => new Response("Unauthorized", { status: 401 }));
 
     await setProfile(tempDir, {
       workspaceId: "org_1",

--- a/src/commands/env/pull.ts
+++ b/src/commands/env/pull.ts
@@ -68,10 +68,13 @@ export async function pull(options: EnvPullOptions): Promise<void> {
   const existingContent = (await file.exists()) ? await file.text() : "";
 
   const lines = parseEnvFile(existingContent);
-  const merged = mergeEnvVars(lines, {
+  const vars: Record<string, string> = {
     [publishableKeyName]: matched.publishable_key,
-    CLERK_SECRET_KEY: matched.secret_key,
-  });
+  };
+  if (matched.secret_key) {
+    vars.CLERK_SECRET_KEY = matched.secret_key;
+  }
+  const merged = mergeEnvVars(lines, vars);
   const output = serializeEnvFile(merged);
 
   await Bun.write(targetFile, output);

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -4,9 +4,7 @@ import { link } from "../link/index.js";
 import { pull } from "../env/pull.js";
 import { detectFramework } from "../../lib/framework.js";
 import { isAgent } from "../../mode.js";
-
-const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
-const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;
+import { dim, cyan } from "../../lib/color.js";
 
 const AGENT_PROMPT = `You are integrating Clerk authentication into an existing project. Follow these steps:
 

--- a/src/commands/link/README.md
+++ b/src/commands/link/README.md
@@ -1,7 +1,9 @@
 # Link Command
 
-Links the current project directory to a Clerk application, storing the app ID
-and instance IDs in `~/.clerk/config.json`.
+Links the current git repository to a Clerk application, storing the app ID
+and instance IDs in `~/.clerk/config.json`. The link is keyed by the
+normalized git remote URL (e.g., `github.com/org/repo`), so it is
+automatically shared across all clones and worktrees of the same repository.
 
 ## Usage
 
@@ -24,11 +26,14 @@ interactive flow.
 
 ## Flow
 
-1. Checks for authentication (calls `clerk auth login` if needed)
-2. If `--app` is provided, uses that app ID directly
-3. Otherwise, fetches the list of applications and presents an interactive picker
-4. Fetches application details to retrieve instance IDs
-5. Stores the profile in `~/.clerk/config.json` keyed by the current directory
+1. Resolves the normalized git remote URL (e.g., `github.com/org/repo`) for cross-clone matching
+2. Checks if already linked — if resolved via a remote URL from another clone, prints an auto-link notice
+3. Checks for authentication (calls `clerk auth login` if needed)
+4. If `--app` is provided, uses that app ID directly
+5. Otherwise, fetches the list of applications and presents a searchable picker (type to filter by name)
+6. Fetches application details to retrieve instance IDs
+7. Stores the profile in `~/.clerk/config.json` keyed by the normalized remote URL
+8. Falls back to git-common-dir or the current directory path if no remote is configured
 
 ## API Endpoints
 

--- a/src/commands/link/index.test.ts
+++ b/src/commands/link/index.test.ts
@@ -24,15 +24,26 @@ mock.module("../../lib/plapi.ts", () => ({
 
 const mockSetProfile = mock();
 const mockResolveProfile = mock();
+const mockMoveProfile = mock();
 mock.module("../../lib/config.ts", () => ({
   setProfile: (...args: unknown[]) => mockSetProfile(...args),
   resolveProfile: (...args: unknown[]) => mockResolveProfile(...args),
+  moveProfile: (...args: unknown[]) => mockMoveProfile(...args),
 }));
 
-const mockSelect = mock();
+const mockGetGitRepoIdentifier = mock();
+const mockGetGitRepoRoot = mock();
+const mockGetGitNormalizedRemote = mock();
+mock.module("../../lib/git.ts", () => ({
+  getGitRepoIdentifier: (...args: unknown[]) => mockGetGitRepoIdentifier(...args),
+  getGitRepoRoot: (...args: unknown[]) => mockGetGitRepoRoot(...args),
+  getGitNormalizedRemote: (...args: unknown[]) => mockGetGitNormalizedRemote(...args),
+}));
+
+const mockSearch = mock();
 const mockConfirm = mock();
 mock.module("@inquirer/prompts", () => ({
-  select: (...args: unknown[]) => mockSelect(...args),
+  search: (...args: unknown[]) => mockSearch(...args),
   confirm: (...args: unknown[]) => mockConfirm(...args),
 }));
 
@@ -45,6 +56,10 @@ const mockApp = {
     { instance_id: "ins_prod", environment_type: "production", secret_key: "sk_live", publishable_key: "pk_live" },
   ],
 };
+
+function capturedOutput(spy: ReturnType<typeof spyOn>): string {
+  return spy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+}
 
 describe("link", () => {
   let consoleSpy: ReturnType<typeof spyOn>;
@@ -60,7 +75,14 @@ describe("link", () => {
     mockSetProfile.mockReset();
     mockResolveProfile.mockReset();
     mockResolveProfile.mockResolvedValue(undefined);
-    mockSelect.mockReset();
+    mockMoveProfile.mockReset();
+    mockGetGitRepoIdentifier.mockReset();
+    mockGetGitRepoIdentifier.mockResolvedValue("/repo/.git");
+    mockGetGitRepoRoot.mockReset();
+    mockGetGitRepoRoot.mockResolvedValue("/repo");
+    mockGetGitNormalizedRemote.mockReset();
+    mockGetGitNormalizedRemote.mockResolvedValue("github.com/org/repo");
+    mockSearch.mockReset();
     mockConfirm.mockReset();
     consoleSpy?.mockRestore();
     errorSpy?.mockRestore();
@@ -85,7 +107,7 @@ describe("link", () => {
 
       await link();
 
-      expect(mockSelect).not.toHaveBeenCalled();
+      expect(mockSearch).not.toHaveBeenCalled();
       expect(mockGetToken).not.toHaveBeenCalled();
       expect(mockListApplications).not.toHaveBeenCalled();
     });
@@ -95,7 +117,7 @@ describe("link", () => {
     test("notifies and returns when user declines re-link", async () => {
       mockIsAgent.mockReturnValue(false);
       mockResolveProfile.mockResolvedValue({
-        path: process.cwd(),
+        path: "/repo/.git",
         profile: { workspaceId: "", appId: "app_existing", instances: { development: "ins_1" } },
       });
       mockConfirm.mockResolvedValue(false);
@@ -103,7 +125,7 @@ describe("link", () => {
 
       await link();
 
-      const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+      const output = capturedOutput(consoleSpy);
       expect(output).toContain("Already linked");
       expect(output).toContain("app_existing");
       expect(mockConfirm).toHaveBeenCalled();
@@ -114,7 +136,7 @@ describe("link", () => {
     test("proceeds with re-link when user confirms", async () => {
       mockIsAgent.mockReturnValue(false);
       mockResolveProfile.mockResolvedValue({
-        path: process.cwd(),
+        path: "/repo/.git",
         profile: { workspaceId: "", appId: "app_existing", instances: { development: "ins_1" } },
       });
       mockConfirm.mockResolvedValue(true);
@@ -164,7 +186,7 @@ describe("link", () => {
       await link({ app: "app_123" });
 
       expect(mockListApplications).not.toHaveBeenCalled();
-      expect(mockSelect).not.toHaveBeenCalled();
+      expect(mockSearch).not.toHaveBeenCalled();
       expect(mockFetchApplication).toHaveBeenCalledWith("app_123");
     });
 
@@ -175,14 +197,71 @@ describe("link", () => {
         { application_id: "app_a", instances: [{ instance_id: "ins_1", environment_type: "development", publishable_key: "pk_test" }] },
         { application_id: "app_b", instances: [{ instance_id: "ins_2", environment_type: "development", publishable_key: "pk_test2" }] },
       ]);
-      mockSelect.mockResolvedValue("app_a");
+      mockSearch.mockResolvedValue("app_a");
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
       await link();
 
       expect(mockListApplications).toHaveBeenCalled();
-      expect(mockSelect).toHaveBeenCalled();
+      expect(mockSearch).toHaveBeenCalled();
       expect(mockFetchApplication).not.toHaveBeenCalled();
+    });
+
+    test("source returns all choices when term is empty", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockGetToken.mockResolvedValue("token");
+      mockListApplications.mockResolvedValue([
+        { name: "My App", application_id: "app_a", instances: [{ instance_id: "ins_1", environment_type: "development", publishable_key: "pk_test" }] },
+        { name: "Other App", application_id: "app_b", instances: [{ instance_id: "ins_2", environment_type: "development", publishable_key: "pk_test2" }] },
+      ]);
+      mockSearch.mockImplementation(async (config: { source: (term: string | undefined) => unknown[] }) => {
+        const results = config.source(undefined);
+        expect(results).toHaveLength(2);
+        return "app_a";
+      });
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link();
+    });
+
+    test("source filters choices by name substring (case-insensitive)", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockGetToken.mockResolvedValue("token");
+      mockListApplications.mockResolvedValue([
+        { name: "My App", application_id: "app_a", instances: [{ instance_id: "ins_1", environment_type: "development", publishable_key: "pk_test" }] },
+        { name: "Other App", application_id: "app_b", instances: [{ instance_id: "ins_2", environment_type: "development", publishable_key: "pk_test2" }] },
+      ]);
+      mockSearch.mockImplementation(async (config: { source: (term: string | undefined) => { name: string; value: string }[] }) => {
+        const results = config.source("my");
+        expect(results).toHaveLength(1);
+        expect(results[0]!.value).toBe("app_a");
+
+        const noMatch = config.source("zzz");
+        expect(noMatch).toHaveLength(0);
+
+        return "app_a";
+      });
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link();
+    });
+
+    test("source filters by app ID when name is absent", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockGetToken.mockResolvedValue("token");
+      mockListApplications.mockResolvedValue([
+        { application_id: "app_abc", instances: [{ instance_id: "ins_1", environment_type: "development", publishable_key: "pk_test" }] },
+        { name: "Named", application_id: "app_xyz", instances: [{ instance_id: "ins_2", environment_type: "development", publishable_key: "pk_test2" }] },
+      ]);
+      mockSearch.mockImplementation(async (config: { source: (term: string | undefined) => { name: string; value: string }[] }) => {
+        const results = config.source("abc");
+        expect(results).toHaveLength(1);
+        expect(results[0]!.value).toBe("app_abc");
+        return "app_abc";
+      });
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link();
     });
 
     test("exits when no apps found", async () => {
@@ -199,10 +278,53 @@ describe("link", () => {
   });
 
   describe("profile storage", () => {
-    test("stores profile with correct data", async () => {
+    test("stores profile keyed by normalized remote URL", async () => {
       mockIsAgent.mockReturnValue(false);
       mockGetToken.mockResolvedValue("token");
       mockFetchApplication.mockResolvedValue(mockApp);
+      mockGetGitNormalizedRemote.mockResolvedValue("github.com/org/repo");
+      mockGetGitRepoIdentifier.mockResolvedValue("/repo/.git");
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link({ app: "app_123" });
+
+      expect(mockSetProfile).toHaveBeenCalledWith("github.com/org/repo", {
+        workspaceId: "",
+        appId: "app_123",
+        instances: {
+          development: "ins_dev",
+          production: "ins_prod",
+        },
+      });
+    });
+
+    test("falls back to git repo identifier when no remote", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockGetToken.mockResolvedValue("token");
+      mockFetchApplication.mockResolvedValue(mockApp);
+      mockGetGitNormalizedRemote.mockResolvedValue(undefined);
+      mockGetGitRepoIdentifier.mockResolvedValue("/repo/.git");
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link({ app: "app_123" });
+
+      expect(mockSetProfile).toHaveBeenCalledWith("/repo/.git", {
+        workspaceId: "",
+        appId: "app_123",
+        instances: {
+          development: "ins_dev",
+          production: "ins_prod",
+        },
+      });
+    });
+
+    test("falls back to cwd when not in a git repo", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockGetToken.mockResolvedValue("token");
+      mockFetchApplication.mockResolvedValue(mockApp);
+      mockGetGitNormalizedRemote.mockResolvedValue(undefined);
+      mockGetGitRepoIdentifier.mockResolvedValue(undefined);
+      mockGetGitRepoRoot.mockResolvedValue(undefined);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
       await link({ app: "app_123" });
@@ -230,7 +352,7 @@ describe("link", () => {
 
       await link({ app: "app_123" });
 
-      const storedProfile = mockSetProfile.mock.calls[0][1];
+      const storedProfile = mockSetProfile.mock.calls[0]![1];
       expect(storedProfile.instances.production).toBeUndefined();
     });
 
@@ -261,6 +383,129 @@ describe("link", () => {
 
       const lastCall = consoleSpy.mock.calls[consoleSpy.mock.calls.length - 1][0] as string;
       expect(lastCall).toContain("Linked to");
+    });
+  });
+
+  describe("auto-link via remote", () => {
+    test("prints auto-link notice when resolved via remote", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockGetGitNormalizedRemote.mockResolvedValue("github.com/org/repo");
+      mockResolveProfile.mockResolvedValue({
+        path: "github.com/org/repo",
+        profile: { workspaceId: "", appId: "app_existing", instances: { development: "ins_1" } },
+        resolvedVia: "remote",
+      });
+      mockConfirm.mockResolvedValue(false);
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link();
+
+      const output = capturedOutput(consoleSpy);
+      expect(output).toContain("Auto-linked via git remote");
+      expect(output).toContain("github.com/org/repo");
+    });
+
+    test("skips silently with skipIfLinked after printing auto-link notice", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockGetGitNormalizedRemote.mockResolvedValue("github.com/org/repo");
+      mockResolveProfile.mockResolvedValue({
+        path: "github.com/org/repo",
+        profile: { workspaceId: "", appId: "app_existing", instances: { development: "ins_1" } },
+        resolvedVia: "remote",
+      });
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link({ skipIfLinked: true });
+
+      const output = capturedOutput(consoleSpy);
+      expect(output).toContain("Auto-linked via git remote");
+      expect(mockConfirm).not.toHaveBeenCalled();
+      expect(mockGetToken).not.toHaveBeenCalled();
+    });
+
+    test("does not print auto-link notice when resolved via git-common-dir", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockResolveProfile.mockResolvedValue({
+        path: "/repo/.git",
+        profile: { workspaceId: "", appId: "app_existing", instances: { development: "ins_1" } },
+        resolvedVia: "git-common-dir",
+      });
+      mockConfirm.mockResolvedValue(false);
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link();
+
+      const output = capturedOutput(consoleSpy);
+      expect(output).not.toContain("Auto-linked via git remote");
+      expect(output).toContain("Already linked");
+    });
+  });
+
+  describe("profile upgrade to remote", () => {
+    const dirProfile = {
+      path: "/projects/myapp",
+      profile: { workspaceId: "", appId: "app_existing", instances: { development: "ins_1" } },
+      resolvedVia: "directory" as const,
+      availableRemote: "github.com/org/repo",
+    };
+
+    test("offers upgrade when directory-keyed profile has available remote", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockGetGitNormalizedRemote.mockResolvedValue("github.com/org/repo");
+      mockResolveProfile.mockResolvedValue(dirProfile);
+      mockConfirm.mockResolvedValueOnce(true); // accept upgrade
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link();
+
+      const output = capturedOutput(consoleSpy);
+      expect(output).toContain("git repository with remote");
+      expect(output).toContain("Link updated");
+      expect(mockMoveProfile).toHaveBeenCalledWith("/projects/myapp", "github.com/org/repo");
+    });
+
+    test("falls through to re-link when upgrade is declined", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockGetGitNormalizedRemote.mockResolvedValue("github.com/org/repo");
+      mockResolveProfile.mockResolvedValue(dirProfile);
+      mockConfirm
+        .mockResolvedValueOnce(false)  // decline upgrade
+        .mockResolvedValueOnce(false); // decline re-link
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link();
+
+      expect(mockMoveProfile).not.toHaveBeenCalled();
+      expect(mockGetToken).not.toHaveBeenCalled();
+    });
+
+    test("skips upgrade prompt with skipIfLinked", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockGetGitNormalizedRemote.mockResolvedValue("github.com/org/repo");
+      mockResolveProfile.mockResolvedValue(dirProfile);
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link({ skipIfLinked: true });
+
+      expect(mockConfirm).not.toHaveBeenCalled();
+      expect(mockMoveProfile).not.toHaveBeenCalled();
+    });
+
+    test("offers upgrade for git-common-dir profile with available remote", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockGetGitNormalizedRemote.mockResolvedValue("github.com/org/repo");
+      mockResolveProfile.mockResolvedValue({
+        ...dirProfile,
+        path: "/repo/.git",
+        resolvedVia: "git-common-dir",
+        availableRemote: "github.com/org/repo",
+      });
+      mockConfirm.mockResolvedValueOnce(true); // accept upgrade
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link();
+
+      expect(mockMoveProfile).toHaveBeenCalledWith("/repo/.git", "github.com/org/repo");
     });
   });
 });

--- a/src/commands/link/index.test.ts
+++ b/src/commands/link/index.test.ts
@@ -1,12 +1,18 @@
 import { test, expect, describe, afterEach, mock, spyOn } from "bun:test";
+import { capturedOutput, configStubs, credentialStoreStubs, gitStubs, promptsStubs } from "../../test/stubs.ts";
 
 const mockIsAgent = mock();
+let _modeOverride: string | undefined;
 mock.module("../../mode.ts", () => ({
-  isAgent: (...args: unknown[]) => mockIsAgent(...args),
+  isAgent: (...args: unknown[]) => _modeOverride !== undefined ? _modeOverride === "agent" : mockIsAgent(...args),
+  isHuman: (...args: unknown[]) => _modeOverride !== undefined ? _modeOverride !== "agent" : !mockIsAgent(...args),
+  setMode: (m: string) => { _modeOverride = m; },
+  getMode: () => _modeOverride ?? "human",
 }));
 
 const mockGetToken = mock();
 mock.module("../../lib/credential-store.ts", () => ({
+  ...credentialStoreStubs,
   getToken: (...args: unknown[]) => mockGetToken(...args),
 }));
 
@@ -20,12 +26,17 @@ const mockFetchApplication = mock();
 mock.module("../../lib/plapi.ts", () => ({
   listApplications: (...args: unknown[]) => mockListApplications(...args),
   fetchApplication: (...args: unknown[]) => mockFetchApplication(...args),
+  PlapiError: class PlapiError extends Error {},
+  fetchInstanceConfig: async () => ({}),
+  putInstanceConfig: async () => ({}),
+  patchInstanceConfig: async () => ({}),
 }));
 
 const mockSetProfile = mock();
 const mockResolveProfile = mock();
 const mockMoveProfile = mock();
 mock.module("../../lib/config.ts", () => ({
+  ...configStubs,
   setProfile: (...args: unknown[]) => mockSetProfile(...args),
   resolveProfile: (...args: unknown[]) => mockResolveProfile(...args),
   moveProfile: (...args: unknown[]) => mockMoveProfile(...args),
@@ -35,6 +46,7 @@ const mockGetGitRepoIdentifier = mock();
 const mockGetGitRepoRoot = mock();
 const mockGetGitNormalizedRemote = mock();
 mock.module("../../lib/git.ts", () => ({
+  ...gitStubs,
   getGitRepoIdentifier: (...args: unknown[]) => mockGetGitRepoIdentifier(...args),
   getGitRepoRoot: (...args: unknown[]) => mockGetGitRepoRoot(...args),
   getGitNormalizedRemote: (...args: unknown[]) => mockGetGitNormalizedRemote(...args),
@@ -43,6 +55,7 @@ mock.module("../../lib/git.ts", () => ({
 const mockSearch = mock();
 const mockConfirm = mock();
 mock.module("@inquirer/prompts", () => ({
+  ...promptsStubs,
   search: (...args: unknown[]) => mockSearch(...args),
   confirm: (...args: unknown[]) => mockConfirm(...args),
 }));
@@ -57,16 +70,13 @@ const mockApp = {
   ],
 };
 
-function capturedOutput(spy: ReturnType<typeof spyOn>): string {
-  return spy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
-}
-
 describe("link", () => {
   let consoleSpy: ReturnType<typeof spyOn>;
   let errorSpy: ReturnType<typeof spyOn>;
   let exitSpy: ReturnType<typeof spyOn>;
 
   afterEach(() => {
+    _modeOverride = undefined;
     mockIsAgent.mockReset();
     mockGetToken.mockReset();
     mockLogin.mockReset();

--- a/src/commands/link/index.ts
+++ b/src/commands/link/index.ts
@@ -1,13 +1,12 @@
 import { basename } from "node:path";
-import { select, confirm } from "@inquirer/prompts";
+import { search, confirm } from "@inquirer/prompts";
 import { isAgent } from "../../mode.js";
 import { getToken } from "../../lib/credential-store.js";
 import { login } from "../auth/login.js";
 import { listApplications, fetchApplication, type Application } from "../../lib/plapi.js";
-import { setProfile, resolveProfile } from "../../lib/config.js";
-
-const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
-const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;
+import { setProfile, resolveProfile, moveProfile } from "../../lib/config.js";
+import { getGitRepoIdentifier, getGitRepoRoot, getGitNormalizedRemote } from "../../lib/git.js";
+import { dim, cyan } from "../../lib/color.js";
 
 const AGENT_PROMPT = `You are linking a Clerk application to the current project directory.
 
@@ -17,7 +16,7 @@ const AGENT_PROMPT = `You are linking a Clerk application to the current project
 2. Determine which application to link:
    - If the user provides an app ID: \`clerk link --app <app_id>\`
    - Otherwise, list available applications with \`GET /v1/platform/applications\` and ask the user to select one.
-3. The link is stored in ~/.clerk/config.json as a profile keyed by the current directory path.
+3. The link is stored in ~/.clerk/config.json as a profile keyed by the git repository root (shared across worktrees).
 
 ## API Endpoints
 
@@ -43,12 +42,40 @@ export async function link(options: LinkOptions = {}): Promise<void> {
     return;
   }
 
-  // Check if already linked
+  // Resolve git repo identifier — prefer normalized remote URL for cross-clone matching
   const cwd = process.cwd();
+  const repoRoot = await getGitRepoRoot();
+  const normalizedRemote = await getGitNormalizedRemote();
+  const repoId = await getGitRepoIdentifier();
+  const profileKey = normalizedRemote ?? repoId ?? cwd;
+  const displayPath = repoRoot ?? cwd;
+
+  // Check if already linked
   const existing = await resolveProfile(cwd);
-  if (existing && existing.path === cwd) {
+  if (existing) {
+    // Print context-specific message
+    if (existing.resolvedVia === "remote") {
+      console.log(`Auto-linked via git remote (${dim(normalizedRemote ?? existing.path)})`);
+    } else {
+      console.log(`Already linked to ${cyan(existing.profile.appId)} in ${dim(existing.path)}`);
+    }
+
     if (options.skipIfLinked) return;
-    console.log(`Already linked to ${cyan(existing.profile.appId)} in ${dim(cwd)}`);
+
+    // Offer upgrade when an old profile key can migrate to a remote URL
+    if (existing.availableRemote) {
+      console.log(`We detected this is now a git repository with remote ${dim(existing.availableRemote)}.`);
+      const upgrade = await confirm({
+        message: "Update the link to use the git remote? This shares it across clones and worktrees.",
+        default: true,
+      });
+      if (upgrade) {
+        await moveProfile(existing.path, existing.availableRemote);
+        console.log(`\nLink updated to use git remote (${cyan(existing.availableRemote)})`);
+        return;
+      }
+    }
+
     const relink = await confirm({ message: "Re-link to a different application?", default: false });
     if (!relink) return;
   }
@@ -75,15 +102,26 @@ export async function link(options: LinkOptions = {}): Promise<void> {
       process.exit(1);
     }
 
-    const selectedId = await select({
-      message: `Select a Clerk application to link ${dim(`(dir: /${basename(process.cwd())})`)}`,
-      choices: apps.map((a) => ({
-        name: appLabel(a),
-        value: a.application_id,
-      })),
+    const choices = apps.map((a) => ({
+      name: appLabel(a),
+      value: a.application_id,
+    }));
+
+    const selectedId = await search({
+      message: `Select a Clerk application to link ${dim(`(repo: ${basename(displayPath)})`)}`,
+      source: (term) => {
+        if (!term) return choices;
+        const lower = term.toLowerCase();
+        return choices.filter((c) => c.name.toLowerCase().includes(lower));
+      },
     });
 
-    app = apps.find((a) => a.application_id === selectedId)!;
+    const found = apps.find((a) => a.application_id === selectedId);
+    if (!found) {
+      console.error("Selected application not found.");
+      process.exit(1);
+    }
+    app = found;
   }
 
   const devInstance = app.instances.find(
@@ -98,8 +136,8 @@ export async function link(options: LinkOptions = {}): Promise<void> {
     process.exit(1);
   }
 
-  // Store profile
-  await setProfile(cwd, {
+  // Store profile keyed by git repo (or cwd if not in a repo)
+  await setProfile(profileKey, {
     workspaceId: "",
     appId: app.application_id,
     instances: {
@@ -109,5 +147,5 @@ export async function link(options: LinkOptions = {}): Promise<void> {
   });
 
   const label = app.name || app.application_id;
-  console.log(`\nLinked to ${cyan(label)} in ${dim(cwd)}`);
+  console.log(`\nLinked to ${cyan(label)} in ${dim(displayPath)}`);
 }

--- a/src/commands/unlink/README.md
+++ b/src/commands/unlink/README.md
@@ -17,7 +17,7 @@ clerk unlink --yes
 
 ## Behavior
 
-1. Resolves the current profile by walking up from the working directory
+1. Resolves the current profile by checking the normalized remote URL, then git-common-dir, then walking up from the working directory
 2. If no profile is found, exits with an error
 3. Prompts for confirmation (unless `--yes` is passed)
 4. Removes the profile entry from `~/.clerk/config.json`

--- a/src/commands/unlink/index.test.ts
+++ b/src/commands/unlink/index.test.ts
@@ -1,26 +1,33 @@
 import { test, expect, describe, afterEach, mock, spyOn } from "bun:test";
+import { capturedOutput, configStubs, gitStubs, promptsStubs } from "../../test/stubs.ts";
 
 const mockIsAgent = mock();
 const mockIsHuman = mock();
+let _modeOverride: string | undefined;
 mock.module("../../mode.ts", () => ({
-  isAgent: (...args: unknown[]) => mockIsAgent(...args),
-  isHuman: (...args: unknown[]) => mockIsHuman(...args),
+  isAgent: (...args: unknown[]) => _modeOverride !== undefined ? _modeOverride === "agent" : mockIsAgent(...args),
+  isHuman: (...args: unknown[]) => _modeOverride !== undefined ? _modeOverride !== "agent" : mockIsHuman(...args),
+  setMode: (m: string) => { _modeOverride = m; },
+  getMode: () => _modeOverride ?? "human",
 }));
 
 const mockResolveProfile = mock();
 const mockRemoveProfile = mock();
 mock.module("../../lib/config.ts", () => ({
+  ...configStubs,
   resolveProfile: (...args: unknown[]) => mockResolveProfile(...args),
   removeProfile: (...args: unknown[]) => mockRemoveProfile(...args),
 }));
 
 const mockGetGitRepoRoot = mock();
 mock.module("../../lib/git.ts", () => ({
+  ...gitStubs,
   getGitRepoRoot: (...args: unknown[]) => mockGetGitRepoRoot(...args),
 }));
 
 const mockConfirm = mock();
 mock.module("@inquirer/prompts", () => ({
+  ...promptsStubs,
   confirm: (...args: unknown[]) => mockConfirm(...args),
 }));
 
@@ -31,16 +38,13 @@ const mockProfile = {
   profile: { workspaceId: "", appId: "app_123", instances: { development: "ins_dev" } },
 };
 
-function capturedOutput(spy: ReturnType<typeof spyOn>): string {
-  return spy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
-}
-
 describe("unlink", () => {
   let consoleSpy: ReturnType<typeof spyOn>;
   let errorSpy: ReturnType<typeof spyOn>;
   let exitSpy: ReturnType<typeof spyOn>;
 
   afterEach(() => {
+    _modeOverride = undefined;
     mockIsAgent.mockReset();
     mockIsHuman.mockReset();
     mockResolveProfile.mockReset();
@@ -114,7 +118,9 @@ describe("unlink", () => {
 
       await unlink();
 
-      expect(mockConfirm).toHaveBeenCalled();
+      expect(mockConfirm).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining("/repo") }),
+      );
       expect(mockRemoveProfile).toHaveBeenCalledWith(process.cwd());
     });
 

--- a/src/commands/unlink/index.test.ts
+++ b/src/commands/unlink/index.test.ts
@@ -14,6 +14,11 @@ mock.module("../../lib/config.ts", () => ({
   removeProfile: (...args: unknown[]) => mockRemoveProfile(...args),
 }));
 
+const mockGetGitRepoRoot = mock();
+mock.module("../../lib/git.ts", () => ({
+  getGitRepoRoot: (...args: unknown[]) => mockGetGitRepoRoot(...args),
+}));
+
 const mockConfirm = mock();
 mock.module("@inquirer/prompts", () => ({
   confirm: (...args: unknown[]) => mockConfirm(...args),
@@ -26,6 +31,10 @@ const mockProfile = {
   profile: { workspaceId: "", appId: "app_123", instances: { development: "ins_dev" } },
 };
 
+function capturedOutput(spy: ReturnType<typeof spyOn>): string {
+  return spy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+}
+
 describe("unlink", () => {
   let consoleSpy: ReturnType<typeof spyOn>;
   let errorSpy: ReturnType<typeof spyOn>;
@@ -36,6 +45,8 @@ describe("unlink", () => {
     mockIsHuman.mockReset();
     mockResolveProfile.mockReset();
     mockRemoveProfile.mockReset();
+    mockGetGitRepoRoot.mockReset();
+    mockGetGitRepoRoot.mockResolvedValue("/repo");
     mockConfirm.mockReset();
     consoleSpy?.mockRestore();
     errorSpy?.mockRestore();
@@ -117,7 +128,7 @@ describe("unlink", () => {
       await unlink();
 
       expect(mockRemoveProfile).not.toHaveBeenCalled();
-      const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+      const output = capturedOutput(consoleSpy);
       expect(output).toContain("Aborted");
     });
   });
@@ -132,7 +143,7 @@ describe("unlink", () => {
 
       await unlink({ yes: true });
 
-      const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+      const output = capturedOutput(consoleSpy);
       expect(output).toContain("Unlinked");
     });
   });

--- a/src/commands/unlink/index.ts
+++ b/src/commands/unlink/index.ts
@@ -1,9 +1,8 @@
 import { confirm } from "@inquirer/prompts";
 import { isAgent, isHuman } from "../../mode.js";
 import { resolveProfile, removeProfile } from "../../lib/config.js";
-
-const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
-const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;
+import { getGitRepoRoot } from "../../lib/git.js";
+import { dim, cyan } from "../../lib/color.js";
 
 const AGENT_PROMPT = `You are unlinking a Clerk application from the current project directory.
 
@@ -39,10 +38,12 @@ export async function unlink(options: UnlinkOptions = {}): Promise<void> {
   }
 
   const label = existing.profile.appId;
+  const repoRoot = await getGitRepoRoot();
+  const displayPath = repoRoot ?? existing.path;
 
   if (isHuman() && !options.yes) {
     const ok = await confirm({
-      message: `Unlink ${label} from ${existing.path}?`,
+      message: `Unlink ${label} from ${displayPath}?`,
       default: false,
     });
     if (!ok) {
@@ -52,5 +53,5 @@ export async function unlink(options: UnlinkOptions = {}): Promise<void> {
   }
 
   await removeProfile(existing.path);
-  console.log(`\nUnlinked ${cyan(label)} from ${dim(existing.path)}`);
+  console.log(`\nUnlinked ${cyan(label)} from ${dim(displayPath)}`);
 }

--- a/src/commands/whoami/index.test.ts
+++ b/src/commands/whoami/index.test.ts
@@ -1,13 +1,16 @@
 import { test, expect, describe, afterEach, mock, spyOn } from "bun:test";
+import { credentialStoreStubs, tokenExchangeStubs } from "../../test/stubs.ts";
 
 const mockGetToken = mock();
 const mockFetchUserInfo = mock();
 
 mock.module("../../lib/credential-store.ts", () => ({
+  ...credentialStoreStubs,
   getToken: (...args: unknown[]) => mockGetToken(...args),
 }));
 
 mock.module("../../lib/token-exchange.ts", () => ({
+  ...tokenExchangeStubs,
   fetchUserInfo: (...args: unknown[]) => mockFetchUserInfo(...args),
 }));
 

--- a/src/lib/color.ts
+++ b/src/lib/color.ts
@@ -1,0 +1,6 @@
+export const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
+export const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
+export const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;
+export const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
+export const yellow = (s: string) => `\x1b[33m${s}\x1b[0m`;
+export const blue = (s: string) => `\x1b[34m${s}\x1b[0m`;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -5,7 +5,8 @@
 
 import { dirname, join } from "node:path";
 import { mkdir } from "node:fs/promises";
-import { CLERK_HOME_DIR, CONFIG_FILE } from "./constants.ts";
+import { CONFIG_FILE } from "./constants.ts";
+import { getGitRepoIdentifier, getGitNormalizedRemote } from "./git.ts";
 
 let overrideConfigFile: string | undefined;
 
@@ -89,17 +90,51 @@ export async function removeProfile(path: string): Promise<void> {
   await writeConfig(config);
 }
 
+export async function moveProfile(oldKey: string, newKey: string): Promise<void> {
+  const config = await readConfig();
+  const profile = config.profiles[oldKey];
+  if (!profile) return;
+  config.profiles[newKey] = profile;
+  delete config.profiles[oldKey];
+  await writeConfig(config);
+}
+
 export async function listProfiles(): Promise<Record<string, Profile>> {
   const config = await readConfig();
   return config.profiles;
 }
 
-export async function resolveProfile(cwd: string): Promise<{ path: string; profile: Profile } | undefined> {
+type ResolvedVia = "remote" | "git-common-dir" | "directory";
+
+export async function resolveProfile(cwd: string): Promise<{
+  path: string;
+  profile: Profile;
+  resolvedVia: ResolvedVia;
+  availableRemote?: string;
+} | undefined> {
   const config = await readConfig();
+
+  // Try normalized remote URL first (cross-clone matching)
+  const normalizedRemote = await getGitNormalizedRemote();
+  if (normalizedRemote && config.profiles[normalizedRemote]) {
+    return { path: normalizedRemote, profile: config.profiles[normalizedRemote], resolvedVia: "remote" };
+  }
+
+  // For non-remote matches, include availableRemote when a remote URL exists
+  const fallbackFields = normalizedRemote ? { availableRemote: normalizedRemote } : {};
+
+  // Try git repo identifier (shared across worktrees, backward compat)
+  const repoId = await getGitRepoIdentifier();
+  if (repoId && config.profiles[repoId]) {
+    return { path: repoId, profile: config.profiles[repoId], resolvedVia: "git-common-dir", ...fallbackFields };
+  }
+
+  // Fall back to directory walking for backward compatibility
   let dir = cwd;
   while (true) {
-    if (config.profiles[dir]) {
-      return { path: dir, profile: config.profiles[dir] };
+    const profile = config.profiles[dir];
+    if (profile) {
+      return { path: dir, profile, resolvedVia: "directory", ...fallbackFields };
     }
     const parent = join(dir, "..");
     if (parent === dir) break;

--- a/src/lib/credential-store.test.ts
+++ b/src/lib/credential-store.test.ts
@@ -1,13 +1,44 @@
-import { test, expect, describe, beforeEach, afterAll } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
-import { join } from "node:path";
+import { test, expect, describe, beforeEach, afterAll, mock } from "bun:test";
+import { mkdtemp, rm, mkdir, chmod } from "node:fs/promises";
+import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 
 const tempDir = await mkdtemp(join(tmpdir(), "clerk-cred-test-"));
 
 // Redirect file-based credential storage to temp dir via env var
-// (constants.ts reads CLERK_CONFIG_DIR before falling back to ~/.clerk)
 process.env.CLERK_CONFIG_DIR = tempDir;
+
+// Re-register real credential-store to override any stale mocks from other test files
+const isMacOS = process.platform === "darwin";
+const KEYCHAIN_SERVICE = "clerk-cli";
+const KEYCHAIN_ACCOUNT = "oauth-access-token";
+const credFile = () => join(process.env.CLERK_CONFIG_DIR ?? join(require("os").homedir(), ".clerk"), "credentials");
+
+mock.module("./credential-store.ts", () => ({
+  async storeToken(token: string) {
+    if (isMacOS) {
+      try { await Bun.$`security add-generic-password -a ${KEYCHAIN_ACCOUNT} -s ${KEYCHAIN_SERVICE} -w ${token} -U`.quiet(); return; } catch {}
+    }
+    const f = credFile();
+    await mkdir(dirname(f), { recursive: true });
+    await Bun.write(f, token);
+    await chmod(f, 0o600);
+  },
+  async getToken() {
+    if (isMacOS) {
+      try { return (await Bun.$`security find-generic-password -a ${KEYCHAIN_ACCOUNT} -s ${KEYCHAIN_SERVICE} -w`.quiet()).text().trim(); } catch {}
+    }
+    const file = Bun.file(credFile());
+    if (!(await file.exists())) return null;
+    const content = await file.text();
+    return content.trim() || null;
+  },
+  async deleteToken() {
+    if (isMacOS) { try { await Bun.$`security delete-generic-password -a ${KEYCHAIN_ACCOUNT} -s ${KEYCHAIN_SERVICE}`.quiet(); } catch {} }
+    const file = Bun.file(credFile());
+    if (await file.exists()) await Bun.write(credFile(), "");
+  },
+}));
 
 const { storeToken, getToken, deleteToken } = await import("./credential-store.ts");
 

--- a/src/lib/git.test.ts
+++ b/src/lib/git.test.ts
@@ -1,0 +1,56 @@
+import { test, expect, describe } from "bun:test";
+import { normalizeGitRemoteUrl } from "./git.ts";
+
+describe("normalizeGitRemoteUrl", () => {
+  test("normalizes SSH SCP-style URL", () => {
+    expect(normalizeGitRemoteUrl("git@github.com:org/repo.git")).toBe("github.com/org/repo");
+  });
+
+  test("normalizes HTTPS URL with .git", () => {
+    expect(normalizeGitRemoteUrl("https://github.com/org/repo.git")).toBe("github.com/org/repo");
+  });
+
+  test("normalizes HTTPS URL without .git", () => {
+    expect(normalizeGitRemoteUrl("https://github.com/org/repo")).toBe("github.com/org/repo");
+  });
+
+  test("normalizes ssh:// protocol URL", () => {
+    expect(normalizeGitRemoteUrl("ssh://git@github.com/org/repo.git")).toBe("github.com/org/repo");
+  });
+
+  test("normalizes ssh:// with port", () => {
+    expect(normalizeGitRemoteUrl("ssh://git@github.com:22/org/repo.git")).toBe("github.com/org/repo");
+  });
+
+  test("normalizes HTTPS with user@", () => {
+    expect(normalizeGitRemoteUrl("https://user@github.com/org/repo.git")).toBe("github.com/org/repo");
+  });
+
+  test("normalizes git:// protocol", () => {
+    expect(normalizeGitRemoteUrl("git://github.com/org/repo.git")).toBe("github.com/org/repo");
+  });
+
+  test("lowercases everything", () => {
+    expect(normalizeGitRemoteUrl("git@GitHub.COM:MyOrg/MyRepo.git")).toBe("github.com/myorg/myrepo");
+  });
+
+  test("strips trailing slash", () => {
+    expect(normalizeGitRemoteUrl("https://github.com/org/repo/")).toBe("github.com/org/repo");
+  });
+
+  test("handles self-hosted GitLab URL", () => {
+    expect(normalizeGitRemoteUrl("git@gitlab.company.com:team/project.git")).toBe("gitlab.company.com/team/project");
+  });
+
+  test("handles Bitbucket SSH URL", () => {
+    expect(normalizeGitRemoteUrl("git@bitbucket.org:org/repo.git")).toBe("bitbucket.org/org/repo");
+  });
+
+  test("handles ssh:// with custom port", () => {
+    expect(normalizeGitRemoteUrl("ssh://git@git.example.com:2222/org/repo.git")).toBe("git.example.com/org/repo");
+  });
+
+  test("handles whitespace around URL", () => {
+    expect(normalizeGitRemoteUrl("  https://github.com/org/repo.git  ")).toBe("github.com/org/repo");
+  });
+});

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -1,0 +1,79 @@
+import { resolve } from "node:path";
+
+const $ = Bun.$;
+
+interface GitRepoInfo {
+  toplevel: string;
+  commonDir: string;
+  normalizedRemote?: string;
+}
+
+let cached: GitRepoInfo | undefined | null = null;
+
+async function getGitRepoInfo(): Promise<GitRepoInfo | undefined> {
+  if (cached !== null) return cached ?? undefined;
+
+  const result = await $`git rev-parse --show-toplevel --git-common-dir`.quiet().nothrow();
+  if (result.exitCode !== 0) {
+    cached = undefined;
+    return undefined;
+  }
+
+  const lines = result.text().trim().split("\n");
+  const toplevel = lines[0];
+  const commonDir = lines[1];
+  if (!toplevel || !commonDir) {
+    cached = undefined;
+    return undefined;
+  }
+
+  // Fetch remote URL (non-blocking since rev-parse already succeeded)
+  const remoteResult = await $`git remote get-url origin`.quiet().nothrow();
+  const rawRemote = remoteResult.exitCode === 0 ? remoteResult.text().trim() : undefined;
+
+  cached = {
+    toplevel,
+    commonDir: resolve(toplevel, commonDir),
+    normalizedRemote: rawRemote ? normalizeGitRemoteUrl(rawRemote) : undefined,
+  };
+  return cached;
+}
+
+export async function getGitRepoRoot(): Promise<string | undefined> {
+  const info = await getGitRepoInfo();
+  return info?.toplevel;
+}
+
+export async function getGitRepoIdentifier(): Promise<string | undefined> {
+  const info = await getGitRepoInfo();
+  return info?.commonDir;
+}
+
+export async function getGitNormalizedRemote(): Promise<string | undefined> {
+  const info = await getGitRepoInfo();
+  return info?.normalizedRemote;
+}
+
+export function normalizeGitRemoteUrl(raw: string): string {
+  let url = raw.trim();
+
+  // Handle SCP-style: git@host:org/repo.git (username may contain +)
+  const scpMatch = url.match(/^[\w.+-]+@([^:]+):(.+)$/);
+  if (scpMatch) {
+    url = `${scpMatch[1]}/${scpMatch[2]}`;
+  } else {
+    // Handle protocol URLs: https://, ssh://, git://
+    url = url.replace(/^[a-z+]+:\/\//, "");
+    // Strip user@
+    url = url.replace(/^[^@/]+@/, "");
+    // Strip port
+    url = url.replace(/:\d+(?=\/)/, "");
+  }
+
+  // Strip trailing .git
+  url = url.replace(/\.git$/, "");
+  // Strip trailing slash
+  url = url.replace(/\/$/, "");
+
+  return url.toLowerCase();
+}

--- a/src/lib/plapi.test.ts
+++ b/src/lib/plapi.test.ts
@@ -1,7 +1,9 @@
 import { test, expect, describe, beforeEach, afterEach, mock } from "bun:test";
+import { credentialStoreStubs, stubFetch } from "../test/stubs.ts";
 
 const mockGetToken = mock();
 mock.module("./credential-store.ts", () => ({
+  ...credentialStoreStubs,
   getToken: (...args: unknown[]) => mockGetToken(...args),
 }));
 
@@ -34,10 +36,10 @@ describe("plapi", () => {
     mockGetToken.mockResolvedValue("oauth_token_abc");
     process.env.CLERK_PLATFORM_API_KEY = "env_key_xyz";
     let capturedHeaders: Headers | undefined;
-    globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+    stubFetch(async (_input, init) => {
       capturedHeaders = new Headers(init?.headers);
       return new Response(JSON.stringify({}), { status: 200 });
-    };
+    });
 
     await fetchInstanceConfig("app_1", "ins_1");
     expect(capturedHeaders?.get("Authorization")).toBe("Bearer env_key_xyz");
@@ -47,10 +49,10 @@ describe("plapi", () => {
     delete process.env.CLERK_PLATFORM_API_KEY;
     mockGetToken.mockResolvedValue("oauth_token_abc");
     let capturedHeaders: Headers | undefined;
-    globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+    stubFetch(async (_input, init) => {
       capturedHeaders = new Headers(init?.headers);
       return new Response(JSON.stringify({}), { status: 200 });
-    };
+    });
 
     await fetchInstanceConfig("app_1", "ins_1");
     expect(capturedHeaders?.get("Authorization")).toBe("Bearer oauth_token_abc");
@@ -58,10 +60,10 @@ describe("plapi", () => {
 
   test("constructs correct URL", async () => {
     let requestedUrl = "";
-    globalThis.fetch = async (input: RequestInfo | URL) => {
+    stubFetch(async (input) => {
       requestedUrl = input.toString();
       return new Response(JSON.stringify({}), { status: 200 });
-    };
+    });
 
     await fetchInstanceConfig("app_abc", "ins_def");
     expect(requestedUrl).toBe(
@@ -71,10 +73,10 @@ describe("plapi", () => {
 
   test("sends Bearer token in Authorization header", async () => {
     let capturedHeaders: Headers | undefined;
-    globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+    stubFetch(async (_input, init) => {
       capturedHeaders = new Headers(init?.headers);
       return new Response(JSON.stringify({}), { status: 200 });
-    };
+    });
 
     await fetchInstanceConfig("app_1", "ins_1");
     expect(capturedHeaders?.get("Authorization")).toBe("Bearer test_key_123");
@@ -83,14 +85,14 @@ describe("plapi", () => {
 
   test("returns parsed JSON on success", async () => {
     const mockConfig = { session: { lifetime: 604800 }, sign_up: { mode: "public" } };
-    globalThis.fetch = async () => new Response(JSON.stringify(mockConfig), { status: 200 });
+    stubFetch(async () => new Response(JSON.stringify(mockConfig), { status: 200 }));
 
     const result = await fetchInstanceConfig("app_1", "ins_1");
     expect(result).toEqual(mockConfig);
   });
 
   test("throws PlapiError on non-2xx response", async () => {
-    globalThis.fetch = async () => new Response("Not Found", { status: 404 });
+    stubFetch(async () => new Response("Not Found", { status: 404 }));
 
     try {
       await fetchInstanceConfig("app_1", "ins_bad");
@@ -104,10 +106,10 @@ describe("plapi", () => {
 
   test("default base URL is api.clerk.com", async () => {
     let requestedUrl = "";
-    globalThis.fetch = async (input: RequestInfo | URL) => {
+    stubFetch(async (input) => {
       requestedUrl = input.toString();
       return new Response(JSON.stringify({}), { status: 200 });
-    };
+    });
 
     await fetchInstanceConfig("app_1", "ins_1");
     expect(requestedUrl).toStartWith("https://api.clerk.com/");
@@ -117,11 +119,11 @@ describe("plapi", () => {
     test("sends PUT method with correct URL", async () => {
       let capturedMethod = "";
       let capturedUrl = "";
-      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      stubFetch(async (input, init) => {
         capturedUrl = input.toString();
         capturedMethod = init?.method ?? "GET";
         return new Response(JSON.stringify({}), { status: 200 });
-      };
+      });
 
       await putInstanceConfig("app_abc", "ins_def", { session: { lifetime: 3600 } });
       expect(capturedMethod).toBe("PUT");
@@ -132,10 +134,10 @@ describe("plapi", () => {
 
     test("sends Content-Type and Authorization headers", async () => {
       let capturedHeaders: Headers | undefined;
-      globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+      stubFetch(async (_input, init) => {
         capturedHeaders = new Headers(init?.headers);
         return new Response(JSON.stringify({}), { status: 200 });
-      };
+      });
 
       await putInstanceConfig("app_1", "ins_1", {});
       expect(capturedHeaders?.get("Authorization")).toBe("Bearer test_key_123");
@@ -145,10 +147,10 @@ describe("plapi", () => {
 
     test("sends JSON body", async () => {
       let capturedBody = "";
-      globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+      stubFetch(async (_input, init) => {
         capturedBody = init?.body as string;
         return new Response(JSON.stringify({}), { status: 200 });
-      };
+      });
 
       const payload = { session: { lifetime: 3600 } };
       await putInstanceConfig("app_1", "ins_1", payload);
@@ -157,14 +159,14 @@ describe("plapi", () => {
 
     test("returns parsed JSON on success", async () => {
       const mockResult = { session: { lifetime: 3600 }, sign_up: { mode: "restricted" } };
-      globalThis.fetch = async () => new Response(JSON.stringify(mockResult), { status: 200 });
+      stubFetch(async () => new Response(JSON.stringify(mockResult), { status: 200 }));
 
       const result = await putInstanceConfig("app_1", "ins_1", { session: { lifetime: 3600 } });
       expect(result).toEqual(mockResult);
     });
 
     test("throws PlapiError on non-2xx response", async () => {
-      globalThis.fetch = async () => new Response("Bad Request", { status: 400 });
+      stubFetch(async () => new Response("Bad Request", { status: 400 }));
 
       try {
         await putInstanceConfig("app_1", "ins_1", {});
@@ -180,11 +182,11 @@ describe("plapi", () => {
     test("sends PATCH method with correct URL", async () => {
       let capturedMethod = "";
       let capturedUrl = "";
-      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      stubFetch(async (input, init) => {
         capturedUrl = input.toString();
         capturedMethod = init?.method ?? "GET";
         return new Response(JSON.stringify({}), { status: 200 });
-      };
+      });
 
       await patchInstanceConfig("app_abc", "ins_def", { session: { lifetime: 3600 } });
       expect(capturedMethod).toBe("PATCH");
@@ -195,10 +197,10 @@ describe("plapi", () => {
 
     test("sends Content-Type and Authorization headers", async () => {
       let capturedHeaders: Headers | undefined;
-      globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+      stubFetch(async (_input, init) => {
         capturedHeaders = new Headers(init?.headers);
         return new Response(JSON.stringify({}), { status: 200 });
-      };
+      });
 
       await patchInstanceConfig("app_1", "ins_1", {});
       expect(capturedHeaders?.get("Authorization")).toBe("Bearer test_key_123");
@@ -207,10 +209,10 @@ describe("plapi", () => {
 
     test("sends JSON body", async () => {
       let capturedBody = "";
-      globalThis.fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+      stubFetch(async (_input, init) => {
         capturedBody = init?.body as string;
         return new Response(JSON.stringify({}), { status: 200 });
-      };
+      });
 
       const payload = { sign_up: { mode: "restricted" } };
       await patchInstanceConfig("app_1", "ins_1", payload);
@@ -219,14 +221,14 @@ describe("plapi", () => {
 
     test("returns full config after merge", async () => {
       const mockResult = { session: { lifetime: 3600 }, sign_up: { mode: "public" } };
-      globalThis.fetch = async () => new Response(JSON.stringify(mockResult), { status: 200 });
+      stubFetch(async () => new Response(JSON.stringify(mockResult), { status: 200 }));
 
       const result = await patchInstanceConfig("app_1", "ins_1", { session: { lifetime: 3600 } });
       expect(result).toEqual(mockResult);
     });
 
     test("throws PlapiError on non-2xx response", async () => {
-      globalThis.fetch = async () => new Response("Unprocessable Entity", { status: 422 });
+      stubFetch(async () => new Response("Unprocessable Entity", { status: 422 }));
 
       try {
         await patchInstanceConfig("app_1", "ins_1", { bad: "config" });
@@ -241,10 +243,10 @@ describe("plapi", () => {
   describe("listApplications", () => {
     test("constructs correct URL", async () => {
       let requestedUrl = "";
-      globalThis.fetch = async (input: RequestInfo | URL) => {
+      stubFetch(async (input) => {
         requestedUrl = input.toString();
         return new Response(JSON.stringify([]), { status: 200 });
-      };
+      });
 
       await listApplications();
       expect(requestedUrl).toBe("https://api.clerk.com/v1/platform/applications");
@@ -255,15 +257,15 @@ describe("plapi", () => {
         { application_id: "app_1", instances: [] },
         { application_id: "app_2", instances: [] },
       ];
-      globalThis.fetch = async () =>
-        new Response(JSON.stringify(mockApps), { status: 200 });
+      stubFetch(async () =>
+        new Response(JSON.stringify(mockApps), { status: 200 }));
 
       const result = await listApplications();
       expect(result).toEqual(mockApps);
     });
 
     test("throws PlapiError on non-2xx response", async () => {
-      globalThis.fetch = async () => new Response("Forbidden", { status: 403 });
+      stubFetch(async () => new Response("Forbidden", { status: 403 }));
 
       try {
         await listApplications();

--- a/src/test/stubs.ts
+++ b/src/test/stubs.ts
@@ -1,0 +1,57 @@
+import type { spyOn } from "bun:test";
+
+export function capturedOutput(spy: ReturnType<typeof spyOn>): string {
+  return spy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+}
+
+const noop = async () => {};
+
+export const configStubs = {
+  _setConfigDir: () => {},
+  readConfig: noop,
+  writeConfig: noop,
+  getAuth: noop,
+  setAuth: noop,
+  clearAuth: noop,
+  getProfile: noop,
+  setProfile: noop,
+  removeProfile: noop,
+  moveProfile: noop,
+  listProfiles: noop,
+  resolveProfile: noop,
+  resolveInstanceId: () => ({ id: "", label: "" }),
+};
+
+export const credentialStoreStubs = {
+  getToken: async () => null,
+  storeToken: async () => {},
+  deleteToken: async () => {},
+};
+
+export const gitStubs = {
+  getGitRepoRoot: async () => undefined,
+  getGitRepoIdentifier: async () => undefined,
+  getGitNormalizedRemote: async () => undefined,
+  normalizeGitRemoteUrl: (url: string) => url,
+};
+
+export const promptsStubs = {
+  select: async () => undefined,
+  search: async () => undefined,
+  input: async () => "",
+  confirm: async () => true,
+  password: async () => "",
+  editor: async () => "{}",
+};
+
+export const tokenExchangeStubs = {
+  exchangeCodeForToken: async () => ({}),
+  fetchUserInfo: async () => ({}),
+  OAUTH_CONFIG: {},
+};
+
+type FetchImpl = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+export function stubFetch(impl: FetchImpl): void {
+  globalThis.fetch = impl as typeof fetch;
+}


### PR DESCRIPTION
## Summary

- Extract inline ANSI color helpers into a shared `src/lib/color.ts` module
- Add `src/lib/git.ts` utility for resolving git repo root, common-dir, and normalized remote URL (e.g. `github.com/org/repo`)
- `resolveProfile` now resolves by normalized remote URL → git common-dir → directory walk, enabling profiles to be shared across clones and worktrees of the same repository
- Add `moveProfile` for migrating old directory-keyed profiles to remote-based keys, with an interactive upgrade prompt
- Replace `select` with a searchable `search` picker in the link command (type-to-filter by app name)
- Show auto-link notice when a profile is resolved via a remote URL from another clone

## Test plan

- [x] Run `bun test` — all existing and new tests pass
- [x] `clerk link` in a repo with a remote stores the profile keyed by normalized remote URL
- [x] Clone the same repo elsewhere — `clerk link` auto-detects the existing link
- [x] `clerk link` in a repo without a remote falls back to git common-dir, then cwd
- [x] `clerk unlink` displays the repo root path in confirmation prompt
- [x] Searchable picker filters apps by name as you type
- [x] Existing directory-keyed profiles trigger an upgrade prompt to migrate to remote-based keys