### PR TITLE
fix(init): scaffold Vue files instead of showing post-instructions

### DIFF
--- a/packages/cli-core/src/commands/init/README.md
+++ b/packages/cli-core/src/commands/init/README.md
@@ -132,9 +132,13 @@ Nuxt's module system auto-configures middleware and auto-imports components.
 
 ### Vue
 
-| Action | File      | Description                                        |
-| ------ | --------- | -------------------------------------------------- |
-| MODIFY | `main.ts` | Add `clerkPlugin` with `publishableKey` to Vue app |
+| Action        | File                    | Description                                        |
+| ------------- | ----------------------- | -------------------------------------------------- |
+| CREATE/MODIFY | `main.ts`               | Add `clerkPlugin` with `publishableKey` to Vue app |
+| CREATE        | `src/views/sign-in.vue` | Sign-in page with `<SignIn />` component           |
+| CREATE        | `src/views/sign-up.vue` | Sign-up page with `<SignUp />` component           |
+| MODIFY        | `src/router/index.ts`   | Add sign-in and sign-up routes (if router exists)  |
+| MODIFY        | `.env`                  | Add sign-in/sign-up route env vars (VITE\_ prefix) |
 
 ## API Endpoints
 

--- a/packages/cli-core/src/commands/init/frameworks/vue.test.ts
+++ b/packages/cli-core/src/commands/init/frameworks/vue.test.ts
@@ -107,11 +107,102 @@ app.mount("#app");
   });
 });
 
