### PR TITLE
build: add macOS code signing and notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,21 @@ jobs:
       artifact-prefix: clerk
     secrets: inherit
 
-  smoke-test:
+  sign-macos:
     needs: [versioning, build]
+    if: ${{ needs.versioning.outputs.release_created == 'true' }}
+    uses: ./.github/workflows/sign-macos.yml
+    with:
+      artifact-prefix: clerk
+    secrets:
+      APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+      APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+      APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+
+  smoke-test:
+    needs: [versioning, build, sign-macos]
     uses: ./.github/workflows/smoke-test.yml
     with:
       version: ${{ needs.versioning.outputs.version }}
@@ -60,7 +73,7 @@ jobs:
       preset: stable
 
   publish-npm:
-    needs: [versioning, build, smoke-test]
+    needs: [versioning, build, sign-macos, smoke-test]
     # Must run on GitHub-hosted runner for npm OIDC trusted publishing
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -90,7 +103,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
   publish-github:
-    needs: [versioning, build, smoke-test, publish-npm]
+    needs: [versioning, build, sign-macos, smoke-test, publish-npm]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -144,8 +157,20 @@ jobs:
       artifact-prefix: clerk-canary
     secrets: inherit
 
-  canary-smoke-test:
+  canary-sign-macos:
     needs: [canary-version, canary-build]
+    uses: ./.github/workflows/sign-macos.yml
+    with:
+      artifact-prefix: clerk-canary
+    secrets:
+      APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+      APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+      APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+
+  canary-smoke-test:
+    needs: [canary-version, canary-build, canary-sign-macos]
     uses: ./.github/workflows/smoke-test.yml
     with:
       version: ${{ needs.canary-version.outputs.version }}
@@ -153,7 +178,7 @@ jobs:
       preset: canary
 
   canary-publish-github:
-    needs: [canary-version, canary-build, canary-smoke-test]
+    needs: [canary-version, canary-build, canary-sign-macos, canary-smoke-test]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/sign-macos.yml
+++ b/.github/workflows/sign-macos.yml
@@ -1,0 +1,67 @@
+name: Sign macOS Binaries
+
+on:
+  workflow_call:
+    inputs:
+      artifact-prefix:
+        required: true
+        type: string
+        description: "Prefix for artifact names (e.g. 'clerk', 'clerk-canary', 'clerk-snapshot')"
+    secrets:
+      APPLE_CERTIFICATE_BASE64:
+        required: true
+      APPLE_CERTIFICATE_PASSWORD:
+        required: true
+      APPLE_API_KEY_BASE64:
+        required: true
+      APPLE_API_KEY_ID:
+        required: true
+      APPLE_API_ISSUER_ID:
+        required: true
+
+jobs:
+  sign:
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - target: darwin-arm64
+          - target: darwin-x64
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/sign-macos.ts
+            scripts/entitlements.plist
+            scripts/releaser/targets.ts
+            bun.lock
+            package.json
+            packages/cli-core/package.json
+          sparse-checkout-cone-mode: false
+
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact-prefix }}-${{ matrix.target }}
+          path: dist/artifacts/${{ matrix.target }}
+
+      - name: Sign and notarize
+        env:
+          APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+        run: bun run scripts/sign-macos.ts --target ${{ matrix.target }} --artifacts-dir dist/artifacts
+
+      - name: Re-upload signed artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-prefix }}-${{ matrix.target }}
+          path: dist/artifacts/${{ matrix.target }}/clerk
+          overwrite: true
+          retention-days: 1

--- a/.github/workflows/sign-macos.yml
+++ b/.github/workflows/sign-macos.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   sign:
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - target: darwin-arm64
@@ -35,10 +35,11 @@ jobs:
           sparse-checkout: |
             scripts/sign-macos.ts
             scripts/entitlements.plist
-            scripts/releaser/targets.ts
+            scripts/releaser/
             bun.lock
             package.json
             packages/cli-core/package.json
+            packages/cli/package.json
           sparse-checkout-cone-mode: false
 
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -77,8 +77,21 @@ jobs:
       ref: ${{ needs.snapshot.outputs.sha }}
       artifact-prefix: clerk-snapshot
 
-  smoke-test:
+  sign-macos:
     needs: [snapshot, build]
+    if: needs.snapshot.outputs.is_fork != 'true'
+    uses: ./.github/workflows/sign-macos.yml
+    with:
+      artifact-prefix: clerk-snapshot
+    secrets:
+      APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+      APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+      APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+
+  smoke-test:
+    needs: [snapshot, build, sign-macos]
     if: needs.snapshot.outputs.is_fork != 'true'
     uses: ./.github/workflows/smoke-test.yml
     with:
@@ -87,7 +100,7 @@ jobs:
       preset: snapshot
 
   publish:
-    needs: [snapshot, build, smoke-test]
+    needs: [snapshot, build, sign-macos, smoke-test]
     if: needs.snapshot.outputs.is_fork != 'true'
     # Must run on GitHub-hosted runner for npm OIDC trusted publishing
     runs-on: ubuntu-latest
