### PR TITLE
feat: Store and display app name

### DIFF
--- a/packages/cli-core/src/commands/api/index.test.ts
+++ b/packages/cli-core/src/commands/api/index.test.ts
@@ -62,18 +62,25 @@ mock.module("../../lib/config.ts", () => ({
         production: "production",
       };
       if (!options.instance) {
-        return { appId: options.app, instanceId: "ins_dev", instanceLabel: "development" };
+        return {
+          appId: options.app,
+          appLabel: options.app,
+          instanceId: "ins_dev",
+          instanceLabel: "development",
+        };
       }
       const env = aliases[options.instance];
       if (!env) {
         return {
           appId: options.app,
+          appLabel: options.app,
           instanceId: options.instance,
           instanceLabel: options.instance,
         };
       }
       return {
         appId: options.app,
+        appLabel: options.app,
         instanceId: env === "production" ? "ins_prod" : "ins_dev",
         instanceLabel: env,
       };
@@ -97,7 +104,12 @@ mock.module("../../lib/config.ts", () => ({
           return { id, label: env };
         })();
 
-    return { appId: profile.appId, instanceId: instance.id, instanceLabel: instance.label };
+    return {
+      appId: profile.appId,
+      appLabel: profile.appId,
+      instanceId: instance.id,
+      instanceLabel: instance.label,
+    };
   },
 }));
 

--- a/packages/cli-core/src/commands/config/pull.test.ts
+++ b/packages/cli-core/src/commands/config/pull.test.ts
@@ -121,7 +121,19 @@ describe("config pull", () => {
     });
 
     await runConfigPull();