-test("returns empty actions with post-instruction when no entry file found", async () => {
+test("creates entry file when none exists", async () => {
   const plan = await vue.scaffold(makeCtx());
 
-  expect(plan.actions).toHaveLength(0);
-  expect(plan.postInstructions.some((i) => i.includes("@clerk/vue"))).toBe(true);
+  const entry = findAction(plan.actions, "src/main.ts");
+  expect(entry.type).toBe("create");
+  if (entry.type === "create") {
+    expect(entry.content).toContain("clerkPlugin");
+    expect(entry.content).toContain("@clerk/vue");
+    expect(entry.content).toContain("PUBLISHABLE_KEY");
+    expect(entry.content).toContain('.mount("#app")');
+  }
+
+  // Auth pages and env should still be scaffolded
+  expect(findAction(plan.actions, "src/views/sign-in.vue").type).toBe("create");
+  expect(findAction(plan.actions, "src/views/sign-up.vue").type).toBe("create");
+  expect(findAction(plan.actions, ".env").type).toBe("modify");
+
+  // No post-instruction about entry file since it was created
+  expect(plan.postInstructions.some((i) => i.includes("@clerk/vue"))).toBe(false);
+});
+
+test("creates sign-in and sign-up pages", async () => {
+  await mkdir(join(tempDir, "src"), { recursive: true });
+  await Bun.write(
+    join(tempDir, "src/main.ts"),
+    `import { createApp } from "vue";
+import App from "./App.vue";
+const app = createApp(App);
+app.mount("#app");
+`,
+  );
+
+  const plan = await vue.scaffold(makeCtx());
+
+  const signIn = findAction(plan.actions, "src/views/sign-in.vue");
+  expect(signIn.type).toBe("create");
+  if (signIn.type === "create") {
+    expect(signIn.content).toContain("<SignIn />");
+    expect(signIn.content).toContain('@clerk/vue"');
+    expect(signIn.content).toContain("<script setup>");
+    expect(signIn.content).toContain("<template>");
+  }
+
+  const signUp = findAction(plan.actions, "src/views/sign-up.vue");
+  expect(signUp.type).toBe("create");
+  if (signUp.type === "create") {
+    expect(signUp.content).toContain("<SignUp />");
+    expect(signUp.content).toContain('@clerk/vue"');
+  }
+});
+
+test("skips auth pages when they already exist", async () => {
+  await mkdir(join(tempDir, "src/views"), { recursive: true });
+  await Bun.write(join(tempDir, "src/views/sign-in.vue"), "<template>existing</template>");
+  await Bun.write(join(tempDir, "src/views/sign-up.vue"), "<template>existing</template>");
+
+  const plan = await vue.scaffold(makeCtx());
+
+  expect(findAction(plan.actions, "src/views/sign-in.vue")).toMatchObject({
+    type: "skip",
+    skipReason: "Sign-in page already exists",
+  });
+  expect(findAction(plan.actions, "src/views/sign-up.vue")).toMatchObject({
+    type: "skip",
+    skipReason: "Sign-up page already exists",
+  });
+});
+
+test("scaffolds env vars with VITE_ prefix", async () => {
+  const plan = await vue.scaffold(makeCtx());
+
+  const envAction = findAction(plan.actions, ".env");
+  expect(envAction.type).toBe("modify");
+  if (envAction.type === "modify") {
+    expect(envAction.content).toContain("VITE_CLERK_SIGN_IN_URL");
+    expect(envAction.content).toContain("VITE_CLERK_SIGN_UP_URL");
+  }
+});
+
+test("uses tailwind classes when tailwindcss is a dependency", async () => {
+  const plan = await vue.scaffold(makeCtx({ deps: { tailwindcss: "^3.0.0" } }));
+
+  const signIn = findAction(plan.actions, "src/views/sign-in.vue");
+  if (signIn.type === "create") {
+    expect(signIn.content).toContain("flex min-h-screen items-center justify-center");
+  }
+});
+
+test("uses inline styles when no tailwind", async () => {
+  const plan = await vue.scaffold(makeCtx());
+
+  const signIn = findAction(plan.actions, "src/views/sign-in.vue");
+  if (signIn.type === "create") {
+    expect(signIn.content).toContain("style=");
+    expect(signIn.content).not.toContain("class=");
+  }
 });
 
 test("uses main.js when typescript is false", async () => {
@@ -148,4 +239,72 @@ app.mount("#app");
 
   const entry = findAction(plan.actions, "main.ts");
   expect(entry.type).toBe("modify");
+
+  // Auth pages should be at views/ (no src/ prefix)
+  expect(findAction(plan.actions, "views/sign-in.vue").type).toBe("create");
+  expect(findAction(plan.actions, "views/sign-up.vue").type).toBe("create");
+});
+
+test("includes vue-router post-instruction only when vue-router is a dep", async () => {
+  const withRouter = await vue.scaffold(makeCtx({ deps: { "vue-router": "^4.0.0" } }));
+  expect(withRouter.postInstructions.some((i) => i.includes("Vue Router"))).toBe(true);
+
+  const withoutRouter = await vue.scaffold(makeCtx());
+  expect(withoutRouter.postInstructions.some((i) => i.includes("Vue Router"))).toBe(false);
+});
+
+test("modifies router file to add sign-in and sign-up routes", async () => {
+  await mkdir(join(tempDir, "src/router"), { recursive: true });
+  await Bun.write(
+    join(tempDir, "src/router/index.ts"),
+    `import { createRouter, createWebHistory } from "vue-router";
+
+const router = createRouter({
+  history: createWebHistory(import.meta.env.BASE_URL),
+  routes: [
+    { path: "/", name: "home", component: () => import("../views/HomeView.vue") },
+  ],
+});
+
+export default router;
+`,
+  );
+
+  const plan = await vue.scaffold(makeCtx({ deps: { "vue-router": "^4.0.0" } }));
+
+  const routerAction = findAction(plan.actions, "src/router/index.ts");
+  expect(routerAction.type).toBe("modify");
+  if (routerAction.type === "modify") {
+    expect(routerAction.content).toContain("/sign-in");
+    expect(routerAction.content).toContain("/sign-up");
+    expect(routerAction.content).toContain("../views/sign-in.vue");
+  }
+
+  // No post-instruction since router was modified
+  expect(plan.postInstructions.some((i) => i.includes("Vue Router"))).toBe(false);
+});
+
+test("skips router when sign routes already exist", async () => {
+  await mkdir(join(tempDir, "src/router"), { recursive: true });
+  await Bun.write(
+    join(tempDir, "src/router/index.ts"),
+    `import { createRouter, createWebHistory } from "vue-router";
+
+const router = createRouter({
+  routes: [
+    { path: "/sign-in", component: () => import("../views/sign-in.vue") },
+    { path: "/sign-up", component: () => import("../views/sign-up.vue") },
+  ],
+});
+
+export default router;
+`,
+  );
+
+  const plan = await vue.scaffold(makeCtx({ deps: { "vue-router": "^4.0.0" } }));
+
+  expect(findAction(plan.actions, "src/router/index.ts")).toMatchObject({
+    type: "skip",
+    skipReason: "Already has sign-in/sign-up routes",
+  });
 });

--- a/packages/cli-core/src/commands/init/frameworks/vue.test.ts
+++ b/packages/cli-core/src/commands/init/frameworks/vue.test.ts
@@ -308,3 +308,27 @@ export default router;
     skipReason: "Already has sign-in/sign-up routes",
   });
 });
