### PR TITLE
Add structured error codes to CLI errors

### DIFF
--- a/packages/cli-core/src/cli-program.ts
+++ b/packages/cli-core/src/cli-program.ts
@@ -13,8 +13,16 @@ import { api } from "./commands/api/index.ts";
 import { link } from "./commands/link/index.ts";
 import { unlink } from "./commands/unlink/index.ts";
 import { doctor } from "./commands/doctor/index.ts";
-import { CliError, UserAbortError, ApiError, EXIT_CODE, throwUsageError } from "./lib/errors.ts";
+import {
+  CliError,
+  UserAbortError,
+  ApiError,
+  EXIT_CODE,
+  throwUsageError,
+  type ErrorCode,
+} from "./lib/errors.ts";
 import { red } from "./lib/color.ts";
+import { isAgent } from "./mode.ts";
 
 export function createProgram() {
   const program = new Command()
@@ -208,11 +216,15 @@ export async function runProgram(
     }
 
     if (error instanceof CliError) {
-      if (error.message) {
-        console.error(red(`error: ${error.message}`));
-      }
-      if (error.docsUrl) {
-        console.error(`\nFor more information, see: ${error.docsUrl}`);
+      if (isAgent() && error.code) {
+        outputJsonError(error.code, error.message, error.docsUrl);
+      } else {
+        if (error.message) {
+          console.error(red(`error: ${error.message}`));
+        }
+        if (error.docsUrl) {
+          console.error(`\nFor more information, see: ${error.docsUrl}`);
+        }
       }
       process.exit(error.exitCode);
     }
@@ -220,16 +232,48 @@ export async function runProgram(
     if (error instanceof ApiError) {
       const detail = formatApiBody(error.body, verbose);
       const prefix = error.context ?? "Request failed";
-      console.error(red(`error: ${prefix} (${error.status}): ${detail}`));
+      if (isAgent()) {
+        const apiCode = extractApiErrorCode(error.body);
+        outputJsonError(apiCode ?? "api_error", `${prefix} (${error.status}): ${detail}`);
+      } else {
+        console.error(red(`error: ${prefix} (${error.status}): ${detail}`));
+      }
       process.exit(EXIT_CODE.GENERAL);
     }
 
     if (error instanceof Error) {
-      console.error(red(`error: ${error.message}`));
+      if (isAgent()) {
+        outputJsonError("unexpected_error", error.message);
+      } else {
+        console.error(red(`error: ${error.message}`));
+      }
       process.exit(EXIT_CODE.GENERAL);
     }
 
-    console.error(red("error: An unexpected error occurred"));
+    if (isAgent()) {
+      outputJsonError("unexpected_error", "An unexpected error occurred");
+    } else {
+      console.error(red("error: An unexpected error occurred"));
+    }
     process.exit(EXIT_CODE.GENERAL);
+  }
+}
+
+/** Output a structured JSON error to stderr for agent/CI consumption. */
+function outputJsonError(code: string, message: string, docsUrl?: string): void {
+  const payload: { error: { code: string; message: string; docsUrl?: string } } = {
+    error: { code, message },
+  };
+  if (docsUrl) payload.error.docsUrl = docsUrl;
+  console.error(JSON.stringify(payload));
+}
+
+/** Extract the error code from a Clerk API JSON response body, if present. */
+function extractApiErrorCode(body: string): string | undefined {
+  try {
+    const parsed = JSON.parse(body);
+    return parsed.errors?.[0]?.code;
+  } catch {
+    return undefined;
   }
 }

--- a/packages/cli-core/src/commands/api/catalog.ts
+++ b/packages/cli-core/src/commands/api/catalog.ts
@@ -7,7 +7,7 @@ import { parse as parseYaml } from "yaml";
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { CLERK_CACHE_DIR, CACHE_TTL_MS, OPENAPI_SPEC_URLS } from "../../lib/constants.ts";
-import { CliError } from "../../lib/errors.ts";
+import { CliError, ERROR_CODE } from "../../lib/errors.ts";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -143,6 +143,7 @@ export async function loadCatalog(options: { platform?: boolean } = {}): Promise
       `Unable to fetch API catalog. Check your network connection.\n` +
         `  URL: ${url}\n` +
         `  ${(error as Error).message}`,
+      { code: ERROR_CODE.CATALOG_ERROR },
     );
   }
 }

