### PR TITLE
feat(release): publish canary releases to GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
           ARTIFACTS_DIR: ${{ github.workspace }}/dist/artifacts
           GH_TOKEN: ${{ github.token }}
 
-  upload-github-assets:
+  publish-github:
     needs: [versioning, build, smoke-test, publish-npm]
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -149,9 +149,46 @@ jobs:
       artifact-prefix: clerk-canary
       preset: canary
 
-  canary-publish:
+  canary-publish-github:
     needs: [canary-version, canary-build, canary-smoke-test]
-    # Must run on GitHub-hosted runner for npm OIDC trusted publishing
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: clerk-canary-*
+          path: dist/artifacts
+
+      - name: Create pre-release and upload binaries
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          tag="v${{ needs.canary-version.outputs.version }}"
+
+          # Create GitHub Release as a pre-release
+          gh release view "$tag" --repo "$GH_REPO" 2>/dev/null || \
+            gh release create "$tag" \
+              --repo "$GH_REPO" \
+              --title "$tag" \
+              --target "${{ github.sha }}" \
+              --prerelease \
+              --notes "Canary release \`$tag\`"
+
+          # Upload binaries
+          for dir in dist/artifacts/clerk-canary-*/; do
+            target=${dir#dist/artifacts/clerk-canary-} && target=${target%/}
+            ext=""; [[ "$target" == win32-* ]] && ext=".exe"
+            gh release upload "$tag" "${dir}clerk${ext}#clerk-${target}${ext}" \
+              --repo "$GH_REPO" --clobber
+          done
+
+  canary-publish-npm:
+    needs:
+      [canary-version, canary-build, canary-smoke-test, canary-publish-github]
+    # Must run on GitHub-hosted runner for npm OIDC trusted publishing.
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           expected="${{ inputs.version }}"
           if [ -n "${{ matrix.docker }}" ]; then
-            actual=$(docker run --rm -v "$PWD:/work" ${{ matrix.docker }} /work/${{ matrix.bin }} --version)
+            actual=$(docker run --rm -v "$PWD:/work" ${{ matrix.docker }} sh -c "apk add --no-cache libstdc++ libgcc >/dev/null 2>&1; /work/${{ matrix.bin }} --version")
           else
             actual=$(${{ matrix.bin }} --version)
           fi

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -70,9 +70,15 @@ curl -fsSL https://raw.githubusercontent.com/clerk/cli/main/install.sh | bash -s
 
 # Install to a custom directory
 curl -fsSL https://raw.githubusercontent.com/clerk/cli/main/install.sh | bash -s -- --install-dir ~/bin
+
+# Install from local build artifacts (after running bun run build:compile:all)
+./install.sh --local
+
+# Install from a custom artifacts directory
+./install.sh --artifacts-dir ./my-build/artifacts
 ```
 
-The script detects the current OS, architecture, and libc (glibc vs musl on Linux), then downloads and installs the matching binary. By default it installs to `/usr/local/bin` (or `~/.local/bin` if `/usr/local/bin` is not writable).
+The script detects the current OS, architecture, and libc (glibc vs musl on Linux), then downloads and installs the matching binary. With `--local`, it copies from `dist/artifacts/<target>/` instead of downloading from GitHub. By default it installs to `/usr/local/bin` (or `~/.local/bin` if `/usr/local/bin` is not writable).
 
 ## Versioning
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -14,7 +14,7 @@ push to main
             → publish-npm: generate platform packages + publish wrapper
             → upload-github-assets: attach binaries to the GitHub Release
   → (if no stable release needed) canary.ts versions packages
-    → build → smoke-test subset → publish @canary
+    → build → smoke-test subset → upload GitHub pre-release → publish @canary (npm, optional)
 
 PR comment "!snapshot [name]"
   → snapshot.ts versions packages from PR branch
@@ -44,13 +44,35 @@ Install: `npm install -g clerk`
 
 Published automatically on every push to `main` that does **not** trigger a stable release. `scripts/canary.ts` uses Changesets snapshot mode to produce versions in the format `x.y.z-canary.v<YYYYMMDDHHmmss>` (e.g., `0.0.1-canary.v20260313145959`). A subset of smoke tests (darwin-arm64, linux-x64, linux-x64-musl) runs before publishing.
 
-Install: `npm install -g clerk@canary`
+Install via script: `curl -fsSL https://raw.githubusercontent.com/clerk/cli/main/install.sh | bash -s -- --canary`
+
+Install via npm: `npm install -g clerk@canary`
 
 ### Snapshot (`@snapshot`)
 
 Published on-demand from PR branches by commenting `!snapshot` (or `!snapshot <name>`) on a pull request. The commenter must be a member or owner of the repository's organization. `scripts/snapshot.ts` uses Changesets snapshot mode to produce versions in the format `x.y.z-<name>.v<YYYYMMDDHHmmss>` (e.g., `0.0.1-snapshot.v20260313145959` or `0.0.1-my-feature.v20260313145959`). The datetime format ensures multiple snapshots from the same PR sort monotonically in semver.
 
 Install: `npm install -g clerk@<version>` (version is posted as a PR comment after publishing)
+
+## Install Script
+
+The repository includes an install script (`install.sh`) that downloads pre-compiled binaries directly from GitHub Releases. This works independently of npm.
+
+```sh
+# Install latest stable release
+curl -fsSL https://raw.githubusercontent.com/clerk/cli/main/install.sh | bash
+
+# Install latest canary release
+curl -fsSL https://raw.githubusercontent.com/clerk/cli/main/install.sh | bash -s -- --canary
+
+# Install a specific version
+curl -fsSL https://raw.githubusercontent.com/clerk/cli/main/install.sh | bash -s -- --version v0.1.0
+
+# Install to a custom directory
+curl -fsSL https://raw.githubusercontent.com/clerk/cli/main/install.sh | bash -s -- --install-dir ~/bin
+```
+
+The script detects the current OS, architecture, and libc (glibc vs musl on Linux), then downloads and installs the matching binary. By default it installs to `/usr/local/bin` (or `~/.local/bin` if `/usr/local/bin` is not writable).
 
 ## Versioning
 
@@ -134,6 +156,7 @@ Attaches the compiled binaries to the GitHub Release for direct download. Binari
 | `packages/cli/package.json`            | Wrapper package (has `prepublishOnly` guard against accidental direct publish) |
 | `packages/cli-core/src/cli.ts`         | CLI entrypoint (reads `CLI_VERSION` global at runtime)                         |
 | `packages/cli-core/src/globals.d.ts`   | TypeScript declaration for the `CLI_VERSION` compile-time define               |
+| `install.sh`                           | Shell install script — downloads binary from GitHub Releases                   |
 | `scripts/releaser/index.ts`            | Generates platform packages and publishes everything to npm                    |
 | `scripts/releaser/targets.ts`          | Target definitions (used by both releaser and build.ts)                        |
 | `scripts/build.ts`                     | Cross-compiles CLI binaries for all 8 platform targets                         |

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -14,7 +14,7 @@ push to main
             → publish-npm: generate platform packages + publish wrapper
             → upload-github-assets: attach binaries to the GitHub Release
   → (if no stable release needed) canary.ts versions packages
-    → build → smoke-test subset → upload GitHub pre-release → publish @canary (npm, optional)
+    → build → smoke-test subset → upload GitHub pre-release → publish @canary (npm)
 
 PR comment "!snapshot [name]"
   → snapshot.ts versions packages from PR branch

--- a/install.sh
+++ b/install.sh
@@ -197,7 +197,8 @@ else
     fi
   elif [ "$CHANNEL" = "canary" ]; then
     TAG=$(gh release list --repo "$REPO" --limit 20 --json tagName,isPrerelease \
-      --jq '[.[] | select(.isPrerelease and (.tagName | contains("canary")))][0].tagName' 2>/dev/null || true)
+      TAG=$(gh release list --repo "$REPO" --limit 20 --json tagName,isPrerelease \
+        --jq '[.[] | select(.isPrerelease and (.tagName | contains("canary")))][0].tagName // empty' 2>/dev/null || true)
 
     if [ -z "$TAG" ]; then
       TAG=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases" \

--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,10 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --version)
+      if [ $# -lt 2 ] || [[ "$2" == -* ]]; then
+        echo "Error: --version requires a value (e.g. --version v0.1.0)" >&2
+        exit 1
+      fi
       VERSION="$2"
       shift 2
       ;;
@@ -39,6 +43,10 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --install-dir)
+      if [ $# -lt 2 ] || [[ "$2" == -* ]]; then
+        echo "Error: --install-dir requires a value (e.g. --install-dir /usr/local/bin)" >&2
+        exit 1
+      fi
       INSTALL_DIR="$2"
       shift 2
       ;;
@@ -51,6 +59,10 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --artifacts-dir)
+      if [ $# -lt 2 ] || [[ "$2" == -* ]]; then
+        echo "Error: --artifacts-dir requires a value (e.g. --artifacts-dir ./build)" >&2
+        exit 1
+      fi
       ARTIFACTS_DIR="$2"
       LOCAL=true
       shift 2

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 # Install script for the Clerk CLI.
-# Downloads a pre-compiled binary from GitHub Releases.
+# Downloads a pre-compiled binary from GitHub Releases, or installs from local build artifacts.
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/clerk/cli/main/install.sh | bash
 #   curl -fsSL https://raw.githubusercontent.com/clerk/cli/main/install.sh | bash -s -- --canary
 #   curl -fsSL https://raw.githubusercontent.com/clerk/cli/main/install.sh | bash -s -- --version v0.1.0-canary.v20260313145959
+#   ./install.sh --local                          # install from dist/artifacts/
+#   ./install.sh --local --artifacts-dir ./build   # install from custom path
 #
 # Environment variables:
 #   CLERK_INSTALL_DIR  — directory to install to (default: /usr/local/bin, or ~/.local/bin if not writable)
@@ -17,6 +19,8 @@ BINARY_NAME="clerk"
 INSTALL_DIR="${CLERK_INSTALL_DIR:-}"
 CHANNEL=""
 VERSION=""
+LOCAL=false
+ARTIFACTS_DIR=""
 
 # ─── Parse arguments ───────────────────────────────────────────────────────────
 
@@ -42,6 +46,20 @@ while [[ $# -gt 0 ]]; do
       INSTALL_DIR="${1#--install-dir=}"
       shift
       ;;
+    --local)
+      LOCAL=true
+      shift
+      ;;
+    --artifacts-dir)
+      ARTIFACTS_DIR="$2"
+      LOCAL=true
+      shift 2
+      ;;
+    --artifacts-dir=*)
+      ARTIFACTS_DIR="${1#--artifacts-dir=}"
+      LOCAL=true
+      shift
+      ;;
     --help|-h)
       echo "Install the Clerk CLI"
       echo ""
