### PR TITLE
chore: Set minimumReleaseAge in bun config

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,3 @@
+[install]
+# Only install package versions published at least 2 days ago
+minimumReleaseAge = 172800


### PR DESCRIPTION
Wait 48 hours before pulling in new dependency versions. Gives us time to react to _most_ supply chain compromises.