### PR TITLE
feat: Improve error passing from backend

### DIFF
--- a/packages/cli-core/src/cli-program.test.ts
+++ b/packages/cli-core/src/cli-program.test.ts
@@ -1,0 +1,187 @@
+import { test, expect, describe } from "bun:test";
+import { formatApiBody } from "./cli-program.ts";
+
+describe("formatApiBody", () => {
+  // --- Single error with meta ---
+
+  test("surfaces unsupported_features from meta", () => {
+    const body = JSON.stringify({
+      errors: [
+        {
+          code: "unsupported_subscription_plan_features",
+          message: "Your plan does not support these features",
+          meta: { unsupported_features: ["saml", "custom_roles"] },
+        },
+      ],
+    });
+    const result = formatApiBody(body, false);
+    expect(result).toContain("Your plan does not support these features");
+    expect(result).toContain("Unsupported features: saml, custom_roles");
+  });
+
+  test("surfaces suggestions from unknown_config_key meta", () => {
+    const body = JSON.stringify({
+      errors: [
+        {
+          code: "unknown_config_key",
+          message: "Unknown config key: sesion",
+          meta: { param_name: "sesion", suggestions: ["session"] },
+        },
+      ],
+    });
+    const result = formatApiBody(body, false);
+    expect(result).toContain("Unknown config key: sesion");
+    expect(result).toContain("Did you mean: session");
+    expect(result).toContain("Parameter: sesion");
+  });
+
+  test("surfaces param_name for config_validation_error", () => {
+    const body = JSON.stringify({
+      errors: [
+        {
+          code: "config_validation_error",
+          message: "Invalid value for session.lifetime",
+          meta: { param_name: "session.lifetime", config_key: "session" },
+        },
+      ],
+    });
+    const result = formatApiBody(body, false);
+    expect(result).toContain("Invalid value for session.lifetime");
+    expect(result).toContain("Parameter: session.lifetime");
+  });
+
+  test("surfaces param_name for destructive_operation_not_allowed", () => {
+    const body = JSON.stringify({
+      errors: [
+        {
+          code: "destructive_operation_not_allowed",
+          message: "Cannot clear this key without destructive=true",
+          meta: { param_name: "sign_up.mode" },
+        },
+      ],
+    });
+    const result = formatApiBody(body, false);
+    expect(result).toContain("Cannot clear this key");
+    expect(result).toContain("Parameter: sign_up.mode");
+  });
+
+  test("surfaces param_name for form_param_value_invalid", () => {
+    const body = JSON.stringify({
+      errors: [
+        {
+          code: "form_param_value_invalid",
+          message: "Value is not in the allowed set",
+          meta: { param_name: "branding.logo_url" },
+        },
+      ],
+    });
+    const result = formatApiBody(body, false);
+    expect(result).toContain("Value is not in the allowed set");
+    expect(result).toContain("Parameter: branding.logo_url");
+  });
+
+  // --- Multiple errors ---
+
+  test("formats multiple errors joined by newlines", () => {
+    const body = JSON.stringify({
+      errors: [
+        {
+          code: "config_validation_error",
+          message: "Invalid session lifetime",
+          meta: { param_name: "session.lifetime" },
+        },
+        {
+          code: "unknown_config_key",
+          message: "Unknown key: bogus",
+          meta: { param_name: "bogus", suggestions: ["session"] },
+        },
+      ],
+    });
+    const result = formatApiBody(body, false);
+    expect(result).toContain("Invalid session lifetime");
+    expect(result).toContain("Unknown key: bogus");
+    expect(result).toContain("Did you mean: session");
+    // Two errors separated by newline
+    const lines = result.split("\n");
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+  });
+
+  // --- Error without meta ---
+
+  test("handles error without meta gracefully", () => {
+    const body = JSON.stringify({
+      errors: [{ code: "resource_not_found", message: "Instance not found" }],
+    });
+    const result = formatApiBody(body, false);
+    expect(result).toBe("Instance not found");
+  });
+
+  // --- Fallback paths ---
+
+  test("falls back to parsed.error when no errors array", () => {
+    const body = JSON.stringify({ error: "Something went wrong" });
+    const result = formatApiBody(body, false);
+    expect(result).toBe("Something went wrong");
+  });
+
+  test("falls back to parsed.message when no errors array or error field", () => {
+    const body = JSON.stringify({ message: "Bad request" });
+    const result = formatApiBody(body, false);
+    expect(result).toBe("Bad request");
+  });
+
+  test("truncates non-JSON body over 200 chars", () => {
+    const body = "x".repeat(300);
+    const result = formatApiBody(body, false);
+    expect(result).toBe("x".repeat(200) + "...");
+  });
+
+  test("returns short non-JSON body as-is", () => {
+    const result = formatApiBody("Bad Request", false);
+    expect(result).toBe("Bad Request");
+  });
+
+  // --- Verbose mode ---
+
+  test("verbose mode returns full pretty-printed JSON", () => {
+    const obj = { errors: [{ code: "test", message: "test msg" }] };
+    const body = JSON.stringify(obj);
+    const result = formatApiBody(body, true);
+    expect(result).toBe("\n" + JSON.stringify(obj, null, 2));
+  });
+
+  test("verbose mode returns raw body for non-JSON", () => {
+    const result = formatApiBody("not json", true);
+    expect(result).toBe("\nnot json");
+  });
+
+  // --- Edge cases ---
+
+  test("handles empty errors array by falling through", () => {
+    const body = JSON.stringify({ errors: [], message: "fallback" });
+    const result = formatApiBody(body, false);
+    expect(result).toBe("fallback");
+  });
+
+  test("handles error with empty meta", () => {
+    const body = JSON.stringify({
+      errors: [{ code: "config_validation_error", message: "Bad value", meta: {} }],
+    });
+    const result = formatApiBody(body, false);
+    expect(result).toBe("Bad value");
+  });
+
+  test("handles unsupported_subscription_plan_features with empty unsupported_features", () => {
+    const body = JSON.stringify({
+      errors: [
+        {
+          code: "unsupported_subscription_plan_features",
+          message: "Plan limitation",
+          meta: { unsupported_features: [] },
+        },
+      ],
+    });
+    const result = formatApiBody(body, false);
+    expect(result).toBe("Plan limitation");
+  });
+});

