### PR TITLE
chore: add `build:bin` and `install:bin` scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "oxlint src/",
     "format": "oxfmt --write src/",
     "format:check": "oxfmt --check src/",
-    "install:bin": "bun run build:bin && mkdir -p \"$HOME/.local/bin\" && install -m 755 ./dist/clerk \"$HOME/.local/bin/clerk\"",
+    "install:bin": "bash scripts/install-bin.sh",
     "prepare": "git config core.hooksPath .hooks"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
   "type": "module",
   "scripts": {
     "build": "bun build ./src/cli.ts --outfile ./dist/cli.js --target node --external @napi-rs/keyring",
+    "build:bin": "bun build ./src/cli.ts --compile --outfile ./dist/clerk --external @napi-rs/keyring",
     "dev": "bun run ./src/cli.ts",
     "test": "bun test",
     "lint": "oxlint src/",
     "format": "oxfmt --write src/",
     "format:check": "oxfmt --check src/",
+    "install:bin": "bun run build:bin && mkdir -p \"$HOME/.local/bin\" && install -m 755 ./dist/clerk \"$HOME/.local/bin/clerk\"",
     "prepare": "git config core.hooksPath .hooks"
   },
   "dependencies": {

--- a/scripts/install-bin.sh
+++ b/scripts/install-bin.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Exit on error, catch unset variables, and fail a pipeline if any step fails.
+set -euo pipefail
+
+# Resolve this file’s directory, then the repo root, and run subsequent commands from there.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+# User-level bin dir
+LOCAL_BIN="${HOME}/.local/bin"
+
+# Marker (comment) in user profile for auto-updating the PATH
+MARKER="# clerk-cli: ~/.local/bin on PATH"
+
+# Compile the standalone binary, ensure the bin directory exists, then copy the binary into place.
+bun run build:bin
+mkdir -p "${LOCAL_BIN}"
+install -m 755 "${REPO_ROOT}/dist/clerk" "${LOCAL_BIN}/clerk"
+
+# Return true if we (or the user) already wired ~/.local/bin into shell startup files.
+path_snippet_present() {
+  local f
+  for f in "${HOME}/.zshrc" "${HOME}/.bash_profile" "${HOME}/.bashrc" "${HOME}/.profile"; do
+    [[ -f "${f}" ]] || continue
+    grep -qF "${MARKER}" "${f}" && return 0
+    grep -qF ".local/bin" "${f}" && return 0
+  done
+  return 1
+}
+
+# Pick the startup file that matches the user’s login shell (macOS default is zsh).
+pick_rc() {
+  case "$(basename "${SHELL:-/bin/zsh}")" in
+    zsh) echo "${HOME}/.zshrc" ;;
+    bash) echo "${HOME}/.bash_profile" ;;
+    *) echo "${HOME}/.profile" ;;
+  esac
+}
+
+# Append PATH setup only when it isn’t already covered in the usual shell startup files.
+added_path_to_rc=false
+rc=""
+if path_snippet_present; then
+  :
+else
+  rc="$(pick_rc)"
+  {
+    echo ""
+    echo "${MARKER}"
+    echo "export PATH=\"\${HOME}/.local/bin:\${PATH}\""
+  } >>"${rc}"
+  added_path_to_rc=true
+fi
+
+# Friendly recap of what ran (always runs after a successful install).
+echo ""
+echo "Installation complete."
+echo "  • Built the standalone clerk binary"
+echo "  • Copied it to ${LOCAL_BIN}/clerk"
+if [[ "${added_path_to_rc}" == true ]]; then
+  echo "  • Added ~/.local/bin to your PATH via ${rc} (new terminals will pick this up automatically)."
+  echo "  • To reload your PATH in this terminal, run: source ${rc}"
+fi

--- a/scripts/install-bin.sh
+++ b/scripts/install-bin.sh
@@ -18,10 +18,15 @@ bun run build:bin
 mkdir -p "${LOCAL_BIN}"
 install -m 755 "${REPO_ROOT}/dist/clerk" "${LOCAL_BIN}/clerk"
 
+# Login shell name (used to pick config file and fish vs POSIX syntax).
+shell_name() {
+  basename "${SHELL:-/bin/zsh}"
+}
+
 # Return true if we (or the user) already wired ~/.local/bin into shell startup files.
 path_snippet_present() {
   local f
-  for f in "${HOME}/.zshrc" "${HOME}/.bash_profile" "${HOME}/.bashrc" "${HOME}/.profile"; do
+  for f in "${HOME}/.config/fish/config.fish" "${HOME}/.zshrc" "${HOME}/.bash_profile" "${HOME}/.bashrc" "${HOME}/.profile"; do
     [[ -f "${f}" ]] || continue
     grep -qF "${MARKER}" "${f}" && return 0
     grep -qF ".local/bin" "${f}" && return 0
@@ -29,12 +34,36 @@ path_snippet_present() {
   return 1
 }
 
-# Pick the startup file that matches the user’s login shell (macOS default is zsh).
-pick_rc() {
-  case "$(basename "${SHELL:-/bin/zsh}")" in
+# Pick the startup file for the user’s login shell (fish, zsh, bash, or POSIX fallback).
+pick_shell_config() {
+  case "$(shell_name)" in
+    fish) echo "${HOME}/.config/fish/config.fish" ;;
     zsh) echo "${HOME}/.zshrc" ;;
     bash) echo "${HOME}/.bash_profile" ;;
     *) echo "${HOME}/.profile" ;;
+  esac
+}
+
+# Append a PATH snippet: fish uses fish_add_path; other shells use a POSIX export.
+append_path_snippet() {
+  local config="$1"
+  mkdir -p "$(dirname "${config}")"
+  case "$(shell_name)" in
+    fish)
+      {
+        echo ""
+        echo "${MARKER}"
+        # fish_add_path is built into fish 3.2+ and updates PATH for new sessions.
+        echo "fish_add_path \$HOME/.local/bin"
+      } >>"${config}"
+      ;;
+    *)
+      {
+        echo ""
+        echo "${MARKER}"
+        echo "export PATH=\"\${HOME}/.local/bin:\${PATH}\""
+      } >>"${config}"
+      ;;
   esac
 }
 
@@ -44,12 +73,8 @@ rc=""
 if path_snippet_present; then
   :
 else
-  rc="$(pick_rc)"
-  {
-    echo ""
-    echo "${MARKER}"
-    echo "export PATH=\"\${HOME}/.local/bin:\${PATH}\""
-  } >>"${rc}"
+  rc="$(pick_shell_config)"
+  append_path_snippet "${rc}"
   added_path_to_rc=true
 fi
 


### PR DESCRIPTION
to simplify local testing / installation

so you can pull down the repo and just run:

```
bun i
bun install:bin
```

and it copies the `clerk` binary to `~/.local/bin`.

It also updates the user's PATH without asking for their permission...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standalone binary build and installation capabilities have been added for command-line tool distribution and usage
  * Installation script automatically detects your shell, updates the appropriate startup configuration files, and configures your PATH environment to make the command immediately accessible from any terminal session

<!-- end of auto-generated comment: release notes by coderabbit.ai -->