### PR TITLE
fix(init): fix Nuxt project initialization

### DIFF
--- a/packages/cli-core/src/commands/doctor/checks.ts
+++ b/packages/cli-core/src/commands/doctor/checks.ts
@@ -2,7 +2,7 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 import { fetchUserInfo } from "../../lib/token-exchange.ts";
 import { PlapiError } from "../../lib/errors.ts";
-import { detectPublishableKeyName } from "../../lib/framework.ts";
+import { detectPublishableKeyName, detectSecretKeyName } from "../../lib/framework.ts";
 import { parseEnvFile } from "../../lib/dotenv.ts";
 import type { CheckResult, DoctorContext, FixAction } from "./types.ts";
 
@@ -231,13 +231,14 @@ export async function checkEnvVars(ctx: DoctorContext): Promise<CheckResult> {
   }
 
   const publishableKeyName = await detectPublishableKeyName(cwd);
+  const secretKeyName = await detectSecretKeyName(cwd);
   const hasPublishable = publishableKeyName in entries && entries[publishableKeyName] !== "";
-  const hasSecret = "CLERK_SECRET_KEY" in entries && entries["CLERK_SECRET_KEY"] !== "";
+  const hasSecret = secretKeyName in entries && entries[secretKeyName] !== "";
 
   if (!hasPublishable || !hasSecret) {
     const missing: string[] = [];
     if (!hasPublishable) missing.push(publishableKeyName);
-    if (!hasSecret) missing.push("CLERK_SECRET_KEY");
+    if (!hasSecret) missing.push(secretKeyName);
 
     return check.warn(`${foundFile} is missing: ${missing.join(", ")}`, {
       remedy: "Run `clerk env pull` to populate your environment variables.",
@@ -248,16 +249,16 @@ export async function checkEnvVars(ctx: DoctorContext): Promise<CheckResult> {
   const envLabel = await identifyEnvironment(
     ctx,
     entries[publishableKeyName]!,
-    entries["CLERK_SECRET_KEY"]!,
+    entries[secretKeyName]!,
   );
 
   if (envLabel) {
     return check.pass(
-      `${foundFile} contains ${publishableKeyName} and CLERK_SECRET_KEY (${envLabel} instance)`,
+      `${foundFile} contains ${publishableKeyName} and ${secretKeyName} (${envLabel} instance)`,
     );
   }
 
-  return check.pass(`${foundFile} contains ${publishableKeyName} and CLERK_SECRET_KEY`);
+  return check.pass(`${foundFile} contains ${publishableKeyName} and ${secretKeyName}`);
 }
 
 async function identifyEnvironment(

--- a/packages/cli-core/src/commands/env/pull.test.ts
+++ b/packages/cli-core/src/commands/env/pull.test.ts
@@ -375,4 +375,23 @@ describe("env pull", () => {
     const content = await Bun.file(join(tempDir, ".env.local")).text();
     expect(content).toContain("NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_abc123");
   });
+
+  test("detects Nuxt and uses NUXT_CLERK_SECRET_KEY", async () => {
+    await setProfile(tempDir, {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+    await Bun.write(
+      join(tempDir, "package.json"),
+      JSON.stringify({ dependencies: { nuxt: "4.0.0" } }),
+    );
+
+    await runEnvPull();
+
+    const content = await Bun.file(join(tempDir, ".env.local")).text();
+    expect(content).toContain("NUXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_abc123");
+    expect(content).toContain("NUXT_CLERK_SECRET_KEY=sk_test_xyz789");
+    expect(content).not.toMatch(/^CLERK_SECRET_KEY=/m);
+  });
 });

--- a/packages/cli-core/src/commands/env/pull.ts
+++ b/packages/cli-core/src/commands/env/pull.ts
@@ -2,7 +2,7 @@ import { join } from "node:path";
 import { resolveAppContext } from "../../lib/config.ts";
 import { fetchApplication } from "../../lib/plapi.ts";
 import { parseEnvFile, mergeEnvVars, serializeEnvFile } from "../../lib/dotenv.ts";
-import { detectPublishableKeyName } from "../../lib/framework.ts";
+import { detectPublishableKeyName, detectSecretKeyName } from "../../lib/framework.ts";
 import { CliError, ERROR_CODE, withApiContext } from "../../lib/errors.ts";
 
 interface EnvPullOptions {
@@ -38,8 +38,10 @@ export async function pull(options: EnvPullOptions): Promise<void> {
     });
   }
 
-  const publishableKeyName = await detectPublishableKeyName(process.cwd());
-  const targetFile = await resolveTargetFile(process.cwd(), options.file);
+  const cwd = process.cwd();
+  const publishableKeyName = await detectPublishableKeyName(cwd);
+  const secretKeyName = await detectSecretKeyName(cwd);
+  const targetFile = await resolveTargetFile(cwd, options.file);
 
   const file = Bun.file(targetFile);
   const existingContent = (await file.exists()) ? await file.text() : "";
@@ -49,7 +51,7 @@ export async function pull(options: EnvPullOptions): Promise<void> {
     [publishableKeyName]: matched.publishable_key,
   };
   if (matched.secret_key) {
-    vars.CLERK_SECRET_KEY = matched.secret_key;
+    vars[secretKeyName] = matched.secret_key;
   }
   const merged = mergeEnvVars(lines, vars);
   const output = serializeEnvFile(merged);

--- a/packages/cli-core/src/commands/init/README.md
+++ b/packages/cli-core/src/commands/init/README.md
@@ -104,11 +104,11 @@ The middleware filename is version-aware: `proxy.ts` for Next.js 16+, `middlewar
 
 ### Nuxt
 
-| Action | File                | Description                              |
-| ------ | ------------------- | ---------------------------------------- |
-| MODIFY | `nuxt.config.ts`    | Add `@clerk/nuxt` to modules array       |
-| CREATE | `pages/sign-in.vue` | Sign-in page with `<SignIn />` component |
-| CREATE | `pages/sign-up.vue` | Sign-up page with `<SignUp />` component |
+| Action | File                          | Description                              |
+| ------ | ----------------------------- | ---------------------------------------- |
+| MODIFY | `nuxt.config.ts`              | Add `@clerk/nuxt` to modules array       |
+| CREATE | `pages/sign-in/[...slug].vue` | Sign-in page with `<SignIn />` component |
+| CREATE | `pages/sign-up/[...slug].vue` | Sign-up page with `<SignUp />` component |
 
 Nuxt's module system auto-configures middleware and auto-imports components.
 

--- a/packages/cli-core/src/commands/init/context.test.ts
+++ b/packages/cli-core/src/commands/init/context.test.ts
@@ -115,6 +115,19 @@ test("detects existing Clerk SDK in dependencies", async () => {
   expect(ctx!.existingClerk).toBe(true);
 });
 
+test("existingClerk is false when a different @clerk package is installed", async () => {
+  await Bun.write(
+    join(tempDir, "package.json"),
+    JSON.stringify({ dependencies: { nuxt: "3.12.0", "@clerk/themes": "2.0.0" } }),
+  );
+
+  const ctx = await gatherContext(tempDir);
+
+  expect(ctx).not.toBeNull();
+  expect(ctx!.framework.sdk).toBe("@clerk/nuxt");
+  expect(ctx!.existingClerk).toBe(false);
+});
+
 test("detects package manager from bun.lockb", async () => {
   await Bun.write(
     join(tempDir, "package.json"),

--- a/packages/cli-core/src/commands/init/context.ts
+++ b/packages/cli-core/src/commands/init/context.ts
@@ -59,7 +59,7 @@ export async function gatherContext(
   const packageManager = await detectPackageManager(cwd);
 
   const deps = await readDeps(cwd);
-  const existingClerk = deps ? Object.keys(deps).some((d) => d.startsWith("@clerk/")) : false;
+  const existingClerk = deps ? framework.sdk in deps : false;
 
   const envFile = (await fileExists(join(cwd, ".env.local"))) ? ".env.local" : ".env";
 

--- a/packages/cli-core/src/commands/init/frameworks/nuxt.test.ts
+++ b/packages/cli-core/src/commands/init/frameworks/nuxt.test.ts
@@ -62,14 +62,14 @@ test("scaffolds all actions for a fresh Nuxt project", async () => {
     expect(config.content).toContain("@clerk/nuxt");
   }
 
-  const signIn = findAction(plan.actions, "pages/sign-in.vue");
+  const signIn = findAction(plan.actions, "pages/sign-in/[...slug].vue");
   expect(signIn.type).toBe("create");
   if (signIn.type === "create") {
     expect(signIn.content).toContain("<template>");
     expect(signIn.content).toContain("SignIn");
   }
 
-  const signUp = findAction(plan.actions, "pages/sign-up.vue");
+  const signUp = findAction(plan.actions, "pages/sign-up/[...slug].vue");
   expect(signUp.type).toBe("create");
 
   const env = findAction(plan.actions, ".env");
@@ -116,12 +116,15 @@ test("skips auth page when it already exists", async () => {
     join(tempDir, "nuxt.config.ts"),
     `export default defineNuxtConfig({ modules: [] });`,
   );
-  await mkdir(join(tempDir, "pages"), { recursive: true });
-  await Bun.write(join(tempDir, "pages/sign-in.vue"), "<template><div>existing</div></template>");
+  await mkdir(join(tempDir, "pages/sign-in"), { recursive: true });
+  await Bun.write(
+    join(tempDir, "pages/sign-in/[...slug].vue"),
+    "<template><div>existing</div></template>",
+  );
 
   const plan = await nuxt.scaffold(makeCtx());
 
-  expect(findAction(plan.actions, "pages/sign-in.vue")).toMatchObject({
+  expect(findAction(plan.actions, "pages/sign-in/[...slug].vue")).toMatchObject({
     type: "skip",
     skipReason: "Sign-in page already exists",
   });

--- a/packages/cli-core/src/commands/init/frameworks/nuxt.ts
+++ b/packages/cli-core/src/commands/init/frameworks/nuxt.ts
@@ -67,7 +67,7 @@ export const nuxt: FrameworkScaffold = {
       scaffoldAuthFiles(
         ctx.cwd,
         authFileSpecs({
-          path: (kind) => `pages/${kind}.vue`,
+          path: (kind) => `pages/${kind}/[...slug].vue`,
           content: (kind) => authPageContent(kind, tailwind),
           surface: "page",
         }),

--- a/packages/cli-core/src/commands/init/prompts/nuxt.md
+++ b/packages/cli-core/src/commands/init/prompts/nuxt.md
@@ -18,7 +18,7 @@ export default defineNuxtConfig({
 });
 ```
 
-## pages/sign-in.vue
+## pages/sign-in/[...slug].vue
 
 ```vue
 <template>
@@ -26,7 +26,7 @@ export default defineNuxtConfig({
 </template>
 ```
 
-## pages/sign-up.vue
+## pages/sign-up/[...slug].vue
 
 ```vue
 <template>

--- a/packages/cli-core/src/lib/framework.ts
+++ b/packages/cli-core/src/lib/framework.ts
@@ -10,6 +10,8 @@ export interface FrameworkInfo {
   name: string;
   sdk: string;
   envVar: string;
+  /** Override for secret key env var name. Defaults to CLERK_SECRET_KEY when omitted. */
+  secretKeyEnvVar?: string;
 }
 
 // Order matters: more specific frameworks first (e.g. next before react, nuxt before vue)
@@ -21,7 +23,13 @@ export const FRAMEWORK_MAP: FrameworkInfo[] = [
     envVar: "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
   },
   { dep: "astro", name: "Astro", sdk: "@clerk/astro", envVar: "PUBLIC_CLERK_PUBLISHABLE_KEY" },
-  { dep: "nuxt", name: "Nuxt", sdk: "@clerk/nuxt", envVar: "NUXT_PUBLIC_CLERK_PUBLISHABLE_KEY" },
+  {
+    dep: "nuxt",
+    name: "Nuxt",
+    sdk: "@clerk/nuxt",
+    envVar: "NUXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+    secretKeyEnvVar: "NUXT_CLERK_SECRET_KEY",
+  },
   {
     dep: "@tanstack/react-start",
     name: "TanStack Start",
@@ -61,6 +69,7 @@ export const FRAMEWORK_NAMES = FRAMEWORK_MAP.map((fw) => {
 });
 
 const FALLBACK_KEY = "CLERK_PUBLISHABLE_KEY";
+const FALLBACK_SECRET_KEY = "CLERK_SECRET_KEY";
 
 export async function readDeps(cwd: string): Promise<Record<string, string> | null> {
   const file = Bun.file(join(cwd, "package.json"));
@@ -88,4 +97,9 @@ export async function detectFramework(cwd: string): Promise<FrameworkInfo | null
 export async function detectPublishableKeyName(cwd: string): Promise<string> {
   const fw = await detectFramework(cwd);
   return fw?.envVar ?? FALLBACK_KEY;
+}
+
+export async function detectSecretKeyName(cwd: string): Promise<string> {
+  const fw = await detectFramework(cwd);
+  return fw?.secretKeyEnvVar ?? FALLBACK_SECRET_KEY;
 }

--- a/packages/cli-core/src/test/integration/onboard.test.ts
+++ b/packages/cli-core/src/test/integration/onboard.test.ts
@@ -52,6 +52,7 @@ test.each([
     framework: "Nuxt",
     deps: { nuxt: "3.0.0" },
     expectedKey: "NUXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+    expectedSecretKey: "NUXT_CLERK_SECRET_KEY",
   },
   {
     framework: "TanStack Start",
@@ -78,7 +79,7 @@ test.each([
     deps: { lodash: "4.0.0" },
     expectedKey: "CLERK_PUBLISHABLE_KEY",
   },
-])("$framework", async ({ deps, devDeps, expectedKey }) => {
+])("$framework", async ({ deps, devDeps, expectedKey, expectedSecretKey }) => {
   const pkg = {
     name: "test-project",
     dependencies: deps,
@@ -106,8 +107,9 @@ test.each([
   // Verify .env.local has correct key=value pairs with no duplicates
   const envContent = await Bun.file(join(h.tempDir, ".env.local")).text();
   const env = parseEnvFile(envContent, ".env.local");
+  const secretKey = expectedSecretKey ?? "CLERK_SECRET_KEY";
   expect(env.get(expectedKey)).toBe(devInstance.publishable_key);
-  expect(env.get("CLERK_SECRET_KEY")).toBe(devInstance.secret_key);
+  expect(env.get(secretKey)).toBe(devInstance.secret_key);
 
   // Verify Platform API calls included auth header
   const plapiCalls = http.requests.filter((r) => r.url.includes("/applications/"));


### PR DESCRIPTION
## Summary

- **Secret key env var**: Use `NUXT_CLERK_SECRET_KEY` instead of `CLERK_SECRET_KEY` for Nuxt projects. Nuxt's runtime config maps `NUXT_CLERK_SECRET_KEY` → `runtimeConfig.clerk.secretKey`, which is what `@clerk/nuxt` reads. The generic name was silently ignored.
- **existingClerk detection**: Check for the exact framework SDK (`@clerk/nuxt`) instead of any `@clerk/*` package. Having `@clerk/themes` installed would incorrectly skip SDK installation.
- **Auth page routes**: Use catch-all routes (`pages/sign-in/[...slug].vue`) instead of flat files. Clerk's multi-step auth flows (MFA, email verification) require the `[...slug]` pattern.

## Test plan

- [x] `bun test` passes (2 pre-existing API test failures unrelated to these changes)
- [ ] Run `clerk init` on a fresh Nuxt project and verify:
  - `.env` contains `NUXT_CLERK_SECRET_KEY` (not `CLERK_SECRET_KEY`)
  - Auth pages are created at `pages/sign-in/[...slug].vue` and `pages/sign-up/[...slug].vue`
  - SDK installation is not skipped when `@clerk/themes` is present but `@clerk/nuxt` is not
- [ ] Run `clerk doctor` on a Nuxt project and verify it checks for `NUXT_CLERK_SECRET_KEY`
- [ ] Run `clerk env pull` on a Nuxt project and verify env var names