### PR TITLE
feat: add key detection and autolink to link command

### DIFF
--- a/src/commands/link/README.md
+++ b/src/commands/link/README.md
@@ -1,7 +1,7 @@
 # Link Command
 
 Links the current git repository to a Clerk application, storing the app ID
-and instance IDs in `~/.clerk/config.json`. The link is keyed by the
+and instance IDs in the config file. The link is keyed by the
 normalized git remote URL (e.g., `github.com/org/repo`), so it is
 automatically shared across all clones and worktrees of the same repository.
 
@@ -33,12 +33,12 @@ interactive flow.
 3. If `skipIfLinked` and not already linked, tries silent autolink (detect keys → match → persist without prompting)
 4. Checks for authentication (calls `clerk auth login` if needed)
 5. If `--app` is provided, fetches that app directly
-6. Otherwise, fetches the list of applications and scans for publishable keys in env vars / `.env` files
+6. Otherwise, fetches the list of applications and scans for publishable keys in env vars / `.env` / `.env.local`
 7. If a key matches an application, suggests it: "We found \<app\>. Link to this application?"
    - If the user confirms (default), links to the detected app
    - If the user declines, falls through to the interactive picker
 8. If no match, presents a searchable picker (type to filter by name)
-9. Stores the profile in `~/.clerk/config.json` keyed by the normalized remote URL
+9. Stores the profile in the config file keyed by the normalized remote URL
 10. Falls back to git-common-dir or the current directory path if no remote is configured
 
 ## Key Detection

--- a/src/commands/link/README.md
+++ b/src/commands/link/README.md
@@ -28,12 +28,43 @@ interactive flow.
 
 1. Resolves the normalized git remote URL (e.g., `github.com/org/repo`) for cross-clone matching
 2. Checks if already linked — if resolved via a remote URL from another clone, prints an auto-link notice
-3. Checks for authentication (calls `clerk auth login` if needed)
-4. If `--app` is provided, uses that app ID directly
-5. Otherwise, fetches the list of applications and presents a searchable picker (type to filter by name)
-6. Fetches application details to retrieve instance IDs
-7. Stores the profile in `~/.clerk/config.json` keyed by the normalized remote URL
-8. Falls back to git-common-dir or the current directory path if no remote is configured
+   - With `skipIfLinked` (used by `clerk init`), returns immediately
+   - Otherwise, offers to upgrade the profile key to use the git remote if available, or asks to re-link
+3. If `skipIfLinked` and not already linked, tries silent autolink (detect keys → match → persist without prompting)
+4. Checks for authentication (calls `clerk auth login` if needed)
+5. If `--app` is provided, fetches that app directly
+6. Otherwise, fetches the list of applications and scans for publishable keys in env vars / `.env` files
+7. If a key matches an application, suggests it: "We found \<app\>. Link to this application?"
+   - If the user confirms (default), links to the detected app
+   - If the user declines, falls through to the interactive picker
+8. If no match, presents a searchable picker (type to filter by name)
+9. Stores the profile in `~/.clerk/config.json` keyed by the normalized remote URL
+10. Falls back to git-common-dir or the current directory path if no remote is configured
+
+## Key Detection
+
+When running `clerk link` without `--app`, the command scans for publishable keys
+and suggests the matching application before showing the interactive picker.
+This is implemented in `src/lib/autolink.ts`.
+
+Framework detection (`src/lib/framework.ts`) reads `package.json` to determine
+the correct publishable key env var name (e.g., `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`
+for Next.js, `CLERK_PUBLISHABLE_KEY` as fallback).
+
+### Detection order
+
+1. **Environment variables** (highest priority):
+   The framework-specific publishable key env var
+   (`NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY`, etc.)
+   or `CLERK_PUBLISHABLE_KEY` as fallback
+2. **`.env.local`** file in the project directory
+3. **`.env`** file in the project directory
+
+### Matching
+
+Detected publishable keys are matched against all applications returned by
+`GET /v1/platform/applications`. A lookup map is built from each instance's
+`publishable_key` field, and the first detected key that matches wins.
 
 ## API Endpoints
 

