### PR TITLE
docs: add examples to clerk api help output

### DIFF
--- a/src/cli-program.ts
+++ b/src/cli-program.ts
@@ -134,6 +134,15 @@ export function createProgram(): Command {
     .option("--platform", "Use Platform API instead of Backend API")
     .option("--dry-run", "Show the request without executing it")
     .option("--yes", "Skip confirmation for mutating requests")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  $ clerk api ls                              List all available endpoints
+  $ clerk api ls users                        List endpoints matching "users"
+  $ clerk api /users                          GET /v1/users
+  $ clerk api /users -d '{"first_name":"Alice"}'  POST with a JSON body`,
+    )
     .action(api);
 
   program

--- a/src/cli-program.ts
+++ b/src/cli-program.ts
@@ -138,10 +138,10 @@ export function createProgram(): Command {
       "after",
       `
 Examples:
-  $ clerk api ls                              List all available endpoints
-  $ clerk api ls users                        List endpoints matching "users"
-  $ clerk api /users                          GET /v1/users
-  $ clerk api /users -d '{"first_name":"Alice"}'  POST with a JSON body`,
+  $ clerk api ls                                   List all available endpoints
+  $ clerk api ls users                             List endpoints matching "users"
+  $ clerk api /users                               GET /v1/users
+  $ clerk api /users -d '{"first_name":"Alice"}'   POST with a JSON body`,
     )
     .action(api);
 


### PR DESCRIPTION
## Motivation
In running some tests, the agent didn't detect the `clerk api ls` command very well and i feel like this is a pretty critical bit of context for it to easily gather. I think by adding it as an example to the `--help` output, it's less likely to miss it. 

## Summary
Makes the `clerk api ls` command more discoverable by adding examples to the help output. Users can now immediately see how to list endpoints, filter them, and make requests.

<img width="1150" height="452" alt="CleanShot 2026-03-16 at 14 20 10@2x" src="https://github.com/user-attachments/assets/a5182096-fb67-44fd-8657-957005e59ffd" />


## Changes
- Add `.addHelpText()` to the api command in cli-program.ts
- Shows 4 practical examples: listing endpoints, filtering, GET request, POST request

🤖 Generated with [Claude Code](https://claude.com/claude-code)