### PR TITLE
Add direct app targeting for config and API flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,18 @@ clerk unlink
   --yes                Skip confirmation prompt
 
 clerk config pull
+  --app <id>           Application ID to target (works from any directory)
   --instance <id>      Instance to target (dev, prod, or a full instance ID)
   --output <file>      Write config to a file instead of stdout
 
 clerk config schema
+  --app <id>           Application ID to target (works from any directory)
   --instance <id>      Instance to target (dev, prod, or a full instance ID)
   --output <file>      Write schema to a file instead of stdout
   --keys <keys...>     Config keys to retrieve schema for
 
 clerk config patch
+  --app <id>           Application ID to target (works from any directory)
   --instance <id>      Instance to target (dev, prod, or a full instance ID)
   --file <path>        Read config JSON from a file
   --json <string>      Pass config JSON inline
@@ -60,6 +63,7 @@ clerk config patch
   --yes                Skip confirmation prompts
 
 clerk config put
+  --app <id>           Application ID to target (works from any directory)
   --instance <id>      Instance to target (dev, prod, or a full instance ID)
   --file <path>        Read config JSON from a file
   --json <string>      Pass config JSON inline
@@ -67,6 +71,7 @@ clerk config put
   --yes                Skip confirmation prompts
 
 clerk env pull
+  --app <id>           Application ID to target (works from any directory)
   --instance <id>      Instance to target (dev, prod, or a full instance ID)
   --file <path>        Target env file (default: auto-detect)
 
@@ -75,6 +80,7 @@ clerk api [endpoint] [filter]
   -d, --data <json>      JSON request body
   --file <path>          Read request body from a file
   --include              Show response headers
+  --app <id>             Application ID to target when resolving keys
   --secret-key <key>     Override the secret key
   --instance <id>        Instance to target (dev, prod, or instance ID)
   --platform             Use Platform API instead of Backend API