--- a/src/commands/link/index.test.ts
+++ b/src/commands/link/index.test.ts
@@ -104,7 +104,6 @@ const mockApp = {
 describe("link", () => {
   let consoleSpy: ReturnType<typeof spyOn>;
   let errorSpy: ReturnType<typeof spyOn>;
-  let exitSpy: ReturnType<typeof spyOn>;
 
   afterEach(() => {
     _modeOverride = undefined;
@@ -133,7 +132,6 @@ describe("link", () => {
     mockConfirm.mockReset();
     consoleSpy?.mockRestore();
     errorSpy?.mockRestore();
-    exitSpy?.mockRestore();
   });
 
   describe("agent mode", () => {

--- a/src/commands/link/index.test.ts
+++ b/src/commands/link/index.test.ts
@@ -802,6 +802,50 @@ describe("link", () => {
       expect(mockFetchApplication).toHaveBeenCalledWith("app_123");
     });
 
+    test("shows target app name in re-link prompt when --app is provided", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockResolveProfile.mockResolvedValue({
+        path: "github.com/org/repo",
+        profile: { workspaceId: "", appId: "app_existing", instances: { development: "ins_1" } },
+      });
+      const namedApp = { ...mockApp, name: "My Cool App" };
+      mockGetToken.mockResolvedValue("token");
+      mockFetchApplication.mockResolvedValue(namedApp);
+      mockConfirm.mockResolvedValue(true);
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link({ app: "app_123" });
+
+      const confirmCall = mockConfirm.mock.calls.find((c: unknown[]) =>
+        (c[0] as { message: string }).message.includes("Re-link"),
+      );
+      expect(confirmCall).toBeDefined();
+      expect((confirmCall![0] as { message: string }).message).toContain("My Cool App");
+    });
+
+    test("does not show app name in re-link prompt without --app", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockResolveProfile.mockResolvedValue({
+        path: "github.com/org/repo",
+        profile: { workspaceId: "", appId: "app_existing", instances: { development: "ins_1" } },
+      });
+      mockConfirm.mockResolvedValue(true);
+      mockGetToken.mockResolvedValue("token");
+      mockListApplications.mockResolvedValue([mockApp]);
+      mockSearch.mockResolvedValue("app_123");
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link();
+
+      const confirmCall = mockConfirm.mock.calls.find((c: unknown[]) =>
+        (c[0] as { message: string }).message.includes("Re-link"),
+      );
+      expect(confirmCall).toBeDefined();
+      expect((confirmCall![0] as { message: string }).message).toBe(
+        "Re-link to a different application?",
+      );
+    });
+
     test("still suggests key match on first-time link", async () => {
       mockIsAgent.mockReturnValue(false);
       mockGetToken.mockResolvedValue("token");

--- a/src/commands/link/index.test.ts
+++ b/src/commands/link/index.test.ts
@@ -742,4 +742,109 @@ describe("link", () => {
       expect(mockSearch).toHaveBeenCalled();
     });
   });
+
+  describe("re-link skips key detection", () => {
+    test("skips key suggestion and shows picker when re-linking", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockResolveProfile.mockResolvedValue({
+        path: "github.com/org/repo",
+        profile: { workspaceId: "", appId: "app_existing", instances: { development: "ins_1" } },
+      });
+      mockConfirm.mockResolvedValue(true);
+      mockGetToken.mockResolvedValue("token");
+      mockListApplications.mockResolvedValue([mockApp]);
+      mockSearch.mockResolvedValue("app_123");
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link();
+
+      expect(mockFindClerkKeys).not.toHaveBeenCalled();
+      expect(mockMatchKeyToApp).not.toHaveBeenCalled();
+      expect(mockSearch).toHaveBeenCalled();
+    });
+
+    test("skips key suggestion when re-linking from auto-linked remote", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockResolveProfile.mockResolvedValue({
+        path: "github.com/org/repo",
+        profile: { workspaceId: "", appId: "app_existing", instances: { development: "ins_1" } },
+        resolvedVia: "remote",
+      });
+      mockConfirm.mockResolvedValue(true);
+      mockGetToken.mockResolvedValue("token");
+      mockListApplications.mockResolvedValue([mockApp]);
+      mockSearch.mockResolvedValue("app_123");
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link();
+
+      const output = capturedOutput(consoleSpy);
+      expect(output).toContain("Auto-linked via git remote");
+      expect(mockFindClerkKeys).not.toHaveBeenCalled();
+      expect(mockSearch).toHaveBeenCalled();
+    });
+
+    test("skips key suggestion but respects --app flag when re-linking", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockResolveProfile.mockResolvedValue({
+        path: "github.com/org/repo",
+        profile: { workspaceId: "", appId: "app_existing", instances: { development: "ins_1" } },
+      });
+      mockConfirm.mockResolvedValue(true);
+      mockGetToken.mockResolvedValue("token");
+      mockFetchApplication.mockResolvedValue(mockApp);
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link({ app: "app_123" });
+
+      expect(mockFindClerkKeys).not.toHaveBeenCalled();
+      expect(mockSearch).not.toHaveBeenCalled();
+      expect(mockFetchApplication).toHaveBeenCalledWith("app_123");
+    });
+
+    test("still suggests key match on first-time link", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockGetToken.mockResolvedValue("token");
+      mockListApplications.mockResolvedValue([mockApp]);
+      mockFindClerkKeys.mockResolvedValue([
+        { key: "pk_test", source: "CLERK_PUBLISHABLE_KEY env var" },
+      ]);
+      mockMatchKeyToApp.mockReturnValue({
+        app: mockApp,
+        instance: mockApp.instances[0],
+        source: "CLERK_PUBLISHABLE_KEY env var",
+      });
+      mockConfirm.mockResolvedValue(true);
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link();
+
+      expect(mockFindClerkKeys).toHaveBeenCalled();
+      expect(mockMatchKeyToApp).toHaveBeenCalled();
+      const output = capturedOutput(consoleSpy);
+      expect(output).toContain("We found");
+    });
+
+    test("skips key suggestion after declining profile upgrade", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockResolveProfile.mockResolvedValue({
+        path: "/repo/.git",
+        profile: { workspaceId: "", appId: "app_existing", instances: { development: "ins_1" } },
+        resolvedVia: "git-common-dir",
+        availableRemote: "github.com/org/repo",
+      });
+      mockConfirm
+        .mockResolvedValueOnce(false) // decline upgrade
+        .mockResolvedValueOnce(true); // accept re-link
+      mockGetToken.mockResolvedValue("token");
+      mockListApplications.mockResolvedValue([mockApp]);
+      mockSearch.mockResolvedValue("app_123");
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link();
+
+      expect(mockFindClerkKeys).not.toHaveBeenCalled();
+      expect(mockSearch).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/commands/link/index.test.ts
+++ b/src/commands/link/index.test.ts
@@ -3,6 +3,7 @@ import {
   capturedOutput,
   configStubs,
   credentialStoreStubs,
+  autolinkStubs,
   gitStubs,
   promptsStubs,
 } from "../../test/stubs.ts";
@@ -50,6 +51,16 @@ mock.module("../../lib/config.ts", () => ({
   setProfile: (...args: unknown[]) => mockSetProfile(...args),
   resolveProfile: (...args: unknown[]) => mockResolveProfile(...args),
   moveProfile: (...args: unknown[]) => mockMoveProfile(...args),
+}));
+
+const mockAutolink = mock();
+const mockFindClerkKeys = mock();
+const mockMatchKeyToApp = mock();
+mock.module("../../lib/autolink.ts", () => ({
+  ...autolinkStubs,
+  autolink: (...args: unknown[]) => mockAutolink(...args),
+  findClerkKeys: (...args: unknown[]) => mockFindClerkKeys(...args),
+  matchKeyToApp: (...args: unknown[]) => mockMatchKeyToApp(...args),
 }));
 
 const mockGetGitRepoIdentifier = mock();
@@ -105,6 +116,12 @@ describe("link", () => {
     mockSetProfile.mockReset();
     mockResolveProfile.mockReset();
     mockResolveProfile.mockResolvedValue(undefined);
+    mockAutolink.mockReset();
+    mockAutolink.mockResolvedValue(undefined);
+    mockFindClerkKeys.mockReset();
+    mockFindClerkKeys.mockResolvedValue([]);
+    mockMatchKeyToApp.mockReset();
+    mockMatchKeyToApp.mockReturnValue(undefined);
     mockMoveProfile.mockReset();
     mockGetGitRepoIdentifier.mockReset();
     mockGetGitRepoIdentifier.mockResolvedValue("/repo/.git");
@@ -595,6 +612,134 @@ describe("link", () => {
       await link();
 
       expect(mockMoveProfile).toHaveBeenCalledWith("/repo/.git", "github.com/org/repo");
+    });
+  });
+
+  describe("autolink from detected keys", () => {
+    test("suggests detected app and links when user confirms", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockGetToken.mockResolvedValue("token");
+      mockListApplications.mockResolvedValue([mockApp]);
+      mockFindClerkKeys.mockResolvedValue([
+        { key: "pk_test", source: "CLERK_PUBLISHABLE_KEY env var" },
+      ]);
+      mockMatchKeyToApp.mockReturnValue({
+        app: mockApp,
+        instance: mockApp.instances[0],
+        source: "CLERK_PUBLISHABLE_KEY env var",
+      });
+      mockConfirm.mockResolvedValue(true);
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link();
+
+      expect(mockFindClerkKeys).toHaveBeenCalled();
+      expect(mockMatchKeyToApp).toHaveBeenCalled();
+      expect(mockConfirm).toHaveBeenCalled();
+      expect(mockSetProfile).toHaveBeenCalledWith("github.com/org/repo", {
+        workspaceId: "",
+        appId: "app_123",
+        instances: {
+          development: "ins_dev",
+          production: "ins_prod",
+        },
+      });
+      expect(mockSearch).not.toHaveBeenCalled();
+    });
+
+    test("shows picker when user declines suggested app", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockGetToken.mockResolvedValue("token");
+      const otherApp = {
+        application_id: "app_other",
+        name: "Other App",
+        instances: [
+          {
+            instance_id: "ins_dev_other",
+            environment_type: "development",
+            publishable_key: "pk_other",
+          },
+        ],
+      };
+      mockListApplications.mockResolvedValue([mockApp, otherApp]);
+      mockFindClerkKeys.mockResolvedValue([
+        { key: "pk_test", source: "CLERK_PUBLISHABLE_KEY env var" },
+      ]);
+      mockMatchKeyToApp.mockReturnValue({
+        app: mockApp,
+        instance: mockApp.instances[0],
+        source: "CLERK_PUBLISHABLE_KEY env var",
+      });
+      mockConfirm.mockResolvedValue(false);
+      mockSearch.mockResolvedValue("app_other");
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link();
+
+      expect(mockSearch).toHaveBeenCalled();
+      expect(mockSetProfile).toHaveBeenCalledWith(
+        "github.com/org/repo",
+        expect.objectContaining({ appId: "app_other" }),
+      );
+    });
+
+    test("skips key detection when --app flag is provided", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockGetToken.mockResolvedValue("token");
+      mockFetchApplication.mockResolvedValue(mockApp);
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link({ app: "app_123" });
+
+      expect(mockFindClerkKeys).not.toHaveBeenCalled();
+      expect(mockMatchKeyToApp).not.toHaveBeenCalled();
+    });
+
+    test("returns silently with skipIfLinked when autolink succeeds", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockAutolink.mockResolvedValue({
+        path: "github.com/org/repo",
+        profile: { workspaceId: "", appId: "app_detected", instances: { development: "ins_1" } },
+      });
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+      errorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+      await link({ skipIfLinked: true });
+
+      expect(mockAutolink).toHaveBeenCalled();
+      expect(mockConfirm).not.toHaveBeenCalled();
+      expect(mockGetToken).not.toHaveBeenCalled();
+    });
+
+    test("falls through to picker when no keys detected", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockGetToken.mockResolvedValue("token");
+      mockListApplications.mockResolvedValue([mockApp]);
+      mockFindClerkKeys.mockResolvedValue([]);
+      mockSearch.mockResolvedValue("app_123");
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link();
+
+      expect(mockFindClerkKeys).toHaveBeenCalled();
+      expect(mockMatchKeyToApp).not.toHaveBeenCalled();
+      expect(mockSearch).toHaveBeenCalled();
+    });
+
+    test("falls through to picker when keys don't match any app", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockGetToken.mockResolvedValue("token");
+      mockListApplications.mockResolvedValue([mockApp]);
+      mockFindClerkKeys.mockResolvedValue([{ key: "sk_unknown", source: ".env" }]);
+      mockMatchKeyToApp.mockReturnValue(undefined);
+      mockSearch.mockResolvedValue("app_123");
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link();
+
+      expect(mockMatchKeyToApp).toHaveBeenCalled();
+      expect(mockConfirm).not.toHaveBeenCalled();
+      expect(mockSearch).toHaveBeenCalled();
     });
   });
 });

