### PR TITLE
feat(config): Schema support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Commands:
   whoami               Show the current logged-in user
   config               Manage instance configuration
     pull [options]     Pull instance configuration from Clerk
+    schema [options]   Pull instance config schema from Clerk
     patch [options]    Partially update instance configuration (PATCH)
     put [options]      Replace entire instance configuration (PUT)
   env                  Manage environment variables
@@ -44,6 +45,11 @@ clerk unlink
 clerk config pull
   --instance <id>      Instance to target (dev, prod, or a full instance ID)
   --output <file>      Write config to a file instead of stdout
+
+clerk config schema
+  --instance <id>      Instance to target (dev, prod, or a full instance ID)
+  --output <file>      Write schema to a file instead of stdout
+  --keys <keys...>     Config keys to retrieve schema for
 
 clerk config patch
   --instance <id>      Instance to target (dev, prod, or a full instance ID)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { pull } from "./commands/env/pull.js";
 import { deploy } from "./commands/deploy/index.js";
 import { configPull } from "./commands/config/pull.js";
 import { configPatch, configPut } from "./commands/config/push.js";
+import { configSchema } from "./commands/config/schema.js";
 import { api } from "./commands/api/index.js";
 import { link } from "./commands/link/index.js";
 import { unlink } from "./commands/unlink/index.js";
@@ -38,14 +39,9 @@ program
   .description("Initialize Clerk in your project")
   .action(init);
 
-const auth = program
-  .command("auth")
-  .description("Manage authentication");
+const auth = program.command("auth").description("Manage authentication");
 
-auth
-  .command("login")
-  .description("Log in to your Clerk account")
-  .action(login);
+auth.command("login").description("Log in to your Clerk account").action(login);
 
 auth
   .command("logout")
@@ -69,14 +65,15 @@ program
   .description("Show the current logged-in user")
   .action(whoami);
 
-const env = program
-  .command("env")
-  .description("Manage environment variables");
+const env = program.command("env").description("Manage environment variables");
 
 env
   .command("pull")
   .description("Pull environment variables from Clerk to .env.local")
-  .option("--instance <id>", "Instance to target (dev, prod, or a full instance ID)")
+  .option(
+    "--instance <id>",
+    "Instance to target (dev, prod, or a full instance ID)",
+  )
   .option("--file <path>", "Target env file (default: auto-detect)")
   .action(pull);
 
@@ -87,14 +84,31 @@ const config = program
 config
   .command("pull")
   .description("Pull instance configuration from Clerk")
-  .option("--instance <id>", "Instance to target (dev, prod, or a full instance ID)")
+  .option(
+    "--instance <id>",
+    "Instance to target (dev, prod, or a full instance ID)",
+  )
   .option("--output <file>", "Write config to a file instead of stdout")
   .action(configPull);
 
 config
+  .command("schema")
+  .description("Pull instance config schema from Clerk")
+  .option(
+    "--instance <id>",
+    "Instance to target (dev, prod, or a full instance ID)",
+  )
+  .option("--output <file>", "Write schema to a file instead of stdout")
+  .option("--keys <keys...>", "Config keys to retrieve schema for")
+  .action(configSchema);
+
+config
   .command("patch")
   .description("Partially update instance configuration (PATCH)")
-  .option("--instance <id>", "Instance to target (dev, prod, or a full instance ID)")
+  .option(
+    "--instance <id>",
+    "Instance to target (dev, prod, or a full instance ID)",
+  )
   .option("--file <path>", "Read config JSON from a file")
   .option("--json <string>", "Pass config JSON inline")
   .option("--dry-run", "Show what would be sent without making the API call")
@@ -104,7 +118,10 @@ config
 config
   .command("put")
   .description("Replace entire instance configuration (PUT)")
-  .option("--instance <id>", "Instance to target (dev, prod, or a full instance ID)")
+  .option(
+    "--instance <id>",
+    "Instance to target (dev, prod, or a full instance ID)",
+  )
   .option("--file <path>", "Read config JSON from a file")
   .option("--json <string>", "Pass config JSON inline")
   .option("--dry-run", "Show what would be sent without making the API call")