+
+test("skips router when only one sign route exists (no duplication)", async () => {
+  await mkdir(join(tempDir, "src/router"), { recursive: true });
+  await Bun.write(
+    join(tempDir, "src/router/index.ts"),
+    `import { createRouter, createWebHistory } from "vue-router";
+
+const router = createRouter({
+  routes: [
+    { path: "/sign-in", component: () => import("../views/sign-in.vue") },
+  ],
+});
+
+export default router;
+`,
+  );
+
+  const plan = await vue.scaffold(makeCtx({ deps: { "vue-router": "^4.0.0" } }));
+
+  expect(findAction(plan.actions, "src/router/index.ts")).toMatchObject({
+    type: "skip",
+    skipReason: "Already has sign-in/sign-up routes",
+  });
+});

--- a/packages/cli-core/src/commands/init/frameworks/vue.ts
+++ b/packages/cli-core/src/commands/init/frameworks/vue.ts
@@ -1,5 +1,19 @@
 import { join } from "node:path";
-import { findFirstFile, insertAfterLastImport, safeAddImport, srcPrefix } from "./helpers.js";
+import {
+  authComponentName,
+  authFileSpecs,
+  findFirstFile,
+  hasTailwindStyles,
+  htmlAuthComponentMarkup,
+  indentBlock,
+  insertAfterLastImport,
+  safeAddImport,
+  scaffoldAuthFiles,
+  scaffoldEnvVars,
+  scriptExt,
+  SIGN_ROUTE_ENV_VARS,
+  srcPrefix,
+} from "./helpers.js";
 import type { FileAction, FrameworkScaffold, ProjectContext, ScaffoldPlan } from "./types.js";
 
 async function findEntryFile(ctx: ProjectContext): Promise<string | null> {
@@ -19,9 +33,36 @@ function addClerkPluginSetup(source: string): string {
   return insertAfterLastImport(result, keyBlock);
 }
 
-async function scaffoldEntry(ctx: ProjectContext): Promise<FileAction | null> {
+function newEntryContent(): string {
+  return `import { createApp } from "vue";
+import { clerkPlugin } from "@clerk/vue";
+import App from "./App.vue";
+
+const PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
+
+if (!PUBLISHABLE_KEY) {
+  throw new Error("Add your Clerk Publishable Key to the .env file");
+}
+
+const app = createApp(App);
+app.use(clerkPlugin, { publishableKey: PUBLISHABLE_KEY });
+app.mount("#app");
+`;
+}
+
+async function scaffoldEntry(ctx: ProjectContext): Promise<FileAction> {
   const entryPath = await findEntryFile(ctx);
-  if (!entryPath) return null;
+
+  if (!entryPath) {
+    const base = srcPrefix(ctx);
+    const ext = scriptExt(ctx);
+    return {
+      type: "create",
+      path: `${base}main.${ext}`,
+      content: newEntryContent(),
+      description: "Create entry file with clerkPlugin setup",
+    };
+  }
 
   const content = await Bun.file(join(ctx.cwd, entryPath)).text();
 
@@ -44,6 +85,58 @@ async function scaffoldEntry(ctx: ProjectContext): Promise<FileAction | null> {
   };
 }
 
+function authPageContent(kind: "sign-in" | "sign-up", tailwind: boolean): string {
+  const component = authComponentName(kind);
+  const content = indentBlock(htmlAuthComponentMarkup(component, tailwind), "  ");
+  return `<script setup>
+import { ${component} } from "@clerk/vue";
+</script>
+
+<template>
+${content}
+</template>
+`;
+}
+
+async function findRouterFile(ctx: ProjectContext): Promise<string | null> {
+  const base = srcPrefix(ctx);
+  const ext = scriptExt(ctx);
+  return findFirstFile(ctx.cwd, [`${base}router/index.${ext}`, `${base}router.${ext}`]);
+}
+
+function addSignRoutes(source: string, viewPrefix: string): string {
+  if (source.includes("/sign-in") && source.includes("/sign-up")) {
+    return source;
+  }
+
+  // Insert sign-in/sign-up routes before the closing ] of the routes array
+  return source.replace(
+    /(routes:\s*\[)([\s\S]*?)(\s*\])/,
+    `$1$2\n    {\n      path: "/sign-in",\n      component: () => import("${viewPrefix}views/sign-in.vue"),\n    },\n    {\n      path: "/sign-up",\n      component: () => import("${viewPrefix}views/sign-up.vue"),\n    },$3`,
+  );
+}
+
+async function scaffoldRouter(ctx: ProjectContext): Promise<FileAction | null> {
+  const routerPath = await findRouterFile(ctx);
+  if (!routerPath) return null;
+
+  const content = await Bun.file(join(ctx.cwd, routerPath)).text();
+
+  if (content.includes("/sign-in") && content.includes("/sign-up")) {
+    return { type: "skip", path: routerPath, skipReason: "Already has sign-in/sign-up routes" };
+  }
+
+  const newContent = addSignRoutes(content, routerPath.includes("router/") ? "../" : "./");
+  if (newContent === content) return null;
+
+  return {
+    path: routerPath,
+    type: "modify",
+    content: newContent,
+    description: "Add sign-in and sign-up routes",
+  };
+}
+
 export const vue: FrameworkScaffold = {
   name: "Vue",
   dep: "vue",
@@ -52,21 +145,33 @@ export const vue: FrameworkScaffold = {
   matches: (ctx) => ctx.framework.dep === "vue",
 
   async scaffold(ctx: ProjectContext): Promise<ScaffoldPlan> {
-    const actions: FileAction[] = [];
+    const tailwind = hasTailwindStyles(ctx);
+    const base = srcPrefix(ctx);
+
+    const [entryAction, authActions, envAction, routerAction] = await Promise.all([
+      scaffoldEntry(ctx),
+      scaffoldAuthFiles(
+        ctx.cwd,
+        authFileSpecs({
+          path: (kind) => `${base}views/${kind}.vue`,
+          content: (kind) => authPageContent(kind, tailwind),
+          surface: "page",
+        }),
+      ),
+      scaffoldEnvVars(ctx, SIGN_ROUTE_ENV_VARS.vite),
+      scaffoldRouter(ctx),
+    ]);
+
+    const actions: FileAction[] = [entryAction, ...authActions, envAction];
     const postInstructions: string[] = [];
 
-    const entryAction = await scaffoldEntry(ctx);
-    if (entryAction) {
-      actions.push(entryAction);
-    } else {
+    if (routerAction) {
+      actions.push(routerAction);
+    } else if (ctx.deps["vue-router"]) {
       postInstructions.push(
-        "Add `import { clerkPlugin } from '@clerk/vue'` and `app.use(clerkPlugin, { publishableKey: PUBLISHABLE_KEY })` to your main.ts. See: https://clerk.com/docs/quickstarts/vue",
+        "Add sign-in and sign-up routes to your Vue Router config (e.g., `{ path: '/sign-in', component: () => import('./views/sign-in.vue') }`)",
       );
     }
-
-    postInstructions.push(
-      "Use <Show>, <SignInButton>, <SignUpButton>, <UserButton> from @clerk/vue in your components",
-    );
 
     return { actions, postInstructions };
   },

--- a/packages/cli-core/src/commands/init/frameworks/vue.ts
+++ b/packages/cli-core/src/commands/init/frameworks/vue.ts
@@ -105,7 +105,7 @@ async function findRouterFile(ctx: ProjectContext): Promise<string | null> {
 }
 
 function addSignRoutes(source: string, viewPrefix: string): string {
-  if (source.includes("/sign-in") && source.includes("/sign-up")) {
+  if (source.includes("/sign-in") || source.includes("/sign-up")) {
     return source;
   }
 
@@ -122,7 +122,7 @@ async function scaffoldRouter(ctx: ProjectContext): Promise<FileAction | null> {
 
   const content = await Bun.file(join(ctx.cwd, routerPath)).text();
 
-  if (content.includes("/sign-in") && content.includes("/sign-up")) {
+  if (content.includes("/sign-in") || content.includes("/sign-up")) {
     return { type: "skip", path: routerPath, skipReason: "Already has sign-in/sign-up routes" };
   }
 


### PR DESCRIPTION
## Summary
- **Create `main.ts` when it doesn't exist** — instead of falling back to a post-instruction telling the user to manually add `clerkPlugin`, the scaffold now generates a complete entry file with Clerk plugin setup
- **Scaffold auth pages + env vars** — creates `sign-in.vue`, `sign-up.vue` pages and adds `VITE_CLERK_*` env vars to `.env`
- **Auto-modify Vue Router config** — finds `src/router/index.ts` (or `.js`) and inserts sign-in/sign-up routes. Only falls back to a post-instruction if `vue-router` is a dep but no router file is found
- Previously running `clerk init` on a Vue project without `main.ts` would show "No files to scaffold" with manual instructions — now it writes all the files

## Test plan
- [x] All 14 Vue scaffold tests pass (`bun test packages/cli-core/src/commands/init/frameworks/vue.test.ts`)
- [x] Full test suite passes (555/557, 2 pre-existing failures in `api/index.test.ts`)
- [x] Lint and format pass
- [ ] Manual test: run `clerk init` on a fresh Vue project without `main.ts` — should create entry file, auth pages, env vars
- [ ] Manual test: run `clerk init` on a Vue project with `vue-router` — should modify router config
- [ ] Manual test: run `clerk init` twice — second run should skip all files (idempotent)