### PR TITLE
Display auth timeout in login command

### DIFF
--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -3,7 +3,7 @@ import { startAuthServer } from "../../lib/auth-server.ts";
 import { OAUTH_CONFIG, exchangeCodeForToken, fetchUserInfo } from "../../lib/token-exchange.ts";
 import { storeToken, getToken } from "../../lib/credential-store.ts";
 import { getAuth, setAuth } from "../../lib/config.ts";
-import { CALLBACK_PATH } from "../../lib/constants.ts";
+import { AUTH_TIMEOUT_MS, CALLBACK_PATH } from "../../lib/constants.ts";
 
 export async function login(): Promise<{ userId: string; email: string }> {
   // Check if already authenticated
@@ -48,7 +48,8 @@ export async function login(): Promise<{ userId: string; email: string }> {
   await proc.exited;
 
   // Wait for the OAuth callback
-  console.log("Waiting for authentication...");
+  const timeoutMinutes = Math.round(AUTH_TIMEOUT_MS / 60_000);
+  console.log(`Waiting for authentication (timeout in ${timeoutMinutes}m)...`);
   let callbackResult: { code: string };
   try {
     callbackResult = await authServer.waitForCallback();


### PR DESCRIPTION
## Motivation
- When testing I ran into a hangup (bc of env vars not being sourced appropriately) but the agent ejected early before the timeout. By printing the timeout explicitly, it is more able to match it with its own tool call timeouts

## Summary
- Display the configured authentication timeout when waiting for browser-based login
- Users now see "Waiting for authentication (timeout in 2m)..." instead of ambiguous "Waiting for authentication..."

## Test plan
- [ ] Run `bun run src/cli.ts auth login` and verify the timeout message displays correctly
- [ ] Verify the timeout still triggers after the specified duration if auth is not completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)