@@ -114,9 +131,15 @@ config
 program
   .command("api")
   .description("Make authenticated requests to the Clerk API")
-  .argument("[endpoint]", "API endpoint path, 'ls' to list endpoints, or omit for interactive mode")
+  .argument(
+    "[endpoint]",
+    "API endpoint path, 'ls' to list endpoints, or omit for interactive mode",
+  )
   .argument("[filter]", "Filter keyword (used with 'ls')")
-  .option("-X, --method <method>", "HTTP method (default: GET, or POST if body provided)")
+  .option(
+    "-X, --method <method>",
+    "HTTP method (default: GET, or POST if body provided)",
+  )
   .option("-d, --data <json>", "JSON request body")
   .option("--file <path>", "Read request body from a file")
   .option("--include", "Show response headers")

--- a/src/commands/config/README.md
+++ b/src/commands/config/README.md
@@ -36,6 +36,38 @@ All requests are made against the Clerk Platform API (default `https://api.clerk
 
 ---
 
+### `clerk config schema`
+
+Fetches the JSON Schema for an instance's configuration from the Clerk Platform API and outputs it as JSON.
+
+```sh
+clerk config schema
+clerk config schema --instance prod
+clerk config schema --output config-schema.json
+clerk config schema --keys session sign_up
+```
+
+#### Options
+
+| Flag | Description |
+|---|---|
+| `--instance <id>` | Instance to target (`dev`, `prod`, or a full instance ID). Defaults to development. |
+| `--output <file>` | Write schema to a file instead of stdout |
+| `--keys <keys...>` | Config keys to retrieve schema for |
+
+#### Requirements
+
+- Must have a Clerk project linked to the current directory (via `clerk init`)
+- Requires the `CLERK_PLATFORM_API_KEY` environment variable
+
+#### API Endpoints
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `GET` | `/v1/platform/applications/{appID}/instances/{instanceID}/config/schema` | Fetches the config JSON Schema. Supports optional `keys` query param to filter to specific config keys. Authenticated via `Bearer` token from `CLERK_PLATFORM_API_KEY`. |
+
+---
+
 ### `clerk config patch`
 
 Partially updates instance configuration using a PATCH request. Only the fields you include in the payload are modified; everything else remains unchanged.

--- a/src/commands/config/push.test.ts
+++ b/src/commands/config/push.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { _setConfigDir, setProfile } from "../../lib/config";
+import { _setTokenOverride } from "../../lib/credential-store";
 
 describe("config push", () => {
   const originalEnv = { ...process.env };
@@ -35,6 +36,7 @@ describe("config push", () => {
 
   afterEach(async () => {
     _setConfigDir(undefined);
+    _setTokenOverride(undefined);
     process.env = { ...originalEnv };
     globalThis.fetch = originalFetch;
     logSpy.mockRestore();
@@ -69,6 +71,7 @@ describe("config push", () => {
       instances: { development: "ins_dev" },
     });
     delete process.env.CLERK_PLATFORM_API_KEY;
+    _setTokenOverride(null);
 
     await expect(runConfigPatch({ json: '{"a":1}', yes: true })).rejects.toThrow("process.exit");
     expect(errorSpy).toHaveBeenCalledWith(

--- a/src/commands/config/schema.test.ts
+++ b/src/commands/config/schema.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { _setConfigDir, setProfile } from "../../lib/config";
 import { _setTokenOverride } from "../../lib/credential-store";
 
-describe("config pull", () => {
+describe("config schema", () => {
   const originalEnv = { ...process.env };
   const originalFetch = globalThis.fetch;
   let tempDir: string;
@@ -13,13 +13,18 @@ describe("config pull", () => {
   let errorSpy: ReturnType<typeof spyOn>;
   let exitSpy: ReturnType<typeof spyOn>;
 
-  const mockConfig = {
-    session: { lifetime: 604800 },
-    sign_up: { mode: "public" },
+  const mockSchema = {
+    type: "object",
+    properties: {
+      session: {
+        type: "object",
+        properties: { lifetime: { type: "integer" } },
+      },
+    },
   };
 
   beforeEach(async () => {
-    tempDir = await mkdtemp(join(tmpdir(), "clerk-config-pull-test-"));
+    tempDir = await mkdtemp(join(tmpdir(), "clerk-config-schema-test-"));
     _setConfigDir(tempDir);
     process.env.CLERK_PLATFORM_API_KEY = "test_key";
     process.env.CLERK_PLATFORM_API_URL = "https://test-api.clerk.com";
@@ -31,7 +36,7 @@ describe("config pull", () => {
     });
 
     globalThis.fetch = async () =>
-      new Response(JSON.stringify(mockConfig), { status: 200 });
+      new Response(JSON.stringify(mockSchema), { status: 200 });
   });
 
   afterEach(async () => {
@@ -45,14 +50,15 @@ describe("config pull", () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
-  // Dynamically import to get fresh module state
-  async function runConfigPull(options: { instance?: string; output?: string } = {}) {
-    const { configPull } = await import("./pull");
-    return configPull(options);
+  async function runConfigSchema(
+    options: { instance?: string; output?: string; keys?: string[] } = {},
+  ) {
+    const { configSchema } = await import("./schema");
+    return configSchema(options);
   }
 
   test("errors when no profile is linked", async () => {
-    await expect(runConfigPull()).rejects.toThrow("process.exit");
+    await expect(runConfigSchema()).rejects.toThrow("process.exit");
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining("No Clerk project linked"),
     );
@@ -67,35 +73,37 @@ describe("config pull", () => {
     delete process.env.CLERK_PLATFORM_API_KEY;
     _setTokenOverride(null);
 
-    await expect(runConfigPull()).rejects.toThrow("process.exit");
+    await expect(runConfigSchema()).rejects.toThrow("process.exit");
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining("CLERK_PLATFORM_API_KEY"),
     );
   });
 
-  test("prints config JSON to stdout by default", async () => {
+  test("prints schema JSON to stdout by default", async () => {
     await setProfile(process.cwd(), {
       workspaceId: "org_1",
       appId: "app_1",
       instances: { development: "ins_dev" },
     });
 
-    await runConfigPull();
-    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(mockConfig, null, 2));
+    await runConfigSchema();
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(mockSchema, null, 2));
   });
 
-  test("writes config to file with --output", async () => {
+  test("writes schema to file with --output", async () => {
     await setProfile(process.cwd(), {
       workspaceId: "org_1",
       appId: "app_1",
       instances: { development: "ins_dev" },
     });
-    const outFile = join(tempDir, "output.json");
+    const outFile = join(tempDir, "schema.json");
 
-    await runConfigPull({ output: outFile });
+    await runConfigSchema({ output: outFile });
     const written = await Bun.file(outFile).json();
-    expect(written).toEqual(mockConfig);
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("Config written to"));
+    expect(written).toEqual(mockSchema);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Schema written to"),
+    );
   });
 
   test("shows which environment is being pulled", async () => {
@@ -105,8 +113,10 @@ describe("config pull", () => {
       instances: { development: "ins_dev" },
     });
 
-    await runConfigPull();
-    expect(errorSpy).toHaveBeenCalledWith("Pulling config from development instance...");
+    await runConfigSchema();
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Pulling config schema from development instance...",
+    );
   });
 
   test("shows production label when --instance prod", async () => {
@@ -116,15 +126,17 @@ describe("config pull", () => {
       instances: { development: "ins_dev", production: "ins_prod" },
     });
 
-    await runConfigPull({ instance: "prod" });
-    expect(errorSpy).toHaveBeenCalledWith("Pulling config from production instance...");
+    await runConfigSchema({ instance: "prod" });
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Pulling config schema from production instance...",
+    );
   });
 
   test("uses development instance by default", async () => {
     let requestedUrl = "";
     globalThis.fetch = async (input: RequestInfo | URL) => {
       requestedUrl = input.toString();
-      return new Response(JSON.stringify(mockConfig), { status: 200 });
+      return new Response(JSON.stringify(mockSchema), { status: 200 });
     };
 
     await setProfile(process.cwd(), {
@@ -133,7 +145,7 @@ describe("config pull", () => {
       instances: { development: "ins_dev", production: "ins_prod" },
     });
 
-    await runConfigPull();
+    await runConfigSchema();
     expect(requestedUrl).toContain("/instances/ins_dev/");
   });
 
@@ -141,7 +153,7 @@ describe("config pull", () => {
     let requestedUrl = "";
     globalThis.fetch = async (input: RequestInfo | URL) => {
       requestedUrl = input.toString();
-      return new Response(JSON.stringify(mockConfig), { status: 200 });
+      return new Response(JSON.stringify(mockSchema), { status: 200 });
     };
 
     await setProfile(process.cwd(), {
@@ -150,7 +162,7 @@ describe("config pull", () => {
       instances: { development: "ins_dev", production: "ins_prod" },
     });
 
-    await runConfigPull({ instance: "prod" });
+    await runConfigSchema({ instance: "prod" });
     expect(requestedUrl).toContain("/instances/ins_prod/");
   });
 
@@ -158,7 +170,7 @@ describe("config pull", () => {
     let requestedUrl = "";
     globalThis.fetch = async (input: RequestInfo | URL) => {
       requestedUrl = input.toString();
-      return new Response(JSON.stringify(mockConfig), { status: 200 });
+      return new Response(JSON.stringify(mockSchema), { status: 200 });
     };
 
     await setProfile(process.cwd(), {
@@ -167,8 +179,27 @@ describe("config pull", () => {
       instances: { development: "ins_dev" },
     });
 
-    await runConfigPull({ instance: "ins_custom_123" });
+    await runConfigSchema({ instance: "ins_custom_123" });
     expect(requestedUrl).toContain("/instances/ins_custom_123/");
+  });
+
+  test("passes --keys to API as query params", async () => {
+    let requestedUrl = "";
+    globalThis.fetch = async (input: RequestInfo | URL) => {
+      requestedUrl = input.toString();
+      return new Response(JSON.stringify(mockSchema), { status: 200 });
+    };
+
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigSchema({ keys: ["session", "sign_up"] });
+    expect(requestedUrl).toContain("keys=session");
+    expect(requestedUrl).toContain("keys=sign_up");
+    expect(requestedUrl).toContain("/config/schema");
   });
 
   test("errors when production instance not configured", async () => {
@@ -178,14 +209,17 @@ describe("config pull", () => {
       instances: { development: "ins_dev" },
     });
 
-    await expect(runConfigPull({ instance: "prod" })).rejects.toThrow("process.exit");
+    await expect(runConfigSchema({ instance: "prod" })).rejects.toThrow(
+      "process.exit",
+    );
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining("No production instance configured"),
     );
   });
 
   test("handles API errors gracefully", async () => {
-    globalThis.fetch = async () => new Response("Unauthorized", { status: 401 });
+    globalThis.fetch = async () =>
+      new Response("Unauthorized", { status: 401 });
 
     await setProfile(process.cwd(), {
       workspaceId: "org_1",
@@ -193,9 +227,9 @@ describe("config pull", () => {
       instances: { development: "ins_dev" },
     });
 
-    await expect(runConfigPull()).rejects.toThrow("process.exit");
+    await expect(runConfigSchema()).rejects.toThrow("process.exit");
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Failed to fetch config"),
+      expect.stringContaining("Failed to fetch config schema"),
     );
   });
 });

--- a/src/commands/config/schema.ts
+++ b/src/commands/config/schema.ts
@@ -13,7 +13,7 @@ export async function configSchema(
   const resolved = await resolveProfile(process.cwd());
   if (!resolved) {
     console.error(
-      "No Clerk project linked to this directory. Run `clerk init` to set up.",
+      "No Clerk project linked to this directory. Run `clerk link` to set up.",
     );
     process.exit(1);
   }

--- a/src/commands/config/schema.ts
+++ b/src/commands/config/schema.ts
@@ -1,0 +1,61 @@
+import { resolveProfile, resolveInstanceId } from "../../lib/config.ts";
+import { fetchInstanceConfigSchema, PlapiError } from "../../lib/plapi.ts";
+
+interface ConfigSchemaOptions {
+  instance?: string;
+  output?: string;
+  keys?: string[];
+}
+
+export async function configSchema(
+  options: ConfigSchemaOptions,
+): Promise<void> {
+  const resolved = await resolveProfile(process.cwd());
+  if (!resolved) {
+    console.error(
+      "No Clerk project linked to this directory. Run `clerk init` to set up.",
+    );
+    process.exit(1);
+  }
+
+  const { profile } = resolved;
+
+  let instance: { id: string; label: string };
+  try {
+    instance = resolveInstanceId(profile, options.instance);
+  } catch (error) {
+    console.error((error as Error).message);
+    process.exit(1);
+  }
+
+  // Use `console.error` for informational messages so stdout is just the JSON response.
+  console.error(`Pulling config schema from ${instance.label} instance...`);
+
+  let schema: Record<string, unknown>;
+  try {
+    schema = await fetchInstanceConfigSchema(
+      profile.appId,
+      instance.id,
+      options.keys,
+    );
+  } catch (error) {
+    if (error instanceof PlapiError) {
+      console.error(`Failed to fetch config schema: ${error.message}`);
+      process.exit(1);
+    }
+    if (error instanceof Error) {
+      console.error(error.message);
+      process.exit(1);
+    }
+    throw error;
+  }
+
+  const json = JSON.stringify(schema, null, 2);
+
+  if (options.output) {
+    await Bun.write(options.output, json + "\n");
+    console.error(`Schema written to ${options.output}`);
+  } else {
+    console.log(json);
+  }
+}

--- a/src/commands/env/pull.test.ts
+++ b/src/commands/env/pull.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { _setConfigDir, setProfile } from "../../lib/config";
+import { _setTokenOverride } from "../../lib/credential-store";
 
 describe("env pull", () => {
   const originalEnv = { ...process.env };
@@ -56,6 +57,7 @@ describe("env pull", () => {
 
   afterEach(async () => {
     _setConfigDir(undefined);
+    _setTokenOverride(undefined);
     process.env = { ...originalEnv };
     process.cwd = originalCwd;
     globalThis.fetch = originalFetch;
@@ -83,6 +85,7 @@ describe("env pull", () => {
       instances: { development: "ins_dev" },
     });
     delete process.env.CLERK_PLATFORM_API_KEY;
+    _setTokenOverride(null);
 
     await expect(runEnvPull()).rejects.toThrow("process.exit");
     expect(errorSpy).toHaveBeenCalledWith(

--- a/src/lib/credential-store.ts
+++ b/src/lib/credential-store.ts
@@ -71,7 +71,15 @@ export async function storeToken(token: string): Promise<void> {
   }
 }
 
+let tokenOverride: string | null | undefined;
+
+/** Test-only: override getToken() result. Pass undefined to clear. */
+export function _setTokenOverride(value: string | null | undefined): void {
+  tokenOverride = value;
+}
+
 export async function getToken(): Promise<string | null> {
+  if (tokenOverride !== undefined) return tokenOverride;
   const token = await keychainGet();
   if (token) return token;
   return fileGet();

--- a/src/lib/plapi.ts
+++ b/src/lib/plapi.ts
@@ -30,6 +30,35 @@ async function getAuthToken(): Promise<string> {
   );
 }
 
+export async function fetchInstanceConfigSchema(
+  applicationId: string,
+  instanceId: string,
+  keys?: string[],
+): Promise<Record<string, unknown>> {
+  const token = await getAuthToken();
+  const url = new URL(
+    `${PLAPI_BASE_URL}/v1/platform/applications/${applicationId}/instances/${instanceId}/config/schema`,
+  );
+  if (keys?.length) {
+    for (const key of keys) {
+      url.searchParams.append("keys", key);
+    }
+  }
+  const response = await fetch(url.toString(), {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new PlapiError(response.status, body);
+  }
+
+  return response.json() as Promise<Record<string, unknown>>;
+}
+
 export async function fetchInstanceConfig(
   applicationId: string,
   instanceId: string,


### PR DESCRIPTION
Implement `config schema` command to allow fetching the schema from PLAPI. This will make Clerk CLI config self-documenting, to an extent. The bare command dumps the whole schema, there is also a `--keys` argument to dump only a specific key. This can be useful to save context.