### PR TITLE
feat(config): Diff support for push

### DIFF
--- a/packages/cli-core/src/commands/config/push.test.ts
+++ b/packages/cli-core/src/commands/config/push.test.ts
@@ -431,6 +431,26 @@ describe("config push", () => {
     expect(errorSpy).toHaveBeenCalledWith("No changes detected.");
   });
 
+  test("put detects no changes when current config has config_version (pull→put roundtrip)", async () => {
+    let mutatingCallMade = false;
+    const configWithVersion = { ...currentConfig, config_version: 42 };
+    stubFetch(async (_input, init) => {
+      if (init?.method) mutatingCallMade = true;
+      return new Response(JSON.stringify(configWithVersion), { status: 200 });
+    });
+
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    // Simulate pull→put: payload includes config_version from the pull output
+    await runConfigPut({ json: JSON.stringify(configWithVersion), yes: true });
+    expect(mutatingCallMade).toBe(false);
+    expect(errorSpy).toHaveBeenCalledWith("No changes detected.");
+  });
+
   // --- Instance targeting ---
 
   test("targets development instance by default", async () => {

--- a/packages/cli-core/src/commands/config/push.test.ts
+++ b/packages/cli-core/src/commands/config/push.test.ts
@@ -23,6 +23,13 @@ describe("config push", () => {
     sign_up: { mode: "public" },
   };
 
+  // The "current" config returned by the GET /config call before push.
+  // Must differ from mockResponse payloads so hasConfigChanges detects changes.
+  const currentConfig = {
+    session: { lifetime: 604800 },
+    sign_up: { mode: "restricted" },
+  };
+
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), "clerk-config-push-test-"));
     _setConfigDir(tempDir);
@@ -35,7 +42,11 @@ describe("config push", () => {
       throw new Error("process.exit");
     });
 
