### PR TITLE
feat(config): Support pipes in prompts; config pull --keys

### DIFF
--- a/packages/cli-core/src/cli-program.ts
+++ b/packages/cli-core/src/cli-program.ts
@@ -101,6 +101,7 @@ export function createProgram() {
     .option("--app <id>", "Application ID to target (works from any directory)")
     .option("--instance <id>", "Instance to target (dev, prod, or a full instance ID)")
     .option("--output <file>", "Write config to a file instead of stdout")
+    .option("--keys <keys...>", "Config keys to retrieve")
     .action(configPull);
 
   config

--- a/packages/cli-core/src/commands/api/index.ts
+++ b/packages/cli-core/src/commands/api/index.ts
@@ -1,4 +1,3 @@
-import { confirm } from "@inquirer/prompts";
 import { resolveAppContext } from "../../lib/config.ts";
 import { fetchApplication, getAuthToken, validateKeyPrefix } from "../../lib/plapi.ts";
 import { BAPI_BASE_URL, PLAPI_BASE_URL } from "../../lib/constants.ts";
@@ -12,6 +11,7 @@ import {
   withApiContext,
 } from "../../lib/errors.ts";
 import { isHuman } from "../../mode.ts";
+import { confirm } from "../../lib/prompts.ts";
 
 export interface ApiOptions {
   method?: string;

--- a/packages/cli-core/src/commands/config/README.md
+++ b/packages/cli-core/src/commands/config/README.md
@@ -13,15 +13,17 @@ clerk config pull
 clerk config pull --app app_123
 clerk config pull --instance prod
 clerk config pull --output clerk-config.json
+clerk config pull --keys session sign_up
 ```
 
 #### Options
 
-| Flag              | Description                                                                         |
-| ----------------- | ----------------------------------------------------------------------------------- |
-| `--app <id>`      | Application ID to target directly (works from any directory)                        |
-| `--instance <id>` | Instance to target (`dev`, `prod`, or a full instance ID). Defaults to development. |
-| `--output <file>` | Write config to a file instead of stdout                                            |
+| Flag               | Description                                                                         |
+| ------------------ | ----------------------------------------------------------------------------------- |
+| `--app <id>`       | Application ID to target directly (works from any directory)                        |
+| `--instance <id>`  | Instance to target (`dev`, `prod`, or a full instance ID). Defaults to development. |
+| `--output <file>`  | Write config to a file instead of stdout                                            |
+| `--keys <keys...>` | Config keys to retrieve                                                             |
 
 #### Requirements
 

--- a/packages/cli-core/src/commands/config/pull.test.ts
+++ b/packages/cli-core/src/commands/config/pull.test.ts
@@ -200,7 +200,13 @@ describe("config pull", () => {
     );
   });
 
-  test("--keys filters output to requested keys", async () => {
+  test("--keys passes keys as query params to the API", async () => {
+    let requestedUrl = "";
+    stubFetch(async (input) => {
+      requestedUrl = input.toString();
+      return new Response(JSON.stringify({ session: { lifetime: 604800 } }), { status: 200 });
+    });
+
     await setProfile(process.cwd(), {
       workspaceId: "org_1",
       appId: "app_1",
@@ -208,29 +214,31 @@ describe("config pull", () => {
     });
 
     await runConfigPull({ keys: ["session"] });
+    expect(requestedUrl).toContain("keys=session");
     expect(logSpy).toHaveBeenCalledWith(JSON.stringify({ session: { lifetime: 604800 } }, null, 2));
   });
 
-  test("--keys silently omits keys not present in config", async () => {
+  test("--keys passes multiple keys as repeated query params", async () => {
+    let requestedUrl = "";
+    stubFetch(async (input) => {
+      requestedUrl = input.toString();
+      return new Response(
+        JSON.stringify({ session: { lifetime: 604800 }, sign_up: { mode: "public" } }),
+        {
+          status: 200,
+        },
+      );
+    });
+
     await setProfile(process.cwd(), {
       workspaceId: "org_1",
       appId: "app_1",
       instances: { development: "ins_dev" },
     });
 
-    await runConfigPull({ keys: ["session", "nonexistent"] });
-    expect(logSpy).toHaveBeenCalledWith(JSON.stringify({ session: { lifetime: 604800 } }, null, 2));
-  });
-
-  test("--keys with no matching keys outputs empty object", async () => {
-    await setProfile(process.cwd(), {
-      workspaceId: "org_1",
-      appId: "app_1",
-      instances: { development: "ins_dev" },
-    });
-
-    await runConfigPull({ keys: ["nonexistent"] });
-    expect(logSpy).toHaveBeenCalledWith(JSON.stringify({}, null, 2));
+    await runConfigPull({ keys: ["session", "sign_up"] });
+    expect(requestedUrl).toContain("keys=session");
+    expect(requestedUrl).toContain("keys=sign_up");
   });
 
   test("handles API errors gracefully", async () => {

--- a/packages/cli-core/src/commands/config/pull.test.ts
+++ b/packages/cli-core/src/commands/config/pull.test.ts
@@ -47,7 +47,9 @@ describe("config pull", () => {
   });
 
   // Dynamically import to get fresh module state
-  async function runConfigPull(options: { app?: string; instance?: string; output?: string } = {}) {
+  async function runConfigPull(
+    options: { app?: string; instance?: string; output?: string; keys?: string[] } = {},
+  ) {
     const { configPull } = await import("./pull.ts");
     return configPull(options);
   }
@@ -196,6 +198,39 @@ describe("config pull", () => {
     await expect(runConfigPull({ instance: "prod" })).rejects.toThrow(
       "No production instance configured",
     );
+  });
+
+  test("--keys filters output to requested keys", async () => {
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigPull({ keys: ["session"] });
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify({ session: { lifetime: 604800 } }, null, 2));
+  });
+
+  test("--keys silently omits keys not present in config", async () => {
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigPull({ keys: ["session", "nonexistent"] });
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify({ session: { lifetime: 604800 } }, null, 2));
+  });
+
+  test("--keys with no matching keys outputs empty object", async () => {
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigPull({ keys: ["nonexistent"] });
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify({}, null, 2));
   });
 
   test("handles API errors gracefully", async () => {

--- a/packages/cli-core/src/commands/config/pull.ts
+++ b/packages/cli-core/src/commands/config/pull.ts
@@ -6,6 +6,7 @@ interface ConfigPullOptions {
   app?: string;
   instance?: string;
   output?: string;
+  keys?: string[];
 }
 
 export async function configPull(options: ConfigPullOptions): Promise<void> {
@@ -13,10 +14,15 @@ export async function configPull(options: ConfigPullOptions): Promise<void> {
 
   console.error(`Pulling config from ${ctx.instanceLabel} instance...`);
 
-  const config = await withApiContext(
+  let config = await withApiContext(
     fetchInstanceConfig(ctx.appId, ctx.instanceId),
     "Failed to fetch config",
   );
+
+  if (options.keys?.length) {
+    config = Object.fromEntries(options.keys.filter((k) => k in config).map((k) => [k, config[k]]));
+  }
+
   const json = JSON.stringify(config, null, 2);
 
   if (options.output) {

--- a/packages/cli-core/src/commands/config/pull.ts
+++ b/packages/cli-core/src/commands/config/pull.ts
@@ -14,14 +14,10 @@ export async function configPull(options: ConfigPullOptions): Promise<void> {
 
   console.error(`Pulling config from ${ctx.instanceLabel} instance...`);
 
-  let config = await withApiContext(
-    fetchInstanceConfig(ctx.appId, ctx.instanceId),
+  const config = await withApiContext(
+    fetchInstanceConfig(ctx.appId, ctx.instanceId, options.keys),
     "Failed to fetch config",
   );
-
-  if (options.keys?.length) {
-    config = Object.fromEntries(options.keys.filter((k) => k in config).map((k) => [k, config[k]]));
-  }
 
   const json = JSON.stringify(config, null, 2);
 

--- a/packages/cli-core/src/commands/config/push.ts
+++ b/packages/cli-core/src/commands/config/push.ts
@@ -1,8 +1,8 @@
-import { confirm } from "@inquirer/prompts";
 import { resolveAppContext } from "../../lib/config.ts";
 import { putInstanceConfig, patchInstanceConfig } from "../../lib/plapi.ts";
 import { isHuman } from "../../mode.ts";
 import { throwUsageError, throwUserAbort, withApiContext, ERROR_CODE } from "../../lib/errors.ts";
+import { confirm } from "../../lib/prompts.ts";
 
 interface ConfigPushOptions {
   app?: string;

--- a/packages/cli-core/src/lib/plapi.ts
+++ b/packages/cli-core/src/lib/plapi.ts
@@ -77,9 +77,17 @@ export async function fetchInstanceConfigSchema(
 export async function fetchInstanceConfig(
   applicationId: string,
   instanceId: string,
+  keys?: string[],
 ): Promise<Record<string, unknown>> {
   const token = await getAuthToken();
-  const url = `${PLAPI_BASE_URL}/v1/platform/applications/${applicationId}/instances/${instanceId}/config`;
+  const url = new URL(
+    `${PLAPI_BASE_URL}/v1/platform/applications/${applicationId}/instances/${instanceId}/config`,
+  );
+  if (keys?.length) {
+    for (const key of keys) {
+      url.searchParams.append("keys", key);
+    }
+  }
   const response = await fetch(url, {
     headers: {
       Authorization: `Bearer ${token}`,

--- a/packages/cli-core/src/lib/prompts.test.ts
+++ b/packages/cli-core/src/lib/prompts.test.ts
@@ -22,11 +22,13 @@ mock.module("@inquirer/prompts", () => ({
 const { confirm } = await import("./prompts.ts");
 
 const originalIsTTY = process.stdin.isTTY;
+const originalPlatform = process.platform;
 
 beforeEach(() => {
   lastConfirmArgs = [];
   confirmResult = true;
   process.stdin.isTTY = originalIsTTY;
+  Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
 });
 
 test("passes config through to inquirer confirm", async () => {
@@ -44,7 +46,7 @@ test("returns false when user declines", async () => {
   expect(result).toBe(false);
 });
 
-test("does not open /dev/tty when stdin is a TTY", async () => {
+test("does not open tty when stdin is a TTY", async () => {
   process.stdin.isTTY = true;
   await confirm({ message: "Continue?" });
 
@@ -52,7 +54,7 @@ test("does not open /dev/tty when stdin is a TTY", async () => {
   expect(lastConfirmArgs[1]).toBeUndefined();
 });
 
-test("opens /dev/tty as input when stdin is not a TTY", async () => {
+test("opens controlling terminal as input when stdin is not a TTY", async () => {
   process.stdin.isTTY = false;
 
   const mockStream = { close: mock(() => {}) };
@@ -62,14 +64,16 @@ test("opens /dev/tty as input when stdin is not a TTY", async () => {
 
   await confirm({ message: "Continue?" });
 
-  expect(createReadStreamSpy).toHaveBeenCalledWith("/dev/tty");
+  // Should use the platform-appropriate TTY path
+  const expectedPath = process.platform === "win32" ? "CONIN$" : "/dev/tty";
+  expect(createReadStreamSpy).toHaveBeenCalledWith(expectedPath);
   expect(lastConfirmArgs[1]).toEqual({ input: mockStream });
   expect(mockStream.close).toHaveBeenCalled();
 
   createReadStreamSpy.mockRestore();
 });
 
-test("closes /dev/tty stream even when confirm throws", async () => {
+test("closes tty stream even when confirm throws", async () => {
   process.stdin.isTTY = false;
   confirmResult = new Error("user cancelled");
 

--- a/packages/cli-core/src/lib/prompts.test.ts
+++ b/packages/cli-core/src/lib/prompts.test.ts
@@ -1,0 +1,85 @@
+import { test, expect, mock, spyOn, beforeEach } from "bun:test";
+
+// Track calls to the underlying inquirer confirm
+let lastConfirmArgs: unknown[] = [];
+let confirmResult: boolean | Error = true;
+
+mock.module("@inquirer/prompts", () => ({
+  confirm: async (...args: unknown[]) => {
+    lastConfirmArgs = args;
+    if (confirmResult instanceof Error) throw confirmResult;
+    return confirmResult;
+  },
+  // Stub the other exports so this mock doesn't break other test files
+  // that share this process and import @inquirer/prompts.
+  select: async () => {},
+  search: async () => {},
+  input: async () => "",
+  password: async () => "",
+  editor: async () => "",
+}));
+
+const { confirm } = await import("./prompts.ts");
+
+const originalIsTTY = process.stdin.isTTY;
+
+beforeEach(() => {
+  lastConfirmArgs = [];
+  confirmResult = true;
+  process.stdin.isTTY = originalIsTTY;
+});
+
+test("passes config through to inquirer confirm", async () => {
+  process.stdin.isTTY = true;
+  const result = await confirm({ message: "Continue?" });
+
+  expect(result).toBe(true);
+  expect(lastConfirmArgs[0]).toEqual({ message: "Continue?" });
+});
+
+test("returns false when user declines", async () => {
+  process.stdin.isTTY = true;
+  confirmResult = false;
+  const result = await confirm({ message: "Continue?" });
+  expect(result).toBe(false);
+});
+
+test("does not open /dev/tty when stdin is a TTY", async () => {
+  process.stdin.isTTY = true;
+  await confirm({ message: "Continue?" });
+
+  // Second arg (context) should be undefined — no tty input needed
+  expect(lastConfirmArgs[1]).toBeUndefined();
+});
+
+test("opens /dev/tty as input when stdin is not a TTY", async () => {
+  process.stdin.isTTY = false;
+
+  const mockStream = { close: mock(() => {}) };
+  const createReadStreamSpy = spyOn(await import("node:fs"), "createReadStream").mockReturnValue(
+    mockStream as any,
+  );
+
+  await confirm({ message: "Continue?" });
+
+  expect(createReadStreamSpy).toHaveBeenCalledWith("/dev/tty");
+  expect(lastConfirmArgs[1]).toEqual({ input: mockStream });
+  expect(mockStream.close).toHaveBeenCalled();
+
+  createReadStreamSpy.mockRestore();
+});
+
+test("closes /dev/tty stream even when confirm throws", async () => {
+  process.stdin.isTTY = false;
+  confirmResult = new Error("user cancelled");
+
+  const mockStream = { close: mock(() => {}) };
+  const createReadStreamSpy = spyOn(await import("node:fs"), "createReadStream").mockReturnValue(
+    mockStream as any,
+  );
+
+  await expect(confirm({ message: "Continue?" })).rejects.toThrow("user cancelled");
+  expect(mockStream.close).toHaveBeenCalled();
+
+  createReadStreamSpy.mockRestore();
+});

--- a/packages/cli-core/src/lib/prompts.ts
+++ b/packages/cli-core/src/lib/prompts.ts
@@ -3,19 +3,25 @@
  *
  * When stdin is piped (e.g. `clerk config pull | clerk config patch`),
  * it gets consumed reading the input data. Interactive prompts then fail
- * because stdin is at EOF. These helpers open /dev/tty as a fallback
- * input so prompts can still read from the user's terminal.
+ * because stdin is at EOF. These helpers open the controlling terminal
+ * as a fallback input so prompts can still read from the user's terminal.
+ *
+ * Uses /dev/tty on Unix and CONIN$ on Windows.
  */
 
 import { createReadStream } from "node:fs";
 import { confirm as inquirerConfirm } from "@inquirer/prompts";
 
+/** OS-specific path to the controlling terminal's input stream. */
+const TTY_PATH = process.platform === "win32" ? "CONIN$" : "/dev/tty";
+
 /**
  * Like `confirm()` from @inquirer/prompts, but works even when stdin
- * has been consumed by a pipe. Falls back to reading from /dev/tty.
+ * has been consumed by a pipe. Falls back to reading from the
+ * controlling terminal.
  */
 export async function confirm(config: { message: string; default?: boolean }): Promise<boolean> {
-  const ttyInput = process.stdin.isTTY ? undefined : createReadStream("/dev/tty");
+  const ttyInput = process.stdin.isTTY ? undefined : createReadStream(TTY_PATH);
   try {
     return await inquirerConfirm(config, ttyInput ? { input: ttyInput } : undefined);
   } finally {

--- a/packages/cli-core/src/lib/prompts.ts
+++ b/packages/cli-core/src/lib/prompts.ts
@@ -1,0 +1,24 @@
+/**
+ * Prompt helpers that handle edge cases like piped stdin.
+ *
+ * When stdin is piped (e.g. `clerk config pull | clerk config patch`),
+ * it gets consumed reading the input data. Interactive prompts then fail
+ * because stdin is at EOF. These helpers open /dev/tty as a fallback
+ * input so prompts can still read from the user's terminal.
+ */
+
+import { createReadStream } from "node:fs";
+import { confirm as inquirerConfirm } from "@inquirer/prompts";
+
+/**
+ * Like `confirm()` from @inquirer/prompts, but works even when stdin
+ * has been consumed by a pipe. Falls back to reading from /dev/tty.
+ */
+export async function confirm(config: { message: string; default?: boolean }): Promise<boolean> {
+  const ttyInput = process.stdin.isTTY ? undefined : createReadStream("/dev/tty");
+  try {
+    return await inquirerConfirm(config, ttyInput ? { input: ttyInput } : undefined);
+  } finally {
+    ttyInput?.close();
+  }
+}


### PR DESCRIPTION
Two connected improvements to `config` to support common CLI workflows:

1. When using pipes, don't clobber prompts.
2. Allow pulling only specific keys, so that then you could do a patch on just those keys as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --keys option to clerk config pull to fetch only specified config keys.
  * Improved confirmation handling so interactive prompts still work when stdin is not a TTY.

* **Documentation**
  * Updated pull command docs with a --keys example and aligned option formatting.

* **Tests**
  * Added tests for key-filtering behavior and prompt handling edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->