### PR TITLE
fix: use --cwd instead of --filter for dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "scripts": {
     "build": "bun run --filter @clerk/cli-core build",
-    "dev": "bun run --filter @clerk/cli-core dev",
+    "dev": "bun run --cwd packages/cli-core dev",
     "test": "bun run --filter @clerk/cli-core test",
     "lint": "bun run --filter @clerk/cli-core lint && oxlint scripts/",
     "format": "bun run --filter @clerk/cli-core format && oxfmt --write scripts/",


### PR DESCRIPTION
## Summary
- Switches the root `dev` script from `bun run --filter` to `bun run --cwd` to fix truncated CLI output
- Bun's `--filter` wraps subprocess output and elides lines (e.g., `[15 lines elided]`), hiding part of CLI output like `--help`
- `--cwd` runs the script directly without the workspace output wrapper

## Test plan
- [x] Run `bun run dev -- --help` from root and verify full help output is displayed
- [x] Run `bun run dev -- auth --help` and verify subcommand help is also fully visible

**BEFORE:**
<img width="747" height="253" alt="image" src="https://github.com/user-attachments/assets/a7f26d26-f512-42c1-a89f-fc54bc4ae976" />

**AFTER:**
<img width="955" height="433" alt="image" src="https://github.com/user-attachments/assets/d97801a5-a17e-42bf-b0ff-38798b09da32" />

> fixes: [AIE-675](https://linear.app/clerk/issue/AIE-675/bun-run-dev-elides-cli-output-when-run-from-workspace-root)