@@ -49,10 +67,12 @@ while [[ $# -gt 0 ]]; do
       echo "  install.sh [options]"
       echo ""
       echo "Options:"
-      echo "  --canary              Install the latest canary release"
-      echo "  --version <tag>       Install a specific version (e.g. v0.1.0)"
-      echo "  --install-dir <path>  Directory to install to"
-      echo "  -h, --help            Show this help"
+      echo "  --canary                Install the latest canary release"
+      echo "  --version <tag>         Install a specific version (e.g. v0.1.0)"
+      echo "  --install-dir <path>    Directory to install to"
+      echo "  --local                 Install from local build artifacts (dist/artifacts/)"
+      echo "  --artifacts-dir <path>  Path to local artifacts directory (implies --local)"
+      echo "  -h, --help              Show this help"
       exit 0
       ;;
     *)
@@ -117,62 +137,77 @@ fi
 
 echo "Detected platform: ${TARGET}"
 
-# ─── Resolve version ──────────────────────────────────────────────────────────
-
-if [ -n "$VERSION" ]; then
-  # Use the explicitly provided version tag
-  TAG="$VERSION"
-  # Ensure it starts with 'v'
-  if [[ "$TAG" != v* ]]; then
-    TAG="v${TAG}"
-  fi
-elif [ "$CHANNEL" = "canary" ]; then
-  # Find the latest canary pre-release
-  TAG=$(gh release list --repo "$REPO" --limit 20 --json tagName,isPrerelease \
-    --jq '[.[] | select(.isPrerelease and (.tagName | contains("canary")))][0].tagName' 2>/dev/null || true)
-
-  if [ -z "$TAG" ]; then
-    # Fallback: use the GitHub API directly (no gh CLI required)
-    TAG=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases" \
-      | grep -o '"tag_name":"[^"]*canary[^"]*"' \
-      | head -1 \
-      | cut -d'"' -f4 || true)
-  fi
-
-  if [ -z "$TAG" ]; then
-    echo "Error: no canary release found" >&2
-    exit 1
-  fi
-else
-  # Find the latest stable release (non-prerelease)
-  TAG=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-    | grep -o '"tag_name":"[^"]*"' \
-    | cut -d'"' -f4 || true)
-
-  if [ -z "$TAG" ]; then
-    echo "Error: no stable release found" >&2
-    exit 1
-  fi
-fi
-
-echo "Installing Clerk CLI ${TAG}..."
-
-# ─── Download binary ──────────────────────────────────────────────────────────
-
-ASSET_NAME="clerk-${TARGET}${EXT}"
-DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${TAG}/${ASSET_NAME}"
+# ─── Resolve source ───────────────────────────────────────────────────────────
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
-echo "Downloading ${DOWNLOAD_URL}..."
-if ! curl -fsSL -o "${TMPDIR}/${BINARY_NAME}${EXT}" "$DOWNLOAD_URL"; then
-  echo "Error: failed to download binary for ${TARGET} from release ${TAG}" >&2
-  echo "Check that this platform is supported and the release exists." >&2
-  exit 1
-fi
+if [ "$LOCAL" = true ]; then
+  # ─── Local artifacts ─────────────────────────────────────────────────────────
+  if [ -z "$ARTIFACTS_DIR" ]; then
+    ARTIFACTS_DIR="dist/artifacts"
+  fi
 