--- a/packages/cli-core/src/cli-program.test.ts
+++ b/packages/cli-core/src/cli-program.test.ts
@@ -35,6 +35,21 @@ describe("formatApiBody", () => {
     expect(result).toContain("Parameter: sesion");
   });
 
+  test("surfaces feature name from feature_not_enabled meta", () => {
+    const body = JSON.stringify({
+      errors: [
+        {
+          code: "feature_not_enabled",
+          message: "This feature is not enabled on this instance",
+          meta: { param_name: "organizations" },
+        },
+      ],
+    });
+    const result = formatApiBody(body, false);
+    expect(result).toContain("This feature is not enabled on this instance");
+    expect(result).toContain("Feature: organizations");
+  });
+
   test("surfaces param_name for config_validation_error", () => {
     const body = JSON.stringify({
       errors: [

--- a/packages/cli-core/src/cli-program.ts
+++ b/packages/cli-core/src/cli-program.ts
@@ -222,6 +222,12 @@ function formatSingleError(err: {
       }
       break;
     }
+    case "feature_not_enabled": {
+      if (meta.param_name) {
+        msg += `\n  Feature: ${meta.param_name}`;
+      }
+      break;
+    }
     case "unknown_config_key": {
       const suggestions = meta.suggestions;
       if (Array.isArray(suggestions) && suggestions.length > 0) {

--- a/packages/cli-core/src/cli-program.ts
+++ b/packages/cli-core/src/cli-program.ts
@@ -181,7 +181,7 @@ Examples:
   return program;
 }
 
-function formatApiBody(body: string, verbose: boolean): string {
+export function formatApiBody(body: string, verbose: boolean): string {
   if (verbose) {
     try {
       return "\n" + JSON.stringify(JSON.parse(body), null, 2);
@@ -192,7 +192,9 @@ function formatApiBody(body: string, verbose: boolean): string {
 
   try {
     const parsed = JSON.parse(body);
-    if (parsed.errors?.[0]?.message) return parsed.errors[0].message;
+    if (Array.isArray(parsed.errors) && parsed.errors.length > 0) {
+      return parsed.errors.map(formatSingleError).join("\n");
+    }
     if (parsed.error) return parsed.error;
     if (parsed.message) return parsed.message;
   } catch {
@@ -201,6 +203,44 @@ function formatApiBody(body: string, verbose: boolean): string {
 
   if (body.length > 200) return body.slice(0, 200) + "...";
   return body;
+}
+
+function formatSingleError(err: {
+  message?: string;
+  code?: string;
+  meta?: Record<string, unknown>;
+}): string {
+  let msg = err.message ?? "Unknown error";
+  const meta = err.meta;
+  if (!meta) return msg;
+
+  switch (err.code) {
+    case "unsupported_subscription_plan_features": {
+      const features = meta.unsupported_features;
+      if (Array.isArray(features) && features.length > 0) {
+        msg += `\n  Unsupported features: ${features.join(", ")}`;
+      }
+      break;
+    }
+    case "unknown_config_key": {
+      const suggestions = meta.suggestions;
+      if (Array.isArray(suggestions) && suggestions.length > 0) {
+        msg += `\n  Did you mean: ${suggestions.join(", ")}`;
+      }
+      if (meta.param_name) {
+        msg += `\n  Parameter: ${meta.param_name}`;
+      }
+      break;
+    }
+    default: {
+      if (meta.param_name) {
+        msg += `\n  Parameter: ${meta.param_name}`;
+      }
+      break;
+    }
+  }
+
+  return msg;
 }
 
 /**
@@ -240,7 +280,13 @@ export async function runProgram(
       const prefix = error.context ?? "Request failed";
       if (isAgent()) {
         const apiCode = extractApiErrorCode(error.body);
-        outputJsonError(apiCode ?? "api_error", `${prefix} (${error.status}): ${detail}`);
+        const apiErrors = extractApiErrors(error.body);
+        outputJsonError(
+          apiCode ?? "api_error",
+          `${prefix} (${error.status}): ${detail}`,
+          undefined,
+          apiErrors,
+        );
       } else {
         console.error(red(`error: ${prefix} (${error.status}): ${detail}`));
       }
@@ -265,12 +311,26 @@ export async function runProgram(
   }
 }
 
+interface ApiErrorEntry {
+  code?: string;
+  message?: string;
+  meta?: Record<string, unknown>;
+}
+
 /** Output a structured JSON error to stderr for agent/CI consumption. */
-function outputJsonError(code: string, message: string, docsUrl?: string): void {
-  const payload: { error: { code: string; message: string; docsUrl?: string } } = {
+function outputJsonError(
+  code: string,
+  message: string,
+  docsUrl?: string,
+  errors?: ApiErrorEntry[],
+): void {
+  const payload: {
+    error: { code: string; message: string; docsUrl?: string; errors?: ApiErrorEntry[] };
+  } = {
     error: { code, message },
   };
   if (docsUrl) payload.error.docsUrl = docsUrl;
+  if (errors?.length) payload.error.errors = errors;
   console.error(JSON.stringify(payload));
 }
 
@@ -282,4 +342,23 @@ function extractApiErrorCode(body: string): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+/** Extract the full errors array from a Clerk API JSON response body, if present. */
+function extractApiErrors(body: string): ApiErrorEntry[] | undefined {
+  try {
+    const parsed = JSON.parse(body);
+    if (Array.isArray(parsed.errors) && parsed.errors.length > 0) {
+      return parsed.errors.map((e: ApiErrorEntry) => {
+        const entry: ApiErrorEntry = {};
+        if (e.code) entry.code = e.code;
+        if (e.message) entry.message = e.message;
+        if (e.meta && Object.keys(e.meta).length > 0) entry.meta = e.meta;
+        return entry;
+      });
+    }
+  } catch {
+    // not JSON
+  }
+  return undefined;
 }


### PR DESCRIPTION
The backend returns an array of errors, each of which can have three important keys: `message`, `code`, and `meta`. `meta`, in particular, includes important information about which parts of a request caused the error. Iterate through the array to make sure we display all the errors, and when the `code` will include a valuable `meta` key, include it in the response. Add it to the JSON for agents and present a human-readable response to humans.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error messages to display detailed, code-specific information including configuration suggestions and feature details
  * Enhanced handling of multiple errors to show all relevant error information clearly and separately

* **Tests**
  * Added comprehensive test suite covering error message formatting, JSON parsing, and edge cases including verbose mode behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->