-    stubFetch(async () => new Response(JSON.stringify(mockResponse), { status: 200 }));
+    stubFetch(async (_input, init) => {
+      const isGet = !init?.method || init.method === "GET";
+      const body = isGet ? currentConfig : mockResponse;
+      return new Response(JSON.stringify(body), { status: 200 });
+    });
   });
 
   afterEach(async () => {
@@ -148,9 +159,12 @@ describe("config push", () => {
     let capturedMethod = "";
     let capturedBody = "";
     stubFetch(async (_input, init) => {
-      capturedMethod = init?.method ?? "GET";
-      capturedBody = init?.body as string;
-      return new Response(JSON.stringify(mockResponse), { status: 200 });
+      if (init?.method) {
+        capturedMethod = init.method;
+        capturedBody = init.body as string;
+      }
+      const body = init?.method ? mockResponse : currentConfig;
+      return new Response(JSON.stringify(body), { status: 200 });
     });
 
     await setProfile(process.cwd(), {
@@ -167,17 +181,21 @@ describe("config push", () => {
   test("patch supports --app without a linked profile", async () => {
     let capturedUrl = "";
     stubFetch(async (input, init) => {
-      capturedUrl = input.toString();
-      if (init?.method === undefined) {
-        return new Response(
-          JSON.stringify({
-            application_id: "app_1",
-            instances: [{ instance_id: "ins_dev", environment_type: "development" }],
-          }),
-          { status: 200 },
-        );
+      const url = input.toString();
+      if (init?.method) {
+        capturedUrl = url;
+        return new Response(JSON.stringify(mockResponse), { status: 200 });
       }
-      return new Response(JSON.stringify(mockResponse), { status: 200 });
+      if (url.includes("/config")) {
+        return new Response(JSON.stringify(currentConfig), { status: 200 });
+      }
+      return new Response(
+        JSON.stringify({
+          application_id: "app_1",
+          instances: [{ instance_id: "ins_dev", environment_type: "development" }],
+        }),
+        { status: 200 },
+      );
     });
 
     await runConfigPatch({
@@ -191,8 +209,9 @@ describe("config push", () => {
   test("patch reads config from --file", async () => {
     let capturedBody = "";
     stubFetch(async (_input, init) => {
-      capturedBody = init?.body as string;
-      return new Response(JSON.stringify(mockResponse), { status: 200 });
+      if (init?.method) capturedBody = init.body as string;
+      const body = init?.method ? mockResponse : currentConfig;
+      return new Response(JSON.stringify(body), { status: 200 });
     });
 
     const configFile = join(tempDir, "input.json");
@@ -235,8 +254,9 @@ describe("config push", () => {
   test("put sends PUT method", async () => {
     let capturedMethod = "";
     stubFetch(async (_input, init) => {
-      capturedMethod = init?.method ?? "GET";
-      return new Response(JSON.stringify(mockResponse), { status: 200 });
+      if (init?.method) capturedMethod = init.method;
+      const body = init?.method ? mockResponse : currentConfig;
+      return new Response(JSON.stringify(body), { status: 200 });
     });
 
     await setProfile(process.cwd(), {
@@ -265,8 +285,9 @@ describe("config push", () => {
   test("put strips config_version from payload before sending", async () => {
     let capturedBody = "";
     stubFetch(async (_input, init) => {
-      capturedBody = init?.body as string;
-      return new Response(JSON.stringify(mockResponse), { status: 200 });
+      if (init?.method) capturedBody = init.body as string;
+      const body = init?.method ? mockResponse : currentConfig;
+      return new Response(JSON.stringify(body), { status: 200 });
     });
 
     await setProfile(process.cwd(), {
@@ -285,8 +306,9 @@ describe("config push", () => {
   test("patch strips config_version from payload before sending", async () => {
     let capturedBody = "";
     stubFetch(async (_input, init) => {
-      capturedBody = init?.body as string;
-      return new Response(JSON.stringify(mockResponse), { status: 200 });
+      if (init?.method) capturedBody = init.body as string;
+      const body = init?.method ? mockResponse : currentConfig;
+      return new Response(JSON.stringify(body), { status: 200 });
     });
 
     await setProfile(process.cwd(), {
@@ -306,9 +328,10 @@ describe("config push", () => {
 
   test("patch sends ?destructive=true when --destructive is set", async () => {
     let capturedUrl = "";
-    stubFetch(async (input) => {
-      capturedUrl = input.toString();
-      return new Response(JSON.stringify(mockResponse), { status: 200 });
+    stubFetch(async (input, init) => {
+      if (init?.method) capturedUrl = input.toString();
+      const body = init?.method ? mockResponse : currentConfig;
+      return new Response(JSON.stringify(body), { status: 200 });
     });
 
     await setProfile(process.cwd(), {
@@ -327,9 +350,10 @@ describe("config push", () => {
 
   test("put sends ?destructive=true when --destructive is set", async () => {
     let capturedUrl = "";
-    stubFetch(async (input) => {
-      capturedUrl = input.toString();
-      return new Response(JSON.stringify(mockResponse), { status: 200 });
+    stubFetch(async (input, init) => {
+      if (init?.method) capturedUrl = input.toString();
+      const body = init?.method ? mockResponse : currentConfig;
+      return new Response(JSON.stringify(body), { status: 200 });
     });
 
     await setProfile(process.cwd(), {
@@ -348,9 +372,10 @@ describe("config push", () => {
 
   test("does not send ?destructive=true by default", async () => {
     let capturedUrl = "";
-    stubFetch(async (input) => {
-      capturedUrl = input.toString();
-      return new Response(JSON.stringify(mockResponse), { status: 200 });
+    stubFetch(async (input, init) => {
+      if (init?.method) capturedUrl = input.toString();
+      const body = init?.method ? mockResponse : currentConfig;
+      return new Response(JSON.stringify(body), { status: 200 });
     });
 
     await setProfile(process.cwd(), {
@@ -363,13 +388,57 @@ describe("config push", () => {
     expect(capturedUrl).not.toContain("destructive");
   });
 
+  // --- No-op when unchanged ---
+
+  test("patch skips API call when payload matches current config", async () => {
+    let mutatingCallMade = false;
+    stubFetch(async (_input, init) => {
+      if (init?.method) mutatingCallMade = true;
+      const body = init?.method ? mockResponse : currentConfig;
+      return new Response(JSON.stringify(body), { status: 200 });
+    });
+
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    // Send a payload that matches the current config for the patched key
+    await runConfigPatch({ json: '{"session":{"lifetime":604800}}', yes: true });
+    expect(mutatingCallMade).toBe(false);
+    expect(errorSpy).toHaveBeenCalledWith("No changes detected.");
+  });
+
+  test("put skips API call when payload matches current config", async () => {
+    let mutatingCallMade = false;
+    stubFetch(async (_input, init) => {
+      if (init?.method) mutatingCallMade = true;
+      return new Response(JSON.stringify(currentConfig), { status: 200 });
+    });
+
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigPut({
+      json: JSON.stringify(currentConfig),
+      yes: true,
+    });
+    expect(mutatingCallMade).toBe(false);
+    expect(errorSpy).toHaveBeenCalledWith("No changes detected.");
+  });
+
   // --- Instance targeting ---
 
   test("targets development instance by default", async () => {
     let requestedUrl = "";
-    stubFetch(async (input) => {
-      requestedUrl = input.toString();
-      return new Response(JSON.stringify(mockResponse), { status: 200 });
+    stubFetch(async (input, init) => {
+      if (init?.method) requestedUrl = input.toString();
+      const body = init?.method ? mockResponse : currentConfig;
+      return new Response(JSON.stringify(body), { status: 200 });
     });
 
     await setProfile(process.cwd(), {
@@ -384,9 +453,10 @@ describe("config push", () => {
 
   test("--instance prod targets production instance", async () => {
     let requestedUrl = "";
-    stubFetch(async (input) => {
-      requestedUrl = input.toString();
-      return new Response(JSON.stringify(mockResponse), { status: 200 });
+    stubFetch(async (input, init) => {
+      if (init?.method) requestedUrl = input.toString();
+      const body = init?.method ? mockResponse : currentConfig;
+      return new Response(JSON.stringify(body), { status: 200 });
     });
 
     await setProfile(process.cwd(), {
@@ -401,9 +471,10 @@ describe("config push", () => {
 
   test("--instance with literal ID passes through", async () => {
     let requestedUrl = "";
-    stubFetch(async (input) => {
-      requestedUrl = input.toString();
-      return new Response(JSON.stringify(mockResponse), { status: 200 });
+    stubFetch(async (input, init) => {
+      if (init?.method) requestedUrl = input.toString();
+      const body = init?.method ? mockResponse : currentConfig;
+      return new Response(JSON.stringify(body), { status: 200 });
     });
 
     await setProfile(process.cwd(), {
@@ -458,7 +529,10 @@ describe("config push", () => {
   // --- API error handling ---
 
   test("handles API errors gracefully", async () => {
-    stubFetch(async () => new Response("Bad Request", { status: 400 }));
+    stubFetch(async (_input, init) => {
+      if (!init?.method) return new Response(JSON.stringify(currentConfig), { status: 200 });
+      return new Response("Bad Request", { status: 400 });
+    });
 
     await setProfile(process.cwd(), {
       workspaceId: "org_1",
@@ -485,8 +559,9 @@ describe("config push", () => {
   test("--json takes priority over --file", async () => {
     let capturedBody = "";
     stubFetch(async (_input, init) => {
-      capturedBody = init?.body as string;
-      return new Response(JSON.stringify(mockResponse), { status: 200 });
+      if (init?.method) capturedBody = init.body as string;
+      const body = init?.method ? mockResponse : currentConfig;
+      return new Response(JSON.stringify(body), { status: 200 });
     });
 
     const configFile = join(tempDir, "should-not-read.json");

--- a/packages/cli-core/src/commands/config/push.test.ts
+++ b/packages/cli-core/src/commands/config/push.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { _setConfigDir, setProfile } from "../../lib/config.ts";
 import { credentialStoreStubs, gitStubs, promptsStubs, stubFetch } from "../../test/stubs.ts";
+import { printDiff } from "./push.ts";
 
 mock.module("../../lib/credential-store.ts", () => credentialStoreStubs);
 mock.module("../../lib/git.ts", () => gitStubs);
@@ -425,5 +426,99 @@ describe("config push", () => {
 
     await runConfigPatch({ json: '{"from":"json"}', file: configFile, yes: true });
     expect(JSON.parse(capturedBody)).toEqual({ from: "json" });
+  });
+});
+
+describe("printDiff", () => {
+  let errorSpy: ReturnType<typeof spyOn>;
+  let lines: string[];
+
+  beforeEach(() => {
+    lines = [];
+    errorSpy = spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      // Strip ANSI codes for easier assertion
+      lines.push(String(args[0]).replace(/\x1b\[[0-9;]*m/g, ""));
+    });
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  test("patch mode: shows only changed leaf values", () => {
+    const current = { session: { lifetime: 604800, cookie: "__session" } };
+    const patch = { session: { lifetime: 3600 } };
+
+    printDiff(current, patch, true);
+
+    expect(lines).toEqual(["  session:", "    lifetime:", "      - 604800", "      + 3600"]);
+  });
+
+  test("patch mode: skips unchanged keys", () => {
+    const current = { session: { lifetime: 3600 }, sign_up: { mode: "public" } };
+    const patch = { session: { lifetime: 3600 } };
+
+    printDiff(current, patch, true);
+
+    expect(lines).toEqual([]);
+  });
+
+  test("patch mode: shows new keys being added", () => {
+    const current = {};
+    const patch = { session: { lifetime: 3600 } };
+
+    printDiff(current, patch, true);
+
+    expect(lines).toEqual(["  session:", '    + {"lifetime":3600}']);
+  });
+
+  test("patch mode: ignores keys not in patch", () => {
+    const current = { session: { lifetime: 604800 }, sign_up: { mode: "public" } };
+    const patch = { session: { lifetime: 3600 } };
+
+    printDiff(current, patch, true);
+
+    // sign_up should not appear
+    expect(lines.some((l) => l.includes("sign_up"))).toBe(false);
+  });
+
+  test("put mode: shows removed keys", () => {
+    const current = { session: { lifetime: 604800 }, sign_up: { mode: "public" } };
+    const payload = { session: { lifetime: 604800 } };
+
+    printDiff(current, payload, false);
+
+    // session is unchanged, sign_up is being removed
+    expect(lines.some((l) => l.includes("sign_up"))).toBe(true);
+    expect(lines.some((l) => l.includes("- {"))).toBe(true);
+  });
+
+  test("put mode: shows both old and new for changed values", () => {
+    const current = { session: { lifetime: 604800 } };
+    const payload = { session: { lifetime: 3600 } };
+
+    printDiff(current, payload, false);
+
+    expect(lines).toContainEqual(expect.stringContaining("- 604800"));
+    expect(lines).toContainEqual(expect.stringContaining("+ 3600"));
+  });
+
+  test("handles deeply nested changes", () => {
+    const current = { a: { b: { c: { d: 1 } } } };
+    const patch = { a: { b: { c: { d: 2 } } } };
+
+    printDiff(current, patch, true);
+
+    expect(lines).toEqual(["  a:", "    b.c.d:", "      - 1", "      + 2"]);
+  });
+
+  test("handles array value changes", () => {
+    const current = { allowed: { origins: ["a.com", "b.com"] } };
+    const patch = { allowed: { origins: ["a.com", "c.com"] } };
+
+    printDiff(current, patch, true);
+
+    expect(lines).toContainEqual(expect.stringContaining('- ["a.com","b.com"]'));
+    expect(lines).toContainEqual(expect.stringContaining('+ ["a.com","c.com"]'));
   });
 });

--- a/packages/cli-core/src/commands/config/push.test.ts
+++ b/packages/cli-core/src/commands/config/push.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { _setConfigDir, setProfile } from "../../lib/config.ts";
 import { credentialStoreStubs, gitStubs, promptsStubs, stubFetch } from "../../test/stubs.ts";
-import { printDiff } from "./push.ts";
+import { printDiff, hasConfigChanges } from "./push.ts";
 
 mock.module("../../lib/credential-store.ts", () => credentialStoreStubs);
 mock.module("../../lib/git.ts", () => gitStubs);
@@ -693,5 +693,35 @@ describe("printDiff", () => {
 
     expect(lines).toContainEqual(expect.stringContaining('- ["a.com","b.com"]'));
     expect(lines).toContainEqual(expect.stringContaining('+ ["a.com","c.com"]'));
+  });
+});
+
+describe("hasConfigChanges", () => {
+  test("patch mode: no change when partial payload matches nested values", () => {
+    const current = { session: { lifetime: 604800, cookie: "__session" } };
+    const payload = { session: { lifetime: 604800 } };
+
+    expect(hasConfigChanges(current, payload, true)).toBe(false);
+  });
+
+  test("patch mode: detects change in nested value", () => {
+    const current = { session: { lifetime: 604800, cookie: "__session" } };
+    const payload = { session: { lifetime: 3600 } };
+
+    expect(hasConfigChanges(current, payload, true)).toBe(true);
+  });
+
+  test("put mode: detects removal of keys not in payload", () => {
+    const current = { session: { lifetime: 604800 }, sign_up: { mode: "public" } };
+    const payload = { session: { lifetime: 604800 } };
+
+    expect(hasConfigChanges(current, payload, false)).toBe(true);
+  });
+
+  test("put mode: no change when both sides match", () => {
+    const current = { session: { lifetime: 604800 } };
+    const payload = { session: { lifetime: 604800 } };
+
+    expect(hasConfigChanges(current, payload, false)).toBe(false);
   });
 });

--- a/packages/cli-core/src/commands/config/push.ts
+++ b/packages/cli-core/src/commands/config/push.ts
@@ -3,7 +3,7 @@ import { fetchInstanceConfig, putInstanceConfig, patchInstanceConfig } from "../
 import { isHuman } from "../../mode.ts";
 import { throwUsageError, throwUserAbort, withApiContext, ERROR_CODE } from "../../lib/errors.ts";
 import { confirm } from "../../lib/prompts.ts";
-import { dim, bold } from "../../lib/color.ts";
+import { dim, bold, red, green } from "../../lib/color.ts";
 
 interface ConfigPushOptions {
   app?: string;
@@ -80,6 +80,9 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
     fetchInstanceConfig(ctx.appId, ctx.instanceId),
     "Failed to fetch current config",
   );
+
+  // Strip config_version from current config to match the payload normalization above
+  delete currentConfig.config_version;
 
   const isPatch = op.method === "PATCH";
   const hasChanges = hasConfigChanges(currentConfig, configPayload, isPatch);
@@ -234,11 +237,11 @@ export function printDiff(
       const useColor = isHuman();
       if (oldVal !== undefined) {
         const line = `${indent}- ${JSON.stringify(oldVal)}`;
-        console.error(useColor ? dim(line) : line);
+        console.error(useColor ? dim(red(line)) : line);
       }
       if (newVal !== undefined) {
         const line = `${indent}+ ${JSON.stringify(newVal)}`;
-        console.error(useColor ? bold(line) : line);
+        console.error(useColor ? bold(green(line)) : line);
       }
     }
   }

--- a/packages/cli-core/src/commands/config/push.ts
+++ b/packages/cli-core/src/commands/config/push.ts
@@ -148,21 +148,80 @@ export async function readInput(options: { file?: string; json?: string }): Prom
   );
 }
 
+type Change = { path: string; oldVal?: unknown; newVal?: unknown };
+
+/**
+ * Recursively collects leaf-level differences between two values.
+ *
+ * When `patchMode` is true, only keys present in the new (payload) side
+ * are walked, so extra keys on the old side are ignored.
+ * When false (PUT), keys from both sides are walked so deletions are visible.
+ */
+function collectChanges(
+  oldObj: unknown,
+  newObj: unknown,
+  path: string,
+  out: Change[],
+  patchMode: boolean,
+): void {
+  if (JSON.stringify(oldObj) === JSON.stringify(newObj)) return;
+
+  const bothObjects =
+    oldObj != null &&
+    newObj != null &&
+    typeof oldObj === "object" &&
+    typeof newObj === "object" &&
+    !Array.isArray(oldObj) &&
+    !Array.isArray(newObj);
+
+  if (bothObjects) {
+    const keys = patchMode
+      ? Object.keys(newObj as Record<string, unknown>)
+      : [
+          ...new Set([
+            ...Object.keys(oldObj as Record<string, unknown>),
+            ...Object.keys(newObj as Record<string, unknown>),
+          ]),
+        ];
+    for (const key of keys) {
+      collectChanges(
+        (oldObj as Record<string, unknown>)[key],
+        (newObj as Record<string, unknown>)[key],
+        path ? `${path}.${key}` : key,
+        out,
+        patchMode,
+      );
+    }
+    return;
+  }
+
+  out.push({ path, oldVal: oldObj, newVal: newObj });
+}
+
+function topLevelKeys(
+  current: Record<string, unknown>,
+  payload: Record<string, unknown>,
+  patchMode: boolean,
+): string[] {
+  return patchMode
+    ? Object.keys(payload)
+    : [...new Set([...Object.keys(current), ...Object.keys(payload)])];
+}
+
 /**
  * Returns true if the payload would change any config values.
- * In patch mode only keys in the payload are compared;
- * in put mode all keys from both sides are compared.
+ * Uses the same recursive walker as printDiff so partial nested
+ * payloads (e.g. patching only session.lifetime) are compared correctly.
  */
 export function hasConfigChanges(
   current: Record<string, unknown>,
   payload: Record<string, unknown>,
   patchMode: boolean,
 ): boolean {
-  const keys = patchMode
-    ? Object.keys(payload)
-    : [...new Set([...Object.keys(current), ...Object.keys(payload)])];
-  for (const key of keys) {
-    if (JSON.stringify(current[key]) !== JSON.stringify(payload[key])) return true;
+  for (const key of topLevelKeys(current, payload, patchMode)) {
+    const changes: Change[] = [];
+    collectChanges(current[key], payload[key], "", changes, patchMode);
+    if (changes.length > 0) return true;
   }
   return false;
 }
@@ -180,52 +239,11 @@ export function printDiff(
   payload: Record<string, unknown>,
   patchMode: boolean,
 ): void {
-  type Change = { path: string; oldVal?: unknown; newVal?: unknown };
+  const keys = topLevelKeys(current, payload, patchMode);
 
-  function collectChanges(oldObj: unknown, newObj: unknown, path: string, out: Change[]): void {
-    if (JSON.stringify(oldObj) === JSON.stringify(newObj)) return;
-
-    const bothObjects =
-      oldObj != null &&
-      newObj != null &&
-      typeof oldObj === "object" &&
-      typeof newObj === "object" &&
-      !Array.isArray(oldObj) &&
-      !Array.isArray(newObj);
-
-    if (bothObjects) {
-      // In patch mode, only walk keys from the new object (the patch payload).
-      // In put mode, walk both sides so deletions are visible.
-      const keys = patchMode
-        ? Object.keys(newObj as Record<string, unknown>)
-        : [
-            ...new Set([
-              ...Object.keys(oldObj as Record<string, unknown>),
-              ...Object.keys(newObj as Record<string, unknown>),
-            ]),
-          ];
-      for (const key of keys) {
-        collectChanges(
-          (oldObj as Record<string, unknown>)[key],
-          (newObj as Record<string, unknown>)[key],
-          path ? `${path}.${key}` : key,
-          out,
-        );
-      }
-      return;
-    }
-
-    out.push({ path, oldVal: oldObj, newVal: newObj });
-  }
-
-  // In put mode, walk all keys from both sides so removed top-level keys show up.
-  const topLevelKeys = patchMode
-    ? Object.keys(payload)
-    : [...new Set([...Object.keys(current), ...Object.keys(payload)])];
-
-  for (const key of topLevelKeys) {
+  for (const key of keys) {
     const changes: Change[] = [];
-    collectChanges(current[key], payload[key], "", changes);
+    collectChanges(current[key], payload[key], "", changes, patchMode);
     if (changes.length === 0) continue;
 
     console.error(`  ${key}:`);

--- a/packages/cli-core/src/commands/config/push.ts
+++ b/packages/cli-core/src/commands/config/push.ts
@@ -1,8 +1,9 @@
 import { confirm } from "@inquirer/prompts";
 import { resolveAppContext } from "../../lib/config.ts";
-import { putInstanceConfig, patchInstanceConfig } from "../../lib/plapi.ts";
+import { fetchInstanceConfig, putInstanceConfig, patchInstanceConfig } from "../../lib/plapi.ts";
 import { isHuman } from "../../mode.ts";
 import { throwUsageError, throwUserAbort, withApiContext, ERROR_CODE } from "../../lib/errors.ts";
+import { dim, bold } from "../../lib/color.ts";
 
 interface ConfigPushOptions {
   app?: string;
@@ -74,8 +75,14 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
   }
 
   if (isHuman() && !options.yes) {
-    console.error(`\n${op.verb} config on ${ctx.instanceLabel} instance:`);
-    console.error(JSON.stringify(configPayload, null, 2));
+    const currentConfig = await withApiContext(
+      fetchInstanceConfig(ctx.appId, ctx.instanceId),
+      "Failed to fetch current config",
+    );
+
+    console.error(`\n${op.verb} config on ${ctx.instanceLabel} instance:\n`);
+    printDiff(currentConfig, configPayload, op.method === "PATCH");
+
     if (op.warning) {
       console.error(`\nWARNING: ${op.warning}`);
     }
@@ -126,4 +133,81 @@ export async function readInput(options: { file?: string; json?: string }): Prom
       '  Example: clerk config patch --json \'{"session":{"lifetime":3600}}\'\n' +
       "  Example: cat config.json | clerk config patch",
   );
+}
+
+/**
+ * Prints a diff showing only leaf values that actually changed,
+ * grouped by top-level config key.
+ *
+ * When `patchMode` is true, only keys present in the payload are walked.
+ * When false (PUT), all keys from both current and payload are walked
+ * so removed keys are visible too.
+ */
+export function printDiff(
+  current: Record<string, unknown>,
+  payload: Record<string, unknown>,
+  patchMode: boolean,
+): void {
+  type Change = { path: string; oldVal?: unknown; newVal?: unknown };
+
+  function collectChanges(oldObj: unknown, newObj: unknown, path: string, out: Change[]): void {
+    if (JSON.stringify(oldObj) === JSON.stringify(newObj)) return;
+
+    const bothObjects =
+      oldObj != null &&
+      newObj != null &&
+      typeof oldObj === "object" &&
+      typeof newObj === "object" &&
+      !Array.isArray(oldObj) &&
+      !Array.isArray(newObj);
+
+    if (bothObjects) {
+      // In patch mode, only walk keys from the new object (the patch payload).
+      // In put mode, walk both sides so deletions are visible.
+      const keys = patchMode
+        ? Object.keys(newObj as Record<string, unknown>)
+        : [
+            ...new Set([
+              ...Object.keys(oldObj as Record<string, unknown>),
+              ...Object.keys(newObj as Record<string, unknown>),
+            ]),
+          ];
+      for (const key of keys) {
+        collectChanges(
+          (oldObj as Record<string, unknown>)[key],
+          (newObj as Record<string, unknown>)[key],
+          path ? `${path}.${key}` : key,
+          out,
+        );
+      }
+      return;
+    }
+
+    out.push({ path, oldVal: oldObj, newVal: newObj });
+  }
+
+  // In put mode, walk all keys from both sides so removed top-level keys show up.
+  const topLevelKeys = patchMode
+    ? Object.keys(payload)
+    : [...new Set([...Object.keys(current), ...Object.keys(payload)])];
+
+  for (const key of topLevelKeys) {
+    const changes: Change[] = [];
+    collectChanges(current[key], payload[key], "", changes);
+    if (changes.length === 0) continue;
+
+    console.error(`  ${key}:`);
+    for (const { path, oldVal, newVal } of changes) {
+      if (path) {
+        console.error(`    ${path}:`);
+      }
+      const indent = path ? "      " : "    ";
+      if (oldVal !== undefined) {
+        console.error(dim(`${indent}- ${JSON.stringify(oldVal)}`));
+      }
+      if (newVal !== undefined) {
+        console.error(bold(`${indent}+ ${JSON.stringify(newVal)}`));
+      }
+    }
+  }
 }

--- a/packages/cli-core/src/commands/config/push.ts
+++ b/packages/cli-core/src/commands/config/push.ts
@@ -89,10 +89,10 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
     return;
   }
 
-  if (isHuman() && !options.yes) {
-    console.error(`\n${op.verb} config on ${ctx.instanceLabel} instance:\n`);
-    printDiff(currentConfig, configPayload, isPatch);
+  console.error(`\n${op.verb} config on ${ctx.instanceLabel} instance:\n`);
+  printDiff(currentConfig, configPayload, isPatch);
 
+  if (isHuman() && !options.yes) {
     if (op.warning) {
       console.error(`\nWARNING: ${op.warning}`);
     }
@@ -231,11 +231,14 @@ export function printDiff(
         console.error(`    ${path}:`);
       }
       const indent = path ? "      " : "    ";
+      const useColor = isHuman();
       if (oldVal !== undefined) {
-        console.error(dim(`${indent}- ${JSON.stringify(oldVal)}`));
+        const line = `${indent}- ${JSON.stringify(oldVal)}`;
+        console.error(useColor ? dim(line) : line);
       }
       if (newVal !== undefined) {
-        console.error(bold(`${indent}+ ${JSON.stringify(newVal)}`));
+        const line = `${indent}+ ${JSON.stringify(newVal)}`;
+        console.error(useColor ? bold(line) : line);
       }
     }
   }

--- a/packages/cli-core/src/test/integration/config-management.test.ts
+++ b/packages/cli-core/src/test/integration/config-management.test.ts
@@ -28,8 +28,6 @@ test.each([{ mode: "human" }, { mode: "agent" }])(
       instances: { development: devInstance.instance_id },
     });
 
-    const updatedConfig = { session: { lifetime: 86400 }, sign_up: { mode: "public" } };
-
     http.mock({
       "/config": MOCK_CONFIG,
     });
@@ -38,16 +36,21 @@ test.each([{ mode: "human" }, { mode: "agent" }])(
     const { stdout: pullOutput } = await clerk("--mode", mode, "config", "pull");
     expect(pullOutput).toContain(`"lifetime": ${MOCK_CONFIG.session.lifetime}`);
 
-    // Pull schema, then patch config
+    // Pull schema
     http.mock({
       "/config/schema": MOCK_SCHEMA,
-      "/config": updatedConfig,
     });
 
     const { stdout: schemaOutput } = await clerk("--mode", mode, "config", "schema");
     expect(schemaOutput).toContain(`"type": "${MOCK_SCHEMA.type}"`);
 
-    // Patch config
+    // Patch config — GET returns current (different) config so changes are detected
+    const updatedConfig = { session: { lifetime: 86400 }, sign_up: { mode: "public" } };
+    http.stub(async (_url, init) => {
+      const body = init?.method ? updatedConfig : MOCK_CONFIG;
+      return new Response(JSON.stringify(body), { status: 200 });
+    });
+
     await clerk(
       "--mode",
       mode,

--- a/packages/cli-core/src/test/integration/config-put.test.ts
+++ b/packages/cli-core/src/test/integration/config-put.test.ts
@@ -73,6 +73,11 @@ test("config put requires confirmation in human mode without --yes", async () =>
 });
 
 test("config put aborted when user declines confirmation", async () => {
+  // Mock the current config endpoint (needed for the diff preview)
+  http.mock({
+    "/config": { session: { lifetime: 604800 } },
+  });
+
   // Queue a "no" confirmation
   mockPrompts.confirm(false);
 

--- a/packages/cli-core/src/test/integration/config-put.test.ts
+++ b/packages/cli-core/src/test/integration/config-put.test.ts
@@ -36,8 +36,10 @@ test.each([{ mode: "human" }, { mode: "agent" }])(
       sign_in: { enabled: true },
     };
 
-    http.mock({
-      "/config": fullConfig,
+    // GET returns a different config so hasConfigChanges detects changes
+    http.stub(async (_url, init) => {
+      const body = init?.method ? fullConfig : { session: { lifetime: 3600 } };
+      return new Response(JSON.stringify(body), { status: 200 });
     });
 
     await clerk("--mode", mode, "config", "put", "--json", JSON.stringify(fullConfig), "--yes");
@@ -59,8 +61,10 @@ test.each([{ mode: "human" }, { mode: "agent" }])(
 test("config put requires confirmation in human mode without --yes", async () => {
   const fullConfig = { session: { lifetime: 3600 } };
 
-  http.mock({
-    "/config": fullConfig,
+  // GET returns different config so changes are detected
+  http.stub(async (_url, init) => {
+    const body = init?.method ? fullConfig : { session: { lifetime: 604800 } };
+    return new Response(JSON.stringify(body), { status: 200 });
   });
 
   // Queue a "yes" confirmation response

--- a/packages/cli-core/src/test/integration/dry-run.test.ts
+++ b/packages/cli-core/src/test/integration/dry-run.test.ts
@@ -66,7 +66,11 @@ test.each([{ mode: "human" }, { mode: "agent" }])(
   "config patch without dry-run sends PATCH ($mode mode)",
   async ({ mode }) => {
     const updatedConfig = { session: { lifetime: 3600 } };
-    http.mock({ "/config": updatedConfig });
+    // GET returns different config so hasConfigChanges detects changes
+    http.stub(async (_url, init) => {
+      const body = init?.method ? updatedConfig : { session: { lifetime: 604800 } };
+      return new Response(JSON.stringify(body), { status: 200 });
+    });
 
     await clerk(
       "--mode",


### PR DESCRIPTION
- When doing a push (put/patch), pull the existing config. If there are no changes, return early.
- Display the diff between the two configs, allowing a clearer confirmation flow when in interactive mode.

Sample output, using dim/bold, +/-, and red/green to be accessible to a variety of users:

<img width="558" height="210" alt="CleanShot 2026-03-27 at 13 38 36@2x" src="https://github.com/user-attachments/assets/f652a2fe-3290-4df7-bafe-c0e2a69b71d0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Push now previews a grouped leaf-value diff of current vs target configuration (colorized in human mode), and exits early with "No changes detected." when there are no effective changes.
* **Tests**
  * Expanded tests for diff rendering and change-detection, including no-op behavior when unchanged and method-sensitive API stubs to distinguish GET vs mutating requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->