### PR TITLE
refactor: centralize error handling with typed error classes

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,13 @@
+{
+  "rules": {
+    "unicorn/no-process-exit": "error"
+  },
+  "overrides": [
+    {
+      "files": ["src/cli.ts"],
+      "rules": {
+        "unicorn/no-process-exit": "off"
+      }
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,3 +126,62 @@ When creating or modifying a command, evaluate whether it needs an agent mode. C
 ### Root README
 
 `README.md` at the project root contains the CLI help output. When commands are added, removed, or their options change, update the help output in `README.md` to stay in sync. You can regenerate it by running `bun run src/cli.ts --help`.
+
+## Error Handling
+
+All error classes and helpers live in `src/lib/errors.ts`. The global error handler in `src/cli.ts` catches thrown errors and formats them for the user. **Never call `console.error` + `process.exit` directly in commands** — throw an error instead and let the global handler deal with output and exit codes.
+
+### Known failures — `CliError`
+
+For user-facing errors (missing config, invalid input, resource not found), throw a `CliError`:
+
+```ts
+import { CliError } from "../../lib/errors.ts";
+
+throw new CliError("No Clerk project linked. Run `clerk link` first.");
+
+// With a docs URL (automatically gets .md appended in agent mode for Clerk URLs):
+throw new CliError("Not authenticated.", {
+  docsUrl: "https://clerk.com/docs/guides/development/clerk-environment-variables",
+});
+```
+
+### Usage/validation errors — `throwUsageError`
+
+For invalid arguments or options, use `throwUsageError` (exits with code 2):
+
+```ts
+import { throwUsageError } from "../../lib/errors.ts";
+
+if (!secretKey) {
+  throwUsageError("No secret key found. Set CLERK_SECRET_KEY or use --secret-key.");
+}
+```
+
+### User cancellation — `throwUserAbort`
+
+When the user cancels a prompt or confirmation, call `throwUserAbort()`. The global handler exits cleanly with no error output:
+
+```ts
+import { throwUserAbort } from "../../lib/errors.ts";
+
+const confirmed = await confirm({ message: "Proceed?" });
+if (!confirmed) throwUserAbort();
+```
+
+### API errors — `withApiContext`
+
+Wrap API calls with `withApiContext` to attach a human-readable context string. The global handler extracts the first error message from the response body and prints it with the context prefix:
+
+```ts
+import { withApiContext } from "../../lib/errors.ts";
+
+const config = await withApiContext(
+  fetchInstanceConfig(appId, instanceId),
+  "Failed to fetch config",
+);
+```
+
+### API error classes
+
+`BapiError` and `PlapiError` (both extend `ApiError`) are thrown by the API helpers in `src/commands/api/bapi.ts` and `src/lib/plapi.ts` respectively. Don't construct these in commands — they're thrown automatically by the fetch wrappers. Use `withApiContext` to add context when calling those helpers.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,18 @@ import { configSchema } from "./commands/config/schema.js";
 import { api } from "./commands/api/index.js";
 import { link } from "./commands/link/index.js";
 import { unlink } from "./commands/unlink/index.js";
+import {
+  CliError,
+  UserAbortError,
+  ApiError,
+  BapiError,
+  PlapiError,
+  EXIT_CODE,
+  usageError,
+} from "./lib/errors.js";
+import { red } from "./lib/color.js";
+
+process.on("SIGINT", () => process.exit(EXIT_CODE.SIGINT));
 
 program
   .name("clerk")
@@ -21,14 +33,14 @@ program
   .option(
     "--mode <mode>",
     "Force interaction mode (human or agent). Defaults to auto-detect based on TTY.",
-  );
+  )
+  .option("--verbose", "Show detailed error output");
 
 program.hook("preAction", () => {
   const opts = program.opts();
   if (opts.mode) {
     if (opts.mode !== "human" && opts.mode !== "agent") {
-      console.error(`Invalid mode "${opts.mode}". Must be "human" or "agent".`);
-      process.exit(1);
+      usageError(`Invalid mode "${opts.mode}". Must be "human" or "agent".`);
     }
     setMode(opts.mode as Mode);
   }
@@ -124,4 +136,65 @@ program
   .option("--debug", "Show debug output")
   .action(deploy);
 
-program.parse();
+function formatApiBody(body: string, verbose: boolean): string {
+  if (verbose) {
+    try {
+      return "\n" + JSON.stringify(JSON.parse(body), null, 2);
+    } catch {
+      return "\n" + body;
+    }
+  }
+
+  try {
+    const parsed = JSON.parse(body);
+    if (parsed.errors?.[0]?.message) return parsed.errors[0].message;
+    if (parsed.error) return parsed.error;
+    if (parsed.message) return parsed.message;
+  } catch {
+    // not JSON
+  }
+
+  if (body.length > 200) return body.slice(0, 200) + "...";
+  return body;
+}
+
+async function main(): Promise<void> {
+  try {
+    await program.parseAsync();
+  } catch (error) {
+    const verbose = program.opts().verbose ?? false;
+
+    if (error instanceof UserAbortError) {
+      process.exit(EXIT_CODE.SUCCESS);
+    }
+
+    if (error instanceof CliError) {
+      if (error.message) {
+        console.error(red(`error: ${error.message}`));
+      }
+      if (error.docsUrl) {
+        console.error(`\nFor more information, see: ${error.docsUrl}`);
+      }
+      process.exit(error.exitCode);
+    }
+
+    if (error instanceof ApiError) {
+      let label = "API";
+      if (error instanceof BapiError) label = "Backend API";
+      else if (error instanceof PlapiError) label = "Platform API";
+      const detail = formatApiBody(error.body, verbose);
+      console.error(red(`error: ${label} request failed (${error.status}): ${detail}`));
+      process.exit(EXIT_CODE.GENERAL);
+    }
+
+    if (error instanceof Error) {
+      console.error(red(`error: ${error.message}`));
+      process.exit(EXIT_CODE.GENERAL);
+    }
+
+    console.error(red("error: An unexpected error occurred"));
+    process.exit(EXIT_CODE.GENERAL);
+  }
+}
+
+main();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ import { configSchema } from "./commands/config/schema.js";
 import { api } from "./commands/api/index.js";
 import { link } from "./commands/link/index.js";
 import { unlink } from "./commands/unlink/index.js";
-import { CliError, UserAbortError, ApiError, EXIT_CODE, usageError } from "./lib/errors.js";
+import { CliError, UserAbortError, ApiError, EXIT_CODE, throwUsageError } from "./lib/errors.js";
 import { red } from "./lib/color.js";
 
 process.on("SIGINT", () => process.exit(EXIT_CODE.SIGINT));
@@ -32,7 +32,7 @@ program.hook("preAction", () => {
   const opts = program.opts();
   if (opts.mode) {
     if (opts.mode !== "human" && opts.mode !== "agent") {
-      usageError(`Invalid mode "${opts.mode}". Must be "human" or "agent".`);
+      throwUsageError(`Invalid mode "${opts.mode}". Must be "human" or "agent".`);
     }
     setMode(opts.mode as Mode);
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,15 +13,7 @@ import { configSchema } from "./commands/config/schema.js";
 import { api } from "./commands/api/index.js";
 import { link } from "./commands/link/index.js";
 import { unlink } from "./commands/unlink/index.js";
-import {
-  CliError,
-  UserAbortError,
-  ApiError,
-  BapiError,
-  PlapiError,
-  EXIT_CODE,
-  usageError,
-} from "./lib/errors.js";
+import { CliError, UserAbortError, ApiError, EXIT_CODE, usageError } from "./lib/errors.js";
 import { red } from "./lib/color.js";
 
 process.on("SIGINT", () => process.exit(EXIT_CODE.SIGINT));
@@ -179,11 +171,9 @@ async function main(): Promise<void> {
     }
 
     if (error instanceof ApiError) {
-      let label = "API";
-      if (error instanceof BapiError) label = "Backend API";
-      else if (error instanceof PlapiError) label = "Platform API";
       const detail = formatApiBody(error.body, verbose);
-      console.error(red(`error: ${label} request failed (${error.status}): ${detail}`));
+      const prefix = error.context ?? "Request failed";
+      console.error(red(`error: ${prefix} (${error.status}): ${detail}`));
       process.exit(EXIT_CODE.GENERAL);
     }
 

--- a/src/commands/api/bapi.test.ts
+++ b/src/commands/api/bapi.test.ts
@@ -1,6 +1,7 @@
 import { test, expect, describe, afterEach } from "bun:test";
 import { stubFetch } from "../../test/stubs.ts";
-import { bapiRequest, BapiError } from "./bapi";
+import { bapiRequest } from "./bapi";
+import { BapiError } from "../../lib/errors";
 
 describe("bapi", () => {
   const originalFetch = globalThis.fetch;

--- a/src/commands/api/bapi.ts
+++ b/src/commands/api/bapi.ts
@@ -4,17 +4,7 @@
  */
 
 import { BAPI_BASE_URL } from "../../lib/constants.ts";
-
-export class BapiError extends Error {
-  constructor(
-    public status: number,
-    public body: string,
-    public headers: Headers,
-  ) {
-    super(`Backend API error (${status}): ${body}`);
-    this.name = "BapiError";
-  }
-}
+import { BapiError } from "../../lib/errors.ts";
 
 export interface BapiResponse {
   status: number;

--- a/src/commands/api/catalog.ts
+++ b/src/commands/api/catalog.ts
@@ -7,6 +7,7 @@ import { parse as parseYaml } from "yaml";
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { CLERK_CACHE_DIR, CACHE_TTL_MS, OPENAPI_SPEC_URLS } from "../../lib/constants.ts";
+import { CliError } from "../../lib/errors.ts";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -138,7 +139,7 @@ export async function loadCatalog(options: { platform?: boolean } = {}): Promise
       console.error("Warning: Unable to refresh API catalog, using cached version.");
       return cached;
     }
-    throw new Error(
+    throw new CliError(
       `Unable to fetch API catalog. Check your network connection.\n` +
         `  URL: ${url}\n` +
         `  ${(error as Error).message}`,

--- a/src/commands/api/index.test.ts
+++ b/src/commands/api/index.test.ts
@@ -102,7 +102,7 @@ describe("api command", () => {
     logSpy.mockRestore();
     errorSpy.mockRestore();
     exitSpy.mockRestore();
-    process.exitCode = undefined;
+    process.exitCode = 0;
     await rm(tempDir, { recursive: true, force: true });
   });
 

--- a/src/commands/api/index.test.ts
+++ b/src/commands/api/index.test.ts
@@ -102,6 +102,7 @@ describe("api command", () => {
     logSpy.mockRestore();
     errorSpy.mockRestore();
     exitSpy.mockRestore();
+    process.exitCode = undefined;
     await rm(tempDir, { recursive: true, force: true });
   });
 
@@ -199,9 +200,8 @@ describe("api command", () => {
 
   test("errors when --file does not exist", async () => {
     await expect(runApi("/users", { file: "/tmp/nonexistent-file.json" })).rejects.toThrow(
-      "process.exit",
+      "File not found",
     );
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("File not found"));
   });
 
   // --- --include option ---
@@ -275,9 +275,8 @@ describe("api command", () => {
     delete process.env.CLERK_PLATFORM_API_KEY;
 
     await expect(runApi("/v1/platform/applications", { platform: true })).rejects.toThrow(
-      "process.exit",
+      "CLERK_PLATFORM_API_KEY",
     );
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("CLERK_PLATFORM_API_KEY"));
   });
 
   // --- Error handling ---
@@ -285,15 +284,15 @@ describe("api command", () => {
   test("errors when no secret key available", async () => {
     delete process.env.CLERK_SECRET_KEY;
 
-    await expect(runApi("/users")).rejects.toThrow("process.exit");
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("No secret key found"));
+    await expect(runApi("/users")).rejects.toThrow("No secret key found");
   });
 
   test("prints API error response body to stdout and exits 1", async () => {
     const errorBody = { errors: [{ message: "not found", code: "resource_not_found" }] };
     stubFetch(async () => new Response(JSON.stringify(errorBody), { status: 404 }));
 
-    await expect(runApi("/users/bad_id")).rejects.toThrow("process.exit");
+    await runApi("/users/bad_id");
+    expect(process.exitCode).toBe(1);
     expect(logSpy).toHaveBeenCalledWith(JSON.stringify(errorBody, null, 2));
   });
 
@@ -306,7 +305,8 @@ describe("api command", () => {
         }),
     );
 
-    await expect(runApi("/users", { include: true })).rejects.toThrow("process.exit");
+    await runApi("/users", { include: true });
+    expect(process.exitCode).toBe(1);
     expect(errorSpy).toHaveBeenCalledWith("HTTP 400");
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("x-request-id: req_err"));
   });

--- a/src/commands/api/index.ts
+++ b/src/commands/api/index.ts
@@ -3,7 +3,13 @@ import { resolveProfile, resolveInstanceId } from "../../lib/config.ts";
 import { fetchApplication } from "../../lib/plapi.ts";
 import { BAPI_BASE_URL, PLAPI_BASE_URL } from "../../lib/constants.ts";
 import { bapiRequest } from "./bapi.ts";
-import { BapiError, CliError, usageError, userAbort, withApiContext } from "../../lib/errors.ts";
+import {
+  BapiError,
+  CliError,
+  throwUsageError,
+  throwUserAbort,
+  withApiContext,
+} from "../../lib/errors.ts";
 import { isHuman } from "../../mode.ts";
 
 export interface ApiOptions {
@@ -50,7 +56,7 @@ export async function api(
   if (options.platform) {
     const key = process.env.CLERK_PLATFORM_API_KEY;
     if (!key) {
-      usageError(
+      throwUsageError(
         "CLERK_PLATFORM_API_KEY environment variable is required for --platform mode.",
         "https://clerk.com/docs/guides/development/clerk-environment-variables",
       );
@@ -79,7 +85,7 @@ export async function api(
     }
     const ok = await confirm({ message: "Proceed?" });
     if (!ok) {
-      userAbort();
+      throwUserAbort();
     }
   }
 
@@ -122,7 +128,7 @@ async function resolveSecretKey(options: ApiOptions): Promise<string> {
   const platformKey = process.env.CLERK_PLATFORM_API_KEY;
 
   if (!resolved || !platformKey) {
-    usageError(
+    throwUsageError(
       "No secret key found. Provide one via:\n" +
         "  --secret-key <key>\n" +
         "  CLERK_SECRET_KEY environment variable\n" +
@@ -152,7 +158,7 @@ async function resolveBody(options: { data?: string; file?: string }): Promise<s
   if (options.file) {
     const file = Bun.file(options.file);
     if (!(await file.exists())) {
-      usageError(`File not found: ${options.file}`);
+      throwUsageError(`File not found: ${options.file}`);
     }
     return file.text();
   }

--- a/src/commands/api/index.ts
+++ b/src/commands/api/index.ts
@@ -1,8 +1,9 @@
 import { confirm } from "@inquirer/prompts";
 import { resolveProfile, resolveInstanceId } from "../../lib/config.ts";
-import { fetchApplication, PlapiError } from "../../lib/plapi.ts";
+import { fetchApplication } from "../../lib/plapi.ts";
 import { BAPI_BASE_URL, PLAPI_BASE_URL } from "../../lib/constants.ts";
-import { bapiRequest, BapiError } from "./bapi.ts";
+import { bapiRequest } from "./bapi.ts";
+import { BapiError, CliError, usageError, userAbort } from "../../lib/errors.ts";
 import { isHuman } from "../../mode.ts";
 
 export interface ApiOptions {
@@ -49,8 +50,10 @@ export async function api(
   if (options.platform) {
     const key = process.env.CLERK_PLATFORM_API_KEY;
     if (!key) {
-      console.error("CLERK_PLATFORM_API_KEY environment variable is required for --platform mode.");
-      process.exit(1);
+      usageError(
+        "CLERK_PLATFORM_API_KEY environment variable is required for --platform mode.",
+        "https://clerk.com/docs/guides/development/clerk-environment-variables",
+      );
     }
     secretKey = key;
     baseUrl = PLAPI_BASE_URL;
@@ -76,8 +79,7 @@ export async function api(
     }
     const ok = await confirm({ message: "Proceed?" });
     if (!ok) {
-      console.error("Aborted.");
-      process.exit(0);
+      userAbort();
     }
   }
 
@@ -96,16 +98,15 @@ export async function api(
     }
     printBody(response.body);
   } catch (error) {
+    // Handle BapiError locally to print the raw API response body to stdout
+    // (for piping), rather than propagating to the global error handler.
     if (error instanceof BapiError) {
       if (options.include) {
         printHeaders(error.status, error.headers);
       }
       prettyPrint(error.body);
-      process.exit(1);
-    }
-    if (error instanceof Error) {
-      console.error(error.message);
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
     throw error;
   }
@@ -118,51 +119,31 @@ async function resolveSecretKey(options: ApiOptions): Promise<string> {
 
   // Resolve from linked profile via Platform API
   const resolved = await resolveProfile(process.cwd());
-  if (!resolved) {
-    console.error(
+  const platformKey = process.env.CLERK_PLATFORM_API_KEY;
+
+  if (!resolved || !platformKey) {
+    usageError(
       "No secret key found. Provide one via:\n" +
         "  --secret-key <key>\n" +
         "  CLERK_SECRET_KEY environment variable\n" +
-        "  Link a project with `clerk init` and set CLERK_PLATFORM_API_KEY",
+        (resolved
+          ? "  Set CLERK_PLATFORM_API_KEY to auto-resolve from your linked project"
+          : "  Link a project with `clerk link` and set CLERK_PLATFORM_API_KEY"),
+      "https://clerk.com/docs/guides/development/clerk-environment-variables",
     );
-    process.exit(1);
   }
 
   const { profile } = resolved;
-  const platformKey = process.env.CLERK_PLATFORM_API_KEY;
-  if (!platformKey) {
-    console.error(
-      "No secret key found. Provide one via:\n" +
-        "  --secret-key <key>\n" +
-        "  CLERK_SECRET_KEY environment variable\n" +
-        "  Set CLERK_PLATFORM_API_KEY to auto-resolve from your linked project",
-    );
-    process.exit(1);
-  }
+  const instance = resolveInstanceId(profile, options.instance);
 
-  let instance: { id: string; label: string };
-  try {
-    instance = resolveInstanceId(profile, options.instance);
-  } catch (error) {
-    console.error((error as Error).message);
-    process.exit(1);
+  const app = await fetchApplication(profile.appId);
+  const matched = app.instances.find((i) => i.instance_id === instance.id);
+  if (!matched) {
+    throw new CliError(`Instance ${instance.id} not found in application.`, {
+      docsUrl: "https://clerk.com/docs/guides/development/managing-environments",
+    });
   }
-
-  try {
-    const app = await fetchApplication(profile.appId);
-    const matched = app.instances.find((i) => i.instance_id === instance.id);
-    if (!matched) {
-      console.error(`Instance ${instance.id} not found in application.`);
-      process.exit(1);
-    }
-    return matched.secret_key;
-  } catch (error) {
-    if (error instanceof PlapiError) {
-      console.error(`Failed to resolve secret key: ${error.message}`);
-      process.exit(1);
-    }
-    throw error;
-  }
+  return matched.secret_key;
 }
 
 async function resolveBody(options: { data?: string; file?: string }): Promise<string | null> {
@@ -171,8 +152,7 @@ async function resolveBody(options: { data?: string; file?: string }): Promise<s
   if (options.file) {
     const file = Bun.file(options.file);
     if (!(await file.exists())) {
-      console.error(`File not found: ${options.file}`);
-      process.exit(1);
+      usageError(`File not found: ${options.file}`);
     }
     return file.text();
   }

--- a/src/commands/api/index.ts
+++ b/src/commands/api/index.ts
@@ -3,7 +3,7 @@ import { resolveProfile, resolveInstanceId } from "../../lib/config.ts";
 import { fetchApplication } from "../../lib/plapi.ts";
 import { BAPI_BASE_URL, PLAPI_BASE_URL } from "../../lib/constants.ts";
 import { bapiRequest } from "./bapi.ts";
-import { BapiError, CliError, usageError, userAbort } from "../../lib/errors.ts";
+import { BapiError, CliError, usageError, userAbort, withApiContext } from "../../lib/errors.ts";
 import { isHuman } from "../../mode.ts";
 
 export interface ApiOptions {
@@ -136,7 +136,7 @@ async function resolveSecretKey(options: ApiOptions): Promise<string> {
   const { profile } = resolved;
   const instance = resolveInstanceId(profile, options.instance);
 
-  const app = await fetchApplication(profile.appId);
+  const app = await withApiContext(fetchApplication(profile.appId), "Failed to resolve secret key");
   const matched = app.instances.find((i) => i.instance_id === instance.id);
   if (!matched) {
     throw new CliError(`Instance ${instance.id} not found in application.`, {

--- a/src/commands/api/interactive.test.ts
+++ b/src/commands/api/interactive.test.ts
@@ -123,11 +123,11 @@ describe("apiInteractive", () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
-  test("shows help and exits in agent mode", async () => {
+  test("shows help and returns in agent mode", async () => {
     setMode("agent");
     const { apiInteractive } = await import("./interactive");
 
-    await expect(apiInteractive({})).rejects.toThrow("process.exit");
+    await apiInteractive({});
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining("Interactive mode requires a TTY"),
     );
@@ -199,9 +199,8 @@ describe("apiInteractive", () => {
     });
     confirmResponses.push(false); // decline
 
-    await apiInteractive({});
+    await expect(apiInteractive({})).rejects.toThrow("User aborted");
 
     expect(fetchCalls.length).toBe(0);
-    expect(errorSpy).toHaveBeenCalledWith("Aborted.");
   });
 });

--- a/src/commands/api/interactive.ts
+++ b/src/commands/api/interactive.ts
@@ -6,7 +6,7 @@ import { select, input, confirm, editor } from "@inquirer/prompts";
 import { isHuman } from "../../mode.ts";
 import { loadCatalog, endpointsByTag, type EndpointInfo } from "./catalog.ts";
 import type { ApiOptions } from "./index.ts";
-import { userAbort } from "../../lib/errors.ts";
+import { throwUserAbort } from "../../lib/errors.ts";
 
 export async function apiInteractive(options: ApiOptions): Promise<void> {
   if (!isHuman()) {
@@ -93,7 +93,7 @@ export async function apiInteractive(options: ApiOptions): Promise<void> {
 
   const proceed = await confirm({ message: "Execute this request?" });
   if (!proceed) {
-    userAbort();
+    throwUserAbort();
   }
 
   // 7. Delegate to the main api handler

--- a/src/commands/api/interactive.ts
+++ b/src/commands/api/interactive.ts
@@ -6,6 +6,7 @@ import { select, input, confirm, editor } from "@inquirer/prompts";
 import { isHuman } from "../../mode.ts";
 import { loadCatalog, endpointsByTag, type EndpointInfo } from "./catalog.ts";
 import type { ApiOptions } from "./index.ts";
+import { userAbort } from "../../lib/errors.ts";
 
 export async function apiInteractive(options: ApiOptions): Promise<void> {
   if (!isHuman()) {
@@ -18,7 +19,7 @@ export async function apiInteractive(options: ApiOptions): Promise<void> {
         "  clerk api /users\n" +
         "  clerk api ls users",
     );
-    process.exit(0);
+    return;
   }
 
   // 1. Load catalog and group by tag
@@ -92,8 +93,7 @@ export async function apiInteractive(options: ApiOptions): Promise<void> {
 
   const proceed = await confirm({ message: "Execute this request?" });
   if (!proceed) {
-    console.error("Aborted.");
-    return;
+    userAbort();
   }
 
   // 7. Delegate to the main api handler

--- a/src/commands/config/pull.test.ts
+++ b/src/commands/config/pull.test.ts
@@ -53,8 +53,7 @@ describe("config pull", () => {
   }
 
   test("errors when no profile is linked", async () => {
-    await expect(runConfigPull()).rejects.toThrow("process.exit");
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("No Clerk project linked"));
+    await expect(runConfigPull()).rejects.toThrow("No Clerk project linked");
   });
 
   test("errors when CLERK_PLATFORM_API_KEY is missing", async () => {
@@ -65,8 +64,7 @@ describe("config pull", () => {
     });
     delete process.env.CLERK_PLATFORM_API_KEY;
 
-    await expect(runConfigPull()).rejects.toThrow("process.exit");
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("CLERK_PLATFORM_API_KEY"));
+    await expect(runConfigPull()).rejects.toThrow("Not authenticated");
   });
 
   test("prints config JSON to stdout by default", async () => {
@@ -174,9 +172,8 @@ describe("config pull", () => {
       instances: { development: "ins_dev" },
     });
 
-    await expect(runConfigPull({ instance: "prod" })).rejects.toThrow("process.exit");
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("No production instance configured"),
+    await expect(runConfigPull({ instance: "prod" })).rejects.toThrow(
+      "No production instance configured",
     );
   });
 
@@ -189,7 +186,6 @@ describe("config pull", () => {
       instances: { development: "ins_dev" },
     });
 
-    await expect(runConfigPull()).rejects.toThrow("process.exit");
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("Failed to fetch config"));
+    await expect(runConfigPull()).rejects.toThrow("API error");
   });
 });

--- a/src/commands/config/pull.ts
+++ b/src/commands/config/pull.ts
@@ -1,5 +1,6 @@
 import { resolveProfile, resolveInstanceId } from "../../lib/config.ts";
-import { fetchInstanceConfig, PlapiError } from "../../lib/plapi.ts";
+import { fetchInstanceConfig } from "../../lib/plapi.ts";
+import { CliError } from "../../lib/errors.ts";
 
 interface ConfigPullOptions {
   instance?: string;
@@ -9,37 +10,15 @@ interface ConfigPullOptions {
 export async function configPull(options: ConfigPullOptions): Promise<void> {
   const resolved = await resolveProfile(process.cwd());
   if (!resolved) {
-    console.error("No Clerk project linked to this directory. Run `clerk init` to set up.");
-    process.exit(1);
+    throw new CliError("No Clerk project linked to this directory. Run `clerk link` to set up.");
   }
 
   const { profile } = resolved;
-
-  let instance: { id: string; label: string };
-  try {
-    instance = resolveInstanceId(profile, options.instance);
-  } catch (error) {
-    console.error((error as Error).message);
-    process.exit(1);
-  }
+  const instance = resolveInstanceId(profile, options.instance);
 
   console.error(`Pulling config from ${instance.label} instance...`);
 
-  let config: Record<string, unknown>;
-  try {
-    config = await fetchInstanceConfig(profile.appId, instance.id);
-  } catch (error) {
-    if (error instanceof PlapiError) {
-      console.error(`Failed to fetch config: ${error.message}`);
-      process.exit(1);
-    }
-    if (error instanceof Error) {
-      console.error(error.message);
-      process.exit(1);
-    }
-    throw error;
-  }
-
+  const config = await fetchInstanceConfig(profile.appId, instance.id);
   const json = JSON.stringify(config, null, 2);
 
   if (options.output) {

--- a/src/commands/config/pull.ts
+++ b/src/commands/config/pull.ts
@@ -1,6 +1,6 @@
 import { resolveProfile, resolveInstanceId } from "../../lib/config.ts";
 import { fetchInstanceConfig } from "../../lib/plapi.ts";
-import { CliError } from "../../lib/errors.ts";
+import { CliError, withApiContext } from "../../lib/errors.ts";
 
 interface ConfigPullOptions {
   instance?: string;
@@ -18,7 +18,10 @@ export async function configPull(options: ConfigPullOptions): Promise<void> {
 
   console.error(`Pulling config from ${instance.label} instance...`);
 
-  const config = await fetchInstanceConfig(profile.appId, instance.id);
+  const config = await withApiContext(
+    fetchInstanceConfig(profile.appId, instance.id),
+    "Failed to fetch config",
+  );
   const json = JSON.stringify(config, null, 2);
 
   if (options.output) {

--- a/src/commands/config/push.test.ts
+++ b/src/commands/config/push.test.ts
@@ -3,10 +3,11 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { _setConfigDir, setProfile } from "../../lib/config";
-import { credentialStoreStubs, gitStubs, stubFetch } from "../../test/stubs.ts";
+import { credentialStoreStubs, gitStubs, promptsStubs, stubFetch } from "../../test/stubs.ts";
 
 mock.module("../../lib/credential-store.ts", () => credentialStoreStubs);
 mock.module("../../lib/git.ts", () => gitStubs);
+mock.module("@inquirer/prompts", () => promptsStubs);
 
 describe("config push", () => {
   const originalEnv = { ...process.env };
@@ -75,8 +76,7 @@ describe("config push", () => {
   // --- Shared error cases ---
 
   test("errors when no profile is linked", async () => {
-    await expect(runConfigPatch({ json: '{"a":1}' })).rejects.toThrow("process.exit");
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("No Clerk project linked"));
+    await expect(runConfigPatch({ json: '{"a":1}' })).rejects.toThrow("No Clerk project linked");
   });
 
   test("errors when CLERK_PLATFORM_API_KEY is missing", async () => {
@@ -87,8 +87,9 @@ describe("config push", () => {
     });
     delete process.env.CLERK_PLATFORM_API_KEY;
 
-    await expect(runConfigPatch({ json: '{"a":1}', yes: true })).rejects.toThrow("process.exit");
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("CLERK_PLATFORM_API_KEY"));
+    await expect(runConfigPatch({ json: '{"a":1}', yes: true })).rejects.toThrow(
+      "Not authenticated",
+    );
   });
 
   test("errors when no input source is provided", async () => {
@@ -99,8 +100,7 @@ describe("config push", () => {
     });
 
     // Without --file or --json, falls through to stdin which yields empty input
-    await expect(runConfigPatch()).rejects.toThrow("process.exit");
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("No input"));
+    await expect(runConfigPatch()).rejects.toThrow("No input");
   });
 
   test("errors on invalid JSON input", async () => {
@@ -110,8 +110,7 @@ describe("config push", () => {
       instances: { development: "ins_dev" },
     });
 
-    await expect(runConfigPatch({ json: "not-json" })).rejects.toThrow("process.exit");
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("Invalid JSON"));
+    await expect(runConfigPatch({ json: "not-json" })).rejects.toThrow("Invalid JSON");
   });
 
   test("errors when JSON is an array", async () => {
@@ -121,8 +120,9 @@ describe("config push", () => {
       instances: { development: "ins_dev" },
     });
 
-    await expect(runConfigPatch({ json: "[1,2,3]" })).rejects.toThrow("process.exit");
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("Config must be a JSON object"));
+    await expect(runConfigPatch({ json: "[1,2,3]" })).rejects.toThrow(
+      "Config must be a JSON object",
+    );
   });
 
   test("errors when --file points to nonexistent file", async () => {
@@ -133,9 +133,8 @@ describe("config push", () => {
     });
 
     await expect(runConfigPatch({ file: "/tmp/does-not-exist.json" })).rejects.toThrow(
-      "process.exit",
+      "File not found",
     );
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("File not found"));
   });
 
   // --- PATCH happy paths ---
@@ -328,8 +327,7 @@ describe("config push", () => {
       instances: { development: "ins_dev" },
     });
 
-    await expect(runConfigPatch({ json: '{"a":1}', yes: true })).rejects.toThrow("process.exit");
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("Failed to push config"));
+    await expect(runConfigPatch({ json: '{"a":1}', yes: true })).rejects.toThrow("API error");
   });
 
   test("shows success message after push", async () => {

--- a/src/commands/config/push.ts
+++ b/src/commands/config/push.ts
@@ -2,7 +2,7 @@ import { confirm } from "@inquirer/prompts";
 import { resolveProfile, resolveInstanceId } from "../../lib/config.ts";
 import { putInstanceConfig, patchInstanceConfig } from "../../lib/plapi.ts";
 import { isHuman } from "../../mode.ts";
-import { CliError, usageError, userAbort, withApiContext } from "../../lib/errors.ts";
+import { CliError, throwUsageError, throwUserAbort, withApiContext } from "../../lib/errors.ts";
 
 interface ConfigPushOptions {
   instance?: string;
@@ -58,11 +58,11 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
   try {
     configPayload = JSON.parse(rawInput);
   } catch {
-    usageError("Invalid JSON input. Please provide valid JSON.");
+    throwUsageError("Invalid JSON input. Please provide valid JSON.");
   }
 
   if (typeof configPayload !== "object" || configPayload === null || Array.isArray(configPayload)) {
-    usageError("Config must be a JSON object.");
+    throwUsageError("Config must be a JSON object.");
   }
 
   if (options.dryRun) {
@@ -79,7 +79,7 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
     }
     const ok = await confirm({ message: "Proceed?" });
     if (!ok) {
-      userAbort();
+      throwUserAbort();
     }
   }
 
@@ -101,7 +101,7 @@ export async function readInput(options: { file?: string; json?: string }): Prom
   if (options.file) {
     const file = Bun.file(options.file);
     if (!(await file.exists())) {
-      usageError(`File not found: ${options.file}`);
+      throwUsageError(`File not found: ${options.file}`);
     }
     return file.text();
   }
@@ -113,12 +113,12 @@ export async function readInput(options: { file?: string; json?: string }): Prom
     }
     const text = Buffer.concat(chunks).toString("utf-8").trim();
     if (!text) {
-      usageError("No input received from stdin.");
+      throwUsageError("No input received from stdin.");
     }
     return text;
   }
 
-  usageError(
+  throwUsageError(
     "No input provided. Use --file <path>, --json <string>, or pipe JSON to stdin.\n" +
       "  Example: clerk config patch --file config.json\n" +
       '  Example: clerk config patch --json \'{"session":{"lifetime":3600}}\'\n' +

--- a/src/commands/config/push.ts
+++ b/src/commands/config/push.ts
@@ -2,7 +2,7 @@ import { confirm } from "@inquirer/prompts";
 import { resolveProfile, resolveInstanceId } from "../../lib/config.ts";
 import { putInstanceConfig, patchInstanceConfig } from "../../lib/plapi.ts";
 import { isHuman } from "../../mode.ts";
-import { CliError, usageError, userAbort } from "../../lib/errors.ts";
+import { CliError, usageError, userAbort, withApiContext } from "../../lib/errors.ts";
 
 interface ConfigPushOptions {
   instance?: string;
@@ -85,7 +85,10 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
 
   console.error(`${op.verb} config on ${instance.label} instance...`);
 
-  const result = await op.apiFn(profile.appId, instance.id, configPayload);
+  const result = await withApiContext(
+    op.apiFn(profile.appId, instance.id, configPayload),
+    "Failed to push config",
+  );
   console.log(JSON.stringify(result, null, 2));
   console.error("Config pushed successfully.");
 }

--- a/src/commands/config/push.ts
+++ b/src/commands/config/push.ts
@@ -1,7 +1,8 @@
 import { confirm } from "@inquirer/prompts";
 import { resolveProfile, resolveInstanceId } from "../../lib/config.ts";
-import { putInstanceConfig, patchInstanceConfig, PlapiError } from "../../lib/plapi.ts";
+import { putInstanceConfig, patchInstanceConfig } from "../../lib/plapi.ts";
 import { isHuman } from "../../mode.ts";
+import { CliError, usageError, userAbort } from "../../lib/errors.ts";
 
 interface ConfigPushOptions {
   instance?: string;
@@ -46,39 +47,22 @@ export async function configPatch(options: ConfigPushOptions): Promise<void> {
 async function configPush(options: ConfigPushOptions, op: Operation): Promise<void> {
   const resolved = await resolveProfile(process.cwd());
   if (!resolved) {
-    console.error("No Clerk project linked to this directory. Run `clerk init` to set up.");
-    process.exit(1);
+    throw new CliError("No Clerk project linked to this directory. Run `clerk link` to set up.");
   }
 
   const { profile } = resolved;
-
-  let instance: { id: string; label: string };
-  try {
-    instance = resolveInstanceId(profile, options.instance);
-  } catch (error) {
-    console.error((error as Error).message);
-    process.exit(1);
-  }
-
-  let rawInput: string;
-  try {
-    rawInput = await readInput(options);
-  } catch (error) {
-    console.error((error as Error).message);
-    process.exit(1);
-  }
+  const instance = resolveInstanceId(profile, options.instance);
+  const rawInput = await readInput(options);
 
   let configPayload: Record<string, unknown>;
   try {
     configPayload = JSON.parse(rawInput);
   } catch {
-    console.error("Invalid JSON input. Please provide valid JSON.");
-    process.exit(1);
+    usageError("Invalid JSON input. Please provide valid JSON.");
   }
 
   if (typeof configPayload !== "object" || configPayload === null || Array.isArray(configPayload)) {
-    console.error("Config must be a JSON object.");
-    process.exit(1);
+    usageError("Config must be a JSON object.");
   }
 
   if (options.dryRun) {
@@ -95,28 +79,15 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
     }
     const ok = await confirm({ message: "Proceed?" });
     if (!ok) {
-      console.error("Aborted.");
-      process.exit(0);
+      userAbort();
     }
   }
 
   console.error(`${op.verb} config on ${instance.label} instance...`);
 
-  try {
-    const result = await op.apiFn(profile.appId, instance.id, configPayload);
-    console.log(JSON.stringify(result, null, 2));
-    console.error("Config pushed successfully.");
-  } catch (error) {
-    if (error instanceof PlapiError) {
-      console.error(`Failed to push config: ${error.message}`);
-      process.exit(1);
-    }
-    if (error instanceof Error) {
-      console.error(error.message);
-      process.exit(1);
-    }
-    throw error;
-  }
+  const result = await op.apiFn(profile.appId, instance.id, configPayload);
+  console.log(JSON.stringify(result, null, 2));
+  console.error("Config pushed successfully.");
 }
 
 export async function readInput(options: { file?: string; json?: string }): Promise<string> {
@@ -127,7 +98,7 @@ export async function readInput(options: { file?: string; json?: string }): Prom
   if (options.file) {
     const file = Bun.file(options.file);
     if (!(await file.exists())) {
-      throw new Error(`File not found: ${options.file}`);
+      usageError(`File not found: ${options.file}`);
     }
     return file.text();
   }
@@ -139,12 +110,12 @@ export async function readInput(options: { file?: string; json?: string }): Prom
     }
     const text = Buffer.concat(chunks).toString("utf-8").trim();
     if (!text) {
-      throw new Error("No input received from stdin.");
+      usageError("No input received from stdin.");
     }
     return text;
   }
 
-  throw new Error(
+  usageError(
     "No input provided. Use --file <path>, --json <string>, or pipe JSON to stdin.\n" +
       "  Example: clerk config patch --file config.json\n" +
       '  Example: clerk config patch --json \'{"session":{"lifetime":3600}}\'\n' +

--- a/src/commands/config/schema.test.ts
+++ b/src/commands/config/schema.test.ts
@@ -59,8 +59,7 @@ describe("config schema", () => {
   }
 
   test("errors when no profile is linked", async () => {
-    await expect(runConfigSchema()).rejects.toThrow("process.exit");
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("No Clerk project linked"));
+    await expect(runConfigSchema()).rejects.toThrow("No Clerk project linked");
   });
 
   test("errors when CLERK_PLATFORM_API_KEY is missing", async () => {
@@ -71,8 +70,7 @@ describe("config schema", () => {
     });
     delete process.env.CLERK_PLATFORM_API_KEY;
 
-    await expect(runConfigSchema()).rejects.toThrow("process.exit");
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("CLERK_PLATFORM_API_KEY"));
+    await expect(runConfigSchema()).rejects.toThrow("Not authenticated");
   });
 
   test("prints schema JSON to stdout by default", async () => {
@@ -199,9 +197,8 @@ describe("config schema", () => {
       instances: { development: "ins_dev" },
     });
 
-    await expect(runConfigSchema({ instance: "prod" })).rejects.toThrow("process.exit");
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("No production instance configured"),
+    await expect(runConfigSchema({ instance: "prod" })).rejects.toThrow(
+      "No production instance configured",
     );
   });
 
@@ -214,7 +211,6 @@ describe("config schema", () => {
       instances: { development: "ins_dev" },
     });
 
-    await expect(runConfigSchema()).rejects.toThrow("process.exit");
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("Failed to fetch config schema"));
+    await expect(runConfigSchema()).rejects.toThrow("API error");
   });
 });

--- a/src/commands/config/schema.ts
+++ b/src/commands/config/schema.ts
@@ -1,6 +1,6 @@
 import { resolveProfile, resolveInstanceId } from "../../lib/config.ts";
 import { fetchInstanceConfigSchema } from "../../lib/plapi.ts";
-import { CliError } from "../../lib/errors.ts";
+import { CliError, withApiContext } from "../../lib/errors.ts";
 
 interface ConfigSchemaOptions {
   instance?: string;
@@ -20,7 +20,10 @@ export async function configSchema(options: ConfigSchemaOptions): Promise<void> 
   // Use `console.error` for informational messages so stdout is just the JSON response.
   console.error(`Pulling config schema from ${instance.label} instance...`);
 
-  const schema = await fetchInstanceConfigSchema(profile.appId, instance.id, options.keys);
+  const schema = await withApiContext(
+    fetchInstanceConfigSchema(profile.appId, instance.id, options.keys),
+    "Failed to fetch config schema",
+  );
 
   const json = JSON.stringify(schema, null, 2);
 

--- a/src/commands/config/schema.ts
+++ b/src/commands/config/schema.ts
@@ -1,5 +1,6 @@
 import { resolveProfile, resolveInstanceId } from "../../lib/config.ts";
-import { fetchInstanceConfigSchema, PlapiError } from "../../lib/plapi.ts";
+import { fetchInstanceConfigSchema } from "../../lib/plapi.ts";
+import { CliError } from "../../lib/errors.ts";
 
 interface ConfigSchemaOptions {
   instance?: string;
@@ -10,37 +11,16 @@ interface ConfigSchemaOptions {
 export async function configSchema(options: ConfigSchemaOptions): Promise<void> {
   const resolved = await resolveProfile(process.cwd());
   if (!resolved) {
-    console.error("No Clerk project linked to this directory. Run `clerk link` to set up.");
-    process.exit(1);
+    throw new CliError("No Clerk project linked to this directory. Run `clerk link` to set up.");
   }
 
   const { profile } = resolved;
-
-  let instance: { id: string; label: string };
-  try {
-    instance = resolveInstanceId(profile, options.instance);
-  } catch (error) {
-    console.error((error as Error).message);
-    process.exit(1);
-  }
+  const instance = resolveInstanceId(profile, options.instance);
 
   // Use `console.error` for informational messages so stdout is just the JSON response.
   console.error(`Pulling config schema from ${instance.label} instance...`);
 
-  let schema: Record<string, unknown>;
-  try {
-    schema = await fetchInstanceConfigSchema(profile.appId, instance.id, options.keys);
-  } catch (error) {
-    if (error instanceof PlapiError) {
-      console.error(`Failed to fetch config schema: ${error.message}`);
-      process.exit(1);
-    }
-    if (error instanceof Error) {
-      console.error(error.message);
-      process.exit(1);
-    }
-    throw error;
-  }
+  const schema = await fetchInstanceConfigSchema(profile.appId, instance.id, options.keys);
 
   const json = JSON.stringify(schema, null, 2);
 

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -8,7 +8,7 @@ const DEPLOY_PROMPT = `You are deploying a Clerk application to production. Foll
 
 Ensure the following before starting:
 - The user is authenticated (\`clerk auth login\` has been run)
-- A Clerk application is linked to the project (\`clerk init\` has been run)
+- A Clerk application is linked to the project (\`clerk link\` has been run)
 - The project has a development instance with a working configuration
 
 ## Step 1: Verify Subscription Compatibility

--- a/src/commands/env/pull.test.ts
+++ b/src/commands/env/pull.test.ts
@@ -31,7 +31,7 @@ mock.module("../../lib/config.ts", () => ({
     const env = INSTANCE_ALIASES[flag];
     if (!env) return { id: flag, label: flag };
     const id = profile.instances[env];
-    if (!id) throw new Error(`No ${env} instance configured. Run \`clerk init\` to set one up.`);
+    if (!id) throw new Error(`No ${env} instance configured. Run \`clerk link\` to set one up.`);
     return { id, label: env };
   },
 }));
@@ -104,8 +104,7 @@ describe("env pull", () => {
   }
 
   test("errors when no profile is linked", async () => {
-    await expect(runEnvPull()).rejects.toThrow("process.exit");
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("No Clerk project linked"));
+    await expect(runEnvPull()).rejects.toThrow("No Clerk project linked");
   });
 
   test("errors when CLERK_PLATFORM_API_KEY is missing", async () => {
@@ -116,8 +115,7 @@ describe("env pull", () => {
     });
     delete process.env.CLERK_PLATFORM_API_KEY;
 
-    await expect(runEnvPull()).rejects.toThrow("process.exit");
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("CLERK_PLATFORM_API_KEY"));
+    await expect(runEnvPull()).rejects.toThrow("Not authenticated");
   });
 
   test("creates .env.local with keys when no env file exists", async () => {
@@ -245,10 +243,7 @@ describe("env pull", () => {
       instances: { development: "ins_unknown" },
     });
 
-    await expect(runEnvPull()).rejects.toThrow("process.exit");
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Instance ins_unknown not found"),
-    );
+    await expect(runEnvPull()).rejects.toThrow("Instance ins_unknown not found");
   });
 
   test("handles API errors gracefully", async () => {
@@ -260,8 +255,7 @@ describe("env pull", () => {
       instances: { development: "ins_dev" },
     });
 
-    await expect(runEnvPull()).rejects.toThrow("process.exit");
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("Failed to fetch API keys"));
+    await expect(runEnvPull()).rejects.toThrow("API error");
   });
 
   test("detects Next.js and uses NEXT_PUBLIC_* key name", async () => {

--- a/src/commands/env/pull.ts
+++ b/src/commands/env/pull.ts
@@ -1,8 +1,9 @@
 import { join } from "node:path";
 import { resolveProfile, resolveInstanceId } from "../../lib/config.ts";
-import { fetchApplication, PlapiError } from "../../lib/plapi.ts";
+import { fetchApplication } from "../../lib/plapi.ts";
 import { parseEnvFile, mergeEnvVars, serializeEnvFile } from "../../lib/dotenv.ts";
 import { detectPublishableKeyName } from "../../lib/framework.ts";
+import { CliError } from "../../lib/errors.ts";
 
 interface EnvPullOptions {
   instance?: string;
@@ -24,41 +25,21 @@ async function resolveTargetFile(cwd: string, flag?: string): Promise<string> {
 export async function pull(options: EnvPullOptions): Promise<void> {
   const resolved = await resolveProfile(process.cwd());
   if (!resolved) {
-    console.error("No Clerk project linked to this directory. Run `clerk init` to set up.");
-    process.exit(1);
+    throw new CliError("No Clerk project linked to this directory. Run `clerk link` to set up.");
   }
 
   const { profile } = resolved;
-
-  let instance: { id: string; label: string };
-  try {
-    instance = resolveInstanceId(profile, options.instance);
-  } catch (error) {
-    console.error((error as Error).message);
-    process.exit(1);
-  }
+  const instance = resolveInstanceId(profile, options.instance);
 
   console.error(`Pulling env vars from ${instance.label} instance...`);
 
-  let app;
-  try {
-    app = await fetchApplication(profile.appId);
-  } catch (error) {
-    if (error instanceof PlapiError) {
-      console.error(`Failed to fetch API keys: ${error.message}`);
-      process.exit(1);
-    }
-    if (error instanceof Error) {
-      console.error(error.message);
-      process.exit(1);
-    }
-    throw error;
-  }
+  const app = await fetchApplication(profile.appId);
 
   const matched = app.instances.find((i) => i.instance_id === instance.id);
   if (!matched) {
-    console.error(`Instance ${instance.id} not found in application response.`);
-    process.exit(1);
+    throw new CliError(`Instance ${instance.id} not found in application response.`, {
+      docsUrl: "https://clerk.com/docs/guides/development/managing-environments",
+    });
   }
 
   const publishableKeyName = await detectPublishableKeyName(process.cwd());

--- a/src/commands/env/pull.ts
+++ b/src/commands/env/pull.ts
@@ -3,7 +3,7 @@ import { resolveProfile, resolveInstanceId } from "../../lib/config.ts";
 import { fetchApplication } from "../../lib/plapi.ts";
 import { parseEnvFile, mergeEnvVars, serializeEnvFile } from "../../lib/dotenv.ts";
 import { detectPublishableKeyName } from "../../lib/framework.ts";
-import { CliError } from "../../lib/errors.ts";
+import { CliError, withApiContext } from "../../lib/errors.ts";
 
 interface EnvPullOptions {
   instance?: string;
@@ -33,7 +33,7 @@ export async function pull(options: EnvPullOptions): Promise<void> {
 
   console.error(`Pulling env vars from ${instance.label} instance...`);
 
-  const app = await fetchApplication(profile.appId);
+  const app = await withApiContext(fetchApplication(profile.appId), "Failed to fetch API keys");
 
   const matched = app.instances.find((i) => i.instance_id === instance.id);
   if (!matched) {

--- a/src/commands/link/index.test.ts
+++ b/src/commands/link/index.test.ts
@@ -353,14 +353,8 @@ describe("link", () => {
       mockIsAgent.mockReturnValue(false);
       mockGetToken.mockResolvedValue("token");
       mockListApplications.mockResolvedValue([]);
-      errorSpy = spyOn(console, "error").mockImplementation(() => {});
-      exitSpy = spyOn(process, "exit").mockImplementation(() => {
-        throw new Error("exit");
-      });
 
-      await expect(link()).rejects.toThrow("exit");
-
-      expect(errorSpy.mock.calls[0][0]).toContain("No applications found");
+      await expect(link()).rejects.toThrow("No applications found");
     });
   });
 
@@ -462,14 +456,10 @@ describe("link", () => {
           },
         ],
       });
-      errorSpy = spyOn(console, "error").mockImplementation(() => {});
-      exitSpy = spyOn(process, "exit").mockImplementation(() => {
-        throw new Error("exit");
-      });
 
-      await expect(link({ app: "app_123" })).rejects.toThrow("exit");
-
-      expect(errorSpy.mock.calls[0][0]).toContain("no development instance");
+      await expect(link({ app: "app_123" })).rejects.toThrow(
+        "Application has no development instance",
+      );
     });
 
     test("logs confirmation message", async () => {

--- a/src/commands/link/index.ts
+++ b/src/commands/link/index.ts
@@ -7,6 +7,7 @@ import { listApplications, fetchApplication, type Application } from "../../lib/
 import { setProfile, resolveProfile, moveProfile } from "../../lib/config.js";
 import { getGitRepoIdentifier, getGitRepoRoot, getGitNormalizedRemote } from "../../lib/git.js";
 import { dim, cyan } from "../../lib/color.js";
+import { CliError } from "../../lib/errors.js";
 
 const AGENT_PROMPT = `You are linking a Clerk application to the current project directory.
 
@@ -100,8 +101,7 @@ export async function link(options: LinkOptions = {}): Promise<void> {
     const apps = await listApplications();
 
     if (apps.length === 0) {
-      console.error("No applications found. Create one at https://dashboard.clerk.com first.");
-      process.exit(1);
+      throw new CliError("No applications found. Create one at https://dashboard.clerk.com first.");
     }
 
     const choices = apps.map((a) => ({
@@ -120,8 +120,7 @@ export async function link(options: LinkOptions = {}): Promise<void> {
 
     const found = apps.find((a) => a.application_id === selectedId);
     if (!found) {
-      console.error("Selected application not found.");
-      process.exit(1);
+      throw new CliError("Selected application not found.");
     }
     app = found;
   }
@@ -130,8 +129,7 @@ export async function link(options: LinkOptions = {}): Promise<void> {
   const prodInstance = app.instances.find((i) => i.environment_type === "production");
 
   if (!devInstance) {
-    console.error("Application has no development instance.");
-    process.exit(1);
+    throw new CliError("Application has no development instance.");
   }
 
   // Store profile keyed by git repo (or cwd if not in a repo)

--- a/src/commands/unlink/index.test.ts
+++ b/src/commands/unlink/index.test.ts
@@ -94,9 +94,7 @@ describe("unlink", () => {
         throw new Error("exit");
       });
 
-      await expect(unlink()).rejects.toThrow("exit");
-
-      expect(errorSpy.mock.calls[0][0]).toContain("not linked");
+      await expect(unlink()).rejects.toThrow("not linked");
     });
   });
 
@@ -137,11 +135,8 @@ describe("unlink", () => {
       mockConfirm.mockResolvedValue(false);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await unlink();
-
+      await expect(unlink()).rejects.toThrow("User aborted");
       expect(mockRemoveProfile).not.toHaveBeenCalled();
-      const output = capturedOutput(consoleSpy);
-      expect(output).toContain("Aborted");
     });
   });
 

--- a/src/commands/unlink/index.ts
+++ b/src/commands/unlink/index.ts
@@ -3,6 +3,7 @@ import { isAgent, isHuman } from "../../mode.js";
 import { resolveProfile, removeProfile } from "../../lib/config.js";
 import { getGitRepoRoot } from "../../lib/git.js";
 import { dim, cyan } from "../../lib/color.js";
+import { CliError, userAbort } from "../../lib/errors.js";
 
 const AGENT_PROMPT = `You are unlinking a Clerk application from the current project directory.
 
@@ -33,8 +34,7 @@ export async function unlink(options: UnlinkOptions = {}): Promise<void> {
   const existing = await resolveProfile(cwd);
 
   if (!existing) {
-    console.error("This directory is not linked to a Clerk application.");
-    process.exit(1);
+    throw new CliError("This directory is not linked to a Clerk application.");
   }
 
   const label = existing.profile.appId;
@@ -47,8 +47,7 @@ export async function unlink(options: UnlinkOptions = {}): Promise<void> {
       default: false,
     });
     if (!ok) {
-      console.log("Aborted.");
-      return;
+      userAbort();
     }
   }
 

--- a/src/commands/unlink/index.ts
+++ b/src/commands/unlink/index.ts
@@ -3,7 +3,7 @@ import { isAgent, isHuman } from "../../mode.js";
 import { resolveProfile, removeProfile } from "../../lib/config.js";
 import { getGitRepoRoot } from "../../lib/git.js";
 import { dim, cyan } from "../../lib/color.js";
-import { CliError, userAbort } from "../../lib/errors.js";
+import { CliError, throwUserAbort } from "../../lib/errors.js";
 
 const AGENT_PROMPT = `You are unlinking a Clerk application from the current project directory.
 
@@ -47,7 +47,7 @@ export async function unlink(options: UnlinkOptions = {}): Promise<void> {
       default: false,
     });
     if (!ok) {
-      userAbort();
+      throwUserAbort();
     }
   }
 

--- a/src/lib/color.ts
+++ b/src/lib/color.ts
@@ -4,3 +4,4 @@ export const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;
 export const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
 export const yellow = (s: string) => `\x1b[33m${s}\x1b[0m`;
 export const blue = (s: string) => `\x1b[34m${s}\x1b[0m`;
+export const red = (s: string) => `\x1b[31m${s}\x1b[0m`;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -7,6 +7,7 @@ import { dirname, join } from "node:path";
 import { mkdir } from "node:fs/promises";
 import { CONFIG_FILE } from "./constants.ts";
 import { getGitRepoIdentifier, getGitNormalizedRemote } from "./git.ts";
+import { CliError } from "./errors.ts";
 
 let overrideConfigFile: string | undefined;
 
@@ -172,7 +173,9 @@ export function resolveInstanceId(profile: Profile, flag?: string): { id: string
 
   const id = profile.instances[env];
   if (!id) {
-    throw new Error(`No ${env} instance configured. Run \`clerk init\` to set one up.`);
+    throw new CliError(`No ${env} instance configured. Run \`clerk link\` to set one up.`, {
+      docsUrl: "https://clerk.com/docs/guides/development/managing-environments",
+    });
   }
   return { id, label: env };
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,151 @@
+/** Standard process exit codes used by the CLI. */
+export const EXIT_CODE = {
+  SUCCESS: 0,
+  GENERAL: 1,
+  USAGE: 2,
+  SIGINT: 130,
+} as const;
+
+type ExitCode = (typeof EXIT_CODE)[keyof typeof EXIT_CODE];
+
+interface CliErrorOptions {
+  exitCode?: ExitCode;
+  docsUrl?: string;
+}
+
+/**
+ * General-purpose CLI error for user-facing messages.
+ *
+ * Throw this when a command encounters a known failure (e.g. missing
+ * configuration, invalid input, resource not found). The global error handler
+ * in `cli.ts` prints the message in red and exits with `exitCode`.
+ *
+ * For usage/validation errors, **prefer {@link usageError}** over constructing
+ * a `CliError` with `EXIT_CODE.USAGE` directly.
+ *
+ * @example
+ * ```ts
+ * throw new CliError("No Clerk project linked. Run `clerk link` first.");
+ * ```
+ */
+export class CliError extends Error {
+  public exitCode: ExitCode;
+  public docsUrl?: string;
+
+  constructor(message: string, options?: CliErrorOptions) {
+    super(message);
+    this.name = "CliError";
+    this.exitCode = options?.exitCode ?? EXIT_CODE.GENERAL;
+    this.docsUrl = options?.docsUrl;
+  }
+}
+
+/**
+ * Signals that the user cancelled an interactive prompt or confirmation.
+ *
+ * The global error handler treats this as a clean exit (`EXIT_CODE.SUCCESS`)
+ * with no error message.
+ *
+ * **Do not construct directly** — use {@link userAbort} instead.
+ */
+export class UserAbortError extends Error {
+  constructor() {
+    super("User aborted");
+    this.name = "UserAbortError";
+  }
+}
+
+/**
+ * Base class for HTTP API errors.
+ *
+ * Thrown when an API request returns a non-OK status. The global error handler
+ * extracts the first error message from the JSON body (or truncates the raw
+ * body) and prints it. Subclasses {@link BapiError} and {@link PlapiError}
+ * add a labeled prefix so users know which API failed.
+ *
+ * @param status - HTTP status code
+ * @param body - Raw response body text
+ * @param headers - Response headers (optional)
+ */
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    public body: string,
+    public headers?: Headers,
+  ) {
+    super(`API error (${status}): ${body}`);
+    this.name = "ApiError";
+  }
+}
+
+/**
+ * Error from the Clerk Platform API (PLAPI).
+ *
+ * Thrown by `src/lib/plapi.ts` helpers when a Platform API request fails.
+ * Displayed as "Platform API request failed" in the global error handler.
+ *
+ * @param status - HTTP status code
+ * @param body - Raw response body text
+ */
+export class PlapiError extends ApiError {
+  constructor(status: number, body: string) {
+    super(status, body);
+    this.name = "PlapiError";
+  }
+}
+
+/**
+ * Error from the Clerk Backend API (BAPI).
+ *
+ * Thrown by `src/commands/api/bapi.ts` when a Backend API request fails.
+ * Displayed as "Backend API request failed" in the global error handler.
+ * Unlike {@link PlapiError}, `headers` is always present (required).
+ *
+ * @param status - HTTP status code
+ * @param body - Raw response body text
+ * @param headers - Response headers (always present for BAPI responses)
+ */
+export class BapiError extends ApiError {
+  declare headers: Headers;
+
+  constructor(status: number, body: string, headers: Headers) {
+    super(status, body, headers);
+    this.name = "BapiError";
+  }
+}
+
+/**
+ * Throw a usage error indicating the user provided invalid arguments or options.
+ *
+ * Exits with `EXIT_CODE.USAGE` (2). Use this for validation failures in
+ * command option parsing, missing required values, or malformed input.
+ *
+ * @param message - Error message describing the usage problem
+ * @param docsUrl - Optional URL to relevant documentation
+ *
+ * @example
+ * ```ts
+ * if (!secretKey) {
+ *   usageError("No secret key found. Set CLERK_SECRET_KEY or use --secret-key.");
+ * }
+ * ```
+ */
+export function usageError(message: string, docsUrl?: string): never {
+  throw new CliError(message, { exitCode: EXIT_CODE.USAGE, docsUrl });
+}
+
+/**
+ * Signal that the user cancelled an interactive prompt.
+ *
+ * Call this when the user declines a confirmation dialog or exits a picker.
+ * The global error handler exits cleanly with no error output.
+ *
+ * @example
+ * ```ts
+ * const confirmed = await confirm({ message: "Proceed?" });
+ * if (!confirmed) userAbort();
+ * ```
+ */
+export function userAbort(): never {
+  throw new UserAbortError();
+}

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,15 +1,21 @@
 /** Standard process exit codes used by the CLI. */
 export const EXIT_CODE = {
+  /** Clean exit, no error. */
   SUCCESS: 0,
+  /** General runtime error. */
   GENERAL: 1,
+  /** Invalid arguments or options. */
   USAGE: 2,
+  /** Interrupted by Ctrl+C (128 + SIGINT signal 2). */
   SIGINT: 130,
 } as const;
 
 type ExitCode = (typeof EXIT_CODE)[keyof typeof EXIT_CODE];
 
 interface CliErrorOptions {
+  /** Process exit code. Defaults to {@link EXIT_CODE.GENERAL}. */
   exitCode?: ExitCode;
+  /** URL to relevant documentation, printed after the error message. */
   docsUrl?: string;
 }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,3 +1,5 @@
+import { isAgent } from "../mode";
+
 /** Standard process exit codes used by the CLI. */
 export const EXIT_CODE = {
   /** Clean exit, no error. */
@@ -24,9 +26,11 @@ interface CliErrorOptions {
  *
  * Throw this when a command encounters a known failure (e.g. missing
  * configuration, invalid input, resource not found). The global error handler
- * in `cli.ts` prints the message in red and exits with `exitCode`.
+ * in `cli.ts` prints the message in red and exits with `exitCode`. Any Clerk
+ * URLs in `docsUrl` will automatically have ".md" appended in agent mode to
+ * link to the raw markdown version.
  *
- * For usage/validation errors, **prefer {@link usageError}** over constructing
+ * For usage/validation errors, **prefer {@link throwUsageError}** over constructing
  * a `CliError` with `EXIT_CODE.USAGE` directly.
  *
  * @example
@@ -42,7 +46,20 @@ export class CliError extends Error {
     super(message);
     this.name = "CliError";
     this.exitCode = options?.exitCode ?? EXIT_CODE.GENERAL;
-    this.docsUrl = options?.docsUrl;
+
+    if (options?.docsUrl) {
+      this.docsUrl = options.docsUrl;
+
+      // If we're running in agent mode and the docs URL is a Clerk docs link
+      // without a .md extension, add .md to get the raw markdown URL.
+      if (
+        isAgent() &&
+        this.docsUrl.startsWith("https://docs.clerk.com/") &&
+        !this.docsUrl.endsWith(".md")
+      ) {
+        this.docsUrl += ".md";
+      }
+    }
   }
 }
 
@@ -52,7 +69,7 @@ export class CliError extends Error {
  * The global error handler treats this as a clean exit (`EXIT_CODE.SUCCESS`)
  * with no error message.
  *
- * **Do not construct directly** — use {@link userAbort} instead.
+ * **Do not construct directly** — use {@link throwUserAbort} instead.
  */
 export class UserAbortError extends Error {
   constructor() {
@@ -126,7 +143,9 @@ export class BapiError extends ApiError {
  * Throw a usage error indicating the user provided invalid arguments or options.
  *
  * Exits with `EXIT_CODE.USAGE` (2). Use this for validation failures in
- * command option parsing, missing required values, or malformed input.
+ * command option parsing, missing required values, or malformed input. Any
+ * Clerk URL's will automatically have ".md" appended in agent mode to link to
+ * the raw markdown version.
  *
  * @param message - Error message describing the usage problem
  * @param docsUrl - Optional URL to relevant documentation
@@ -138,7 +157,7 @@ export class BapiError extends ApiError {
  * }
  * ```
  */
-export function usageError(message: string, docsUrl?: string): never {
+export function throwUsageError(message: string, docsUrl?: string): never {
   throw new CliError(message, { exitCode: EXIT_CODE.USAGE, docsUrl });
 }
 
@@ -154,7 +173,7 @@ export function usageError(message: string, docsUrl?: string): never {
  * if (!confirmed) userAbort();
  * ```
  */
-export function userAbort(): never {
+export function throwUserAbort(): never {
   throw new UserAbortError();
 }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -68,6 +68,8 @@ export class UserAbortError extends Error {
  * @param headers - Response headers (optional)
  */
 export class ApiError extends Error {
+  public context?: string;
+
   constructor(
     public status: number,
     public body: string,
@@ -148,4 +150,25 @@ export function usageError(message: string, docsUrl?: string): never {
  */
 export function userAbort(): never {
   throw new UserAbortError();
+}
+
+/**
+ * Wrap a promise so that any {@link ApiError} it rejects with gets a
+ * human-readable `context` string attached before re-throwing.
+ *
+ * @example
+ * ```ts
+ * const config = await withApiContext(
+ *   fetchInstanceConfig(appId, instanceId),
+ *   "Failed to fetch config",
+ * );
+ * ```
+ */
+export function withApiContext<T>(promise: Promise<T>, context: string): Promise<T> {
+  return promise.catch((error) => {
+    if (error instanceof ApiError) {
+      error.context = context;
+    }
+    throw error;
+  });
 }

--- a/src/lib/plapi.test.ts
+++ b/src/lib/plapi.test.ts
@@ -7,13 +7,9 @@ mock.module("./credential-store.ts", () => ({
   getToken: (...args: unknown[]) => mockGetToken(...args),
 }));
 
-const {
-  fetchInstanceConfig,
-  putInstanceConfig,
-  patchInstanceConfig,
-  listApplications,
-  PlapiError,
-} = await import("./plapi.ts");
+const { fetchInstanceConfig, putInstanceConfig, patchInstanceConfig, listApplications } =
+  await import("./plapi.ts");
+const { PlapiError } = await import("./errors.ts");
 
 describe("plapi", () => {
   const originalEnv = { ...process.env };

--- a/src/lib/plapi.ts
+++ b/src/lib/plapi.ts
@@ -5,16 +5,7 @@
 
 import { PLAPI_BASE_URL } from "./constants.ts";
 import { getToken } from "./credential-store.ts";
-
-export class PlapiError extends Error {
-  constructor(
-    public status: number,
-    public body: string,
-  ) {
-    super(`Platform API error (${status}): ${body}`);
-    this.name = "PlapiError";
-  }
-}
+import { CliError, PlapiError } from "./errors.ts";
 
 async function getAuthToken(): Promise<string> {
   // Prefer platform API key (OAuth token doesn't have platform scopes yet)
@@ -25,7 +16,9 @@ async function getAuthToken(): Promise<string> {
   const oauthToken = await getToken();
   if (oauthToken) return oauthToken;
 
-  throw new Error("Not authenticated. Run `clerk auth login` or set CLERK_PLATFORM_API_KEY.");
+  throw new CliError("Not authenticated. Run `clerk auth login` or set CLERK_PLATFORM_API_KEY.", {
+    docsUrl: "https://clerk.com/docs/guides/development/clerk-environment-variables",
+  });
 }
 
 export async function fetchInstanceConfigSchema(

--- a/src/lib/token-exchange.test.ts
+++ b/src/lib/token-exchange.test.ts
@@ -74,7 +74,7 @@ describe("exchangeCodeForToken", () => {
         codeVerifier: "verifier",
         redirectUri: "http://127.0.0.1:3000/callback",
       }),
-    ).rejects.toThrow("Token exchange failed (400)");
+    ).rejects.toThrow("API error (400)");
   });
 
   test("includes error body in thrown message", async () => {
@@ -125,7 +125,7 @@ describe("fetchUserInfo", () => {
       return new Response("Unauthorized", { status: 401 });
     }) as typeof fetch;
 
-    await expect(fetchUserInfo("expired-token")).rejects.toThrow("Failed to fetch user info (401)");
+    await expect(fetchUserInfo("expired-token")).rejects.toThrow("API error (401)");
   });
 
   test("includes response body in error message", async () => {

--- a/src/lib/token-exchange.ts
+++ b/src/lib/token-exchange.ts
@@ -10,6 +10,7 @@
  */
 
 import { OAUTH } from "./constants.ts";
+import { ApiError } from "./errors.ts";
 
 export const OAUTH_CONFIG = OAUTH;
 
@@ -46,7 +47,7 @@ export async function exchangeCodeForToken(params: {
 
   if (!response.ok) {
     const error = await response.text();
-    throw new Error(`Token exchange failed (${response.status}): ${error}`);
+    throw new ApiError(response.status, error);
   }
 
   return response.json() as Promise<TokenResponse>;
@@ -59,7 +60,7 @@ export async function fetchUserInfo(accessToken: string): Promise<UserInfo> {
 
   if (!response.ok) {
     const error = await response.text();
-    throw new Error(`Failed to fetch user info (${response.status}): ${error}`);
+    throw new ApiError(response.status, error);
   }
 
   const data = (await response.json()) as Record<string, unknown>;

--- a/src/lib/token-exchange.ts
+++ b/src/lib/token-exchange.ts
@@ -10,7 +10,7 @@
  */
 
 import { OAUTH } from "./constants.ts";
-import { ApiError } from "./errors.ts";
+import { ApiError, withApiContext } from "./errors.ts";
 
 export const OAUTH_CONFIG = OAUTH;
 
@@ -39,34 +39,44 @@ export async function exchangeCodeForToken(params: {
     redirect_uri: params.redirectUri,
   });
 
-  const response = await fetch(OAUTH_CONFIG.tokenUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: body.toString(),
-  });
+  return withApiContext(
+    (async () => {
+      const response = await fetch(OAUTH_CONFIG.tokenUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: body.toString(),
+      });
 
-  if (!response.ok) {
-    const error = await response.text();
-    throw new ApiError(response.status, error);
-  }
+      if (!response.ok) {
+        const error = await response.text();
+        throw new ApiError(response.status, error);
+      }
 
-  return response.json() as Promise<TokenResponse>;
+      return response.json() as Promise<TokenResponse>;
+    })(),
+    "Token exchange failed",
+  );
 }
 
 export async function fetchUserInfo(accessToken: string): Promise<UserInfo> {
-  const response = await fetch(OAUTH_CONFIG.userinfoUrl, {
-    headers: { Authorization: `Bearer ${accessToken}` },
-  });
+  return withApiContext(
+    (async () => {
+      const response = await fetch(OAUTH_CONFIG.userinfoUrl, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
 
-  if (!response.ok) {
-    const error = await response.text();
-    throw new ApiError(response.status, error);
-  }
+      if (!response.ok) {
+        const error = await response.text();
+        throw new ApiError(response.status, error);
+      }
 
-  const data = (await response.json()) as Record<string, unknown>;
+      const data = (await response.json()) as Record<string, unknown>;
 
-  return {
-    userId: data.sub as string,
-    email: data.email as string,
-  };
+      return {
+        userId: data.sub as string,
+        email: data.email as string,
+      };
+    })(),
+    "Failed to fetch user info",
+  );
 }


### PR DESCRIPTION
## What

- Introduce a typed error hierarchy (`CliError`, `UserAbortError`, `ApiError`, `BapiError`, `PlapiError`) in `src/lib/errors.ts` with standardized exit codes
- Add a single top-level error handler in `cli.ts` that catches all typed errors and formats output consistently
- Add `--verbose` flag for detailed API error output
- Add `SIGINT` handler that exits with code 130
- Add oxlint configuration (`.oxlintrc.json`)

## Why

Error handling was scattered across every command — each had its own `try/catch` + `console.error` + `process.exit` with inconsistent formatting, exit codes, and messaging. This made it difficult to maintain consistent UX and meant every new command had to reimplement error handling. Centralizing it ensures uniform behavior and reduces per-command boilerplate.

## How

- Created `src/lib/errors.ts` with a class hierarchy: `CliError` for general CLI errors, `ApiError` (with `BapiError`/`PlapiError` subclasses) for HTTP failures, and `UserAbortError` for prompt cancellations. Helper functions `usageError()` and `userAbort()` provide ergonomic throwing.
- Wrapped `program.parseAsync()` in a `main()` function with a centralized `catch` that dispatches on error type — clean exit for aborts, red-formatted messages for CLI errors, labeled API error details for API failures.
- Updated all commands to throw typed errors instead of handling exits locally.
- Updated all tests to assert on thrown errors rather than spying on `process.exit`.

AIE-626