@@ -161,7 +174,7 @@ jobs:
           gh pr comment "${PR_NUMBER}" --repo "${GH_REPO}" --body-file /tmp/comment-body.md
 
   notify-failure:
-    needs: [snapshot, build, smoke-test, publish]
+    needs: [snapshot, build, sign-macos, smoke-test, publish]
     if: >-
       always() &&
       contains(needs.*.result, 'failure')

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -10,18 +10,20 @@ push to main
     → merge "Version Packages" PR
       → check-release.ts detects unpublished version
         → build job: cross-compile all 8 targets (~5.5s total)
-          → smoke-test job: verify binaries on native runners
-            → publish-npm: generate platform packages + publish wrapper
-            → upload-github-assets: attach binaries to the GitHub Release
+          → sign-macos job: code sign + notarize darwin binaries
+            → smoke-test job: verify binaries on native runners
+              → publish-npm: generate platform packages + publish wrapper
+              → upload-github-assets: attach binaries to the GitHub Release
   → (if no stable release needed) canary.ts versions packages
-    → build → smoke-test subset → upload GitHub pre-release → publish @canary (npm)
+    → build → sign-macos → smoke-test subset → upload GitHub pre-release → publish @canary (npm)
 
 PR comment "!snapshot [name]"
   → snapshot.ts versions packages from PR branch
     → build job: cross-compile binaries