--- a/packages/cli-core/src/cli-program.ts
+++ b/packages/cli-core/src/cli-program.ts
@@ -74,6 +74,7 @@ export function createProgram() {
   env
     .command("pull")
     .description("Pull environment variables from Clerk to .env.local")
+    .option("--app <id>", "Application ID to target (works from any directory)")
     .option("--instance <id>", "Instance to target (dev, prod, or a full instance ID)")
     .option("--file <path>", "Target env file (default: auto-detect)")
     .action(pull);
@@ -83,6 +84,7 @@ export function createProgram() {
   config
     .command("pull")
     .description("Pull instance configuration from Clerk")
+    .option("--app <id>", "Application ID to target (works from any directory)")
     .option("--instance <id>", "Instance to target (dev, prod, or a full instance ID)")
     .option("--output <file>", "Write config to a file instead of stdout")
     .action(configPull);
@@ -90,6 +92,7 @@ export function createProgram() {
   config
     .command("schema")
     .description("Pull instance config schema from Clerk")
+    .option("--app <id>", "Application ID to target (works from any directory)")
     .option("--instance <id>", "Instance to target (dev, prod, or a full instance ID)")
     .option("--output <file>", "Write schema to a file instead of stdout")
     .option("--keys <keys...>", "Config keys to retrieve schema for")
@@ -98,6 +101,7 @@ export function createProgram() {
   config
     .command("patch")
     .description("Partially update instance configuration (PATCH)")
+    .option("--app <id>", "Application ID to target (works from any directory)")
     .option("--instance <id>", "Instance to target (dev, prod, or a full instance ID)")
     .option("--file <path>", "Read config JSON from a file")
     .option("--json <string>", "Pass config JSON inline")
@@ -108,6 +112,7 @@ export function createProgram() {
   config
     .command("put")
     .description("Replace entire instance configuration (PUT)")
+    .option("--app <id>", "Application ID to target (works from any directory)")
     .option("--instance <id>", "Instance to target (dev, prod, or a full instance ID)")
     .option("--file <path>", "Read config JSON from a file")
     .option("--json <string>", "Pass config JSON inline")
@@ -127,6 +132,7 @@ export function createProgram() {
     .option("-d, --data <json>", "JSON request body")
     .option("--file <path>", "Read request body from a file")
     .option("--include", "Show response headers")
+    .option("--app <id>", "Application ID to target when resolving keys")
     .option("--secret-key <key>", "Override the secret key")
     .option("--instance <id>", "Instance to target (dev, prod, or instance ID)")
     .option("--platform", "Use Platform API instead of Backend API")

--- a/packages/cli-core/src/commands/api/README.md
+++ b/packages/cli-core/src/commands/api/README.md
@@ -47,6 +47,9 @@ clerk api /users -X DELETE --dry-run
 # Use a specific secret key
 clerk api /users --secret-key sk_test_abc123
 
+# Resolve a secret key from an app directly
+clerk api /users --app app_123 --instance prod
+
 # Target production instance (requires CLERK_PLATFORM_API_KEY)
 clerk api /users --instance prod
 
@@ -62,6 +65,7 @@ clerk api /v1/platform/applications --platform
 | `-d, --data <json>`     | JSON request body (inline)                                        |
 | `--file <path>`         | Read request body from a file                                     |
 | `--include`             | Show response status and headers                                  |
+| `--app <id>`            | Application ID to target when resolving keys                      |
 | `--secret-key <key>`    | Override the secret key                                           |
 | `--instance <id>`       | Instance to target for key resolution (`dev`, `prod`, or full ID) |
 | `--platform`            | Use Platform API instead of Backend API                           |
@@ -74,9 +78,16 @@ Secret key resolution order:
 
 1. `--secret-key` flag (explicit)
 2. `CLERK_SECRET_KEY` environment variable
-3. Auto-resolve from linked project profile (requires `CLERK_PLATFORM_API_KEY`)
+3. Auto-resolve from `--app <id>` plus `CLERK_PLATFORM_API_KEY`
+4. Auto-resolve from linked project profile (requires `CLERK_PLATFORM_API_KEY`)
 
-For `--platform` mode, uses `CLERK_PLATFORM_API_KEY` environment variable.
+`--platform` mode uses the same Platform API auth path as other PLAPI-backed commands:
+
+1. `CLERK_PLATFORM_API_KEY`
+2. Stored `clerk auth login` token
+3. Interactive human-mode prompt for a Platform API key
+
+The CLI validates key prefixes and will warn if you pass an `ak_` key where an `sk_` key is expected, or vice versa.
 
 ## API Endpoints
 
@@ -92,9 +103,9 @@ Base URL: `https://api.clerk.dev` (overridable via `CLERK_BACKEND_API_URL`)
 
 Base URL: `https://api.clerk.com` (overridable via `CLERK_PLATFORM_API_URL`)
 
-| Method | Endpoint     | Description                                                                                         |
-| ------ | ------------ | --------------------------------------------------------------------------------------------------- |
-| Any    | `/v1/{path}` | Pass-through to Clerk Platform API. Authenticated via `Bearer` token from `CLERK_PLATFORM_API_KEY`. |
+| Method | Endpoint     | Description                                                                                                                        |
+| ------ | ------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Any    | `/v1/{path}` | Pass-through to Clerk Platform API. Authenticated via `Bearer` token from `CLERK_PLATFORM_API_KEY`, `clerk auth login`, or prompt. |
 
 ## Subcommands
 

--- a/packages/cli-core/src/commands/api/index.test.ts
+++ b/packages/cli-core/src/commands/api/index.test.ts
@@ -10,7 +10,11 @@ import {
   stubFetch,
 } from "../../test/stubs.ts";
 
-mock.module("../../lib/credential-store.ts", () => credentialStoreStubs);
+let mockStoredToken: string | null = null;
+mock.module("../../lib/credential-store.ts", () => ({
+  ...credentialStoreStubs,
+  getToken: async () => mockStoredToken,
+}));
 mock.module("../../lib/git.ts", () => gitStubs);
 
 let _mode = "human";
@@ -49,6 +53,52 @@ mock.module("../../lib/config.ts", () => ({
     if (!id) throw new Error(`No ${env} instance configured.`);
     return { id, label: env };
   },
+  resolveAppContext: async (options: { app?: string; instance?: string }) => {
+    if (options.app) {
+      const aliases: Record<string, string> = {
+        dev: "development",
+        development: "development",
+        prod: "production",
+        production: "production",
+      };
+      if (!options.instance) {
+        return { appId: options.app, instanceId: "ins_dev", instanceLabel: "development" };
+      }
+      const env = aliases[options.instance];
+      if (!env) {
+        return {
+          appId: options.app,
+          instanceId: options.instance,
+          instanceLabel: options.instance,
+        };
+      }
+      return {
+        appId: options.app,
+        instanceId: env === "production" ? "ins_prod" : "ins_dev",
+        instanceLabel: env,
+      };
+    }
+
+    const profile = _profiles[process.cwd()];
+    if (!profile) throw new Error("No Clerk project linked");
+    const instance = !options.instance
+      ? { id: profile.instances.development, label: "development" }
+      : (() => {
+          const aliases: Record<string, string> = {
+            dev: "development",
+            development: "development",
+            prod: "production",
+            production: "production",
+          };
+          const env = aliases[options.instance];
+          if (!env) return { id: options.instance, label: options.instance };
+          const id = profile.instances[env];
+          if (!id) throw new Error(`No ${env} instance configured.`);
+          return { id, label: env };
+        })();
+
+    return { appId: profile.appId, instanceId: instance.id, instanceLabel: instance.label };
+  },
 }));
 
 mock.module("@inquirer/prompts", () => promptsStubs);
@@ -70,6 +120,7 @@ describe("api command", () => {
 
   beforeEach(async () => {
     Object.keys(_profiles).forEach((k) => delete _profiles[k]);
+    mockStoredToken = null;
     _mode = "human";
     tempDir = await mkdtemp(join(tmpdir(), "clerk-api-test-"));
     _setConfigDir(tempDir);
@@ -252,6 +303,76 @@ describe("api command", () => {
     expect(capturedHeaders?.get("Authorization")).toBe("Bearer sk_live_override");
   });
 
+  test("rejects a platform key passed as --secret-key", async () => {
+    await expect(runApi("/users", { secretKey: "ak_test_wrong" })).rejects.toThrow(
+      "Expected a Secret key",
+    );
+  });
+
+  test("uses --app to resolve a secret key without a linked profile", async () => {
+    delete process.env.CLERK_SECRET_KEY;
+    process.env.CLERK_PLATFORM_API_KEY = "ak_test_platform";
+    let capturedHeaders: Headers | undefined;
+
+    stubFetch(async (input, init) => {
+      const url = input.toString();
+      if (url.endsWith("/v1/platform/applications/app_1")) {
+        return new Response(
+          JSON.stringify({
+            application_id: "app_1",
+            instances: [
+              {
+                instance_id: "ins_dev",
+                environment_type: "development",
+                secret_key: "sk_test_derived",
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      capturedHeaders = new Headers(init?.headers);
+      return new Response(JSON.stringify({}), { status: 200 });
+    });
+
+    await runApi("/users", { app: "app_1" });
+    expect(capturedHeaders?.get("Authorization")).toBe("Bearer sk_test_derived");
+  });
+
+  test("uses stored auth token to resolve a secret key for --app", async () => {
+    delete process.env.CLERK_SECRET_KEY;
+    delete process.env.CLERK_PLATFORM_API_KEY;
+    mockStoredToken = "oauth_token_123";
+    let capturedHeaders: Headers | undefined;
+
+    stubFetch(async (input, init) => {
+      const url = input.toString();
+      if (url.endsWith("/v1/platform/applications/app_1")) {
+        expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer oauth_token_123");
+        return new Response(
+          JSON.stringify({
+            application_id: "app_1",
+            instances: [
+              {
+                instance_id: "ins_dev",
+                environment_type: "development",
+                secret_key: "sk_test_oauth",
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+
+      capturedHeaders = new Headers(init?.headers);
+      return new Response(JSON.stringify({}), { status: 200 });
+    });
+
+    await runApi("/users", { app: "app_1" });
+    expect(capturedHeaders?.get("Authorization")).toBe("Bearer sk_test_oauth");
+  });
+
   // --- --platform mode ---
 
   test("--platform uses Platform API URL and key", async () => {
@@ -275,7 +396,7 @@ describe("api command", () => {
     delete process.env.CLERK_PLATFORM_API_KEY;
 
     await expect(runApi("/v1/platform/applications", { platform: true })).rejects.toThrow(
-      "CLERK_PLATFORM_API_KEY",
+      "Not authenticated",
     );
   });
 

--- a/packages/cli-core/src/commands/api/index.test.ts
+++ b/packages/cli-core/src/commands/api/index.test.ts
@@ -316,7 +316,7 @@ describe("api command", () => {
 
     stubFetch(async (input, init) => {
       const url = input.toString();
-      if (url.endsWith("/v1/platform/applications/app_1")) {
+      if (url.includes("/v1/platform/applications/app_1")) {
         return new Response(
           JSON.stringify({
             application_id: "app_1",
@@ -348,7 +348,7 @@ describe("api command", () => {
 
     stubFetch(async (input, init) => {
       const url = input.toString();
-      if (url.endsWith("/v1/platform/applications/app_1")) {
+      if (url.includes("/v1/platform/applications/app_1")) {
         expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer oauth_token_123");
         return new Response(
           JSON.stringify({

--- a/packages/cli-core/src/commands/api/index.ts
+++ b/packages/cli-core/src/commands/api/index.ts
@@ -1,6 +1,6 @@
 import { confirm } from "@inquirer/prompts";
-import { resolveProfile, resolveInstanceId } from "../../lib/config.ts";
-import { fetchApplication } from "../../lib/plapi.ts";
+import { resolveAppContext } from "../../lib/config.ts";
+import { fetchApplication, getAuthToken, validateKeyPrefix } from "../../lib/plapi.ts";
 import { BAPI_BASE_URL, PLAPI_BASE_URL } from "../../lib/constants.ts";
 import { bapiRequest } from "./bapi.ts";
 import {
@@ -17,6 +17,7 @@ export interface ApiOptions {
   data?: string;
   file?: string;
   include?: boolean;
+  app?: string;
   secretKey?: string;
   instance?: string;
   platform?: boolean;
@@ -54,14 +55,7 @@ export async function api(
   let baseUrl: string;
 
   if (options.platform) {
-    const key = process.env.CLERK_PLATFORM_API_KEY;
-    if (!key) {
-      throwUsageError(
-        "CLERK_PLATFORM_API_KEY environment variable is required for --platform mode.",
-        "https://clerk.com/docs/guides/development/clerk-environment-variables",
-      );
-    }
-    secretKey = key;
+    secretKey = await getAuthToken();
     baseUrl = PLAPI_BASE_URL;
   } else {
     secretKey = await resolveSecretKey(options);
@@ -119,34 +113,43 @@ export async function api(
 }
 
 async function resolveSecretKey(options: ApiOptions): Promise<string> {
-  if (options.secretKey) return options.secretKey;
-
-  if (process.env.CLERK_SECRET_KEY) return process.env.CLERK_SECRET_KEY;
-
-  // Resolve from linked profile via Platform API
-  const resolved = await resolveProfile(process.cwd());
-  const platformKey = process.env.CLERK_PLATFORM_API_KEY;
-
-  if (!resolved || !platformKey) {
-    throwUsageError(
-      "No secret key found. Provide one via:\n" +
-        "  --secret-key <key>\n" +
-        "  CLERK_SECRET_KEY environment variable\n" +
-        (resolved
-          ? "  Set CLERK_PLATFORM_API_KEY to auto-resolve from your linked project"
-          : "  Link a project with `clerk link` and set CLERK_PLATFORM_API_KEY"),
-      "https://clerk.com/docs/guides/development/clerk-environment-variables",
-    );
+  if (options.secretKey) {
+    validateKeyPrefix(options.secretKey, "sk_");
+    return options.secretKey;
   }
 
-  const { profile } = resolved;
-  const instance = resolveInstanceId(profile, options.instance);
+  if (process.env.CLERK_SECRET_KEY) {
+    validateKeyPrefix(process.env.CLERK_SECRET_KEY, "sk_");
+    return process.env.CLERK_SECRET_KEY;
+  }
 
-  const app = await withApiContext(fetchApplication(profile.appId), "Failed to resolve secret key");
-  const matched = app.instances.find((i) => i.instance_id === instance.id);
+  // Resolve from linked profile via Platform API
+  let ctx: Awaited<ReturnType<typeof resolveAppContext>>;
+  try {
+    ctx = await resolveAppContext({ app: options.app, instance: options.instance });
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("No Clerk project linked")) {
+      throwUsageError(
+        "No secret key found. Provide one via:\n" +
+          "  --secret-key <key>\n" +
+          "  CLERK_SECRET_KEY environment variable\n" +
+          "  Link a project with `clerk link`, or pass --app <app_id>",
+        "https://clerk.com/docs/guides/development/clerk-environment-variables",
+      );
+    }
+    throw error;
+  }
+
+  const app = await withApiContext(fetchApplication(ctx.appId), "Failed to resolve secret key");
+  const matched = app.instances.find((i) => i.instance_id === ctx.instanceId);
   if (!matched) {
-    throw new CliError(`Instance ${instance.id} not found in application.`, {
+    throw new CliError(`Instance ${ctx.instanceId} not found in application.`, {
       docsUrl: "https://clerk.com/docs/guides/development/managing-environments",
+    });
+  }
+  if (!matched.secret_key) {
+    throw new CliError(`No secret key found for ${ctx.instanceLabel} instance.`, {
+      docsUrl: "https://clerk.com/docs/guides/development/clerk-environment-variables",
     });
   }
   return matched.secret_key;

--- a/packages/cli-core/src/commands/config/README.md
+++ b/packages/cli-core/src/commands/config/README.md
@@ -10,6 +10,7 @@ Fetches the instance configuration from the Clerk Platform API and outputs it as
 
 ```sh
 clerk config pull
+clerk config pull --app app_123
 clerk config pull --instance prod
 clerk config pull --output clerk-config.json
 ```
@@ -18,13 +19,16 @@ clerk config pull --output clerk-config.json
 
 | Flag              | Description                                                                         |
 | ----------------- | ----------------------------------------------------------------------------------- |
+| `--app <id>`      | Application ID to target directly (works from any directory)                        |
 | `--instance <id>` | Instance to target (`dev`, `prod`, or a full instance ID). Defaults to development. |
 | `--output <file>` | Write config to a file instead of stdout                                            |
 
 #### Requirements
 
-- Must have a Clerk project linked to the current directory (via `clerk init`)
-- Requires the `CLERK_PLATFORM_API_KEY` environment variable
+- Requires either:
+  - a linked Clerk project in the current directory, or
+  - `--app <id>` to target an application directly
+- Authenticated via `CLERK_PLATFORM_API_KEY`, `clerk auth login`, or the interactive human-mode prompt
 
 #### API Endpoints
 
@@ -42,6 +46,7 @@ Fetches the JSON Schema for an instance's configuration from the Clerk Platform 
 
 ```sh
 clerk config schema
+clerk config schema --app app_123
 clerk config schema --instance prod
 clerk config schema --output config-schema.json
 clerk config schema --keys session sign_up
@@ -51,14 +56,17 @@ clerk config schema --keys session sign_up
 
 | Flag               | Description                                                                         |
 | ------------------ | ----------------------------------------------------------------------------------- |
+| `--app <id>`       | Application ID to target directly (works from any directory)                        |
 | `--instance <id>`  | Instance to target (`dev`, `prod`, or a full instance ID). Defaults to development. |
 | `--output <file>`  | Write schema to a file instead of stdout                                            |
 | `--keys <keys...>` | Config keys to retrieve schema for                                                  |
 
 #### Requirements
 
-- Must have a Clerk project linked to the current directory (via `clerk init`)
-- Requires the `CLERK_PLATFORM_API_KEY` environment variable
+- Requires either:
+  - a linked Clerk project in the current directory, or
+  - `--app <id>` to target an application directly
+- Authenticated via `CLERK_PLATFORM_API_KEY`, `clerk auth login`, or the interactive human-mode prompt
 
 #### API Endpoints
 
@@ -76,6 +84,7 @@ Input can be provided via `--json` (inline), `--file` (path to a JSON file), or 
 
 ```sh
 clerk config patch --json '{"session":{"lifetime":3600}}'
+clerk config patch --app app_123 --json '{"session":{"lifetime":3600}}'
 clerk config patch --file partial-config.json
 cat partial-config.json | clerk config patch
 clerk config patch --file partial-config.json --dry-run
@@ -85,6 +94,7 @@ clerk config patch --file partial-config.json --dry-run
 
 | Flag              | Description                                                                         |
 | ----------------- | ----------------------------------------------------------------------------------- |
+| `--app <id>`      | Application ID to target directly (works from any directory)                        |
 | `--instance <id>` | Instance to target (`dev`, `prod`, or a full instance ID). Defaults to development. |
 | `--file <path>`   | Read config JSON from a file                                                        |
 | `--json <string>` | Pass config JSON inline (takes priority over `--file`)                              |
@@ -93,8 +103,10 @@ clerk config patch --file partial-config.json --dry-run
 
 #### Requirements
 
-- Must have a Clerk project linked to the current directory (via `clerk init`)
-- Requires the `CLERK_PLATFORM_API_KEY` environment variable
+- Requires either:
+  - a linked Clerk project in the current directory, or
+  - `--app <id>` to target an application directly
+- Authenticated via `CLERK_PLATFORM_API_KEY`, `clerk auth login`, or the interactive human-mode prompt
 
 #### API Endpoints
 
@@ -112,6 +124,7 @@ Input can be provided via `--json` (inline), `--file` (path to a JSON file), or 
 
 ```sh
 clerk config put --file full-config.json
+clerk config put --app app_123 --file full-config.json
 clerk config put --json '{"session":{"lifetime":3600},"sign_in":{"enabled":true}}'
 cat full-config.json | clerk config put
 clerk config put --file full-config.json --dry-run
@@ -121,6 +134,7 @@ clerk config put --file full-config.json --dry-run
 
 | Flag              | Description                                                                         |
 | ----------------- | ----------------------------------------------------------------------------------- |
+| `--app <id>`      | Application ID to target directly (works from any directory)                        |
 | `--instance <id>` | Instance to target (`dev`, `prod`, or a full instance ID). Defaults to development. |
 | `--file <path>`   | Read config JSON from a file                                                        |
 | `--json <string>` | Pass config JSON inline (takes priority over `--file`)                              |
@@ -129,8 +143,10 @@ clerk config put --file full-config.json --dry-run
 
 #### Requirements
 
-- Must have a Clerk project linked to the current directory (via `clerk init`)
-- Requires the `CLERK_PLATFORM_API_KEY` environment variable
+- Requires either:
+  - a linked Clerk project in the current directory, or
+  - `--app <id>` to target an application directly
+- Authenticated via `CLERK_PLATFORM_API_KEY`, `clerk auth login`, or the interactive human-mode prompt
 
 #### API Endpoints
 

--- a/packages/cli-core/src/commands/config/pull.test.ts
+++ b/packages/cli-core/src/commands/config/pull.test.ts
@@ -47,7 +47,7 @@ describe("config pull", () => {
   });
 
   // Dynamically import to get fresh module state
-  async function runConfigPull(options: { instance?: string; output?: string } = {}) {
+  async function runConfigPull(options: { app?: string; instance?: string; output?: string } = {}) {
     const { configPull } = await import("./pull.ts");
     return configPull(options);
   }
@@ -75,6 +75,24 @@ describe("config pull", () => {
     });
 
     await runConfigPull();
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(mockConfig, null, 2));
+  });
+
+  test("supports --app without a linked profile", async () => {
+    const mockApp = {
+      application_id: "app_1",
+      instances: [{ instance_id: "ins_dev", environment_type: "development" }],
+    };
+
+    stubFetch(async (input) => {
+      const url = input.toString();
+      if (url.endsWith("/v1/platform/applications/app_1")) {
+        return new Response(JSON.stringify(mockApp), { status: 200 });
+      }
+      return new Response(JSON.stringify(mockConfig), { status: 200 });
+    });
+
+    await runConfigPull({ app: "app_1" });
     expect(logSpy).toHaveBeenCalledWith(JSON.stringify(mockConfig, null, 2));
   });
 

--- a/packages/cli-core/src/commands/config/pull.test.ts
+++ b/packages/cli-core/src/commands/config/pull.test.ts
@@ -86,10 +86,13 @@ describe("config pull", () => {
 
     stubFetch(async (input) => {
       const url = input.toString();
-      if (url.endsWith("/v1/platform/applications/app_1")) {
+      if (url.includes("/instances/") && url.includes("/config")) {
+        return new Response(JSON.stringify(mockConfig), { status: 200 });
+      }
+      if (url.includes("/v1/platform/applications/app_1")) {
         return new Response(JSON.stringify(mockApp), { status: 200 });
       }
-      return new Response(JSON.stringify(mockConfig), { status: 200 });
+      throw new Error(`Unexpected fetch: ${url}`);
     });
 
     await runConfigPull({ app: "app_1" });

--- a/packages/cli-core/src/commands/config/pull.ts
+++ b/packages/cli-core/src/commands/config/pull.ts
@@ -1,25 +1,20 @@
-import { resolveProfile, resolveInstanceId } from "../../lib/config.ts";
+import { resolveAppContext } from "../../lib/config.ts";
 import { fetchInstanceConfig } from "../../lib/plapi.ts";
-import { CliError, withApiContext } from "../../lib/errors.ts";
+import { withApiContext } from "../../lib/errors.ts";
 
 interface ConfigPullOptions {
+  app?: string;
   instance?: string;
   output?: string;
 }
 
 export async function configPull(options: ConfigPullOptions): Promise<void> {
-  const resolved = await resolveProfile(process.cwd());
-  if (!resolved) {
-    throw new CliError("No Clerk project linked to this directory. Run `clerk link` to set up.");
-  }
+  const ctx = await resolveAppContext(options);
 
-  const { profile } = resolved;
-  const instance = resolveInstanceId(profile, options.instance);
-
-  console.error(`Pulling config from ${instance.label} instance...`);
+  console.error(`Pulling config from ${ctx.instanceLabel} instance...`);
 
   const config = await withApiContext(
-    fetchInstanceConfig(profile.appId, instance.id),
+    fetchInstanceConfig(ctx.appId, ctx.instanceId),
     "Failed to fetch config",
   );
   const json = JSON.stringify(config, null, 2);

--- a/packages/cli-core/src/commands/config/push.test.ts
+++ b/packages/cli-core/src/commands/config/push.test.ts
@@ -49,6 +49,7 @@ describe("config push", () => {
 
   async function runConfigPatch(
     options: {
+      app?: string;
       instance?: string;
       file?: string;
       json?: string;
@@ -62,6 +63,7 @@ describe("config push", () => {
 
   async function runConfigPut(
     options: {
+      app?: string;
       instance?: string;
       file?: string;
       json?: string;
@@ -157,6 +159,26 @@ describe("config push", () => {
     await runConfigPatch({ json: '{"session":{"lifetime":3600}}', yes: true });
     expect(capturedMethod).toBe("PATCH");
     expect(JSON.parse(capturedBody)).toEqual({ session: { lifetime: 3600 } });
+  });
+
+  test("patch supports --app without a linked profile", async () => {
+    let capturedUrl = "";
+    stubFetch(async (input, init) => {
+      capturedUrl = input.toString();
+      if (init?.method === undefined) {
+        return new Response(
+          JSON.stringify({
+            application_id: "app_1",
+            instances: [{ instance_id: "ins_dev", environment_type: "development" }],
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify(mockResponse), { status: 200 });
+    });
+
+    await runConfigPatch({ app: "app_1", json: '{"session":{"lifetime":3600}}', yes: true });
+    expect(capturedUrl).toContain("/instances/ins_dev/");
   });
 
   test("patch reads config from --file", async () => {

--- a/packages/cli-core/src/commands/config/push.ts
+++ b/packages/cli-core/src/commands/config/push.ts
@@ -1,10 +1,11 @@
 import { confirm } from "@inquirer/prompts";
-import { resolveProfile, resolveInstanceId } from "../../lib/config.ts";
+import { resolveAppContext } from "../../lib/config.ts";
 import { putInstanceConfig, patchInstanceConfig } from "../../lib/plapi.ts";
 import { isHuman } from "../../mode.ts";
-import { CliError, throwUsageError, throwUserAbort, withApiContext } from "../../lib/errors.ts";
+import { throwUsageError, throwUserAbort, withApiContext } from "../../lib/errors.ts";
 
 interface ConfigPushOptions {
+  app?: string;
   instance?: string;
   file?: string;
   json?: string;
@@ -45,13 +46,7 @@ export async function configPatch(options: ConfigPushOptions): Promise<void> {
 }
 
 async function configPush(options: ConfigPushOptions, op: Operation): Promise<void> {
-  const resolved = await resolveProfile(process.cwd());
-  if (!resolved) {
-    throw new CliError("No Clerk project linked to this directory. Run `clerk link` to set up.");
-  }
-
-  const { profile } = resolved;
-  const instance = resolveInstanceId(profile, options.instance);
+  const ctx = await resolveAppContext(options);
   const rawInput = await readInput(options);
 
   let configPayload: Record<string, unknown>;
@@ -66,13 +61,13 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
   }
 
   if (options.dryRun) {
-    console.error(`[dry-run] Would ${op.method} config on ${instance.label} instance:`);
+    console.error(`[dry-run] Would ${op.method} config on ${ctx.instanceLabel} instance:`);
     console.log(JSON.stringify(configPayload, null, 2));
     return;
   }
 
   if (isHuman() && !options.yes) {
-    console.error(`\n${op.verb} config on ${instance.label} instance:`);
+    console.error(`\n${op.verb} config on ${ctx.instanceLabel} instance:`);
     console.error(JSON.stringify(configPayload, null, 2));
     if (op.warning) {
       console.error(`\nWARNING: ${op.warning}`);
@@ -83,10 +78,10 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
     }
   }
 
-  console.error(`${op.verb} config on ${instance.label} instance...`);
+  console.error(`${op.verb} config on ${ctx.instanceLabel} instance...`);
 
   const result = await withApiContext(
-    op.apiFn(profile.appId, instance.id, configPayload),
+    op.apiFn(ctx.appId, ctx.instanceId, configPayload),
     "Failed to push config",
   );
   console.log(JSON.stringify(result, null, 2));

--- a/packages/cli-core/src/commands/config/schema.test.ts
+++ b/packages/cli-core/src/commands/config/schema.test.ts
@@ -92,10 +92,13 @@ describe("config schema", () => {
 
     stubFetch(async (input) => {
       const url = input.toString();
-      if (url.endsWith("/v1/platform/applications/app_1")) {
+      if (url.includes("/instances/") && url.includes("/config")) {
+        return new Response(JSON.stringify(mockSchema), { status: 200 });
+      }
+      if (url.includes("/v1/platform/applications/app_1")) {
         return new Response(JSON.stringify(mockApp), { status: 200 });
       }
-      return new Response(JSON.stringify(mockSchema), { status: 200 });
+      throw new Error(`Unexpected fetch: ${url}`);
     });
 
     await runConfigSchema({ app: "app_1" });

--- a/packages/cli-core/src/commands/config/schema.test.ts
+++ b/packages/cli-core/src/commands/config/schema.test.ts
@@ -52,7 +52,7 @@ describe("config schema", () => {
   });
 
   async function runConfigSchema(
-    options: { instance?: string; output?: string; keys?: string[] } = {},
+    options: { app?: string; instance?: string; output?: string; keys?: string[] } = {},
   ) {
     const { configSchema } = await import("./schema.ts");
     return configSchema(options);
@@ -81,6 +81,24 @@ describe("config schema", () => {
     });
 
     await runConfigSchema();
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(mockSchema, null, 2));
+  });
+
+  test("supports --app without a linked profile", async () => {
+    const mockApp = {
+      application_id: "app_1",
+      instances: [{ instance_id: "ins_dev", environment_type: "development" }],
+    };
+
+    stubFetch(async (input) => {
+      const url = input.toString();
+      if (url.endsWith("/v1/platform/applications/app_1")) {
+        return new Response(JSON.stringify(mockApp), { status: 200 });
+      }
+      return new Response(JSON.stringify(mockSchema), { status: 200 });
+    });
+
+    await runConfigSchema({ app: "app_1" });
     expect(logSpy).toHaveBeenCalledWith(JSON.stringify(mockSchema, null, 2));
   });
 

--- a/packages/cli-core/src/commands/config/schema.ts
+++ b/packages/cli-core/src/commands/config/schema.ts
@@ -1,27 +1,22 @@
-import { resolveProfile, resolveInstanceId } from "../../lib/config.ts";
+import { resolveAppContext } from "../../lib/config.ts";
 import { fetchInstanceConfigSchema } from "../../lib/plapi.ts";
-import { CliError, withApiContext } from "../../lib/errors.ts";
+import { withApiContext } from "../../lib/errors.ts";
 
 interface ConfigSchemaOptions {
+  app?: string;
   instance?: string;
   output?: string;
   keys?: string[];
 }
 
 export async function configSchema(options: ConfigSchemaOptions): Promise<void> {
-  const resolved = await resolveProfile(process.cwd());
-  if (!resolved) {
-    throw new CliError("No Clerk project linked to this directory. Run `clerk link` to set up.");
-  }
-
-  const { profile } = resolved;
-  const instance = resolveInstanceId(profile, options.instance);
+  const ctx = await resolveAppContext(options);
 
   // Use `console.error` for informational messages so stdout is just the JSON response.
-  console.error(`Pulling config schema from ${instance.label} instance...`);
+  console.error(`Pulling config schema from ${ctx.instanceLabel} instance...`);
 
   const schema = await withApiContext(
-    fetchInstanceConfigSchema(profile.appId, instance.id, options.keys),
+    fetchInstanceConfigSchema(ctx.appId, ctx.instanceId, options.keys),
     "Failed to fetch config schema",
   );
 

--- a/packages/cli-core/src/commands/env/README.md
+++ b/packages/cli-core/src/commands/env/README.md
@@ -4,16 +4,17 @@ Pulls Clerk API keys for the linked instance and merges them into the project's 
 
 ## Usage
 
-```
-clerk env pull [--instance dev|prod|<instance_id>] [--file <path>]
+```sh
+clerk env pull [--app <app_id>] [--instance dev|prod|<instance_id>] [--file <path>]
 ```
 
 ### Options
 
-| Option            | Description                                               |
-| ----------------- | --------------------------------------------------------- |
-| `--instance <id>` | Instance to target (`dev`, `prod`, or a full instance ID) |
-| `--file <path>`   | Target env file (default: auto-detect)                    |
+| Option            | Description                                                  |
+| ----------------- | ------------------------------------------------------------ |
+| `--app <id>`      | Application ID to target directly (works from any directory) |
+| `--instance <id>` | Instance to target (`dev`, `prod`, or a full instance ID)    |
+| `--file <path>`   | Target env file (default: auto-detect)                       |
 
 ## Sequence Diagram
 
@@ -24,11 +25,15 @@ sequenceDiagram
     participant API as Clerk Platform API
     participant FS as File System
 
-    Note over CLI: clerk env pull [--instance dev|prod] [--file .env]
+    Note over CLI: clerk env pull [--app app_123] [--instance dev|prod] [--file .env]
 
-    %% Resolve project profile
-    CLI->>FS: Read ~/.clerk/config.json
-    FS-->>CLI: { appId, instances }
+    alt --app flag provided
+        CLI->>API: GET /v1/platform/applications/{appId}
+        API-->>CLI: { instances }
+    else Resolve project profile
+        CLI->>FS: Read ~/.clerk/config.json
+        FS-->>CLI: { appId, instances }
+    end
 
     %% Fetch application with keys
     CLI->>API: GET /v1/platform/applications/{appId}
@@ -62,10 +67,10 @@ sequenceDiagram
 
 ## API Endpoints
 
-| Step              | Method | Endpoint                            | Notes                                       |
-| ----------------- | ------ | ----------------------------------- | ------------------------------------------- |
-| Auth              | —      | Local config                        | Token from `CLERK_PLATFORM_API_KEY` env var |
-| Fetch application | `GET`  | `/v1/platform/applications/{appId}` | Returns all instances with keys             |
+| Step              | Method | Endpoint                            | Notes                                                                   |
+| ----------------- | ------ | ----------------------------------- | ----------------------------------------------------------------------- |
+| Auth              | —      | Local config                        | Uses `CLERK_PLATFORM_API_KEY`, `clerk auth login`, or human-mode prompt |
+| Fetch application | `GET`  | `/v1/platform/applications/{appId}` | Returns all instances with keys                                         |
 
 ## Framework Detection
 

--- a/packages/cli-core/src/commands/env/pull.test.ts
+++ b/packages/cli-core/src/commands/env/pull.test.ts
@@ -34,6 +34,56 @@ mock.module("../../lib/config.ts", () => ({
     if (!id) throw new Error(`No ${env} instance configured. Run \`clerk link\` to set one up.`);
     return { id, label: env };
   },
+  resolveAppContext: async (options: { app?: string; instance?: string }) => {
+    if (options.app) {
+      const app = {
+        application_id: "app_1",
+        instances: [
+          {
+            instance_id: "ins_dev",
+            environment_type: "development",
+            publishable_key: "pk_test_abc123",
+            secret_key: "sk_test_xyz789",
+          },
+          {
+            instance_id: "ins_prod",
+            environment_type: "production",
+            publishable_key: "pk_live_abc123",
+            secret_key: "sk_live_xyz789",
+          },
+        ],
+      };
+      if (options.instance) {
+        const env = INSTANCE_ALIASES[options.instance];
+        if (env) {
+          const matched = app.instances.find((i) => i.environment_type === env);
+          if (!matched) throw new Error(`No ${env} instance found for application ${options.app}.`);
+          return { appId: options.app, instanceId: matched.instance_id, instanceLabel: env };
+        }
+        return {
+          appId: options.app,
+          instanceId: options.instance,
+          instanceLabel: options.instance,
+        };
+      }
+      return { appId: options.app, instanceId: "ins_dev", instanceLabel: "development" };
+    }
+
+    const profile = _profiles[process.cwd()];
+    if (!profile) throw new Error("No Clerk project linked");
+    const instance = !options.instance
+      ? { id: profile.instances.development, label: "development" }
+      : (() => {
+          const env = INSTANCE_ALIASES[options.instance];
+          if (!env) return { id: options.instance, label: options.instance };
+          const id = profile.instances[env];
+          if (!id)
+            throw new Error(`No ${env} instance configured. Run \`clerk link\` to set one up.`);
+          return { id, label: env };
+        })();
+
+    return { appId: profile.appId, instanceId: instance.id, instanceLabel: instance.label };
+  },
 }));
 
 const { _setConfigDir, setProfile } = (await import("../../lib/config.ts")) as any;
@@ -98,7 +148,7 @@ describe("env pull", () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
-  async function runEnvPull(options: { instance?: string; file?: string } = {}) {
+  async function runEnvPull(options: { app?: string; instance?: string; file?: string } = {}) {
     const { pull } = await import("./pull.ts");
     return pull(options);
   }
@@ -210,6 +260,14 @@ describe("env pull", () => {
     const content = await Bun.file(join(tempDir, ".env.local")).text();
     expect(content).toContain("CLERK_PUBLISHABLE_KEY=pk_live_abc123");
     expect(content).toContain("CLERK_SECRET_KEY=sk_live_xyz789");
+  });
+
+  test("uses --app without a linked profile", async () => {
+    await runEnvPull({ app: "app_1" });
+
+    const content = await Bun.file(join(tempDir, ".env.local")).text();
+    expect(content).toContain("CLERK_PUBLISHABLE_KEY=pk_test_abc123");
+    expect(content).toContain("CLERK_SECRET_KEY=sk_test_xyz789");
   });
 
   test("shows instance label in status message", async () => {

--- a/packages/cli-core/src/commands/env/pull.ts
+++ b/packages/cli-core/src/commands/env/pull.ts
@@ -1,11 +1,12 @@
 import { join } from "node:path";
-import { resolveProfile, resolveInstanceId } from "../../lib/config.ts";
+import { resolveAppContext } from "../../lib/config.ts";
 import { fetchApplication } from "../../lib/plapi.ts";
 import { parseEnvFile, mergeEnvVars, serializeEnvFile } from "../../lib/dotenv.ts";
 import { detectPublishableKeyName } from "../../lib/framework.ts";
 import { CliError, withApiContext } from "../../lib/errors.ts";
 
 interface EnvPullOptions {
+  app?: string;
   instance?: string;
   file?: string;
 }
@@ -23,21 +24,15 @@ async function resolveTargetFile(cwd: string, flag?: string): Promise<string> {
 }
 
 export async function pull(options: EnvPullOptions): Promise<void> {
-  const resolved = await resolveProfile(process.cwd());
-  if (!resolved) {
-    throw new CliError("No Clerk project linked to this directory. Run `clerk link` to set up.");
-  }
+  const ctx = await resolveAppContext(options);
 
-  const { profile } = resolved;
-  const instance = resolveInstanceId(profile, options.instance);
+  console.error(`Pulling env vars from ${ctx.instanceLabel} instance...`);
 
-  console.error(`Pulling env vars from ${instance.label} instance...`);
+  const app = await withApiContext(fetchApplication(ctx.appId), "Failed to fetch API keys");
 
-  const app = await withApiContext(fetchApplication(profile.appId), "Failed to fetch API keys");
-
-  const matched = app.instances.find((i) => i.instance_id === instance.id);
+  const matched = app.instances.find((i) => i.instance_id === ctx.instanceId);
   if (!matched) {
-    throw new CliError(`Instance ${instance.id} not found in application response.`, {
+    throw new CliError(`Instance ${ctx.instanceId} not found in application response.`, {
       docsUrl: "https://clerk.com/docs/guides/development/managing-environments",
     });
   }

--- a/packages/cli-core/src/lib/config.ts
+++ b/packages/cli-core/src/lib/config.ts
@@ -180,4 +180,68 @@ export function resolveInstanceId(profile: Profile, flag?: string): { id: string
   return { id, label: env };
 }
 
+/**
+ * Resolve app context from explicit flags or linked profile.
+ * This is the isomorphic resolution chain used by profile-dependent commands:
+ *   1. Explicit --app flag (works from any directory)
+ *   2. resolveProfile(cwd) (project-aware, existing behavior)
+ *   3. Error with helpful message
+ */
+export async function resolveAppContext(options: {
+  app?: string;
+  instance?: string;
+}): Promise<{ appId: string; instanceId: string; instanceLabel: string }> {
+  if (options.app) {
+    const { fetchApplication } = await import("./plapi.ts");
+    const app = await fetchApplication(options.app);
+
+    if (options.instance) {
+      const env = INSTANCE_ALIASES[options.instance];
+      if (env) {
+        const matched = app.instances.find((instance) => instance.environment_type === env);
+        if (!matched) {
+          throw new CliError(`No ${env} instance found for application ${options.app}.`);
+        }
+        return { appId: options.app, instanceId: matched.instance_id, instanceLabel: env };
+      }
+
+      return {
+        appId: options.app,
+        instanceId: options.instance,
+        instanceLabel: options.instance,
+      };
+    }
+
+    const development = app.instances.find(
+      (instance) => instance.environment_type === "development",
+    );
+    if (!development) {
+      throw new CliError(`No development instance found for application ${options.app}.`);
+    }
+
+    return {
+      appId: options.app,
+      instanceId: development.instance_id,
+      instanceLabel: "development",
+    };
+  }
+
+  const resolved = await resolveProfile(process.cwd());
+  if (!resolved) {
+    throw new CliError(
+      "No Clerk project linked to this directory.\n" +
+        "Either:\n" +
+        "  - Run `clerk link` from your project directory\n" +
+        "  - Pass --app <app_id> to target an app directly",
+    );
+  }
+
+  const instance = resolveInstanceId(resolved.profile, options.instance);
+  return {
+    appId: resolved.profile.appId,
+    instanceId: instance.id,
+    instanceLabel: instance.label,
+  };
+}
+
 export type { Auth, Profile, ClerkConfig };

--- a/packages/cli-core/src/lib/plapi.ts
+++ b/packages/cli-core/src/lib/plapi.ts
@@ -7,10 +7,32 @@ import { PLAPI_BASE_URL } from "./constants.ts";
 import { getToken } from "./credential-store.ts";
 import { CliError, PlapiError } from "./errors.ts";
 
-async function getAuthToken(): Promise<string> {
+/**
+ * Validate that a key has the expected prefix and suggest the correct key type
+ * if the user mixed them up.
+ */
+export function validateKeyPrefix(key: string, expected: "ak_" | "sk_"): void {
+  if (key.startsWith(expected)) return;
+
+  const wrongPrefix = expected === "ak_" ? "sk_" : "ak_";
+  const expectedLabel = expected === "ak_" ? "Platform API key (ak_...)" : "Secret key (sk_...)";
+  const wrongLabel = expected === "ak_" ? "secret key (sk_...)" : "Platform API key (ak_...)";
+
+  if (key.startsWith(wrongPrefix)) {
+    throw new CliError(
+      `Expected a ${expectedLabel}, but received a ${wrongLabel}.\n` +
+        "Get the correct key from: https://dashboard.clerk.com/last-active?path=api-keys",
+    );
+  }
+}
+
+export async function getAuthToken(): Promise<string> {
   // Prefer platform API key (OAuth token doesn't have platform scopes yet)
   const key = process.env.CLERK_PLATFORM_API_KEY;
-  if (key) return key;
+  if (key) {
+    validateKeyPrefix(key, "ak_");
+    return key;
+  }
 
   // Fall back to OAuth access token from `clerk auth login`
   const oauthToken = await getToken();

--- a/packages/cli-core/src/test/stubs.ts
+++ b/packages/cli-core/src/test/stubs.ts
@@ -21,6 +21,7 @@ export const configStubs = {
   resolveProfile: noop,
   resolveProfileOrAutolink: noop,
   resolveInstanceId: () => ({ id: "", label: "" }),
+  resolveAppContext: async () => ({ appId: "", instanceId: "", instanceLabel: "" }),
 };
 
 export const autolinkStubs = {


### PR DESCRIPTION
## Summary
Add direct app targeting to config and env commands, and use `--app` to resolve secret keys in `api`.

## Changes
- Add `--app` and `--instance` flags to `env pull`, `config pull`, `config schema`, `config patch`, `config put`
- Use `--app` to resolve secret keys in `api` command via PLAPI
- Share app-context resolution across commands via `resolveAppContext()` in `config.ts`
- Validate `ak_` vs `sk_` key prefix mixups with helpful error messages
- Update READMEs and tests

## Tested (manual, from unlinked directory)

| # | Test | Command | Result |
|---|------|---------|--------|
| 1 | `env pull --app` (dev default) | `env pull --app app_xxx` | `pk_test_` written to .env.local |
| 2 | `env pull --app --instance prod` | `env pull --app app_xxx --instance prod` | `pk_live_` written to .env.local |
| 3 | `config pull --app` | `config pull --app app_xxx` | Full JSON config returned |
| 4 | `config schema --app --keys` | `config schema --app app_xxx --keys auth_password` | Filtered schema returned |
| 5 | `config patch --app --dry-run` | `config patch --app app_xxx --json '...' --dry-run` | Shows PATCH payload |
| 6 | `api --secret-key` (correct prefix) | `api /users --secret-key sk_xxx --dry-run` | Dry-run shows request |
| 7 | Explicit instance ID | `env pull --app app_xxx --instance ins_xxx` | Works with raw instance ID |
| 8 | No config residue | After all tests, no `.clerk/` dir in test directory | Clean |

### Error cases

| # | Test | Result |
|---|------|--------|
| E1 | `env pull` from unlinked dir (no flags) | `"Pass --app <app_id> to target an app directly"` |
| E2 | `CLERK_PLATFORM_API_KEY=sk_...` (wrong prefix) | `"Expected ak_..., received sk_..."` with dashboard link |
| E3 | `api --secret-key ak_...` (wrong prefix) | `"Expected sk_..., received ak_..."` with dashboard link |

### Note
`api --app` secret key resolution depends on PLAPI returning `secret_key` in the application response. Currently PLAPI requires `include_secret_keys=true` param, tracked in #36.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--app <id>` option to `config pull`, `config schema`, `config patch`, `config put`, `env pull`, and `api` commands, enabling users to target a specific application directly from any directory without a linked project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->