-chmod +x "${TMPDIR}/${BINARY_NAME}${EXT}"
+  LOCAL_BINARY="${ARTIFACTS_DIR}/${TARGET}/${BINARY_NAME}${EXT}"
+  if [ ! -f "$LOCAL_BINARY" ]; then
+    echo "Error: no binary found at ${LOCAL_BINARY}" >&2
+    echo "Run 'bun run build:compile:all' or 'bun run scripts/build.ts --target=${TARGET}' first." >&2
+    exit 1
+  fi
+
+  cp "$LOCAL_BINARY" "${TMPDIR}/${BINARY_NAME}${EXT}"
+  chmod +x "${TMPDIR}/${BINARY_NAME}${EXT}"
+
+  # Read version from the binary itself
+  TAG=$("${TMPDIR}/${BINARY_NAME}${EXT}" --version 2>/dev/null || echo "local")
+  echo "Installing Clerk CLI ${TAG} from local artifacts..."
+else
+  # ─── GitHub Releases ─────────────────────────────────────────────────────────
+  if [ -n "$VERSION" ]; then
+    TAG="$VERSION"
+    if [[ "$TAG" != v* ]]; then
+      TAG="v${TAG}"
+    fi
+  elif [ "$CHANNEL" = "canary" ]; then
+    TAG=$(gh release list --repo "$REPO" --limit 20 --json tagName,isPrerelease \
+      --jq '[.[] | select(.isPrerelease and (.tagName | contains("canary")))][0].tagName' 2>/dev/null || true)
+
+    if [ -z "$TAG" ]; then
+      TAG=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases" \
+        | grep -o '"tag_name":"[^"]*canary[^"]*"' \
+        | head -1 \
+        | cut -d'"' -f4 || true)
+    fi
+
+    if [ -z "$TAG" ]; then
+      echo "Error: no canary release found" >&2
+      exit 1
+    fi
+  else
+    TAG=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+      | grep -o '"tag_name":"[^"]*"' \
+      | cut -d'"' -f4 || true)
+
+    if [ -z "$TAG" ]; then
+      echo "Error: no stable release found" >&2
+      exit 1
+    fi
+  fi
+
+  echo "Installing Clerk CLI ${TAG}..."
+
+  ASSET_NAME="clerk-${TARGET}${EXT}"
+  DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${TAG}/${ASSET_NAME}"
+
+  echo "Downloading ${DOWNLOAD_URL}..."
+  if ! curl -fsSL -o "${TMPDIR}/${BINARY_NAME}${EXT}" "$DOWNLOAD_URL"; then
+    echo "Error: failed to download binary for ${TARGET} from release ${TAG}" >&2
+    echo "Check that this platform is supported and the release exists." >&2
+    exit 1
+  fi
+
+  chmod +x "${TMPDIR}/${BINARY_NAME}${EXT}"
+fi
 
 # ─── Install binary ───────────────────────────────────────────────────────────
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Install script for the Clerk CLI.
+# Downloads a pre-compiled binary from GitHub Releases.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/clerk/cli/main/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/clerk/cli/main/install.sh | bash -s -- --canary
+#   curl -fsSL https://raw.githubusercontent.com/clerk/cli/main/install.sh | bash -s -- --version v0.1.0-canary.v20260313145959
+#
+# Environment variables:
+#   CLERK_INSTALL_DIR  — directory to install to (default: /usr/local/bin, or ~/.local/bin if not writable)
+
+set -euo pipefail
+
+REPO="clerk/cli"
+BINARY_NAME="clerk"
+INSTALL_DIR="${CLERK_INSTALL_DIR:-}"
+CHANNEL=""
+VERSION=""
+
+# ─── Parse arguments ───────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --canary)
+      CHANNEL="canary"
+      shift
+      ;;
+    --version)
+      VERSION="$2"
+      shift 2
+      ;;
+    --version=*)
+      VERSION="${1#--version=}"
+      shift
+      ;;
+    --install-dir)
+      INSTALL_DIR="$2"
+      shift 2
+      ;;
+    --install-dir=*)
+      INSTALL_DIR="${1#--install-dir=}"
+      shift
+      ;;
+    --help|-h)
+      echo "Install the Clerk CLI"
+      echo ""
+      echo "Usage:"
+      echo "  install.sh [options]"
+      echo ""
+      echo "Options:"
+      echo "  --canary              Install the latest canary release"
+      echo "  --version <tag>       Install a specific version (e.g. v0.1.0)"
+      echo "  --install-dir <path>  Directory to install to"
+      echo "  -h, --help            Show this help"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ─── Detect platform ──────────────────────────────────────────────────────────
+
+detect_target() {
+  local os arch libc=""
+
+  case "$(uname -s)" in
+    Darwin) os="darwin" ;;
+    Linux)  os="linux" ;;
+    MINGW*|MSYS*|CYGWIN*) os="win32" ;;
+    *)
+      echo "Error: unsupported operating system: $(uname -s)" >&2
+      exit 1
+      ;;
+  esac
+
+  case "$(uname -m)" in
+    x86_64|amd64) arch="x64" ;;
+    arm64|aarch64) arch="arm64" ;;
+    *)
+      echo "Error: unsupported architecture: $(uname -m)" >&2
+      exit 1
+      ;;
+  esac
+
+  # Detect musl on Linux
+  if [ "$os" = "linux" ]; then
+    if ldd --version 2>&1 | grep -qi musl; then
+      libc="-musl"
+    elif command -v ldd >/dev/null 2>&1; then
+      libc=""  # glibc
+    elif [ -f /etc/alpine-release ]; then
+      libc="-musl"
+    fi
+
+    # The musl binary requires libstdc++ and libgcc_s (not shipped by default on Alpine)
+    if [ "$libc" = "-musl" ] && [ -f /etc/alpine-release ]; then
+      if ! [ -f /usr/lib/libstdc++.so.6 ]; then
+        echo "Installing required dependencies (libstdc++, libgcc)..."
+        apk add --no-cache libstdc++ libgcc >/dev/null 2>&1 || \
+          echo "Warning: could not install libstdc++/libgcc — the binary may fail to run."
+      fi
+    fi
+  fi
+
+  echo "${os}-${arch}${libc}"
+}
+
+TARGET="$(detect_target)"
+EXT=""
+if [[ "$TARGET" == win32-* ]]; then
+  EXT=".exe"
+fi
+
+echo "Detected platform: ${TARGET}"
+
+# ─── Resolve version ──────────────────────────────────────────────────────────
+
+if [ -n "$VERSION" ]; then
+  # Use the explicitly provided version tag
+  TAG="$VERSION"
+  # Ensure it starts with 'v'
+  if [[ "$TAG" != v* ]]; then
+    TAG="v${TAG}"
+  fi
+elif [ "$CHANNEL" = "canary" ]; then
+  # Find the latest canary pre-release
+  TAG=$(gh release list --repo "$REPO" --limit 20 --json tagName,isPrerelease \
+    --jq '[.[] | select(.isPrerelease and (.tagName | contains("canary")))][0].tagName' 2>/dev/null || true)
+
+  if [ -z "$TAG" ]; then
+    # Fallback: use the GitHub API directly (no gh CLI required)
+    TAG=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases" \
+      | grep -o '"tag_name":"[^"]*canary[^"]*"' \
+      | head -1 \
+      | cut -d'"' -f4 || true)
+  fi
+
+  if [ -z "$TAG" ]; then
+    echo "Error: no canary release found" >&2
+    exit 1
+  fi
+else
+  # Find the latest stable release (non-prerelease)
+  TAG=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | grep -o '"tag_name":"[^"]*"' \
+    | cut -d'"' -f4 || true)
+
+  if [ -z "$TAG" ]; then
+    echo "Error: no stable release found" >&2
+    exit 1
+  fi
+fi
+
+echo "Installing Clerk CLI ${TAG}..."
+
+# ─── Download binary ──────────────────────────────────────────────────────────
+
+ASSET_NAME="clerk-${TARGET}${EXT}"
+DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${TAG}/${ASSET_NAME}"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "Downloading ${DOWNLOAD_URL}..."
+if ! curl -fsSL -o "${TMPDIR}/${BINARY_NAME}${EXT}" "$DOWNLOAD_URL"; then
+  echo "Error: failed to download binary for ${TARGET} from release ${TAG}" >&2
+  echo "Check that this platform is supported and the release exists." >&2
+  exit 1
+fi
+
+chmod +x "${TMPDIR}/${BINARY_NAME}${EXT}"
+
+# ─── Install binary ───────────────────────────────────────────────────────────
+
+if [ -z "$INSTALL_DIR" ]; then
+  if [ -w /usr/local/bin ]; then
+    INSTALL_DIR="/usr/local/bin"
+  else
+    INSTALL_DIR="${HOME}/.local/bin"
+    mkdir -p "$INSTALL_DIR"
+  fi
+fi
+
+mv "${TMPDIR}/${BINARY_NAME}${EXT}" "${INSTALL_DIR}/${BINARY_NAME}${EXT}"
+
+echo ""
+echo "Clerk CLI ${TAG} installed to ${INSTALL_DIR}/${BINARY_NAME}${EXT}"
+
+# Check if install dir is in PATH
+if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
+  echo ""
+  echo "Warning: ${INSTALL_DIR} is not in your PATH."
+  echo "Add it to your shell profile:"
+  echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+fi
+
+echo ""
+"${INSTALL_DIR}/${BINARY_NAME}${EXT}" --version

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@
 
 set -euo pipefail
 
