### PR TITLE
feat: add strict CLI typings with @commander-js/extra-typings

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "marseille",
       "dependencies": {
+        "@commander-js/extra-typings": "^14.0.0",
         "@inquirer/prompts": "^8.2.0",
         "@napi-rs/keyring": "^1.2.0",
         "commander": "^14.0.3",
@@ -23,6 +24,8 @@
     },
   },
   "packages": {
+    "@commander-js/extra-typings": ["@commander-js/extra-typings@14.0.0", "", { "peerDependencies": { "commander": "~14.0.0" } }, "sha512-hIn0ncNaJRLkZrxBIp5AsW/eXEHNKYQBh0aPdoUqNgD+Io3NIykQqpKFyKcuasZhicGaEZJX/JBSIkZ4e5x8Dg=="],
+
     "@inquirer/ansi": ["@inquirer/ansi@2.0.3", "", {}, "sha512-g44zhR3NIKVs0zUesa4iMzExmZpLUdTLRMCStqX3GE5NT6VkPcxQGJ+uC8tDgBUC/vB1rUhUd55cOf++4NZcmw=="],
 
     "@inquirer/checkbox": ["@inquirer/checkbox@5.0.4", "", { "dependencies": { "@inquirer/ansi": "^2.0.3", "@inquirer/core": "^11.1.1", "@inquirer/figures": "^2.0.3", "@inquirer/type": "^4.0.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-DrAMU3YBGMUAp6ArwTIp/25CNDtDbxk7UjIrrtM25JVVrlVYlVzHh5HR1BDFu9JMyUoZ4ZanzeaHqNDttf3gVg=="],

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "prepare": "git config core.hooksPath .hooks"
   },
   "dependencies": {
+    "@commander-js/extra-typings": "^14.0.0",
     "@inquirer/prompts": "^8.2.0",
     "@napi-rs/keyring": "^1.2.0",
     "commander": "^14.0.3",

--- a/src/cli-program.ts
+++ b/src/cli-program.ts
@@ -1,4 +1,4 @@
-import { Command } from "commander";
+import { Command } from "@commander-js/extra-typings";
 import { setMode, type Mode } from "./mode.js";
 import { init } from "./commands/init/index.js";
 import { login } from "./commands/auth/login.js";
@@ -16,10 +16,8 @@ import { doctor } from "./commands/doctor/index.js";
 import { CliError, UserAbortError, ApiError, EXIT_CODE, throwUsageError } from "./lib/errors.js";
 import { red } from "./lib/color.js";
 
-export function createProgram(): Command {
-  const program = new Command();
-
-  program
+export function createProgram() {
+  const program = new Command()
     .name("clerk")
     .description("Clerk CLI")
     .version(require("../package.json").version)
@@ -181,9 +179,9 @@ function formatApiBody(body: string, verbose: boolean): string {
  * Used by `cli.ts` for real execution and by integration tests.
  */
 export async function runProgram(
-  program: Command,
+  program: ReturnType<typeof createProgram>,
   args?: string[],
-  options?: { from?: "user" | "node" },
+  options?: { from: "user" | "node" },
 ): Promise<void> {
   try {
     await program.parseAsync(args, options);


### PR DESCRIPTION
## Summary

- **Strict option inference** — swap the `commander` import for `@commander-js/extra-typings` (types-only, zero runtime change) so `.opts()` and `.action()` callbacks get inferred types from the `.option()` / `.argument()` chain
- **Chained program creation** — capture `new Command().name().option()...` in a single expression so TypeScript can track the accumulated option types (`{ mode?: string; verbose?: true }`)
- **Typed `runProgram`** — use `ReturnType<typeof createProgram>` instead of bare `Command` so `program.opts().verbose` is typed in the error handler
- Existing manual option interfaces in command files (e.g. `ApiOptions`, `ConfigPushOptions`) are now validated against the command chain at compile time — drift between `.option()` definitions and handler signatures becomes a type error

## Test plan

- [ ] `bun test` — 362 tests pass
- [ ] `bunx tsc --noEmit` — no new type errors in `cli-program.ts`
- [ ] `bun run src/cli.ts --help` — CLI runs normally