### PR TITLE
fix: Strip `config_version` before pushing

### DIFF
--- a/packages/cli-core/src/commands/config/push.test.ts
+++ b/packages/cli-core/src/commands/config/push.test.ts
@@ -253,6 +253,48 @@ describe("config push", () => {
     expect(errorSpy).toHaveBeenCalledWith("Replacing config on development instance...");
   });
 
+  // --- config_version stripping ---
+
+  test("put strips config_version from payload before sending", async () => {
+    let capturedBody = "";
+    stubFetch(async (_input, init) => {
+      capturedBody = init?.body as string;
+      return new Response(JSON.stringify(mockResponse), { status: 200 });
+    });
+
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigPut({
+      json: '{"config_version":42,"session":{"lifetime":3600}}',
+      yes: true,
+    });
+    expect(JSON.parse(capturedBody)).toEqual({ session: { lifetime: 3600 } });
+  });
+
+  test("patch strips config_version from payload before sending", async () => {
+    let capturedBody = "";
+    stubFetch(async (_input, init) => {
+      capturedBody = init?.body as string;
+      return new Response(JSON.stringify(mockResponse), { status: 200 });
+    });
+
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigPatch({
+      json: '{"config_version":42,"session":{"lifetime":3600}}',
+      yes: true,
+    });
+    expect(JSON.parse(capturedBody)).toEqual({ session: { lifetime: 3600 } });
+  });
+
   // --- Instance targeting ---
 
   test("targets development instance by default", async () => {

--- a/packages/cli-core/src/commands/config/push.ts
+++ b/packages/cli-core/src/commands/config/push.ts
@@ -64,6 +64,9 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
     throwUsageError("Config must be a JSON object.", undefined, ERROR_CODE.INVALID_JSON);
   }
 
+  // Strip config_version — it's returned by pull but not accepted by the backend
+  delete configPayload.config_version;
+
   if (options.dryRun) {
     console.error(`[dry-run] Would ${op.method} config on ${ctx.instanceLabel} instance:`);
     console.log(JSON.stringify(configPayload, null, 2));


### PR DESCRIPTION
The backend returns a `config_version` as part of each PATCH or GET for the config. Strip this when doing a push (PATCH or PUT) to allow seamless pull-push workflows, like transferring the config from one application to another.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed config push operations to exclude the `config_version` field from the payload sent to the backend for both PUT and PATCH API requests, including during dry-run mode.

* **Tests**
  * Added test cases verifying that `config_version` is properly excluded from outbound requests while other configuration content remains intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->