--- a/packages/cli-core/src/commands/api/index.ts
+++ b/packages/cli-core/src/commands/api/index.ts
@@ -6,6 +6,7 @@ import { bapiRequest } from "./bapi.ts";
 import {
   BapiError,
   CliError,
+  ERROR_CODE,
   throwUsageError,
   throwUserAbort,
   withApiContext,
@@ -135,6 +136,7 @@ async function resolveSecretKey(options: ApiOptions): Promise<string> {
           "  CLERK_SECRET_KEY environment variable\n" +
           "  Link a project with `clerk link`, or pass --app <app_id>",
         "https://clerk.com/docs/guides/development/clerk-environment-variables",
+        ERROR_CODE.NO_SECRET_KEY,
       );
     }
     throw error;
@@ -144,11 +146,13 @@ async function resolveSecretKey(options: ApiOptions): Promise<string> {
   const matched = app.instances.find((i) => i.instance_id === ctx.instanceId);
   if (!matched) {
     throw new CliError(`Instance ${ctx.instanceId} not found in application.`, {
+      code: ERROR_CODE.INSTANCE_NOT_FOUND,
       docsUrl: "https://clerk.com/docs/guides/development/managing-environments",
     });
   }
   if (!matched.secret_key) {
     throw new CliError(`No secret key found for ${ctx.instanceLabel} instance.`, {
+      code: ERROR_CODE.NO_SECRET_KEY,
       docsUrl: "https://clerk.com/docs/guides/development/clerk-environment-variables",
     });
   }
@@ -161,7 +165,7 @@ async function resolveBody(options: { data?: string; file?: string }): Promise<s
   if (options.file) {
     const file = Bun.file(options.file);
     if (!(await file.exists())) {
-      throwUsageError(`File not found: ${options.file}`);
+      throwUsageError(`File not found: ${options.file}`, undefined, ERROR_CODE.FILE_NOT_FOUND);
     }
     return file.text();
   }

--- a/packages/cli-core/src/commands/config/push.ts
+++ b/packages/cli-core/src/commands/config/push.ts
@@ -2,7 +2,7 @@ import { confirm } from "@inquirer/prompts";
 import { resolveAppContext } from "../../lib/config.ts";
 import { putInstanceConfig, patchInstanceConfig } from "../../lib/plapi.ts";
 import { isHuman } from "../../mode.ts";
-import { throwUsageError, throwUserAbort, withApiContext } from "../../lib/errors.ts";
+import { throwUsageError, throwUserAbort, withApiContext, ERROR_CODE } from "../../lib/errors.ts";
 
 interface ConfigPushOptions {
   app?: string;
@@ -53,11 +53,15 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
   try {
     configPayload = JSON.parse(rawInput);
   } catch {
-    throwUsageError("Invalid JSON input. Please provide valid JSON.");
+    throwUsageError(
+      "Invalid JSON input. Please provide valid JSON.",
+      undefined,
+      ERROR_CODE.INVALID_JSON,
+    );
   }
 
   if (typeof configPayload !== "object" || configPayload === null || Array.isArray(configPayload)) {
-    throwUsageError("Config must be a JSON object.");
+    throwUsageError("Config must be a JSON object.", undefined, ERROR_CODE.INVALID_JSON);
   }
 
   if (options.dryRun) {
@@ -96,7 +100,7 @@ export async function readInput(options: { file?: string; json?: string }): Prom
   if (options.file) {
     const file = Bun.file(options.file);
     if (!(await file.exists())) {
-      throwUsageError(`File not found: ${options.file}`);
+      throwUsageError(`File not found: ${options.file}`, undefined, ERROR_CODE.FILE_NOT_FOUND);
     }
     return file.text();
   }

--- a/packages/cli-core/src/commands/doctor/index.ts
+++ b/packages/cli-core/src/commands/doctor/index.ts
@@ -1,6 +1,6 @@
 import { isHuman } from "../../mode.ts";
 import { bold, green, red } from "../../lib/color.ts";
-import { CliError } from "../../lib/errors.ts";
+import { CliError, ERROR_CODE } from "../../lib/errors.ts";
 import { createDoctorContext } from "./context.ts";
 import {
   checkLoggedIn,
@@ -113,7 +113,9 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 
       const hasVerifyFailure = verifyResults.some((r) => r.status === "fail");
       if (hasVerifyFailure) {
-        throw new CliError("Some checks still failing after auto-fix.");
+        throw new CliError("Some checks still failing after auto-fix.", {
+          code: ERROR_CODE.DOCTOR_FAILED,
+        });
       }
       return;
     }
@@ -121,6 +123,8 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 
   const hasFailure = allResults.some((r) => r.status === "fail");
   if (hasFailure) {
-    throw new CliError("Doctor found issues with your Clerk integration.");
+    throw new CliError("Doctor found issues with your Clerk integration.", {
+      code: ERROR_CODE.DOCTOR_FAILED,
+    });
   }
 }

--- a/packages/cli-core/src/commands/env/pull.ts
+++ b/packages/cli-core/src/commands/env/pull.ts
@@ -3,7 +3,7 @@ import { resolveAppContext } from "../../lib/config.ts";
 import { fetchApplication } from "../../lib/plapi.ts";
 import { parseEnvFile, mergeEnvVars, serializeEnvFile } from "../../lib/dotenv.ts";
 import { detectPublishableKeyName } from "../../lib/framework.ts";
-import { CliError, withApiContext } from "../../lib/errors.ts";
+import { CliError, ERROR_CODE, withApiContext } from "../../lib/errors.ts";
 
 interface EnvPullOptions {
   app?: string;
@@ -33,6 +33,7 @@ export async function pull(options: EnvPullOptions): Promise<void> {
   const matched = app.instances.find((i) => i.instance_id === ctx.instanceId);
   if (!matched) {
     throw new CliError(`Instance ${ctx.instanceId} not found in application response.`, {
+      code: ERROR_CODE.INSTANCE_NOT_FOUND,
       docsUrl: "https://clerk.com/docs/guides/development/managing-environments",
     });
   }

--- a/packages/cli-core/src/commands/link/index.ts
+++ b/packages/cli-core/src/commands/link/index.ts
@@ -8,7 +8,7 @@ import { setProfile, resolveProfile, moveProfile } from "../../lib/config.ts";
 import { autolink, findClerkKeys, matchKeyToApp } from "../../lib/autolink.ts";
 import { getGitRepoIdentifier, getGitRepoRoot, getGitNormalizedRemote } from "../../lib/git.ts";
 import { dim, cyan } from "../../lib/color.ts";
-import { CliError } from "../../lib/errors.ts";
+import { CliError, ERROR_CODE } from "../../lib/errors.ts";
 
 const AGENT_PROMPT = `You are linking a Clerk application to the current project directory.
 
@@ -76,7 +76,9 @@ export async function link(options: LinkOptions = {}): Promise<void> {
   const prodInstance = app.instances.find((i) => i.environment_type === "production");
 
   if (!devInstance) {
-    throw new CliError("Application has no development instance.");
+    throw new CliError("Application has no development instance.", {
+      code: ERROR_CODE.INSTANCE_NOT_FOUND,
+    });
   }
 
   await setProfile(profileKey, {
@@ -150,7 +152,9 @@ async function resolveApp(
   const apps = await listApplications();
 
   if (apps.length === 0) {
-    throw new CliError("No applications found. Create one at https://dashboard.clerk.com first.");
+    throw new CliError("No applications found. Create one at https://dashboard.clerk.com first.", {
+      code: ERROR_CODE.APP_NOT_FOUND,
+    });
   }
 
   if (detectKeys) {
@@ -188,7 +192,9 @@ async function pickApp(apps: Application[], displayPath: string): Promise<Applic
 
   const found = apps.find((a) => a.application_id === selectedId);
   if (!found) {
-    throw new CliError("Selected application not found.");
+    throw new CliError("Selected application not found.", {
+      code: ERROR_CODE.APP_NOT_FOUND,
+    });
   }
   return found;
 }

--- a/packages/cli-core/src/commands/unlink/index.ts
+++ b/packages/cli-core/src/commands/unlink/index.ts
@@ -3,7 +3,7 @@ import { isAgent, isHuman } from "../../mode.ts";
 import { resolveProfile, removeProfile } from "../../lib/config.ts";
 import { getGitRepoRoot } from "../../lib/git.ts";
 import { dim, cyan } from "../../lib/color.ts";
-import { CliError, throwUserAbort } from "../../lib/errors.ts";
+import { CliError, ERROR_CODE, throwUserAbort } from "../../lib/errors.ts";
 
 const AGENT_PROMPT = `You are unlinking a Clerk application from the current project directory.
 
@@ -34,7 +34,9 @@ export async function unlink(options: UnlinkOptions = {}): Promise<void> {
   const existing = await resolveProfile(cwd);
 
   if (!existing) {
-    throw new CliError("This directory is not linked to a Clerk application.");
+    throw new CliError("This directory is not linked to a Clerk application.", {
+      code: ERROR_CODE.NOT_LINKED,
+    });
   }
 
   const label = existing.profile.appId;

--- a/packages/cli-core/src/lib/config.ts
+++ b/packages/cli-core/src/lib/config.ts
@@ -7,7 +7,7 @@ import { dirname, join } from "node:path";
 import { mkdir } from "node:fs/promises";
 import { CONFIG_FILE } from "./constants.ts";
 import { getGitRepoIdentifier, getGitNormalizedRemote } from "./git.ts";
-import { CliError } from "./errors.ts";
+import { CliError, ERROR_CODE } from "./errors.ts";
 
 let overrideConfigFile: string | undefined;
 
@@ -174,6 +174,7 @@ export function resolveInstanceId(profile: Profile, flag?: string): { id: string
   const id = profile.instances[env];
   if (!id) {
     throw new CliError(`No ${env} instance configured. Run \`clerk link\` to set one up.`, {
+      code: ERROR_CODE.INSTANCE_NOT_FOUND,
       docsUrl: "https://clerk.com/docs/guides/development/managing-environments",
     });
   }
@@ -200,7 +201,9 @@ export async function resolveAppContext(options: {
       if (env) {
         const matched = app.instances.find((instance) => instance.environment_type === env);
         if (!matched) {
-          throw new CliError(`No ${env} instance found for application ${options.app}.`);
+          throw new CliError(`No ${env} instance found for application ${options.app}.`, {
+            code: ERROR_CODE.INSTANCE_NOT_FOUND,
+          });
         }
         return { appId: options.app, instanceId: matched.instance_id, instanceLabel: env };
       }
@@ -216,7 +219,9 @@ export async function resolveAppContext(options: {
       (instance) => instance.environment_type === "development",
     );
     if (!development) {
-      throw new CliError(`No development instance found for application ${options.app}.`);
+      throw new CliError(`No development instance found for application ${options.app}.`, {
+        code: ERROR_CODE.INSTANCE_NOT_FOUND,
+      });
     }
 
     return {
@@ -233,6 +238,7 @@ export async function resolveAppContext(options: {
         "Either:\n" +
         "  - Run `clerk link` from your project directory\n" +
         "  - Pass --app <app_id> to target an app directly",
+      { code: ERROR_CODE.NOT_LINKED },
     );
   }
 

--- a/packages/cli-core/src/lib/errors.ts
+++ b/packages/cli-core/src/lib/errors.ts
@@ -14,7 +14,42 @@ export const EXIT_CODE = {
 
 type ExitCode = (typeof EXIT_CODE)[keyof typeof EXIT_CODE];
 
+/**
+ * Machine-readable error codes for programmatic consumption.
+ *
+ * Agents and CI scripts can branch on these codes instead of regex-matching
+ * error messages. Every {@link CliError} should include a code from this list.
+ */
+export const ERROR_CODE = {
+  /** Not authenticated — run `clerk auth login` or set an API key. */
+  AUTH_REQUIRED: "auth_required",
+  /** No project linked to this directory. */
+  NOT_LINKED: "not_linked",
+  /** API key has wrong prefix (e.g. sk_ where ak_ expected). */
+  INVALID_KEY_FORMAT: "invalid_key_format",
+  /** Invalid command arguments or options. */
+  USAGE_ERROR: "usage_error",
+  /** Referenced instance not found. */
+  INSTANCE_NOT_FOUND: "instance_not_found",
+  /** Referenced application not found or has no matching resources. */
+  APP_NOT_FOUND: "app_not_found",
+  /** Secret key unavailable for the target instance. */
+  NO_SECRET_KEY: "no_secret_key",
+  /** File not found on disk. */
+  FILE_NOT_FOUND: "file_not_found",
+  /** Input is not valid JSON or not an object. */
+  INVALID_JSON: "invalid_json",
+  /** Failed to fetch or parse the OpenAPI catalog. */
+  CATALOG_ERROR: "catalog_error",
+  /** Doctor checks found issues. */
+  DOCTOR_FAILED: "doctor_failed",
+} as const;
+
+export type ErrorCode = (typeof ERROR_CODE)[keyof typeof ERROR_CODE];
+
 interface CliErrorOptions {
+  /** Machine-readable error code for programmatic consumption. */
+  code?: ErrorCode;
   /** Process exit code. Defaults to {@link EXIT_CODE.GENERAL}. */
   exitCode?: ExitCode;
   /** URL to relevant documentation, printed after the error message. */
@@ -35,16 +70,20 @@ interface CliErrorOptions {
  *
  * @example
  * ```ts
- * throw new CliError("No Clerk project linked. Run `clerk link` first.");
+ * throw new CliError("No Clerk project linked.", {
+ *   code: ERROR_CODE.NOT_LINKED,
+ * });
  * ```
  */
 export class CliError extends Error {
+  public code?: ErrorCode;
   public exitCode: ExitCode;
   public docsUrl?: string;
 
   constructor(message: string, options?: CliErrorOptions) {
     super(message);
     this.name = "CliError";
+    this.code = options?.code;
     this.exitCode = options?.exitCode ?? EXIT_CODE.GENERAL;
 
     if (options?.docsUrl) {
@@ -157,8 +196,12 @@ export class BapiError extends ApiError {
  * }
  * ```
  */
-export function throwUsageError(message: string, docsUrl?: string): never {
-  throw new CliError(message, { exitCode: EXIT_CODE.USAGE, docsUrl });
+export function throwUsageError(message: string, docsUrl?: string, code?: ErrorCode): never {
+  throw new CliError(message, {
+    code: code ?? ERROR_CODE.USAGE_ERROR,
+    exitCode: EXIT_CODE.USAGE,
+    docsUrl,
+  });
 }
 
 /**

--- a/packages/cli-core/src/lib/plapi.ts
+++ b/packages/cli-core/src/lib/plapi.ts
@@ -5,7 +5,7 @@
 
 import { PLAPI_BASE_URL } from "./constants.ts";
 import { getToken } from "./credential-store.ts";
-import { CliError, PlapiError } from "./errors.ts";
+import { CliError, PlapiError, ERROR_CODE } from "./errors.ts";
 
 /**
  * Validate that a key has the expected prefix and suggest the correct key type
@@ -22,6 +22,7 @@ export function validateKeyPrefix(key: string, expected: "ak_" | "sk_"): void {
     throw new CliError(
       `Expected a ${expectedLabel}, but received a ${wrongLabel}.\n` +
         "Get the correct key from: https://dashboard.clerk.com/last-active?path=api-keys",
+      { code: ERROR_CODE.INVALID_KEY_FORMAT },
     );
   }
 }
@@ -39,6 +40,7 @@ export async function getAuthToken(): Promise<string> {
   if (oauthToken) return oauthToken;
 
   throw new CliError("Not authenticated. Run `clerk auth login` or set CLERK_PLATFORM_API_KEY.", {
+    code: ERROR_CODE.AUTH_REQUIRED,
     docsUrl: "https://clerk.com/docs/guides/development/clerk-environment-variables",
   });
 }

--- a/packages/cli-core/src/test/integration/error-codes.test.ts
+++ b/packages/cli-core/src/test/integration/error-codes.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Structured error codes in agent mode
+ * Agents receive JSON errors on stderr with machine-readable codes.
+ */
+
+import { test, expect } from "bun:test";
+import { useIntegrationTestHarness, clerk, mockState } from "../lib/setup.ts";
+
+useIntegrationTestHarness();
+
+function parseJsonError(stderr: string): { code: string; message: string; docsUrl?: string } {
+  const parsed = JSON.parse(stderr);
+  return parsed.error;
+}
+
+test("not_linked error includes code in agent mode", async () => {
+  const result = await clerk.raw("--mode", "agent", "env", "pull");
+  expect(result.exitCode).toBe(1);
+  const error = parseJsonError(result.stderr);
+  expect(error.code).toBe("not_linked");
+  expect(error.message).toContain("No Clerk project linked");
+});
+
+test("auth_required error includes code in agent mode", async () => {
+  delete process.env.CLERK_PLATFORM_API_KEY;
+  mockState.storedToken = null;
+  const result = await clerk.raw("--mode", "agent", "env", "pull", "--app", "app_test");
+  expect(result.exitCode).toBe(1);
+  const error = parseJsonError(result.stderr);
+  expect(error.code).toBe("auth_required");
+  expect(error.docsUrl).toBeDefined();
+});
+
+test("invalid_key_format error includes code in agent mode", async () => {
+  process.env.CLERK_PLATFORM_API_KEY = "sk_wrong_prefix";
+  const result = await clerk.raw("--mode", "agent", "env", "pull", "--app", "app_test");
+  expect(result.exitCode).toBe(1);
+  const error = parseJsonError(result.stderr);
+  expect(error.code).toBe("invalid_key_format");
+  expect(error.message).toContain("Expected a Platform API key");
+});
+
+test("usage_error code for invalid mode flag", async () => {
+  const result = await clerk.raw("--mode", "agent", "--mode", "banana", "env", "pull");
+  expect(result.exitCode).toBe(2);
+  const error = parseJsonError(result.stderr);
+  expect(error.code).toBe("usage_error");
+});
+
+test("human mode still shows plain text errors (no JSON)", async () => {
+  const result = await clerk.raw("--mode", "human", "env", "pull");
+  expect(result.exitCode).toBe(1);
+  expect(result.stderr).toContain("error:");
+  expect(result.stderr).not.toContain('"code"');
+});


### PR DESCRIPTION
## Summary

Add machine-readable error codes so agents and CI can branch on error type instead of regex-matching messages.

## Changes

- Add `ERROR_CODE` registry with 11 codes: `auth_required`, `not_linked`, `invalid_key_format`, `usage_error`, `instance_not_found`, `app_not_found`, `no_secret_key`, `file_not_found`, `invalid_json`, `catalog_error`, `doctor_failed`
- Add optional `code` field to `CliError`
- Annotate all throw sites with codes
- In agent mode, errors emit structured JSON to stderr: `{"error":{"code":"not_linked","message":"..."}}`
- Human mode unchanged
- Integration tests for agent-mode JSON error output

## Example

```bash
$ clerk --mode agent env pull
{"error":{"code":"not_linked","message":"No Clerk project linked..."}}
```