### PR TITLE
test: add a local env example file

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,18 @@
+# Local development environment
+# Copy this to .env.local
+# Run `make deps` and `make up` in clerk/clerk_go
+
+# ── OAuth ────────────────────────────────────────────────────────────────────
+CLERK_OAUTH_CLIENT_ID=AoIrcWIr840sy5pY
+CLERK_OAUTH_BASE_URL=https://clerk.prod.lclclerk.com
+# CLERK_OAUTH_SCOPES=profile email
+
+# ── Backend API ─────────────────────────────────────────────────────────────-
+CLERK_BACKEND_API_URL=https://api.lclclerk.com
+
+# ── Platform API ─────────────────────────────────────────────────────────────
+# CLERK_PLATFORM_API_KEY=your_platform_api_key
+CLERK_PLATFORM_API_URL=https://api.lclclerk.com
+
+# ── Dashboard API ────────────────────────────────────────────────────────────
+CLERK_DAPI_BASE_URL=https://dapi.prod.lclclerk.com


### PR DESCRIPTION
These settings actually work with clerk_go out of the box because we have a [pre-configured oauth app](https://github.com/clerk/clerk_go/blob/b504e10cb2ddba59acf252cba94eb22345e99c5c/cmd/seed_data/main.go#L1535) and because [fosite does not validate ports for loopback redirects](https://github.com/ory/fosite/blob/653c812bc40cbda049857b432ad3346f1a53d42d/authorize_helper.go#L135)


```
% cp .env.local.example .env.local
% bun dev auth login
$ bun run ./src/cli.ts auth login
Waiting for authentication...
Logged in as jacob.foshee@clerk.dev

% security find-generic-password -a oauth-access-token -s clerk-cli -w
eyJhbGciOiJSUzI1NiIsImtpZCI6Imluc18zQVp1OTZkYmxaS1E5OFZSVENEdVpseTBiMkciLCJ0eXAiOiJhdCtqd3QifQ.eyJjbGllbnRfaWQiOiJBb0lyY1dJcjg0MHN5NXBZIiwiZXhwIjoxNzczMjYwMjk4LCJpYXQiOjE3NzMxNzM4OTcsImlzcyI6Imh0dHBzOi8vY2xlcmsucHJvZC5sY2xjbGVyay5jb20iLCJqdGkiOiJvYXRfMzRKWFZDM1Y1MlZSSzBFTiIsIm5iZiI6MTc3MzE3Mzg4Nywic2NvcGUiOiJwcm9maWxlIGVtYWlsIG9mZmxpbmVfYWNjZXNzIiwic3ViIjoidXNlcl8zQWxlYlhNWktObXFYeXN5NEdRZ1A3YVE2QlUifQ.36XgxGnx7SREGgQJglVbhRLuM3mxziy72dPOl76nIAa3hAYK2dDQXj07Y99n-_QhgVvVFvUSNPSy8MM1n00T1qaixswqzRkdTbUQjI8efG_PbzwAnqUMO1yLFJcoClwetof1m0fOlX41vbzIi7SRP5182Qpmy0qlALm9LBAoFCP-0vOOc4WHsfIgfeTCcRk3ZsY4k32AWU5wWlGCw1bE2dQ-YWri48-M6xdVW4Ey53cGGo_7jRsW5ouy7ezFvnj5VZCkFyZeBs4Bd2dL-E5G8xu2RB5jTyo8RIhFkZJv1l4O4YhzyHNK5ut6Fi-kXg-fVTKuCTQ211gLNDkPi3LvSQ
```