--- a/src/commands/link/index.ts
+++ b/src/commands/link/index.ts
@@ -49,8 +49,8 @@ export async function link(options: LinkOptions = {}): Promise<void> {
   const profileKey = normalizedRemote ?? repoId ?? cwd;
   const displayPath = repoRoot ?? cwd;
 
-  const shouldContinue = await handleExistingProfile(cwd, normalizedRemote, options);
-  if (!shouldContinue) return;
+  const isRelinking = await handleExistingProfile(cwd, normalizedRemote, options);
+  if (isRelinking === undefined) return;
 
   if (options.skipIfLinked && !options.app) {
     const autolinked = await autolink(cwd);
@@ -63,7 +63,7 @@ export async function link(options: LinkOptions = {}): Promise<void> {
     await login();
   }
 
-  const app = await resolveApp(cwd, displayPath, options);
+  const app = await resolveApp(cwd, displayPath, options, isRelinking);
 
   const devInstance = app.instances.find((i) => i.environment_type === "development");
   const prodInstance = app.instances.find((i) => i.environment_type === "production");
@@ -85,13 +85,16 @@ export async function link(options: LinkOptions = {}): Promise<void> {
   console.log(`\nLinked to ${cyan(label)} in ${dim(displayPath)}`);
 }
 
+/**
+ * Returns `undefined` to stop, `false` for first-time link, `true` for re-link.
+ */
 async function handleExistingProfile(
   cwd: string,
   normalizedRemote: string | undefined,
   options: LinkOptions,
-): Promise<boolean> {
+): Promise<boolean | undefined> {
   const existing = await resolveProfile(cwd);
-  if (!existing) return true;
+  if (!existing) return false;
 
   if (existing.resolvedVia === "remote") {
     console.log(`Auto-linked via git remote (${dim(normalizedRemote ?? existing.path)})`);
@@ -99,7 +102,7 @@ async function handleExistingProfile(
     console.log(`Already linked to ${cyan(existing.profile.appId)} in ${dim(existing.path)}`);
   }
 
-  if (options.skipIfLinked) return false;
+  if (options.skipIfLinked) return undefined;
 
   if (existing.availableRemote) {
     console.log(
@@ -112,7 +115,7 @@ async function handleExistingProfile(
     if (upgrade) {
       await moveProfile(existing.path, existing.availableRemote);
       console.log(`\nLink updated to use git remote (${cyan(existing.availableRemote)})`);
-      return false;
+      return undefined;
     }
   }
 
@@ -120,13 +123,14 @@ async function handleExistingProfile(
     message: "Re-link to a different application?",
     default: false,
   });
-  return relink;
+  return relink ? true : undefined;
 }
 
 async function resolveApp(
   cwd: string,
   displayPath: string,
   options: LinkOptions,
+  isRelinking: boolean,
 ): Promise<Application> {
   if (options.app) {
     return fetchApplication(options.app);
@@ -138,21 +142,22 @@ async function resolveApp(
     throw new CliError("No applications found. Create one at https://dashboard.clerk.com first.");
   }
 
-  const detectedKeys = await findClerkKeys(cwd);
-  const match = detectedKeys.length > 0 ? matchKeyToApp(detectedKeys, apps) : undefined;
+  if (!isRelinking) {
+    const detectedKeys = await findClerkKeys(cwd);
+    const match = detectedKeys.length > 0 ? matchKeyToApp(detectedKeys, apps) : undefined;
 
-  if (!match) {
-    return pickApp(apps, displayPath);
+    if (match) {
+      const label = appLabel(match.app);
+      console.log(`We found ${cyan(label)} from ${dim(match.source)}.`);
+      const useDetected = await confirm({
+        message: "Link to this application?",
+        default: true,
+      });
+      if (useDetected) return match.app;
+    }
   }
 
-  const label = appLabel(match.app);
-  console.log(`We found ${cyan(label)} from ${dim(match.source)}.`);
-  const useDetected = await confirm({
-    message: "Link to this application?",
-    default: true,
-  });
-
-  return useDetected ? match.app : pickApp(apps, displayPath);
+  return pickApp(apps, displayPath);
 }
 
 async function pickApp(apps: Application[], displayPath: string): Promise<Application> {

--- a/src/commands/link/index.ts
+++ b/src/commands/link/index.ts
@@ -49,21 +49,28 @@ export async function link(options: LinkOptions = {}): Promise<void> {
   const profileKey = normalizedRemote ?? repoId ?? cwd;
   const displayPath = repoRoot ?? cwd;
 
-  const isRelinking = await handleExistingProfile(cwd, normalizedRemote, options);
-  if (isRelinking === undefined) return;
+  const existing = await resolveProfile(cwd);
 
-  if (options.skipIfLinked && !options.app) {
+  if (existing && options.skipIfLinked) {
+    printExistingStatus(existing, normalizedRemote);
+    return;
+  }
+
+  if (!existing && options.skipIfLinked && !options.app) {
     const autolinked = await autolink(cwd);
     if (autolinked) return;
   }
 
-  const token = await getToken();
-  if (!token) {
-    console.log("Not logged in. Authenticating first...");
-    await login();
+  if (existing) {
+    const shouldRelink = await handleExistingProfile(existing, normalizedRemote, options);
+    if (!shouldRelink) return;
   }
 
-  const app = await resolveApp(cwd, displayPath, options, isRelinking);
+  await ensureAuth();
+
+  const app = options.app
+    ? await fetchApplication(options.app)
+    : await resolveApp(cwd, displayPath, !existing);
 
   const devInstance = app.instances.find((i) => i.environment_type === "development");
   const prodInstance = app.instances.find((i) => i.environment_type === "production");
@@ -85,24 +92,31 @@ export async function link(options: LinkOptions = {}): Promise<void> {
   console.log(`\nLinked to ${cyan(label)} in ${dim(displayPath)}`);
 }
 
-/**
- * Returns `undefined` to stop, `false` for first-time link, `true` for re-link.
- */
-async function handleExistingProfile(
-  cwd: string,
-  normalizedRemote: string | undefined,
-  options: LinkOptions,
-): Promise<boolean | undefined> {
-  const existing = await resolveProfile(cwd);
-  if (!existing) return false;
+async function ensureAuth() {
+  const token = await getToken();
+  if (!token) {
+    console.log("Not logged in. Authenticating first...");
+    await login();
+  }
+}
 
+function printExistingStatus(
+  existing: Awaited<ReturnType<typeof resolveProfile>> & {},
+  normalizedRemote: string | undefined,
+) {
   if (existing.resolvedVia === "remote") {
     console.log(`Auto-linked via git remote (${dim(normalizedRemote ?? existing.path)})`);
   } else {
     console.log(`Already linked to ${cyan(existing.profile.appId)} in ${dim(existing.path)}`);
   }
+}
 
-  if (options.skipIfLinked) return undefined;
+async function handleExistingProfile(
+  existing: Awaited<ReturnType<typeof resolveProfile>> & {},
+  normalizedRemote: string | undefined,
+  options: LinkOptions,
+): Promise<boolean> {
+  printExistingStatus(existing, normalizedRemote);
 
   if (existing.availableRemote) {
     console.log(
@@ -115,34 +129,31 @@ async function handleExistingProfile(
     if (upgrade) {
       await moveProfile(existing.path, existing.availableRemote);
       console.log(`\nLink updated to use git remote (${cyan(existing.availableRemote)})`);
-      return undefined;
+      return false;
     }
   }
 
-  const relink = await confirm({
-    message: "Re-link to a different application?",
-    default: false,
-  });
-  return relink ? true : undefined;
+  if (options.app) {
+    await ensureAuth();
+    const targetApp = await fetchApplication(options.app);
+    return confirm({ message: `Re-link to ${cyan(appLabel(targetApp))}?`, default: false });
+  }
+
+  return confirm({ message: "Re-link to a different application?", default: false });
 }
 
 async function resolveApp(
   cwd: string,
   displayPath: string,
-  options: LinkOptions,
-  isRelinking: boolean,
+  detectKeys: boolean,
 ): Promise<Application> {
-  if (options.app) {
-    return fetchApplication(options.app);
-  }
-
   const apps = await listApplications();
 
   if (apps.length === 0) {
     throw new CliError("No applications found. Create one at https://dashboard.clerk.com first.");
   }
 
-  if (!isRelinking) {
+  if (detectKeys) {
     const detectedKeys = await findClerkKeys(cwd);
     const match = detectedKeys.length > 0 ? matchKeyToApp(detectedKeys, apps) : undefined;
 

--- a/src/commands/link/index.ts
+++ b/src/commands/link/index.ts
@@ -5,6 +5,7 @@ import { getToken } from "../../lib/credential-store.js";
 import { login } from "../auth/login.js";
 import { listApplications, fetchApplication, type Application } from "../../lib/plapi.js";
 import { setProfile, resolveProfile, moveProfile } from "../../lib/config.js";
+import { autolink, findClerkKeys, matchKeyToApp } from "../../lib/autolink.js";
 import { getGitRepoIdentifier, getGitRepoRoot, getGitNormalizedRemote } from "../../lib/git.js";
 import { dim, cyan } from "../../lib/color.js";
 import { CliError } from "../../lib/errors.js";
@@ -41,7 +42,6 @@ export async function link(options: LinkOptions = {}): Promise<void> {
     return;
   }
 
-  // Resolve git repo identifier — prefer normalized remote URL for cross-clone matching
   const cwd = process.cwd();
   const repoRoot = await getGitRepoRoot();
   const normalizedRemote = await getGitNormalizedRemote();
@@ -49,81 +49,21 @@ export async function link(options: LinkOptions = {}): Promise<void> {
   const profileKey = normalizedRemote ?? repoId ?? cwd;
   const displayPath = repoRoot ?? cwd;
 
-  // Check if already linked
-  const existing = await resolveProfile(cwd);
-  if (existing) {
-    // Print context-specific message
-    if (existing.resolvedVia === "remote") {
-      console.log(`Auto-linked via git remote (${dim(normalizedRemote ?? existing.path)})`);
-    } else {
-      console.log(`Already linked to ${cyan(existing.profile.appId)} in ${dim(existing.path)}`);
-    }
+  const shouldContinue = await handleExistingProfile(cwd, normalizedRemote, options);
+  if (!shouldContinue) return;
 
-    if (options.skipIfLinked) return;
-
-    // Offer upgrade when an old profile key can migrate to a remote URL
-    if (existing.availableRemote) {
-      console.log(
-        `We detected this is now a git repository with remote ${dim(existing.availableRemote)}.`,
-      );
-      const upgrade = await confirm({
-        message:
-          "Update the link to use the git remote? This shares it across clones and worktrees.",
-        default: true,
-      });
-      if (upgrade) {
-        await moveProfile(existing.path, existing.availableRemote);
-        console.log(`\nLink updated to use git remote (${cyan(existing.availableRemote)})`);
-        return;
-      }
-    }
-
-    const relink = await confirm({
-      message: "Re-link to a different application?",
-      default: false,
-    });
-    if (!relink) return;
+  if (options.skipIfLinked && !options.app) {
+    const autolinked = await autolink(cwd);
+    if (autolinked) return;
   }
 
-  // Ensure authenticated
   const token = await getToken();
   if (!token) {
     console.log("Not logged in. Authenticating first...");
     await login();
   }
 
-  // Determine which app to link
-  let app: Application;
-
-  if (options.app) {
-    app = await fetchApplication(options.app);
-  } else {
-    const apps = await listApplications();
-
-    if (apps.length === 0) {
-      throw new CliError("No applications found. Create one at https://dashboard.clerk.com first.");
-    }
-
-    const choices = apps.map((a) => ({
-      name: appLabel(a),
-      value: a.application_id,
-    }));
-
-    const selectedId = await search({
-      message: `Select a Clerk application to link ${dim(`(repo: ${basename(displayPath)})`)}`,
-      source: (term) => {
-        if (!term) return choices;
-        const lower = term.toLowerCase();
-        return choices.filter((c) => c.name.toLowerCase().includes(lower));
-      },
-    });
-
-    const found = apps.find((a) => a.application_id === selectedId);
-    if (!found) {
-      throw new CliError("Selected application not found.");
-    }
-    app = found;
-  }
+  const app = await resolveApp(cwd, displayPath, options);
 
   const devInstance = app.instances.find((i) => i.environment_type === "development");
   const prodInstance = app.instances.find((i) => i.environment_type === "production");
@@ -132,7 +72,6 @@ export async function link(options: LinkOptions = {}): Promise<void> {
     throw new CliError("Application has no development instance.");
   }
 
-  // Store profile keyed by git repo (or cwd if not in a repo)
   await setProfile(profileKey, {
     workspaceId: "",
     appId: app.application_id,
@@ -144,4 +83,96 @@ export async function link(options: LinkOptions = {}): Promise<void> {
 
   const label = app.name || app.application_id;
   console.log(`\nLinked to ${cyan(label)} in ${dim(displayPath)}`);
+}
+
+async function handleExistingProfile(
+  cwd: string,
+  normalizedRemote: string | undefined,
+  options: LinkOptions,
+): Promise<boolean> {
+  const existing = await resolveProfile(cwd);
+  if (!existing) return true;
+
+  if (existing.resolvedVia === "remote") {
+    console.log(`Auto-linked via git remote (${dim(normalizedRemote ?? existing.path)})`);
+  } else {
+    console.log(`Already linked to ${cyan(existing.profile.appId)} in ${dim(existing.path)}`);
+  }
+
+  if (options.skipIfLinked) return false;
+
+  if (existing.availableRemote) {
+    console.log(
+      `We detected this is now a git repository with remote ${dim(existing.availableRemote)}.`,
+    );
+    const upgrade = await confirm({
+      message: "Update the link to use the git remote? This shares it across clones and worktrees.",
+      default: true,
+    });
+    if (upgrade) {
+      await moveProfile(existing.path, existing.availableRemote);
+      console.log(`\nLink updated to use git remote (${cyan(existing.availableRemote)})`);
+      return false;
+    }
+  }
+
+  const relink = await confirm({
+    message: "Re-link to a different application?",
+    default: false,
+  });
+  return relink;
+}
+
+async function resolveApp(
+  cwd: string,
+  displayPath: string,
+  options: LinkOptions,
+): Promise<Application> {
+  if (options.app) {
+    return fetchApplication(options.app);
+  }
+
+  const apps = await listApplications();
+
+  if (apps.length === 0) {
+    throw new CliError("No applications found. Create one at https://dashboard.clerk.com first.");
+  }
+
+  const detectedKeys = await findClerkKeys(cwd);
+  const match = detectedKeys.length > 0 ? matchKeyToApp(detectedKeys, apps) : undefined;
+
+  if (!match) {
+    return pickApp(apps, displayPath);
+  }
+
+  const label = appLabel(match.app);
+  console.log(`We found ${cyan(label)} from ${dim(match.source)}.`);
+  const useDetected = await confirm({
+    message: "Link to this application?",
+    default: true,
+  });
+
+  return useDetected ? match.app : pickApp(apps, displayPath);
+}
+
+async function pickApp(apps: Application[], displayPath: string): Promise<Application> {
+  const choices = apps.map((a) => ({
+    name: appLabel(a),
+    value: a.application_id,
+  }));
+
+  const selectedId = await search({
+    message: `Select a Clerk application to link ${dim(`(repo: ${basename(displayPath)})`)}`,
+    source: (term) => {
+      if (!term) return choices;
+      const lower = term.toLowerCase();
+      return choices.filter((c) => c.name.toLowerCase().includes(lower));
+    },
+  });
+
+  const found = apps.find((a) => a.application_id === selectedId);
+  if (!found) {
+    throw new CliError("Selected application not found.");
+  }
+  return found;
 }

--- a/src/lib/autolink.test.ts
+++ b/src/lib/autolink.test.ts
@@ -1,0 +1,386 @@
+import { test, expect, describe, beforeEach, afterEach, mock, spyOn } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { credentialStoreStubs, gitStubs, stubFetch } from "../test/stubs.ts";
+
+mock.module("./credential-store.ts", () => credentialStoreStubs);
+
+const mockGetGitRepoIdentifier = mock();
+const mockGetGitNormalizedRemote = mock();
+mock.module("./git.ts", () => ({
+  ...gitStubs,
+  getGitRepoIdentifier: (...args: unknown[]) => mockGetGitRepoIdentifier(...args),
+  getGitNormalizedRemote: (...args: unknown[]) => mockGetGitNormalizedRemote(...args),
+}));
+
+const { findClerkKeys, matchKeyToApp, autolink } = await import("./autolink.ts");
+const { _setConfigDir, readConfig } = await import("./config.ts");
+
+const mockApps = [
+  {
+    application_id: "app_123",
+    name: "My App",
+    instances: [
+      {
+        instance_id: "ins_dev",
+        environment_type: "development",
+        publishable_key: "pk_test_abc",
+      },
+      {
+        instance_id: "ins_prod",
+        environment_type: "production",
+        publishable_key: "pk_live_abc",
+      },
+    ],
+  },
+  {
+    application_id: "app_456",
+    name: "Other App",
+    instances: [
+      {
+        instance_id: "ins_dev_2",
+        environment_type: "development",
+        publishable_key: "pk_test_def",
+      },
+    ],
+  },
+];
+
+async function writePackageJson(dir: string, dep: string) {
+  await Bun.write(join(dir, "package.json"), JSON.stringify({ dependencies: { [dep]: "latest" } }));
+}
+
+describe("findClerkKeys", () => {
+  const originalEnv = { ...process.env };
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "clerk-autolink-test-"));
+    process.env = { ...originalEnv };
+    delete process.env.CLERK_PUBLISHABLE_KEY;
+    delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+    delete process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY;
+    delete process.env.NUXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+    delete process.env.VITE_CLERK_PUBLISHABLE_KEY;
+    delete process.env.PUBLIC_CLERK_PUBLISHABLE_KEY;
+  });
+
+  afterEach(async () => {
+    process.env = { ...originalEnv };
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("returns empty when no keys found", async () => {
+    const keys = await findClerkKeys(tempDir);
+    expect(keys).toEqual([]);
+  });
+
+  test("detects CLERK_PUBLISHABLE_KEY from env var", async () => {
+    process.env.CLERK_PUBLISHABLE_KEY = "pk_test_abc";
+    const keys = await findClerkKeys(tempDir);
+    expect(keys).toEqual([{ key: "pk_test_abc", source: "CLERK_PUBLISHABLE_KEY env var" }]);
+  });
+
+  test("detects NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY from env var", async () => {
+    await writePackageJson(tempDir, "next");
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_next";
+    const keys = await findClerkKeys(tempDir);
+    expect(keys).toEqual([
+      { key: "pk_test_next", source: "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY env var" },
+    ]);
+  });
+
+  test("detects keys from .env.local file", async () => {
+    await Bun.write(join(tempDir, ".env.local"), "CLERK_PUBLISHABLE_KEY=pk_test_file\n");
+    const keys = await findClerkKeys(tempDir);
+    expect(keys).toEqual([{ key: "pk_test_file", source: ".env.local" }]);
+  });
+
+  test("detects keys from .env file", async () => {
+    await Bun.write(join(tempDir, ".env"), "CLERK_PUBLISHABLE_KEY=pk_test_dotenv\n");
+    const keys = await findClerkKeys(tempDir);
+    expect(keys).toEqual([{ key: "pk_test_dotenv", source: ".env" }]);
+  });
+
+  test("prioritizes env vars over .env files", async () => {
+    process.env.CLERK_PUBLISHABLE_KEY = "pk_from_env";
+    await Bun.write(join(tempDir, ".env.local"), "CLERK_PUBLISHABLE_KEY=pk_from_file\n");
+    const keys = await findClerkKeys(tempDir);
+    expect(keys).toHaveLength(2);
+    expect(keys[0]).toEqual({ key: "pk_from_env", source: "CLERK_PUBLISHABLE_KEY env var" });
+    expect(keys[1]).toEqual({ key: "pk_from_file", source: ".env.local" });
+  });
+
+  test("deduplicates identical keys across sources", async () => {
+    process.env.CLERK_PUBLISHABLE_KEY = "pk_test_same";
+    await Bun.write(join(tempDir, ".env.local"), "CLERK_PUBLISHABLE_KEY=pk_test_same\n");
+    const keys = await findClerkKeys(tempDir);
+    expect(keys).toHaveLength(1);
+    expect(keys[0]!.source).toBe("CLERK_PUBLISHABLE_KEY env var");
+  });
+
+  test("prioritizes .env.local over .env", async () => {
+    await Bun.write(join(tempDir, ".env.local"), "CLERK_PUBLISHABLE_KEY=pk_local\n");
+    await Bun.write(join(tempDir, ".env"), "CLERK_PUBLISHABLE_KEY=pk_dotenv\n");
+    const keys = await findClerkKeys(tempDir);
+    expect(keys).toHaveLength(2);
+    expect(keys[0]!.key).toBe("pk_local");
+    expect(keys[1]!.key).toBe("pk_dotenv");
+  });
+
+  test("detects framework-specific publishable keys from .env files", async () => {
+    await writePackageJson(tempDir, "next");
+    await Bun.write(
+      join(tempDir, ".env.local"),
+      "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_next\n",
+    );
+    const keys = await findClerkKeys(tempDir);
+    expect(keys).toEqual([{ key: "pk_test_next", source: ".env.local" }]);
+  });
+
+  test("handles quoted values in .env files", async () => {
+    await Bun.write(join(tempDir, ".env"), 'CLERK_PUBLISHABLE_KEY="pk_test_quoted"\n');
+    const keys = await findClerkKeys(tempDir);
+    expect(keys).toEqual([{ key: "pk_test_quoted", source: ".env" }]);
+  });
+
+  test("skips empty values", async () => {
+    await Bun.write(join(tempDir, ".env"), "CLERK_PUBLISHABLE_KEY=\n");
+    const keys = await findClerkKeys(tempDir);
+    expect(keys).toEqual([]);
+  });
+});
+
+describe("matchKeyToApp", () => {
+  test("matches by publishable key", () => {
+    const keys = [{ key: "pk_test_abc", source: ".env.local" }];
+    const result = matchKeyToApp(keys, mockApps);
+    expect(result).toBeDefined();
+    expect(result!.app.application_id).toBe("app_123");
+    expect(result!.instance.instance_id).toBe("ins_dev");
+  });
+
+  test("matches production instance", () => {
+    const keys = [{ key: "pk_live_abc", source: "env" }];
+    const result = matchKeyToApp(keys, mockApps);
+    expect(result).toBeDefined();
+    expect(result!.app.application_id).toBe("app_123");
+    expect(result!.instance.instance_id).toBe("ins_prod");
+  });
+
+  test("returns undefined when no match", () => {
+    const keys = [{ key: "pk_test_unknown", source: "env" }];
+    const result = matchKeyToApp(keys, mockApps);
+    expect(result).toBeUndefined();
+  });
+
+  test("returns undefined for empty keys", () => {
+    const result = matchKeyToApp([], mockApps);
+    expect(result).toBeUndefined();
+  });
+
+  test("returns undefined for empty apps", () => {
+    const keys = [{ key: "pk_test_abc", source: "env" }];
+    const result = matchKeyToApp(keys, []);
+    expect(result).toBeUndefined();
+  });
+
+  test("returns first match when multiple keys match", () => {
+    const keys = [
+      { key: "pk_test_def", source: "env" },
+      { key: "pk_test_abc", source: ".env" },
+    ];
+    const result = matchKeyToApp(keys, mockApps);
+    expect(result!.app.application_id).toBe("app_456");
+    expect(result!.source).toBe("env");
+  });
+
+  test("does not match by secret key", () => {
+    const appsWithSecrets = [
+      {
+        application_id: "app_999",
+        name: "Secret App",
+        instances: [
+          {
+            instance_id: "ins_secret",
+            environment_type: "development",
+            secret_key: "sk_test_secret",
+            publishable_key: "pk_test_secret",
+          },
+        ],
+      },
+    ];
+    const keys = [{ key: "sk_test_secret", source: "env" }];
+    const result = matchKeyToApp(keys, appsWithSecrets);
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("autolink", () => {
+  const originalEnv = { ...process.env };
+  const originalFetch = globalThis.fetch;
+  let tempDir: string;
+  let errorSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "clerk-autolink-test-"));
+    _setConfigDir(tempDir);
+    process.env = { ...originalEnv };
+    delete process.env.CLERK_PUBLISHABLE_KEY;
+    process.env.CLERK_PLATFORM_API_KEY = "test_platform_key";
+    process.env.CLERK_PLATFORM_API_URL = "https://test-api.clerk.com";
+    mockGetGitRepoIdentifier.mockReset();
+    mockGetGitRepoIdentifier.mockResolvedValue(undefined);
+    mockGetGitNormalizedRemote.mockReset();
+    mockGetGitNormalizedRemote.mockResolvedValue(undefined);
+    errorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    stubFetch(async () => new Response(JSON.stringify(mockApps), { status: 200 }));
+  });
+
+  afterEach(async () => {
+    _setConfigDir(undefined);
+    process.env = { ...originalEnv };
+    globalThis.fetch = originalFetch;
+    errorSpy.mockRestore();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("returns undefined when no keys detected", async () => {
+    const result = await autolink(tempDir);
+    expect(result).toBeUndefined();
+  });
+
+  test("returns undefined when not authenticated", async () => {
+    process.env.CLERK_PUBLISHABLE_KEY = "pk_test_abc";
+    delete process.env.CLERK_PLATFORM_API_KEY;
+
+    const result = await autolink(tempDir);
+    expect(result).toBeUndefined();
+  });
+
+  test("returns undefined when API returns error", async () => {
+    process.env.CLERK_PUBLISHABLE_KEY = "pk_test_abc";
+    stubFetch(async () => new Response("Unauthorized", { status: 401 }));
+
+    const result = await autolink(tempDir);
+    expect(result).toBeUndefined();
+  });
+
+  test("returns undefined when key doesn't match any app", async () => {
+    process.env.CLERK_PUBLISHABLE_KEY = "pk_test_unknown";
+
+    const result = await autolink(tempDir);
+    expect(result).toBeUndefined();
+  });
+
+  test("auto-links when publishable key matches via env var", async () => {
+    process.env.CLERK_PUBLISHABLE_KEY = "pk_test_abc";
+
+    const result = await autolink(tempDir);
+
+    expect(result).toBeDefined();
+    expect(result!.profile.appId).toBe("app_123");
+    expect(result!.profile.instances.development).toBe("ins_dev");
+    expect(result!.profile.instances.production).toBe("ins_prod");
+
+    // Verify profile was persisted
+    const config = await readConfig();
+    expect(config.profiles[tempDir]).toBeDefined();
+    expect(config.profiles[tempDir]!.appId).toBe("app_123");
+  });
+
+  test("auto-links when publishable key matches via .env file", async () => {
+    await Bun.write(join(tempDir, ".env.local"), "CLERK_PUBLISHABLE_KEY=pk_test_def\n");
+
+    const result = await autolink(tempDir);
+
+    expect(result).toBeDefined();
+    expect(result!.profile.appId).toBe("app_456");
+    expect(result!.profile.instances.development).toBe("ins_dev_2");
+  });
+
+  test("uses normalized remote as profile key when available", async () => {
+    process.env.CLERK_PUBLISHABLE_KEY = "pk_test_abc";
+    mockGetGitNormalizedRemote.mockResolvedValue("github.com/org/repo");
+
+    const result = await autolink(tempDir);
+
+    expect(result!.path).toBe("github.com/org/repo");
+    const config = await readConfig();
+    expect(config.profiles["github.com/org/repo"]).toBeDefined();
+  });
+
+  test("uses git repo identifier when no remote", async () => {
+    process.env.CLERK_PUBLISHABLE_KEY = "pk_test_abc";
+    mockGetGitNormalizedRemote.mockResolvedValue(undefined);
+    mockGetGitRepoIdentifier.mockResolvedValue("/repo/.git");
+
+    const result = await autolink(tempDir);
+
+    expect(result!.path).toBe("/repo/.git");
+    const config = await readConfig();
+    expect(config.profiles["/repo/.git"]).toBeDefined();
+  });
+
+  test("falls back to cwd when not in a git repo", async () => {
+    process.env.CLERK_PUBLISHABLE_KEY = "pk_test_abc";
+
+    const result = await autolink(tempDir);
+
+    expect(result!.path).toBe(tempDir);
+  });
+
+  test("prints auto-link message to stderr", async () => {
+    process.env.CLERK_PUBLISHABLE_KEY = "pk_test_abc";
+
+    await autolink(tempDir);
+
+    const output = errorSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    expect(output).toContain("Auto-linked to");
+    expect(output).toContain("My App");
+    expect(output).toContain("CLERK_PUBLISHABLE_KEY env var");
+  });
+
+  test("returns undefined when matched app has no development instance", async () => {
+    process.env.CLERK_PUBLISHABLE_KEY = "pk_live_only";
+    stubFetch(
+      async () =>
+        new Response(
+          JSON.stringify([
+            {
+              application_id: "app_no_dev",
+              instances: [
+                {
+                  instance_id: "ins_prod",
+                  environment_type: "production",
+                  publishable_key: "pk_live_only",
+                },
+              ],
+            },
+          ]),
+          { status: 200 },
+        ),
+    );
+
+    const result = await autolink(tempDir);
+    expect(result).toBeUndefined();
+  });
+
+  test("handles non-array response from listApplications", async () => {
+    process.env.CLERK_PUBLISHABLE_KEY = "pk_test_abc";
+    stubFetch(async () => new Response(JSON.stringify({ error: "not an array" }), { status: 200 }));
+
+    const result = await autolink(tempDir);
+    expect(result).toBeUndefined();
+  });
+
+  test("omits production instance when not present", async () => {
+    process.env.CLERK_PUBLISHABLE_KEY = "pk_test_def";
+
+    const result = await autolink(tempDir);
+
+    expect(result!.profile.instances.production).toBeUndefined();
+  });
+});

--- a/src/lib/autolink.test.ts
+++ b/src/lib/autolink.test.ts
@@ -112,21 +112,21 @@ describe("findClerkKeys", () => {
     expect(keys[1]).toEqual({ key: "pk_from_file", source: ".env.local" });
   });
 
-  test("deduplicates identical keys across sources", async () => {
+  test("deduplicates identical keys across sources (last wins)", async () => {
     process.env.CLERK_PUBLISHABLE_KEY = "pk_test_same";
     await Bun.write(join(tempDir, ".env.local"), "CLERK_PUBLISHABLE_KEY=pk_test_same\n");
     const keys = await findClerkKeys(tempDir);
     expect(keys).toHaveLength(1);
-    expect(keys[0]!.source).toBe("CLERK_PUBLISHABLE_KEY env var");
+    expect(keys[0]!.source).toBe(".env.local");
   });
 
-  test("prioritizes .env.local over .env", async () => {
-    await Bun.write(join(tempDir, ".env.local"), "CLERK_PUBLISHABLE_KEY=pk_local\n");
+  test(".env.local overrides .env for the same key (last wins)", async () => {
     await Bun.write(join(tempDir, ".env"), "CLERK_PUBLISHABLE_KEY=pk_dotenv\n");
+    await Bun.write(join(tempDir, ".env.local"), "CLERK_PUBLISHABLE_KEY=pk_local\n");
     const keys = await findClerkKeys(tempDir);
     expect(keys).toHaveLength(2);
-    expect(keys[0]!.key).toBe("pk_local");
-    expect(keys[1]!.key).toBe("pk_dotenv");
+    expect(keys[0]!.key).toBe("pk_dotenv");
+    expect(keys[1]!.key).toBe("pk_local");
   });
 
   test("detects framework-specific publishable keys from .env files", async () => {
@@ -222,6 +222,7 @@ describe("autolink", () => {
   const originalFetch = globalThis.fetch;
   let tempDir: string;
   let errorSpy: ReturnType<typeof spyOn>;
+  let debugSpy: ReturnType<typeof spyOn>;
 
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), "clerk-autolink-test-"));
@@ -235,6 +236,7 @@ describe("autolink", () => {
     mockGetGitNormalizedRemote.mockReset();
     mockGetGitNormalizedRemote.mockResolvedValue(undefined);
     errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    debugSpy = spyOn(console, "debug").mockImplementation(() => {});
 
     stubFetch(async () => new Response(JSON.stringify(mockApps), { status: 200 }));
   });
@@ -244,6 +246,7 @@ describe("autolink", () => {
     process.env = { ...originalEnv };
     globalThis.fetch = originalFetch;
     errorSpy.mockRestore();
+    debugSpy.mockRestore();
     await rm(tempDir, { recursive: true, force: true });
   });
 

--- a/src/lib/autolink.ts
+++ b/src/lib/autolink.ts
@@ -6,22 +6,29 @@ import { parseEnvFile } from "./dotenv.ts";
 import { detectPublishableKeyName } from "./framework.ts";
 import { dim, cyan } from "./color.ts";
 
-const ENV_FILES = [".env.local", ".env"];
+const ENV_FILES = [".env", ".env.local"];
 
 interface DetectedKey {
   key: string;
   source: string;
 }
 
+/**
+ * Collects Clerk publishable keys from the environment and .env files.
+ * Sources are checked in order: process.env, .env, .env.local (last wins for duplicates).
+ */
 export async function findClerkKeys(cwd: string): Promise<DetectedKey[]> {
   const keys: DetectedKey[] = [];
-  const seen = new Set<string>();
   const publishableKeyName = await detectPublishableKeyName(cwd);
 
   function add(key: string, source: string) {
-    if (!key || seen.has(key)) return;
-    seen.add(key);
-    keys.push({ key, source });
+    if (!key) return;
+    const existing = keys.findIndex((k) => k.key === key);
+    if (existing !== -1) {
+      keys[existing]!.source = source;
+    } else {
+      keys.push({ key, source });
+    }
   }
 
   if (process.env[publishableKeyName]) {
@@ -46,6 +53,10 @@ export async function findClerkKeys(cwd: string): Promise<DetectedKey[]> {
   return keys;
 }
 
+/**
+ * Returns the first key/app pair where a detected key matches an app instance's publishable key.
+ * Keys are tried in order, so earlier entries in `keys` have higher priority.
+ */
 export function matchKeyToApp(
   keys: DetectedKey[],
   apps: Application[],
@@ -73,7 +84,8 @@ export async function autolink(
   let apps: Application[];
   try {
     apps = await listApplications();
-  } catch {
+  } catch (err) {
+    console.error(`Failed to list applications: ${err}`);
     return undefined;
   }
 
@@ -91,13 +103,17 @@ export async function autolink(
 
   if (!devInstance) return undefined;
 
+  const instances: Profile["instances"] = {
+    development: devInstance.instance_id,
+  };
+  if (prodInstance) {
+    instances.production = prodInstance.instance_id;
+  }
+
   const profile: Profile = {
     workspaceId: "",
     appId: match.app.application_id,
-    instances: {
-      development: devInstance.instance_id,
-      ...(prodInstance ? { production: prodInstance.instance_id } : {}),
-    },
+    instances,
   };
 
   await setProfile(profileKey, profile);

--- a/src/lib/autolink.ts
+++ b/src/lib/autolink.ts
@@ -1,0 +1,109 @@
+import { join } from "node:path";
+import { setProfile, type Profile } from "./config.ts";
+import { listApplications, type Application, type ApplicationInstance } from "./plapi.ts";
+import { getGitRepoIdentifier, getGitNormalizedRemote } from "./git.ts";
+import { parseEnvFile } from "./dotenv.ts";
+import { detectPublishableKeyName } from "./framework.ts";
+import { dim, cyan } from "./color.ts";
+
+const ENV_FILES = [".env.local", ".env"];
+
+interface DetectedKey {
+  key: string;
+  source: string;
+}
+
+export async function findClerkKeys(cwd: string): Promise<DetectedKey[]> {
+  const keys: DetectedKey[] = [];
+  const seen = new Set<string>();
+  const publishableKeyName = await detectPublishableKeyName(cwd);
+
+  function add(key: string, source: string) {
+    if (!key || seen.has(key)) return;
+    seen.add(key);
+    keys.push({ key, source });
+  }
+
+  if (process.env[publishableKeyName]) {
+    add(process.env[publishableKeyName]!, `${publishableKeyName} env var`);
+  }
+
+  for (const envFile of ENV_FILES) {
+    const filePath = join(cwd, envFile);
+    const file = Bun.file(filePath);
+    if (!(await file.exists())) continue;
+
+    const content = await file.text();
+    const lines = parseEnvFile(content);
+    for (const line of lines) {
+      if (line.type !== "entry") continue;
+      if (line.key === publishableKeyName) {
+        add(line.value, envFile);
+      }
+    }
+  }
+
+  return keys;
+}
+
+export function matchKeyToApp(
+  keys: DetectedKey[],
+  apps: Application[],
+): { app: Application; instance: ApplicationInstance; source: string } | undefined {
+  const byKey = new Map<string, { app: Application; instance: ApplicationInstance }>();
+  for (const app of apps) {
+    for (const instance of app.instances) {
+      byKey.set(instance.publishable_key, { app, instance });
+    }
+  }
+
+  for (const { key, source } of keys) {
+    const match = byKey.get(key);
+    if (match) return { ...match, source };
+  }
+  return undefined;
+}
+
+export async function autolink(
+  cwd: string,
+): Promise<{ path: string; profile: Profile } | undefined> {
+  const detectedKeys = await findClerkKeys(cwd);
+  if (detectedKeys.length === 0) return undefined;
+
+  let apps: Application[];
+  try {
+    apps = await listApplications();
+  } catch {
+    return undefined;
+  }
+
+  if (!Array.isArray(apps)) return undefined;
+
+  const match = matchKeyToApp(detectedKeys, apps);
+  if (!match) return undefined;
+
+  const normalizedRemote = await getGitNormalizedRemote();
+  const repoId = await getGitRepoIdentifier();
+  const profileKey = normalizedRemote ?? repoId ?? cwd;
+
+  const devInstance = match.app.instances.find((i) => i.environment_type === "development");
+  const prodInstance = match.app.instances.find((i) => i.environment_type === "production");
+
+  if (!devInstance) return undefined;
+
+  const profile: Profile = {
+    workspaceId: "",
+    appId: match.app.application_id,
+    instances: {
+      development: devInstance.instance_id,
+      ...(prodInstance ? { production: prodInstance.instance_id } : {}),
+    },
+  };
+
+  await setProfile(profileKey, profile);
+
+  const label = match.app.name || match.app.application_id;
+  console.error(`Auto-linked to ${cyan(label)} ${dim(`(detected key in ${match.source})`)}`);
+
+  return { path: profileKey, profile };
+}

--- a/src/test/stubs.ts
+++ b/src/test/stubs.ts
@@ -19,7 +19,14 @@ export const configStubs = {
   moveProfile: noop,
   listProfiles: noop,
   resolveProfile: noop,
+  resolveProfileOrAutolink: noop,
   resolveInstanceId: () => ({ id: "", label: "" }),
+};
+
+export const autolinkStubs = {
+  findClerkKeys: async () => [],
+  matchKeyToApp: () => undefined,
+  autolink: async () => undefined,
 };
 
 export const credentialStoreStubs = {


### PR DESCRIPTION
## Summary

- Adds `src/lib/autolink.ts` with `findClerkKeys()` and `matchKeyToApp()` to detect publishable keys from env vars and `.env` files, then match them against Platform API applications
- Uses `detectPublishableKeyName(cwd)` from `framework.ts` to resolve the correct env var name based on the project's framework (e.g., `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` for Next.js)
- Integrates key detection into `clerk link`: when keys are found, suggests the matching app before showing the interactive picker
- Refactors `link()` to extract `handleExistingProfile()`, `resolveApp()`, and `ensureAuth()` helpers, flattening nested control flow
- Skips key suggestion when re-linking (user already linked, chose to switch apps) to avoid suggesting the same app twice
- Shows the target app name in the re-link prompt when `--app` is provided (e.g., "Re-link to My App (app_123)?")

## Test plan

- [x] `bun test` — all 365 tests pass
- [x] Run `clerk link` in a project with a `.env.local` containing a valid publishable key — should suggest the matching app
- [x] Confirm the suggestion and verify the profile is persisted
- [x] Decline the suggestion and verify the interactive picker is shown
- [x] Run `clerk link` when already linked, accept re-link — should show picker directly without suggesting the detected app
- [x] Run `clerk link --app <id>` when already linked — re-link prompt should show the target app name
- [x] Run `clerk link --app <id>` — should skip key detection entirely
- [x] Run `clerk link` with no keys present — should go straight to the picker