### PR TITLE
feat(init): support CLERK_PLATFORM_API_KEY for non-interactive auth

### DIFF
--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -51,23 +51,36 @@ export async function init(options: InitOptions = {}) {
 }
 
 async function authenticateAndLink(cwd: string): Promise<void> {
+  // If Platform API key is set, skip OAuth entirely
+  const hasApiKey = Boolean(process.env.CLERK_PLATFORM_API_KEY);
+  const profile = await resolveProfile(cwd);
+
+  if (hasApiKey && profile) {
+    console.log(dim(`Using API key · Linked to ${profile.profile.appId}`));
+    return;
+  }
+
+  if (hasApiKey) {
+    await link({ skipIfLinked: true });
+    return;
+  }
+
   // Check if fully ready (authenticated + linked)
   const email = await getAuthenticatedEmail();
-  const profile = await resolveProfile(cwd);
 
   if (email && profile) {
     console.log(dim(`Logged in as ${email} · Linked to ${profile.profile.appId}`));
     return;
   }
 
-  // Authenticated but not linked — skip login, just link
+  // Authenticated but not linked
   if (email) {
     console.log(dim(`Logged in as ${email}`));
     await link({ skipIfLinked: true });
     return;
   }
 
-  // Not authenticated — full flow
+  // Not authenticated
   await login();
   await link({ skipIfLinked: true });
 }

--- a/packages/cli-core/src/commands/link/index.ts
+++ b/packages/cli-core/src/commands/link/index.ts
@@ -102,6 +102,10 @@ export async function link(options: LinkOptions = {}): Promise<void> {
 }
 
 async function ensureAuth() {
+  // CLERK_PLATFORM_API_KEY is a valid non-interactive auth mechanism.
+  // The PLAPI fetch helpers use it directly for API calls, so no OAuth
+  // token is needed when this key is present.
+  if (process.env.CLERK_PLATFORM_API_KEY) return;
   const token = await getToken();
   if (!token) {
     console.log("Not logged in. Authenticating first...");


### PR DESCRIPTION
## Summary

- Support `CLERK_PLATFORM_API_KEY` env var in `clerk init` and `clerk link` for non-interactive authentication
- When set, the CLI skips the OAuth browser flow entirely, enabling CI/CD pipelines and automated scripts
- `link` also bypasses token checks when the platform API key is present since PLAPI fetch helpers use it directly

## Test plan

- [ ] `bun run test` passes
- [ ] `bun run lint` passes
- [ ] `clerk init` works with OAuth flow (existing behavior unchanged)
- [ ] `CLERK_PLATFORM_API_KEY=<key> clerk init` skips OAuth and links via API key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now authenticate via API key environment variable during CLI setup, streamlining initialization and linking workflows without interactive login steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->