### PR TITLE
feat(config): Support destructive flag

### DIFF
--- a/packages/cli-core/src/cli-program.ts
+++ b/packages/cli-core/src/cli-program.ts
@@ -121,6 +121,10 @@ export function createProgram() {
     .option("--json <string>", "Pass config JSON inline")
     .option("--dry-run", "Show what would be sent without making the API call")
     .option("--yes", "Skip confirmation prompts")
+    .option(
+      "--destructive",
+      "Allow destructive changes that delete resources (e.g. session templates, custom OAuth providers) rather than just resetting config to defaults",
+    )
     .action(configPatch);
 
   config
@@ -132,6 +136,10 @@ export function createProgram() {
     .option("--json <string>", "Pass config JSON inline")
     .option("--dry-run", "Show what would be sent without making the API call")
     .option("--yes", "Skip confirmation prompts")
+    .option(
+      "--destructive",
+      "Allow destructive changes that delete resources (e.g. session templates, custom OAuth providers) rather than just resetting config to defaults",
+    )
     .action(configPut);
 
   program

--- a/packages/cli-core/src/commands/config/push.test.ts
+++ b/packages/cli-core/src/commands/config/push.test.ts
@@ -55,6 +55,7 @@ describe("config push", () => {
       json?: string;
       dryRun?: boolean;
       yes?: boolean;
+      destructive?: boolean;
     } = {},
   ) {
     const { configPatch } = await import("./push.ts");
@@ -69,6 +70,7 @@ describe("config push", () => {
       json?: string;
       dryRun?: boolean;
       yes?: boolean;
+      destructive?: boolean;
     } = {},
   ) {
     const { configPut } = await import("./push.ts");
@@ -177,7 +179,11 @@ describe("config push", () => {
       return new Response(JSON.stringify(mockResponse), { status: 200 });
     });
 
-    await runConfigPatch({ app: "app_1", json: '{"session":{"lifetime":3600}}', yes: true });
+    await runConfigPatch({
+      app: "app_1",
+      json: '{"session":{"lifetime":3600}}',
+      yes: true,
+    });
     expect(capturedUrl).toContain("/instances/ins_dev/");
   });
 
@@ -295,6 +301,67 @@ describe("config push", () => {
     expect(JSON.parse(capturedBody)).toEqual({ session: { lifetime: 3600 } });
   });
 
+  // --- --destructive flag ---
+
+  test("patch sends ?destructive=true when --destructive is set", async () => {
+    let capturedUrl = "";
+    stubFetch(async (input) => {
+      capturedUrl = input.toString();
+      return new Response(JSON.stringify(mockResponse), { status: 200 });
+    });
+
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigPatch({
+      json: '{"session":null}',
+      yes: true,
+      destructive: true,
+    });
+    expect(capturedUrl).toContain("?destructive=true");
+  });
+
+  test("put sends ?destructive=true when --destructive is set", async () => {
+    let capturedUrl = "";
+    stubFetch(async (input) => {
+      capturedUrl = input.toString();
+      return new Response(JSON.stringify(mockResponse), { status: 200 });
+    });
+
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigPut({
+      json: '{"session":null}',
+      yes: true,
+      destructive: true,
+    });
+    expect(capturedUrl).toContain("?destructive=true");
+  });
+
+  test("does not send ?destructive=true by default", async () => {
+    let capturedUrl = "";
+    stubFetch(async (input) => {
+      capturedUrl = input.toString();
+      return new Response(JSON.stringify(mockResponse), { status: 200 });
+    });
+
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigPatch({ json: '{"session":{"lifetime":3600}}', yes: true });
+    expect(capturedUrl).not.toContain("destructive");
+  });
+
   // --- Instance targeting ---
 
   test("targets development instance by default", async () => {
@@ -344,7 +411,11 @@ describe("config push", () => {
       instances: { development: "ins_dev" },
     });
 
-    await runConfigPut({ json: '{"a":1}', instance: "ins_custom_123", yes: true });
+    await runConfigPut({
+      json: '{"a":1}',
+      instance: "ins_custom_123",
+      yes: true,
+    });
     expect(requestedUrl).toContain("/instances/ins_custom_123/");
   });
 
@@ -363,7 +434,10 @@ describe("config push", () => {
       instances: { development: "ins_dev" },
     });
 
-    await runConfigPatch({ json: '{"session":{"lifetime":3600}}', dryRun: true });
+    await runConfigPatch({
+      json: '{"session":{"lifetime":3600}}',
+      dryRun: true,
+    });
     expect(fetchCalled).toBe(false);
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("[dry-run]"));
     expect(logSpy).toHaveBeenCalledWith(JSON.stringify({ session: { lifetime: 3600 } }, null, 2));
@@ -423,7 +497,11 @@ describe("config push", () => {
       instances: { development: "ins_dev" },
     });
 
-    await runConfigPatch({ json: '{"from":"json"}', file: configFile, yes: true });
+    await runConfigPatch({
+      json: '{"from":"json"}',
+      file: configFile,
+      yes: true,
+    });
     expect(JSON.parse(capturedBody)).toEqual({ from: "json" });
   });
 });

--- a/packages/cli-core/src/commands/config/push.ts
+++ b/packages/cli-core/src/commands/config/push.ts
@@ -11,6 +11,7 @@ interface ConfigPushOptions {
   json?: string;
   dryRun?: boolean;
   yes?: boolean;
+  destructive?: boolean;
 }
 
 type Operation = {
@@ -21,6 +22,7 @@ type Operation = {
     appId: string,
     instId: string,
     config: Record<string, unknown>,
+    options?: { destructive?: boolean },
   ) => Promise<Record<string, unknown>>;
 };
 