-      → smoke-test job: verify linux-x64 binary
-        → publish-npm: publish @snapshot packages
-          → post installation comment on PR
+      → sign-macos job: code sign + notarize darwin binaries
+        → smoke-test job: verify linux-x64 binary
+          → publish-npm: publish @snapshot packages
+            → post installation comment on PR
 ```
 
 ## Architecture
@@ -109,7 +111,43 @@ Defined in [`.github/workflows/build-binaries.yml`](../.github/workflows/build-b
 3. Verifies the binary format using `file` output
 4. The workflow then uploads each binary as a separate GitHub Actions artifact
 
-### 2. Smoke Test Job (matrix)
+### 2. Sign macOS Job
+
+Defined in [`.github/workflows/sign-macos.yml`](../.github/workflows/sign-macos.yml) and called by the release, canary, and snapshot pipelines. Runs on a macOS runner (one job per darwin architecture) using `scripts/sign-macos.ts`. For each target, the script:
+
+1. Creates a temporary macOS Keychain and imports the Developer ID Application certificate
+2. Signs the binary with `codesign --options runtime` (hardened runtime, required for notarization) and [entitlements](../scripts/entitlements.plist) for Bun's JIT engine
+3. Creates a ZIP archive via `ditto` and submits it to Apple's notary service via `xcrun notarytool submit --wait`
+4. On success, re-uploads the signed binary as a GitHub Actions artifact (overwriting the unsigned one)
+
+Standalone CLI binaries **cannot be stapled** — `xcrun stapler` only works on `.app` bundles, `.dmg`, and `.pkg` files. The notarization ticket lives online; Gatekeeper checks Apple's servers on first execution. This requires internet on first run (standard for CLI tools distributed via npm).
+
+On notarization failure, the script fetches and displays the notarization log for debugging.
+
+#### Required Secrets
+
+The signing workflow requires these GitHub Actions secrets:
+
+| Secret                       | Description                                                                                    |
+| ---------------------------- | ---------------------------------------------------------------------------------------------- |
+| `APPLE_CERTIFICATE_BASE64`   | Base64-encoded `.p12` file containing the Developer ID Application certificate and private key |
+| `APPLE_CERTIFICATE_PASSWORD` | Password that unlocks the `.p12` file                                                          |
+| `APPLE_API_KEY_BASE64`       | Base64-encoded `.p8` App Store Connect API key (for `notarytool`)                              |
+| `APPLE_API_KEY_ID`           | 10-character App Store Connect API key ID                                                      |
+| `APPLE_API_ISSUER_ID`        | App Store Connect issuer UUID                                                                  |
+
+**Certificate expiration:** Developer ID Application certificates are valid for 5 years. When the certificate expires, generate a new one via the Apple Developer portal and update `APPLE_CERTIFICATE_BASE64` and `APPLE_CERTIFICATE_PASSWORD`.
+
+**Local testing:** You can test signing locally (requires macOS with the certificate in your Keychain):
+
+```sh
+bun run scripts/build.ts --target darwin-arm64
+APPLE_CERTIFICATE_BASE64="..." APPLE_CERTIFICATE_PASSWORD="..." \
+APPLE_API_KEY_BASE64="..." APPLE_API_KEY_ID="..." APPLE_API_ISSUER_ID="..." \
+bun run scripts/sign-macos.ts --target darwin-arm64 --artifacts-dir dist/artifacts
+```
+
+### 3. Smoke Test Job (matrix)
 
 Downloads each compiled binary and runs `--version` to verify the binary actually executes. Smoke testing is handled by a reusable workflow (`.github/workflows/smoke-test.yml`) shared across stable, canary, and snapshot pipelines. Each caller passes a preset name (`stable`, `canary`, or `snapshot`); the reusable workflow resolves the preset to a target matrix internally. glibc targets run natively on a platform-matched GitHub-hosted runner; musl targets run inside an Alpine Docker container on a Linux runner.
 
@@ -117,7 +155,7 @@ Not all targets have a native runner available. `win32-arm64` is published as be
 
 Publishing and GitHub Release upload are gated on all smoke tests passing.
 
-### 3. Publish npm Job
+### 4. Publish npm Job
 
 Runs the releaser script (`scripts/releaser/index.ts`) via `bun run release` (stable), `bun run release:canary` (canary), or `bun run release:snapshot` (snapshot):
 
@@ -150,7 +188,7 @@ Publishing uses [npm OIDC trusted publishing](https://docs.npmjs.com/trusted-pub
 
 > **First publish**: New packages cannot use trusted publishing until they exist on npm. The very first stable release requires a one-time `NODE_AUTH_TOKEN` with a granular access token. After that, configure trusted publishers for all packages and remove the token.
 
-### 4. Upload GitHub Assets Job
+### 5. Upload GitHub Assets Job
 
 Attaches the compiled binaries to the GitHub Release for direct download. Binaries are uploaded with display names following the `clerk-<target>` convention (e.g., `clerk-darwin-arm64`, `clerk-win32-x64.exe`).
 
@@ -166,11 +204,14 @@ Attaches the compiled binaries to the GitHub Release for direct download. Binari
 | `scripts/releaser/index.ts`            | Generates platform packages and publishes everything to npm                    |
 | `scripts/releaser/targets.ts`          | Target definitions (used by both releaser and build.ts)                        |
 | `scripts/build.ts`                     | Cross-compiles CLI binaries for all 8 platform targets                         |
+| `scripts/sign-macos.ts`                | Signs and notarizes macOS binaries (keychain, codesign, notarytool)            |
+| `scripts/entitlements.plist`           | macOS entitlements for Bun's JIT engine (used by codesign)                     |
 | `scripts/canary.ts`                    | Versions packages for canary channel using Changesets snapshots                |
 | `scripts/snapshot.ts`                  | Versions packages for snapshot channel using Changesets snapshots              |
 | `scripts/check-release.ts`             | Detects if a stable release is needed (compares version to npm registry)       |
 | `.changeset/config.json`               | Changesets configuration                                                       |
 | `.github/workflows/build-binaries.yml` | Reusable workflow for cross-compiling binaries (called by release + snapshot)  |
+| `.github/workflows/sign-macos.yml`     | Reusable workflow for macOS code signing and notarization                      |
 | `.github/workflows/smoke-test.yml`     | Reusable workflow for smoke-testing binaries (called by release + snapshot)    |
 | `.github/workflows/release.yml`        | GitHub Actions release + canary workflow                                       |
 | `.github/workflows/snapshot.yml`       | GitHub Actions snapshot workflow (triggered by PR comments)                    |
@@ -230,4 +271,5 @@ If your change is internal-only (CI, tests, docs, refactoring), you can skip the
 - **Native smoke tests**: Each binary is executed on a native runner for its platform before publishing. This catches cross-compilation issues that format checks alone would miss.
 - **Org membership check**: Snapshot releases require the commenter to be a `MEMBER` or `OWNER` of the repository's organization, verified via `author_association`.
 - **OIDC trusted publishing**: Publish jobs authenticate via GitHub's OIDC provider instead of stored npm tokens. This eliminates secret rotation, prevents token exfiltration, and scopes publish permissions to specific workflow files.
+- **macOS code signing and notarization**: macOS binaries are signed with a Developer ID Application certificate and notarized by Apple before publishing. Gatekeeper checks the notarization ticket online on first execution.
 - **CI build check**: Every PR to `main` runs a JS bundle build to catch bundler-specific failures before merge.

--- a/scripts/entitlements.plist
+++ b/scripts/entitlements.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-executable-page-protection</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/scripts/sign-macos.test.ts
+++ b/scripts/sign-macos.test.ts
@@ -1,0 +1,56 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import { requireEnvOrFlag, getDarwinTargets } from "./sign-macos.ts";
+
+describe("requireEnvOrFlag", () => {
+  afterEach(() => {
+    delete process.env.__TEST_SIGN_VAR;
+  });
+
+  test("returns flag value when provided", () => {
+    expect(requireEnvOrFlag("flag-value", "__TEST_SIGN_VAR", "test-flag")).toBe("flag-value");
+  });
+
+  test("falls back to env var when flag is undefined", () => {
+    process.env.__TEST_SIGN_VAR = "env-value";
+    expect(requireEnvOrFlag(undefined, "__TEST_SIGN_VAR", "test-flag")).toBe("env-value");
+  });
+
+  test("prefers flag value over env var", () => {
+    process.env.__TEST_SIGN_VAR = "env-value";
+    expect(requireEnvOrFlag("flag-value", "__TEST_SIGN_VAR", "test-flag")).toBe("flag-value");
+  });
+
+  test("throws when neither flag nor env var is provided", () => {
+    expect(() => requireEnvOrFlag(undefined, "__TEST_SIGN_VAR", "test-flag")).toThrow(
+      "Missing test-flag: pass --test-flag or set __TEST_SIGN_VAR",
+    );
+  });
+});
+
+describe("getDarwinTargets", () => {
+  test("returns all darwin targets when no filter is provided", () => {
+    const result = getDarwinTargets();
+    expect(result.length).toBe(2);
+    expect(result.map((t) => t.name)).toEqual(["darwin-arm64", "darwin-x64"]);
+  });
+
+  test("filters to darwin-arm64 when specified", () => {
+    const result = getDarwinTargets("darwin-arm64");
+    expect(result.length).toBe(1);
+    expect(result[0].name).toBe("darwin-arm64");
+  });
+
+  test("filters to darwin-x64 when specified", () => {
+    const result = getDarwinTargets("darwin-x64");
+    expect(result.length).toBe(1);
+    expect(result[0].name).toBe("darwin-x64");
+  });
+
+  test("throws for an invalid target", () => {
+    expect(() => getDarwinTargets("linux-x64")).toThrow("Unknown darwin target: linux-x64");
+  });
+
+  test("throws for a completely unknown target", () => {
+    expect(() => getDarwinTargets("freebsd-arm64")).toThrow("Unknown darwin target: freebsd-arm64");
+  });
+});

--- a/scripts/sign-macos.ts
+++ b/scripts/sign-macos.ts
@@ -160,14 +160,42 @@ if (import.meta.main) {
     );
 
     run(
-      ["security", "import", certPath, "-k", KEYCHAIN_NAME, "-P", certificatePassword, "-T", "/usr/bin/codesign"],
+      [
+        "security",
+        "import",
+        certPath,
+        "-k",
+        KEYCHAIN_NAME,
+        "-P",
+        certificatePassword,
+        "-T",
+        "/usr/bin/codesign",
+      ],
       ["security", "import", certPath, "-k", KEYCHAIN_NAME, "-P", "***", "-T", "/usr/bin/codesign"],
     );
 
     // Allow codesign to access the keychain without UI prompts
     run(
-      ["security", "set-key-partition-list", "-S", "apple-tool:,apple:,codesign:", "-s", "-k", keychainPassword, KEYCHAIN_NAME],
-      ["security", "set-key-partition-list", "-S", "apple-tool:,apple:,codesign:", "-s", "-k", "***", KEYCHAIN_NAME],
+      [
+        "security",
+        "set-key-partition-list",
+        "-S",
+        "apple-tool:,apple:,codesign:",
+        "-s",
+        "-k",
+        keychainPassword,
+        KEYCHAIN_NAME,
+      ],
+      [
+        "security",
+        "set-key-partition-list",
+        "-S",
+        "apple-tool:,apple:,codesign:",
+        "-s",
+        "-k",
+        "***",
+        KEYCHAIN_NAME,
+      ],
     );
 
     // Prepend our keychain to the search list

--- a/scripts/sign-macos.ts
+++ b/scripts/sign-macos.ts
@@ -11,6 +11,11 @@ const KEYCHAIN_NAME = "clerk-signing.keychain-db";
 // Helpers (exported for testing)
 // ---------------------------------------------------------------------------
 
+/**
+ * Resolves a configuration value from either a CLI flag or an environment
+ * variable, preferring the flag when both are present. Throws if neither
+ * source provides a value.
+ */
 export function requireEnvOrFlag(
   flagValue: string | undefined,
   envVar: string,
@@ -23,6 +28,10 @@ export function requireEnvOrFlag(
   return value;
 }
 
+/**
+ * Returns the list of macOS (darwin) build targets. When `targetFilter` is
+ * provided, returns only the matching target or throws if it does not exist.
+ */
 export function getDarwinTargets(targetFilter?: string) {
   const darwinTargets = targets.filter((t) => t.os === "darwin");
 
@@ -40,6 +49,7 @@ export function getDarwinTargets(targetFilter?: string) {
   return matched;
 }
 
+/** Executes a command synchronously and returns its stdout. Throws on non-zero exit. */
 function run(cmd: string[]): string {
   console.log(`$ ${cmd.join(" ")}`);
   const result = Bun.spawnSync(cmd, {
@@ -54,6 +64,7 @@ function run(cmd: string[]): string {
   return result.stdout.toString().trim();
 }
 
+/** Like `run`, but returns `undefined` instead of throwing on failure. */
 function runMaybe(cmd: string[]): string | undefined {
   console.log(`$ ${cmd.join(" ")} (non-fatal)`);
   const result = Bun.spawnSync(cmd, {

--- a/scripts/sign-macos.ts
+++ b/scripts/sign-macos.ts
@@ -240,7 +240,7 @@ if (import.meta.main) {
         "json",
         "--wait",
         "--timeout",
-        "10m",
+        "30m",
       ];
       console.log(`$ ${notaryCmd.join(" ")}`);
       const notaryProc = Bun.spawnSync(notaryCmd, {

--- a/scripts/sign-macos.ts
+++ b/scripts/sign-macos.ts
@@ -1,0 +1,289 @@
+import { join } from "node:path";
+import { mkdir, rm } from "node:fs/promises";
+import { parseArgs } from "node:util";
+import { targets } from "./releaser/targets.ts";
+
+const ENTITLEMENTS_PATH = join(import.meta.dir, "entitlements.plist");
+const KEYCHAIN_NAME = "clerk-signing.keychain-db";
+const KEYCHAIN_PASSWORD = "clerk-signing-temp";
+
+// ---------------------------------------------------------------------------
+// Helpers (exported for testing)
+// ---------------------------------------------------------------------------
+
+export function requireEnvOrFlag(
+  flagValue: string | undefined,
+  envVar: string,
+  label: string,
+): string {
+  const value = flagValue ?? process.env[envVar];
+  if (!value) {
+    throw new Error(`Missing ${label}: pass --${label} or set ${envVar}`);
+  }
+  return value;
+}
+
+export function getDarwinTargets(targetFilter?: string) {
+  const darwinTargets = targets.filter((t) => t.os === "darwin");
+
+  if (!targetFilter) {
+    return darwinTargets;
+  }
+
+  const matched = darwinTargets.filter((t) => t.name === targetFilter);
+  if (matched.length === 0) {
+    throw new Error(
+      `Unknown darwin target: ${targetFilter}\nAvailable: ${darwinTargets.map((t) => t.name).join(", ")}`,
+    );
+  }
+
+  return matched;
+}
+
+function run(cmd: string[]): string {
+  console.log(`$ ${cmd.join(" ")}`);
+  const result = Bun.spawnSync(cmd, {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.exitCode !== 0) {
+    const stderr = result.stderr.toString().trim();
+    throw new Error(
+      `${cmd.join(" ")} failed (exit ${result.exitCode})${stderr ? `:\n${stderr}` : ""}`,
+    );
+  }
+  return result.stdout.toString().trim();
+}
+
+function runMaybe(cmd: string[]): string | undefined {
+  console.log(`$ ${cmd.join(" ")} (non-fatal)`);
+  const result = Bun.spawnSync(cmd, {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.exitCode !== 0) {
+    const stderr = result.stderr.toString().trim();
+    console.warn(
+      `Warning: ${cmd.join(" ")} failed (exit ${result.exitCode})${stderr ? `: ${stderr}` : ""}`,
+    );
+    return undefined;
+  }
+  return result.stdout.toString().trim();
+}
+
+// ---------------------------------------------------------------------------
+// Main — only runs when executed directly (not when imported by tests)
+// ---------------------------------------------------------------------------
+
+if (import.meta.main) {
+  const { values } = parseArgs({
+    args: Bun.argv.slice(2),
+    options: {
+      target: { type: "string" },
+      "artifacts-dir": { type: "string" },
+      "certificate-base64": { type: "string" },
+      "certificate-password": { type: "string" },
+      "api-key-base64": { type: "string" },
+      "api-key-id": { type: "string" },
+      "api-issuer-id": { type: "string" },
+    },
+  });
+
+  const artifactsDir = requireEnvOrFlag(values["artifacts-dir"], "ARTIFACTS_DIR", "artifacts-dir");
+  const certificateBase64 = requireEnvOrFlag(
+    values["certificate-base64"],
+    "APPLE_CERTIFICATE_BASE64",
+    "certificate-base64",
+  );
+  const certificatePassword = requireEnvOrFlag(
+    values["certificate-password"],
+    "APPLE_CERTIFICATE_PASSWORD",
+    "certificate-password",
+  );
+  const apiKeyBase64 = requireEnvOrFlag(
+    values["api-key-base64"],
+    "APPLE_API_KEY_BASE64",
+    "api-key-base64",
+  );
+  const apiKeyId = requireEnvOrFlag(values["api-key-id"], "APPLE_API_KEY_ID", "api-key-id");
+  const apiIssuerId = requireEnvOrFlag(
+    values["api-issuer-id"],
+    "APPLE_API_ISSUER_ID",
+    "api-issuer-id",
+  );
+
+  const selectedTargets = getDarwinTargets(values.target);
+
+  console.log(
+    `Signing ${selectedTargets.length} target(s): ${selectedTargets.map((t) => t.name).join(", ")}\n`,
+  );
+
+  // Write the API key to a temp file (shared across targets)
+  const apiKeyDir = join(import.meta.dir, ".tmp-api-key");
+  const apiKeyPath = join(apiKeyDir, `AuthKey_${apiKeyId}.p8`);
+
+  try {
+    await mkdir(apiKeyDir, { recursive: true });
+    await Bun.write(apiKeyPath, Buffer.from(apiKeyBase64, "base64"));
+    // -- Create temporary keychain and import certificate --
+    const certPath = join(import.meta.dir, ".tmp-cert.p12");
+    await Bun.write(certPath, Buffer.from(certificateBase64, "base64"));
+
+    run(["security", "create-keychain", "-p", KEYCHAIN_PASSWORD, KEYCHAIN_NAME]);
+    run(["security", "set-keychain-settings", "-lut", "21600", KEYCHAIN_NAME]);
+    run(["security", "unlock-keychain", "-p", KEYCHAIN_PASSWORD, KEYCHAIN_NAME]);
+
+    run([
+      "security",
+      "import",
+      certPath,
+      "-k",
+      KEYCHAIN_NAME,
+      "-P",
+      certificatePassword,
+      "-T",
+      "/usr/bin/codesign",
+    ]);
+
+    // Allow codesign to access the keychain without UI prompts
+    run([
+      "security",
+      "set-key-partition-list",
+      "-S",
+      "apple-tool:,apple:",
+      "-s",
+      "-k",
+      KEYCHAIN_PASSWORD,
+      KEYCHAIN_NAME,
+    ]);
+
+    // Prepend our keychain to the search list
+    const existingKeychains = run(["security", "list-keychains", "-d", "user"]);
+    const keychainList = existingKeychains
+      .split("\n")
+      .map((k) => k.trim().replace(/^"|"$/g, ""))
+      .filter(Boolean);
+    run(["security", "list-keychains", "-d", "user", "-s", KEYCHAIN_NAME, ...keychainList]);
+
+    // Clean up temp cert file
+    await Bun.file(certPath).delete();
+
+    // -- Extract signing identity --
+    const identityOutput = run([
+      "security",
+      "find-identity",
+      "-v",
+      "-p",
+      "codesigning",
+      KEYCHAIN_NAME,
+    ]);
+    const identityMatch = identityOutput.match(/"([^"]+)"/);
+    if (!identityMatch) {
+      throw new Error(`No codesigning identity found in keychain.\nOutput: ${identityOutput}`);
+    }
+    const identity = identityMatch[1];
+    console.log(`Signing identity: ${identity}\n`);
+
+    // -- Sign and notarize each target --
+    for (const target of selectedTargets) {
+      const binaryPath = join(artifactsDir, target.name, "clerk");
+      console.log(`\n--- ${target.name} ---`);
+
+      // Code sign with hardened runtime
+      run([
+        "codesign",
+        "--sign",
+        identity,
+        "--entitlements",
+        ENTITLEMENTS_PATH,
+        "--options",
+        "runtime",
+        "--timestamp",
+        "--force",
+        binaryPath,
+      ]);
+
+      // Verify signature
+      run(["codesign", "--verify", "--verbose", binaryPath]);
+
+      // Create ZIP for notarization (Apple requires ditto format)
+      const zipPath = `${binaryPath}.zip`;
+      run(["ditto", "-c", "-k", "--keepParent", binaryPath, zipPath]);
+
+      // Submit for notarization (don't use run() — notarytool may exit non-zero
+      // while still emitting valid JSON to stdout, e.g. status "Invalid")
+      console.log("Submitting for notarization...");
+      const notaryCmd = [
+        "xcrun",
+        "notarytool",
+        "submit",
+        zipPath,
+        "--key",
+        apiKeyPath,
+        "--key-id",
+        apiKeyId,
+        "--issuer",
+        apiIssuerId,
+        "--output-format",
+        "json",
+        "--wait",
+      ];
+      console.log(`$ ${notaryCmd.join(" ")}`);
+      const notaryProc = Bun.spawnSync(notaryCmd, {
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const notaryStdout = notaryProc.stdout.toString().trim();
+      const notaryStderr = notaryProc.stderr.toString().trim();
+      if (notaryStderr) {
+        console.error(notaryStderr);
+      }
+
+      // Parse notarization result from stdout (available regardless of exit code)
+      let notaryResult: { id?: string; status?: string };
+      try {
+        notaryResult = JSON.parse(notaryStdout);
+      } catch {
+        throw new Error(
+          `Failed to parse notarytool output (exit ${notaryProc.exitCode}):\n${notaryStdout}`,
+        );
+      }
+
+      console.log(
+        `Notarization status: ${notaryResult.status ?? "unknown"} (id: ${notaryResult.id ?? "unknown"})`,
+      );
+
+      if (notaryResult.status !== "Accepted") {
+        // Fetch and display the notarization log for debugging
+        if (notaryResult.id) {
+          const log = runMaybe([
+            "xcrun",
+            "notarytool",
+            "log",
+            notaryResult.id,
+            "--key",
+            apiKeyPath,
+            "--key-id",
+            apiKeyId,
+            "--issuer",
+            apiIssuerId,
+          ]);
+          if (log) {
+            console.error("Notarization log:\n" + log);
+          }
+        }
+        throw new Error(`Notarization failed with status: ${notaryResult.status}`);
+      }
+
+      // Clean up the ZIP
+      await Bun.file(zipPath).delete();
+
+      console.log(`${target.name} signed and notarized successfully.`);
+    }
+
+    console.log("\nAll targets signed and notarized successfully.");
+  } finally {
+    // -- Keychain cleanup --
+    runMaybe(["security", "delete-keychain", KEYCHAIN_NAME]);
+
+    // Clean up API key
+    await rm(apiKeyDir, { recursive: true, force: true });
+  }
+}

--- a/scripts/sign-macos.ts
+++ b/scripts/sign-macos.ts
@@ -1,11 +1,11 @@
 import { join } from "node:path";
 import { mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { parseArgs } from "node:util";
 import { targets } from "./releaser/targets.ts";
 
 const ENTITLEMENTS_PATH = join(import.meta.dir, "entitlements.plist");
 const KEYCHAIN_NAME = "clerk-signing.keychain-db";
-const KEYCHAIN_PASSWORD = "clerk-signing-temp";
 
 // ---------------------------------------------------------------------------
 // Helpers (exported for testing)
@@ -116,20 +116,23 @@ if (import.meta.main) {
     `Signing ${selectedTargets.length} target(s): ${selectedTargets.map((t) => t.name).join(", ")}\n`,
   );
 
-  // Write the API key to a temp file (shared across targets)
-  const apiKeyDir = join(import.meta.dir, ".tmp-api-key");
+  // Use OS temp dir for secrets — never write them to the source tree
+  const tempDir = process.env.RUNNER_TEMP ?? tmpdir();
+  const apiKeyDir = join(tempDir, "clerk-sign-keys");
   const apiKeyPath = join(apiKeyDir, `AuthKey_${apiKeyId}.p8`);
+  const certPath = join(tempDir, "clerk-sign-cert.p12");
+  const keychainPassword = crypto.randomUUID();
 
   try {
     await mkdir(apiKeyDir, { recursive: true });
     await Bun.write(apiKeyPath, Buffer.from(apiKeyBase64, "base64"));
+
     // -- Create temporary keychain and import certificate --
-    const certPath = join(import.meta.dir, ".tmp-cert.p12");
     await Bun.write(certPath, Buffer.from(certificateBase64, "base64"));
 
-    run(["security", "create-keychain", "-p", KEYCHAIN_PASSWORD, KEYCHAIN_NAME]);
+    run(["security", "create-keychain", "-p", keychainPassword, KEYCHAIN_NAME]);
     run(["security", "set-keychain-settings", "-lut", "21600", KEYCHAIN_NAME]);
-    run(["security", "unlock-keychain", "-p", KEYCHAIN_PASSWORD, KEYCHAIN_NAME]);
+    run(["security", "unlock-keychain", "-p", keychainPassword, KEYCHAIN_NAME]);
 
     run([
       "security",
@@ -148,10 +151,10 @@ if (import.meta.main) {
       "security",
       "set-key-partition-list",
       "-S",
-      "apple-tool:,apple:",
+      "apple-tool:,apple:,codesign:",
       "-s",
       "-k",
-      KEYCHAIN_PASSWORD,
+      keychainPassword,
       KEYCHAIN_NAME,
     ]);
 
@@ -162,9 +165,6 @@ if (import.meta.main) {
       .map((k) => k.trim().replace(/^"|"$/g, ""))
       .filter(Boolean);
     run(["security", "list-keychains", "-d", "user", "-s", KEYCHAIN_NAME, ...keychainList]);
-
-    // Clean up temp cert file
-    await Bun.file(certPath).delete();
 
     // -- Extract signing identity --
     const identityOutput = run([
@@ -192,6 +192,8 @@ if (import.meta.main) {
         "codesign",
         "--sign",
         identity,
+        "--keychain",
+        KEYCHAIN_NAME,
         "--entitlements",
         ENTITLEMENTS_PATH,
         "--options",
@@ -225,6 +227,8 @@ if (import.meta.main) {
         "--output-format",
         "json",
         "--wait",
+        "--timeout",
+        "10m",
       ];
       console.log(`$ ${notaryCmd.join(" ")}`);
       const notaryProc = Bun.spawnSync(notaryCmd, {
@@ -280,10 +284,9 @@ if (import.meta.main) {
 
     console.log("\nAll targets signed and notarized successfully.");
   } finally {
-    // -- Keychain cleanup --
+    // -- Cleanup: keychain, certificate, and API key --
     runMaybe(["security", "delete-keychain", KEYCHAIN_NAME]);
-
-    // Clean up API key
+    await rm(certPath, { force: true });
     await rm(apiKeyDir, { recursive: true, force: true });
   }
 }

--- a/scripts/sign-macos.ts
+++ b/scripts/sign-macos.ts
@@ -49,31 +49,39 @@ export function getDarwinTargets(targetFilter?: string) {
   return matched;
 }
 
-/** Executes a command synchronously and returns its stdout. Throws on non-zero exit. */
-function run(cmd: string[]): string {
-  console.log(`$ ${cmd.join(" ")}`);
+/**
+ * Executes a command synchronously and returns its stdout. Throws on non-zero
+ * exit. When `displayCmd` is provided it is used for logging and error messages
+ * instead of `cmd`, so that secrets passed in argv are never printed.
+ */
+function run(cmd: string[], displayCmd = cmd): string {
+  console.log(`$ ${displayCmd.join(" ")}`);
   const result = Bun.spawnSync(cmd, {
     stdio: ["ignore", "pipe", "pipe"],
   });
   if (result.exitCode !== 0) {
     const stderr = result.stderr.toString().trim();
     throw new Error(
-      `${cmd.join(" ")} failed (exit ${result.exitCode})${stderr ? `:\n${stderr}` : ""}`,
+      `${displayCmd.join(" ")} failed (exit ${result.exitCode})${stderr ? `:\n${stderr}` : ""}`,
     );
   }
   return result.stdout.toString().trim();
 }
 
-/** Like `run`, but returns `undefined` instead of throwing on failure. */
-function runMaybe(cmd: string[]): string | undefined {
-  console.log(`$ ${cmd.join(" ")} (non-fatal)`);
+/**
+ * Like `run`, but returns `undefined` instead of throwing on failure. When
+ * `displayCmd` is provided it is used for logging and warning messages instead
+ * of `cmd`, so that secrets passed in argv are never printed.
+ */
+function runMaybe(cmd: string[], displayCmd = cmd): string | undefined {
+  console.log(`$ ${displayCmd.join(" ")} (non-fatal)`);
   const result = Bun.spawnSync(cmd, {
     stdio: ["ignore", "pipe", "pipe"],
   });
   if (result.exitCode !== 0) {
     const stderr = result.stderr.toString().trim();
     console.warn(
-      `Warning: ${cmd.join(" ")} failed (exit ${result.exitCode})${stderr ? `: ${stderr}` : ""}`,
+      `Warning: ${displayCmd.join(" ")} failed (exit ${result.exitCode})${stderr ? `: ${stderr}` : ""}`,
     );
     return undefined;
   }
@@ -141,33 +149,26 @@ if (import.meta.main) {
     // -- Create temporary keychain and import certificate --
     await Bun.write(certPath, Buffer.from(certificateBase64, "base64"));
 
-    run(["security", "create-keychain", "-p", keychainPassword, KEYCHAIN_NAME]);
+    run(
+      ["security", "create-keychain", "-p", keychainPassword, KEYCHAIN_NAME],
+      ["security", "create-keychain", "-p", "***", KEYCHAIN_NAME],
+    );
     run(["security", "set-keychain-settings", "-lut", "21600", KEYCHAIN_NAME]);
-    run(["security", "unlock-keychain", "-p", keychainPassword, KEYCHAIN_NAME]);
+    run(
+      ["security", "unlock-keychain", "-p", keychainPassword, KEYCHAIN_NAME],
+      ["security", "unlock-keychain", "-p", "***", KEYCHAIN_NAME],
+    );
 
-    run([
-      "security",
-      "import",
-      certPath,
-      "-k",
-      KEYCHAIN_NAME,
-      "-P",
-      certificatePassword,
-      "-T",
-      "/usr/bin/codesign",
-    ]);
+    run(
+      ["security", "import", certPath, "-k", KEYCHAIN_NAME, "-P", certificatePassword, "-T", "/usr/bin/codesign"],
+      ["security", "import", certPath, "-k", KEYCHAIN_NAME, "-P", "***", "-T", "/usr/bin/codesign"],
+    );
 
     // Allow codesign to access the keychain without UI prompts
-    run([
-      "security",
-      "set-key-partition-list",
-      "-S",
-      "apple-tool:,apple:,codesign:",
-      "-s",
-      "-k",
-      keychainPassword,
-      KEYCHAIN_NAME,
-    ]);
+    run(
+      ["security", "set-key-partition-list", "-S", "apple-tool:,apple:,codesign:", "-s", "-k", keychainPassword, KEYCHAIN_NAME],
+      ["security", "set-key-partition-list", "-S", "apple-tool:,apple:,codesign:", "-s", "-k", "***", KEYCHAIN_NAME],
+    );
 
     // Prepend our keychain to the search list
     const existingKeychains = run(["security", "list-keychains", "-d", "user"]);


### PR DESCRIPTION
## Summary

- Add `scripts/sign-macos.ts` — a Bun script that handles keychain setup, certificate import, code signing with hardened runtime + entitlements, and Apple notarization via `xcrun notarytool`
- Add `.github/workflows/sign-macos.yml` — a thin reusable workflow that calls the script between the build and smoke-test jobs
- Wire signing into all three release channels (stable, canary, snapshot)
- Standalone binaries cannot be stapled; the notarization ticket lives online and Gatekeeper checks it on first execution

## Test plan

- [ ] Configure the 5 required GitHub Actions secrets (see `docs/releasing.md` "Required Secrets" section)
- [ ] Trigger a snapshot release from this PR: `!snapshot codesign-test`
- [ ] Verify the sign-macos job completes with "Notarization accepted" for both `darwin-arm64` and `darwin-x64`
- [ ] Install the snapshot on a Mac: `npm install -g clerk@<version>`
- [ ] Run `clerk --version` and verify no Gatekeeper "unidentified developer" warning appears
- [ ] Verify `codesign --verify --verbose $(which clerk)` shows a valid signature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Integrated macOS signing & notarization into stable, snapshot, and canary CI flows; signing now gates downstream publish and smoke-test steps and re-uploads signed artifacts.
  * Added macOS entitlements used during signing.

* **New Features**
  * Added a reusable macOS signing workflow that signs and notarizes per-architecture artifacts.

* **Tests**
  * Added tests for signing CLI/env resolution and macOS target selection.

* **Documentation**
  * Updated release docs to reflect the new signing stage and pipeline ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->