-    expect(errorSpy).toHaveBeenCalledWith("Pulling config from development instance...");
+    expect(errorSpy).toHaveBeenCalledWith("Pulling config from app_1 (development)...");
+  });
+
+  test("shows app name when stored in profile", async () => {
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      appName: "My SaaS App",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigPull();
+    expect(errorSpy).toHaveBeenCalledWith("Pulling config from My SaaS App (development)...");
   });
 
   test("shows production label when --instance prod", async () => {
@@ -132,7 +144,7 @@ describe("config pull", () => {
     });
 
     await runConfigPull({ instance: "prod" });
-    expect(errorSpy).toHaveBeenCalledWith("Pulling config from production instance...");
+    expect(errorSpy).toHaveBeenCalledWith("Pulling config from app_1 (production)...");
   });
 
   test("uses development instance by default", async () => {

--- a/packages/cli-core/src/commands/config/pull.ts
+++ b/packages/cli-core/src/commands/config/pull.ts
@@ -11,7 +11,7 @@ interface ConfigPullOptions {
 export async function configPull(options: ConfigPullOptions): Promise<void> {
   const ctx = await resolveAppContext(options);
 
-  console.error(`Pulling config from ${ctx.instanceLabel} instance...`);
+  console.error(`Pulling config from ${ctx.appLabel} (${ctx.instanceLabel})...`);
 
   const config = await withApiContext(
     fetchInstanceConfig(ctx.appId, ctx.instanceId),

--- a/packages/cli-core/src/commands/config/push.test.ts
+++ b/packages/cli-core/src/commands/config/push.test.ts
@@ -220,7 +220,7 @@ describe("config push", () => {
     });
 
     await runConfigPatch({ json: '{"session":{"lifetime":3600}}', yes: true });
-    expect(errorSpy).toHaveBeenCalledWith("Updating config on development instance...");
+    expect(errorSpy).toHaveBeenCalledWith("Updating config on app_1 (development)...");
   });
 
   // --- PUT happy paths ---
@@ -250,7 +250,7 @@ describe("config push", () => {
     });
 
     await runConfigPut({ json: '{"session":{"lifetime":3600}}', yes: true });
-    expect(errorSpy).toHaveBeenCalledWith("Replacing config on development instance...");
+    expect(errorSpy).toHaveBeenCalledWith("Replacing config on app_1 (development)...");
   });
 
   // --- config_version stripping ---

--- a/packages/cli-core/src/commands/config/push.ts
+++ b/packages/cli-core/src/commands/config/push.ts
@@ -68,13 +68,13 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
   delete configPayload.config_version;
 
   if (options.dryRun) {
-    console.error(`[dry-run] Would ${op.method} config on ${ctx.instanceLabel} instance:`);
+    console.error(`[dry-run] Would ${op.method} config on ${ctx.appLabel} (${ctx.instanceLabel}):`);
     console.log(JSON.stringify(configPayload, null, 2));
     return;
   }
 
   if (isHuman() && !options.yes) {
-    console.error(`\n${op.verb} config on ${ctx.instanceLabel} instance:`);
+    console.error(`\n${op.verb} config on ${ctx.appLabel} (${ctx.instanceLabel}):`);
     console.error(JSON.stringify(configPayload, null, 2));
     if (op.warning) {
       console.error(`\nWARNING: ${op.warning}`);
@@ -85,7 +85,7 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
     }
   }
 
-  console.error(`${op.verb} config on ${ctx.instanceLabel} instance...`);
+  console.error(`${op.verb} config on ${ctx.appLabel} (${ctx.instanceLabel})...`);
 
   const result = await withApiContext(
     op.apiFn(ctx.appId, ctx.instanceId, configPayload),

--- a/packages/cli-core/src/commands/config/schema.test.ts
+++ b/packages/cli-core/src/commands/config/schema.test.ts
@@ -127,7 +127,7 @@ describe("config schema", () => {
     });
 
     await runConfigSchema();
-    expect(errorSpy).toHaveBeenCalledWith("Pulling config schema from development instance...");
+    expect(errorSpy).toHaveBeenCalledWith("Pulling config schema from app_1 (development)...");
   });
 
   test("shows production label when --instance prod", async () => {
@@ -138,7 +138,7 @@ describe("config schema", () => {
     });
 
     await runConfigSchema({ instance: "prod" });
-    expect(errorSpy).toHaveBeenCalledWith("Pulling config schema from production instance...");
+    expect(errorSpy).toHaveBeenCalledWith("Pulling config schema from app_1 (production)...");
   });
 
   test("uses development instance by default", async () => {

--- a/packages/cli-core/src/commands/config/schema.ts
+++ b/packages/cli-core/src/commands/config/schema.ts
@@ -13,7 +13,7 @@ export async function configSchema(options: ConfigSchemaOptions): Promise<void> 
   const ctx = await resolveAppContext(options);
 
   // Use `console.error` for informational messages so stdout is just the JSON response.
-  console.error(`Pulling config schema from ${ctx.instanceLabel} instance...`);
+  console.error(`Pulling config schema from ${ctx.appLabel} (${ctx.instanceLabel})...`);
 
   const schema = await withApiContext(
     fetchInstanceConfigSchema(ctx.appId, ctx.instanceId, options.keys),

--- a/packages/cli-core/src/commands/env/pull.test.ts
+++ b/packages/cli-core/src/commands/env/pull.test.ts
@@ -58,15 +58,26 @@ mock.module("../../lib/config.ts", () => ({
         if (env) {
           const matched = app.instances.find((i) => i.environment_type === env);
           if (!matched) throw new Error(`No ${env} instance found for application ${options.app}.`);
-          return { appId: options.app, instanceId: matched.instance_id, instanceLabel: env };
+          return {
+            appId: options.app,
+            appLabel: options.app,
+            instanceId: matched.instance_id,
+            instanceLabel: env,
+          };
         }
         return {
           appId: options.app,
+          appLabel: options.app,
           instanceId: options.instance,
           instanceLabel: options.instance,
         };
       }
-      return { appId: options.app, instanceId: "ins_dev", instanceLabel: "development" };
+      return {
+        appId: options.app,
+        appLabel: options.app,
+        instanceId: "ins_dev",
+        instanceLabel: "development",
+      };
     }
 
     const profile = _profiles[process.cwd()];
@@ -82,7 +93,12 @@ mock.module("../../lib/config.ts", () => ({
           return { id, label: env };
         })();
 
-    return { appId: profile.appId, instanceId: instance.id, instanceLabel: instance.label };
+    return {
+      appId: profile.appId,
+      appLabel: profile.appId,
+      instanceId: instance.id,
+      instanceLabel: instance.label,
+    };
   },
 }));
 

--- a/packages/cli-core/src/commands/link/index.ts
+++ b/packages/cli-core/src/commands/link/index.ts
@@ -84,6 +84,7 @@ export async function link(options: LinkOptions = {}): Promise<void> {
   await setProfile(profileKey, {
     workspaceId: "",
     appId: app.application_id,
+    appName: app.name,
     instances: {
       development: devInstance.instance_id,
       ...(prodInstance ? { production: prodInstance.instance_id } : {}),

--- a/packages/cli-core/src/lib/autolink.ts
+++ b/packages/cli-core/src/lib/autolink.ts
@@ -113,6 +113,7 @@ export async function autolink(
   const profile: Profile = {
     workspaceId: "",
     appId: match.app.application_id,
+    appName: match.app.name,
     instances,
   };
 

--- a/packages/cli-core/src/lib/config.test.ts
+++ b/packages/cli-core/src/lib/config.test.ts
@@ -10,6 +10,7 @@ import {
   listProfiles,
   resolveProfile,
   resolveInstanceId,
+  resolveAppContext,
   _setConfigDir,
   type Profile,
 } from "./config.ts";
@@ -162,6 +163,34 @@ describe("config", () => {
         instances: { development: "ins_dev" },
       };
       expect(() => resolveInstanceId(devOnly, "prod")).toThrow("No production instance configured");
+    });
+  });
+
+  describe("resolveAppContext (linked profile)", () => {
+    test("uses appName as appLabel when available", async () => {
+      const cwd = process.cwd();
+      await setProfile(cwd, {
+        workspaceId: "org_1",
+        appId: "app_1",
+        appName: "My Cool App",
+        instances: { development: "ins_dev" },
+      });
+
+      const ctx = await resolveAppContext({});
+      expect(ctx.appLabel).toBe("My Cool App");
+      expect(ctx.appId).toBe("app_1");
+    });
+
+    test("falls back to appId when appName is not set", async () => {
+      const cwd = process.cwd();
+      await setProfile(cwd, {
+        workspaceId: "org_1",
+        appId: "app_1",
+        instances: { development: "ins_dev" },
+      });
+
+      const ctx = await resolveAppContext({});
+      expect(ctx.appLabel).toBe("app_1");
     });
   });
 });

--- a/packages/cli-core/src/lib/config.ts
+++ b/packages/cli-core/src/lib/config.ts
@@ -27,6 +27,7 @@ interface Auth {
 interface Profile {
   workspaceId: string;
   appId: string;
+  appName?: string;
   instances: {
     development: string;
     production?: string;
@@ -191,10 +192,11 @@ export function resolveInstanceId(profile: Profile, flag?: string): { id: string
 export async function resolveAppContext(options: {
   app?: string;
   instance?: string;
-}): Promise<{ appId: string; instanceId: string; instanceLabel: string }> {
+}): Promise<{ appId: string; appLabel: string; instanceId: string; instanceLabel: string }> {
   if (options.app) {
     const { fetchApplication } = await import("./plapi.ts");
     const app = await fetchApplication(options.app);
+    const appLabel = app.name || options.app;
 
     if (options.instance) {
       const env = INSTANCE_ALIASES[options.instance];
@@ -205,11 +207,17 @@ export async function resolveAppContext(options: {
             code: ERROR_CODE.INSTANCE_NOT_FOUND,
           });
         }
-        return { appId: options.app, instanceId: matched.instance_id, instanceLabel: env };
+        return {
+          appId: options.app,
+          appLabel,
+          instanceId: matched.instance_id,
+          instanceLabel: env,
+        };
       }
 
       return {
         appId: options.app,
+        appLabel,
         instanceId: options.instance,
         instanceLabel: options.instance,
       };
@@ -226,6 +234,7 @@ export async function resolveAppContext(options: {
 
     return {
       appId: options.app,
+      appLabel,
       instanceId: development.instance_id,
       instanceLabel: "development",
     };
@@ -245,6 +254,7 @@ export async function resolveAppContext(options: {
   const instance = resolveInstanceId(resolved.profile, options.instance);
   return {
     appId: resolved.profile.appId,
+    appLabel: resolved.profile.appName || resolved.profile.appId,
     instanceId: instance.id,
     instanceLabel: instance.label,
   };

--- a/packages/cli-core/src/test/stubs.ts
+++ b/packages/cli-core/src/test/stubs.ts
@@ -21,7 +21,7 @@ export const configStubs = {
   resolveProfile: noop,
   resolveProfileOrAutolink: noop,
   resolveInstanceId: () => ({ id: "", label: "" }),
-  resolveAppContext: async () => ({ appId: "", instanceId: "", instanceLabel: "" }),
+  resolveAppContext: async () => ({ appId: "", appLabel: "", instanceId: "", instanceLabel: "" }),
 };
 
 export const autolinkStubs = {


### PR DESCRIPTION
Save the app name when we link and display it in our messages so that users can verify which app they are operating on. When there is no app name saved, fall back to the app ID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Status messages now display both the target app identifier and environment label (e.g., "Pulling config from MyApp (production)") for clearer context.
  * App names are now persisted and referenced in command output, improving readability when managing multiple applications.

* **Chores**
  * Updated test expectations to match enhanced status messaging across config and environment commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->