@@ -88,7 +90,7 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
   console.error(`${op.verb} config on ${ctx.instanceLabel} instance...`);
 
   const result = await withApiContext(
-    op.apiFn(ctx.appId, ctx.instanceId, configPayload),
+    op.apiFn(ctx.appId, ctx.instanceId, configPayload, { destructive: options.destructive }),
     "Failed to push config",
   );
   console.log(JSON.stringify(result, null, 2));

--- a/packages/cli-core/src/lib/plapi.ts
+++ b/packages/cli-core/src/lib/plapi.ts
@@ -52,14 +52,15 @@ export async function fetchInstanceConfigSchema(
 ): Promise<Record<string, unknown>> {
   const token = await getAuthToken();
   const url = new URL(
-    `${PLAPI_BASE_URL}/v1/platform/applications/${applicationId}/instances/${instanceId}/config/schema`,
+    `/v1/platform/applications/${applicationId}/instances/${instanceId}/config/schema`,
+    PLAPI_BASE_URL,
   );
   if (keys?.length) {
     for (const key of keys) {
       url.searchParams.append("keys", key);
     }
   }
-  const response = await fetch(url.toString(), {
+  const response = await fetch(url, {
     headers: {
       Authorization: `Bearer ${token}`,
       Accept: "application/json",
@@ -79,7 +80,10 @@ export async function fetchInstanceConfig(
   instanceId: string,
 ): Promise<Record<string, unknown>> {
   const token = await getAuthToken();
-  const url = `${PLAPI_BASE_URL}/v1/platform/applications/${applicationId}/instances/${instanceId}/config`;
+  const url = new URL(
+    `/v1/platform/applications/${applicationId}/instances/${instanceId}/config`,
+    PLAPI_BASE_URL,
+  );
   const response = await fetch(url, {
     headers: {
       Authorization: `Bearer ${token}`,
@@ -110,9 +114,9 @@ export interface Application {
 
 export async function fetchApplication(applicationId: string): Promise<Application> {
   const token = await getAuthToken();
-  const url = new URL(`${PLAPI_BASE_URL}/v1/platform/applications/${applicationId}`);
+  const url = new URL(`/v1/platform/applications/${applicationId}`, PLAPI_BASE_URL);
   url.searchParams.set("include_secret_keys", "true");
-  const response = await fetch(url.toString(), {
+  const response = await fetch(url, {
     headers: {
       Authorization: `Bearer ${token}`,
       Accept: "application/json",
@@ -135,9 +139,12 @@ async function sendInstanceConfig(
   options?: { destructive?: boolean },
 ): Promise<Record<string, unknown>> {
   const token = await getAuthToken();
-  let url = `${PLAPI_BASE_URL}/v1/platform/applications/${applicationId}/instances/${instanceId}/config`;
+  const url = new URL(
+    `/v1/platform/applications/${applicationId}/instances/${instanceId}/config`,
+    PLAPI_BASE_URL,
+  );
   if (options?.destructive) {
-    url += "?destructive=true";
+    url.searchParams.set("destructive", "true");
   }
   const response = await fetch(url, {
     method,
@@ -173,7 +180,7 @@ export const patchInstanceConfig = (
 
 export async function listApplications(): Promise<Application[]> {
   const token = await getAuthToken();
-  const url = `${PLAPI_BASE_URL}/v1/platform/applications`;
+  const url = new URL("/v1/platform/applications", PLAPI_BASE_URL);
   const response = await fetch(url, {
     headers: {
       Authorization: `Bearer ${token}`,

--- a/packages/cli-core/src/lib/plapi.ts
+++ b/packages/cli-core/src/lib/plapi.ts
@@ -132,9 +132,13 @@ async function sendInstanceConfig(
   applicationId: string,
   instanceId: string,
   config: Record<string, unknown>,
+  options?: { destructive?: boolean },
 ): Promise<Record<string, unknown>> {
   const token = await getAuthToken();
-  const url = `${PLAPI_BASE_URL}/v1/platform/applications/${applicationId}/instances/${instanceId}/config`;
+  let url = `${PLAPI_BASE_URL}/v1/platform/applications/${applicationId}/instances/${instanceId}/config`;
+  if (options?.destructive) {
+    url += "?destructive=true";
+  }
   const response = await fetch(url, {
     method,
     headers: {
@@ -157,13 +161,15 @@ export const putInstanceConfig = (
   applicationId: string,
   instanceId: string,
   config: Record<string, unknown>,
-) => sendInstanceConfig("PUT", applicationId, instanceId, config);
+  options?: { destructive?: boolean },
+) => sendInstanceConfig("PUT", applicationId, instanceId, config, options);
 
 export const patchInstanceConfig = (
   applicationId: string,
   instanceId: string,
   config: Record<string, unknown>,
-) => sendInstanceConfig("PATCH", applicationId, instanceId, config);
+  options?: { destructive?: boolean },
+) => sendInstanceConfig("PATCH", applicationId, instanceId, config, options);
 
 export async function listApplications(): Promise<Application[]> {
   const token = await getAuthToken();


### PR DESCRIPTION
Add support for the `--destructive` flag on `put` and `patch`. We need to use this for operations that destroyed created config objects, like custom JWT templates or custom OAuth providers.

The behavior of `--destructive` is a bit subtle so I tried to make the help text as clear as possible, but it's probably possible to improve it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--destructive` flag to `config patch` and `config put`, allowing operations that can remove resources via an explicit destructive option.

* **Tests**
  * Added test coverage verifying the destructive flag is sent when enabled and omitted when not set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->