### PR TITLE
chore: add script for devs to "install" cli globally

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "format:check": "bun run --filter @clerk/cli-core format:check && oxfmt --check scripts/",
     "build:compile": "bun run --filter @clerk/cli-core build:compile",
     "build:compile:all": "bun run scripts/build.ts",
-    "dev:global": "bun link --cwd packages/cli-core",
-    "dev:global:unlink": "bun unlink --cwd packages/cli-core",
+    "global:link": "bun link --cwd packages/cli-core",
+    "global:unlink": "bun unlink --cwd packages/cli-core",
     "start": "bun run build:compile && ./packages/cli-core/dist/clerk",
     "prepare": "git config core.hooksPath .hooks"
   },

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "format:check": "bun run --filter @clerk/cli-core format:check && oxfmt --check scripts/",
     "build:compile": "bun run --filter @clerk/cli-core build:compile",
     "build:compile:all": "bun run scripts/build.ts",
+    "dev:global": "bun link --cwd packages/cli-core",
+    "dev:global:unlink": "bun unlink --cwd packages/cli-core",
     "start": "bun run build:compile && ./packages/cli-core/dist/clerk",
     "prepare": "git config core.hooksPath .hooks"
   },

--- a/packages/cli-core/package.json
+++ b/packages/cli-core/package.json
@@ -2,6 +2,9 @@
   "name": "@clerk/cli-core",
   "version": "0.0.0",
   "private": true,
+  "bin": {
+    "clerk": "./src/cli.ts"
+  },
   "type": "module",
   "scripts": {
     "build": "bun build ./src/cli.ts --outfile ./dist/cli.js --target node --external @napi-rs/keyring",

--- a/packages/cli-core/src/cli.ts
+++ b/packages/cli-core/src/cli.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env bun
 import { createProgram, runProgram } from "./cli-program.ts";
 import { EXIT_CODE } from "./lib/errors.ts";
 process.on("SIGINT", () => process.exit(EXIT_CODE.SIGINT));


### PR DESCRIPTION
by leveraging `bun link`

So `install` is not really the right term. But the end result is after running the new script you can execute `clerk` from any directory on your system and it will always use the latest code.

So this is for CLI devs who want convenience to demo/test the CLI

### Considerations

I also looked at using:

```
bun add -g ./
```

to install it globally. That did not work out of the box. And I believe it installs a snapshot of the files rather than a live link.

Because I am trying to solve a local dev story here I think the live link is preferable. The idea is I make a change in my CLI code, then go over to my test project and try `clerk xyz` immediately. No need to build or anything.  So I think the `link` serves this story quite elegantly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added root-level scripts to link and unlink the CLI package for local development and testing.
  * Registered the CLI as a system executable and switched its runtime to the Bun environment, updating how the command is invoked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->