-REPO="clerk/cli"
+REPO="clerk/cli-new"
 BINARY_NAME="clerk"
 INSTALL_DIR="${CLERK_INSTALL_DIR:-}"
 CHANNEL=""

--- a/install.sh
+++ b/install.sh
@@ -116,12 +116,27 @@ detect_target() {
       libc="-musl"
     fi
 
-    # The musl binary requires libstdc++ and libgcc_s (not shipped by default on Alpine)
-    if [ "$libc" = "-musl" ] && [ -f /etc/alpine-release ]; then
-      if ! [ -f /usr/lib/libstdc++.so.6 ]; then
-        echo "Installing required dependencies (libstdc++, libgcc)..."
-        apk add --no-cache libstdc++ libgcc >/dev/null 2>&1 || \
-          echo "Warning: could not install libstdc++/libgcc — the binary may fail to run."
+    # The musl binary dynamically links libstdc++ and libgcc_s (Bun embeds
+    # JavaScriptCore which is C++).  These are not shipped by default on
+    # Alpine and other minimal musl distros.
+    if [ "$libc" = "-musl" ]; then
+      local missing=""
+      if ! ldconfig -p 2>/dev/null | grep -q libstdc++ && ! [ -f /usr/lib/libstdc++.so.6 ]; then
+        missing="libstdc++"
+      fi
+      if ! ldconfig -p 2>/dev/null | grep -q libgcc_s && ! [ -f /usr/lib/libgcc_s.so.1 ]; then
+        missing="${missing:+$missing, }libgcc"
+      fi
+      if [ -n "$missing" ]; then
+        echo "Error: missing required shared libraries: ${missing}" >&2
+        echo "" >&2
+        echo "The Clerk CLI binary requires libstdc++ and libgcc to run." >&2
+        if [ -f /etc/alpine-release ]; then
+          echo "Install them with:  apk add libstdc++ libgcc" >&2
+        else
+          echo "Install the libstdc++ and libgcc packages for your distribution." >&2
+        fi
+        exit 1
       fi
     fi
   fi

--- a/install.sh
+++ b/install.sh
@@ -197,8 +197,7 @@ else
     fi
   elif [ "$CHANNEL" = "canary" ]; then
     TAG=$(gh release list --repo "$REPO" --limit 20 --json tagName,isPrerelease \
-      TAG=$(gh release list --repo "$REPO" --limit 20 --json tagName,isPrerelease \
-        --jq '[.[] | select(.isPrerelease and (.tagName | contains("canary")))][0].tagName // empty' 2>/dev/null || true)
+      --jq '[.[] | select(.isPrerelease and (.tagName | contains("canary")))][0].tagName // empty' 2>/dev/null || true)
 
     if [ -z "$TAG" ]; then
       TAG=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases" \

--- a/install.test.ts
+++ b/install.test.ts
@@ -1,0 +1,54 @@
+import { test, expect, describe } from "bun:test";
+
+const INSTALL_SCRIPT = "./install.sh";
+
+async function runInstall(...args: string[]) {
+  const proc = Bun.spawn(["bash", INSTALL_SCRIPT, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+  return { stdout, stderr, exitCode };
+}
+
+describe("install.sh flag validation", () => {
+  test("--version without a value exits with error", async () => {
+    const { stderr, exitCode } = await runInstall("--version");
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("--version requires a value");
+  });
+
+  test("--version followed by another flag exits with error", async () => {
+    const { stderr, exitCode } = await runInstall("--version", "--canary");
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("--version requires a value");
+  });
+
+  test("--install-dir without a value exits with error", async () => {
+    const { stderr, exitCode } = await runInstall("--install-dir");
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("--install-dir requires a value");
+  });
+
+  test("--install-dir followed by another flag exits with error", async () => {
+    const { stderr, exitCode } = await runInstall("--install-dir", "--local");
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("--install-dir requires a value");
+  });
+
+  test("--artifacts-dir without a value exits with error", async () => {
+    const { stderr, exitCode } = await runInstall("--artifacts-dir");
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("--artifacts-dir requires a value");
+  });
+
+  test("--artifacts-dir followed by another flag exits with error", async () => {
+    const { stderr, exitCode } = await runInstall("--artifacts-dir", "--canary");
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("--artifacts-dir requires a value");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `canary-publish-github` job to the release workflow that creates a GitHub pre-release and uploads all 8 platform binaries for every canary build. npm publishing (`canary-publish-npm`) runs after but is not required for the workflow to succeed.
- Adds an `install.sh` script that downloads the correct binary from GitHub Releases, with support for `--canary`, `--version`, and `--install-dir` flags. Detects OS, architecture, and musl vs glibc automatically.
- Fixes the musl smoke test by installing `libstdc++` and `libgcc` in the Alpine container, since the Bun-compiled musl binary dynamically links these.
- Updates release docs with the new canary flow diagram, install script section, and key files table.

## Test plan

- [ ] Merge and verify the canary workflow creates a GitHub pre-release with binaries attached
- [ ] Test `install.sh` on macOS and Linux (glibc + musl)
- [ ] Verify musl smoke test passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a cross-platform installer script that detects OS/arch, supports stable/canary/specific versions, local installs, and installs the CLI into a suitable bin directory.

* **Documentation**
  * Updated release docs with script-based installation instructions, install-script guidance, and revised canary release workflow details.

* **Chores**
  * Canary publishing now creates/uploads a GitHub pre-release before npm canary publishing; publish jobs and upload behavior adjusted for stable and canary flows.
  * CI smoke tests for containerized runs now install required runtime libraries before executing the binary.

* **Tests**
  * Added tests validating installer flag parsing and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->