### PR TITLE
feat: Add switch-env command and environment profile support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Bun compile artifacts
 *.bun-build
+
+# Environment profiles
+.env-profiles.json

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "global:link": "bun link --cwd packages/cli-core",
     "global:unlink": "bun unlink --cwd packages/cli-core",
     "start": "bun run build:compile && ./packages/cli-core/dist/clerk",
-    "prepare": "git config core.hooksPath .hooks"
+    "prepare": "git config core.hooksPath .hooks",
+    "load-env-profiles": "bun run scripts/load-env-profiles.ts"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.4",

--- a/packages/cli-core/src/cli-program.ts
+++ b/packages/cli-core/src/cli-program.ts
@@ -13,14 +13,10 @@ import { api } from "./commands/api/index.ts";
 import { link } from "./commands/link/index.ts";
 import { unlink } from "./commands/unlink/index.ts";
 import { doctor } from "./commands/doctor/index.ts";
-import {
-  CliError,
-  UserAbortError,
-  ApiError,
-  EXIT_CODE,
-  throwUsageError,
-  type ErrorCode,
-} from "./lib/errors.ts";
+import { switchEnv } from "./commands/switch-env/index.ts";
+import { getEnvironment } from "./lib/config.ts";
+import { setCurrentEnv, isValidEnv, getCurrentEnvName } from "./lib/environment.ts";
+import { CliError, UserAbortError, ApiError, EXIT_CODE, throwUsageError } from "./lib/errors.ts";
 import { red } from "./lib/color.ts";
 import { isAgent } from "./mode.ts";
 
@@ -35,13 +31,26 @@ export function createProgram() {
     )
     .option("--verbose", "Show detailed error output");
 
-  program.hook("preAction", () => {
+  program.hook("preAction", async () => {
     const opts = program.opts();
     if (opts.mode) {
       if (opts.mode !== "human" && opts.mode !== "agent") {
         throwUsageError(`Invalid mode "${opts.mode}". Must be "human" or "agent".`);
       }
       setMode(opts.mode as Mode);
+    }
+
+    // Initialize the active environment from persisted config
+    const envName = await getEnvironment();
+    if (envName && isValidEnv(envName)) {
+      setCurrentEnv(envName);
+    }
+
+    // Print environment banner to stderr when not on production,
+    // so it doesn't pollute stdout for piped commands.
+    const activeEnv = getCurrentEnvName();
+    if (activeEnv !== "production") {
+      process.stderr.write(`[${activeEnv.toUpperCase()}]\n`);
     }
   });
 
@@ -314,6 +323,20 @@ Examples:
   $ clerk doctor --spotlight         Only show warnings and failures`,
     )
     .action(doctor);
+
+  program
+    .command("switch-env")
+    .description("Switch the active Clerk CLI environment")
+    .argument("[environment]", "Environment to switch to (e.g. production, staging)")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  $ clerk switch-env                   Show current environment
+  $ clerk switch-env staging           Switch to staging
+  $ clerk switch-env production        Switch back to production`,
+    )
+    .action(switchEnv);
 
   program
     .command("deploy", { hidden: true })

--- a/packages/cli-core/src/commands/api/bapi.test.ts
+++ b/packages/cli-core/src/commands/api/bapi.test.ts
@@ -1,13 +1,23 @@
-import { test, expect, describe, afterEach } from "bun:test";
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
 import { stubFetch } from "../../test/stubs.ts";
 import { bapiRequest } from "./bapi.ts";
 import { BapiError } from "../../lib/errors.ts";
 
 describe("bapi", () => {
   const originalFetch = globalThis.fetch;
+  const originalBapiUrl = process.env.CLERK_BACKEND_API_URL;
+
+  beforeEach(() => {
+    process.env.CLERK_BACKEND_API_URL = "https://api.clerk.dev";
+  });
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    if (originalBapiUrl === undefined) {
+      delete process.env.CLERK_BACKEND_API_URL;
+    } else {
+      process.env.CLERK_BACKEND_API_URL = originalBapiUrl;
+    }
   });
 
   test("constructs correct URL with /v1/ prefix", async () => {

--- a/packages/cli-core/src/commands/api/bapi.ts
+++ b/packages/cli-core/src/commands/api/bapi.ts
@@ -3,7 +3,7 @@
  * Thin HTTP wrapper for Clerk's Backend API endpoints.
  */
 
-import { BAPI_BASE_URL } from "../../lib/constants.ts";
+import { getBapiBaseUrl } from "../../lib/constants.ts";
 import { BapiError } from "../../lib/errors.ts";
 
 export interface BapiResponse {
@@ -20,7 +20,7 @@ export async function bapiRequest(options: {
   body?: string;
   baseUrl?: string;
 }): Promise<BapiResponse> {
-  const base = options.baseUrl ?? BAPI_BASE_URL;
+  const base = options.baseUrl ?? getBapiBaseUrl();
 
   // Normalize: ensure path starts with /v1/ if not already versioned
   let path = options.path;

--- a/packages/cli-core/src/commands/api/bapi.ts
+++ b/packages/cli-core/src/commands/api/bapi.ts
@@ -3,7 +3,7 @@
  * Thin HTTP wrapper for Clerk's Backend API endpoints.
  */
 
-import { getBapiBaseUrl } from "../../lib/constants.ts";
+import { getBapiBaseUrl } from "../../lib/environment.ts";
 import { BapiError } from "../../lib/errors.ts";
 
 export interface BapiResponse {

--- a/packages/cli-core/src/commands/api/index.ts
+++ b/packages/cli-core/src/commands/api/index.ts
@@ -1,6 +1,6 @@
 import { resolveAppContext } from "../../lib/config.ts";
 import { fetchApplication, getAuthToken, validateKeyPrefix } from "../../lib/plapi.ts";
-import { BAPI_BASE_URL, PLAPI_BASE_URL } from "../../lib/constants.ts";
+import { getBapiBaseUrl, getPlapiBaseUrl } from "../../lib/constants.ts";
 import { bapiRequest } from "./bapi.ts";
 import {
   BapiError,
@@ -57,10 +57,10 @@ export async function api(
 
   if (options.platform) {
     secretKey = await getAuthToken();
-    baseUrl = PLAPI_BASE_URL;
+    baseUrl = getPlapiBaseUrl();
   } else {
     secretKey = await resolveSecretKey(options);
-    baseUrl = BAPI_BASE_URL;
+    baseUrl = getBapiBaseUrl();
   }
 
   // 4. Dry run

--- a/packages/cli-core/src/commands/api/index.ts
+++ b/packages/cli-core/src/commands/api/index.ts
@@ -1,6 +1,6 @@
 import { resolveAppContext } from "../../lib/config.ts";
 import { fetchApplication, getAuthToken, validateKeyPrefix } from "../../lib/plapi.ts";
-import { getBapiBaseUrl, getPlapiBaseUrl } from "../../lib/constants.ts";
+import { getBapiBaseUrl, getPlapiBaseUrl } from "../../lib/environment.ts";
 import { bapiRequest } from "./bapi.ts";
 import {
   BapiError,

--- a/packages/cli-core/src/commands/auth/login.test.ts
+++ b/packages/cli-core/src/commands/auth/login.test.ts
@@ -26,7 +26,7 @@ mock.module("../../lib/token-exchange.ts", () => ({
   fetchUserInfo: (...args: unknown[]) => mockFetchUserInfo(...args),
 }));
 
-mock.module("../../lib/constants.ts", () => ({
+mock.module("../../lib/environment.ts", () => ({
   getOAuthConfig: () => ({
     clientId: "test-client-id",
     scopes: "profile email",
@@ -34,6 +34,9 @@ mock.module("../../lib/constants.ts", () => ({
     tokenUrl: "https://test.example.com/oauth/token",
     userinfoUrl: "https://test.example.com/oauth/userinfo",
   }),
+}));
+
+mock.module("../../lib/constants.ts", () => ({
   CALLBACK_PATH: "/callback",
   AUTH_TIMEOUT_MS: 120000,
 }));

--- a/packages/cli-core/src/commands/auth/login.test.ts
+++ b/packages/cli-core/src/commands/auth/login.test.ts
@@ -24,13 +24,18 @@ mock.module("../../lib/config.ts", () => ({
 mock.module("../../lib/token-exchange.ts", () => ({
   exchangeCodeForToken: (...args: unknown[]) => mockExchangeCodeForToken(...args),
   fetchUserInfo: (...args: unknown[]) => mockFetchUserInfo(...args),
-  OAUTH_CONFIG: {
+}));
+
+mock.module("../../lib/constants.ts", () => ({
+  getOAuthConfig: () => ({
     clientId: "test-client-id",
     scopes: "profile email",
     authorizeUrl: "https://test.example.com/oauth/authorize",
     tokenUrl: "https://test.example.com/oauth/token",
     userinfoUrl: "https://test.example.com/oauth/userinfo",
-  },
+  }),
+  CALLBACK_PATH: "/callback",
+  AUTH_TIMEOUT_MS: 120000,
 }));
 
 mock.module("../../lib/pkce.ts", () => ({

--- a/packages/cli-core/src/commands/auth/login.ts
+++ b/packages/cli-core/src/commands/auth/login.ts
@@ -1,6 +1,7 @@
 import { generateCodeVerifier, generateCodeChallenge, generateState } from "../../lib/pkce.ts";
 import { startAuthServer } from "../../lib/auth-server.ts";
-import { OAUTH_CONFIG, exchangeCodeForToken, fetchUserInfo } from "../../lib/token-exchange.ts";
+import { exchangeCodeForToken, fetchUserInfo } from "../../lib/token-exchange.ts";
+import { getOAuthConfig } from "../../lib/constants.ts";
 import { storeToken, getToken } from "../../lib/credential-store.ts";
 import { getAuth, setAuth } from "../../lib/config.ts";
 import { AUTH_TIMEOUT_MS, CALLBACK_PATH } from "../../lib/constants.ts";
@@ -32,11 +33,12 @@ export async function login(): Promise<{ userId: string; email: string }> {
   const redirectUri = `http://127.0.0.1:${authServer.port}${CALLBACK_PATH}`;
 
   // Build authorization URL
-  const authorizeUrl = new URL(OAUTH_CONFIG.authorizeUrl);
-  authorizeUrl.searchParams.set("client_id", OAUTH_CONFIG.clientId);
+  const oauth = getOAuthConfig();
+  const authorizeUrl = new URL(oauth.authorizeUrl);
+  authorizeUrl.searchParams.set("client_id", oauth.clientId);
   authorizeUrl.searchParams.set("redirect_uri", redirectUri);
   authorizeUrl.searchParams.set("response_type", "code");
-  authorizeUrl.searchParams.set("scope", OAUTH_CONFIG.scopes);
+  authorizeUrl.searchParams.set("scope", oauth.scopes);
   authorizeUrl.searchParams.set("state", state);
   authorizeUrl.searchParams.set("code_challenge", codeChallenge);
   authorizeUrl.searchParams.set("code_challenge_method", "S256");

--- a/packages/cli-core/src/commands/auth/login.ts
+++ b/packages/cli-core/src/commands/auth/login.ts
@@ -1,7 +1,7 @@
 import { generateCodeVerifier, generateCodeChallenge, generateState } from "../../lib/pkce.ts";
 import { startAuthServer } from "../../lib/auth-server.ts";
 import { exchangeCodeForToken, fetchUserInfo } from "../../lib/token-exchange.ts";
-import { getOAuthConfig } from "../../lib/constants.ts";
+import { getOAuthConfig } from "../../lib/environment.ts";
 import { storeToken, getToken } from "../../lib/credential-store.ts";
 import { getAuth, setAuth } from "../../lib/config.ts";
 import { AUTH_TIMEOUT_MS, CALLBACK_PATH } from "../../lib/constants.ts";

--- a/packages/cli-core/src/commands/switch-env/README.md
+++ b/packages/cli-core/src/commands/switch-env/README.md
@@ -1,0 +1,31 @@
+# switch-env
+
+> **Internal command.** This command is intended for Clerk engineers and is not exposed to external users.
+
+Switch the active Clerk CLI environment (e.g. `production`, `staging`).
+
+The selected environment determines which Clerk infrastructure the CLI communicates with — OAuth endpoints, Platform API, and Backend API. Auth tokens are stored per-environment, so switching back does not require re-authentication.
+
+## Usage
+
+```sh
+# Show current environment and available options
+clerk switch-env
+
+# Switch to staging
+clerk switch-env staging
+
+# Switch back to production
+clerk switch-env production
+```
+
+## Behavior
+
+- Validates the environment name against the set of available profiles (injected at build time via `CLI_ENV_PROFILES`).
+- Persists the selection in `~/.clerk/config.json` under the `environment` key.
+- All subsequent commands use the selected environment's API endpoints and OAuth client.
+- If no auth token exists for the target environment, prints a reminder to run `clerk auth login`.
+
+## API endpoints
+
+This command does not make any API calls. It only reads and writes the local config file.

--- a/packages/cli-core/src/commands/switch-env/index.test.ts
+++ b/packages/cli-core/src/commands/switch-env/index.test.ts
@@ -1,0 +1,98 @@
+import { test, expect, describe, afterEach, mock, spyOn } from "bun:test";
+import { configStubs, credentialStoreStubs } from "../../test/stubs.ts";
+
+const mockSetEnvironment = mock();
+const mockGetToken = mock();
+let mockCurrentEnv = "production";
+
+mock.module("../../lib/config.ts", () => ({
+  ...configStubs,
+  setEnvironment: (...args: unknown[]) => mockSetEnvironment(...args),
+}));
+
+mock.module("../../lib/credential-store.ts", () => ({
+  ...credentialStoreStubs,
+  getToken: (...args: unknown[]) => mockGetToken(...args),
+}));
+
+const MOCK_ENVS = ["production", "staging"];
+
+mock.module("../../lib/environment.ts", () => ({
+  getCurrentEnvName: () => mockCurrentEnv,
+  getAvailableEnvs: () => MOCK_ENVS,
+  isValidEnv: (name: string) => MOCK_ENVS.includes(name),
+  setCurrentEnv: (name: string) => {
+    mockCurrentEnv = name;
+  },
+}));
+
+const { switchEnv } = await import("./index.ts");
+
+describe("switch-env", () => {
+  let logSpy: ReturnType<typeof spyOn>;
+
+  afterEach(() => {
+    mockSetEnvironment.mockReset();
+    mockGetToken.mockReset();
+    mockCurrentEnv = "production";
+    logSpy?.mockRestore();
+  });
+
+  test("prints current environment when no argument given", async () => {
+    logSpy = spyOn(console, "log").mockImplementation(() => {});
+    await switchEnv(undefined);
+
+    expect(logSpy).toHaveBeenCalledWith("Current environment: production");
+    expect(logSpy).toHaveBeenCalledWith("Available environments: production, staging");
+  });
+
+  test("switches to a valid environment", async () => {
+    mockSetEnvironment.mockResolvedValue(undefined);
+    mockGetToken.mockResolvedValue("some-token");
+
+    logSpy = spyOn(console, "log").mockImplementation(() => {});
+    await switchEnv("staging");
+
+    expect(mockCurrentEnv).toBe("staging");
+    expect(mockSetEnvironment).toHaveBeenCalledWith("staging");
+    expect(logSpy).toHaveBeenCalledWith("Switched from production to staging.");
+  });
+
+  test("reports already on environment when switching to current", async () => {
+    mockSetEnvironment.mockResolvedValue(undefined);
+    mockGetToken.mockResolvedValue("some-token");
+
+    logSpy = spyOn(console, "log").mockImplementation(() => {});
+    await switchEnv("production");
+
+    expect(logSpy).toHaveBeenCalledWith("Already on production environment.");
+  });
+
+  test("throws on invalid environment", async () => {
+    await expect(switchEnv("nonexistent")).rejects.toThrow(
+      'Unknown environment "nonexistent". Available environments: production, staging',
+    );
+  });
+
+  test("warns about missing credentials after switching", async () => {
+    mockSetEnvironment.mockResolvedValue(undefined);
+    mockGetToken.mockResolvedValue(null);
+
+    logSpy = spyOn(console, "log").mockImplementation(() => {});
+    await switchEnv("staging");
+
+    expect(logSpy).toHaveBeenCalledWith(
+      "No credentials found for staging. Run `clerk auth login` to authenticate.",
+    );
+  });
+
+  test("does not warn about credentials when token exists", async () => {
+    mockSetEnvironment.mockResolvedValue(undefined);
+    mockGetToken.mockResolvedValue("valid-token");
+
+    logSpy = spyOn(console, "log").mockImplementation(() => {});
+    await switchEnv("staging");
+
+    expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining("No credentials found"));
+  });
+});

--- a/packages/cli-core/src/commands/switch-env/index.ts
+++ b/packages/cli-core/src/commands/switch-env/index.ts
@@ -36,14 +36,14 @@ export async function switchEnv(environment: string | undefined): Promise<void> 
 
   const previousEnv = getCurrentEnvName();
 
-  // Update the in-memory state and persist
-  setCurrentEnv(environment);
-  await setEnvironment(environment);
-
   if (previousEnv === environment) {
     console.log(`Already on ${environment} environment.`);
     return;
   }
+
+  // Update the in-memory state and persist
+  setCurrentEnv(environment);
+  await setEnvironment(environment);
 
   console.log(`Switched from ${previousEnv} to ${environment}.`);
 

--- a/packages/cli-core/src/commands/switch-env/index.ts
+++ b/packages/cli-core/src/commands/switch-env/index.ts
@@ -1,0 +1,57 @@
+/**
+ * Switch the active Clerk CLI environment (e.g. production, staging).
+ *
+ * Persists the choice in ~/.clerk/config.json so all subsequent commands
+ * use the selected environment's API endpoints and OAuth credentials.
+ * Auth tokens are stored per-environment, so switching back does not
+ * require re-authentication.
+ */
+
+import { setEnvironment } from "../../lib/config.ts";
+import { getToken } from "../../lib/credential-store.ts";
+import {
+  getCurrentEnvName,
+  getAvailableEnvs,
+  isValidEnv,
+  setCurrentEnv,
+} from "../../lib/environment.ts";
+import { CliError } from "../../lib/errors.ts";
+
+export async function switchEnv(environment: string | undefined): Promise<void> {
+  const available = getAvailableEnvs();
+
+  // No argument: print current environment
+  if (!environment) {
+    const current = getCurrentEnvName();
+    console.log(`Current environment: ${current}`);
+    console.log(`Available environments: ${available.join(", ")}`);
+    return;
+  }
+
+  if (!isValidEnv(environment)) {
+    throw new CliError(
+      `Unknown environment "${environment}". Available environments: ${available.join(", ")}`,
+    );
+  }
+
+  const previousEnv = getCurrentEnvName();
+
+  // Update the in-memory state and persist
+  setCurrentEnv(environment);
+  await setEnvironment(environment);
+
+  if (previousEnv === environment) {
+    console.log(`Already on ${environment} environment.`);
+    return;
+  }
+
+  console.log(`Switched from ${previousEnv} to ${environment}.`);
+
+  // Check if there's a stored token for the target environment
+  const token = await getToken();
+  if (!token) {
+    console.log(
+      `No credentials found for ${environment}. Run \`clerk auth login\` to authenticate.`,
+    );
+  }
+}

--- a/packages/cli-core/src/globals.d.ts
+++ b/packages/cli-core/src/globals.d.ts
@@ -1,1 +1,13 @@
 declare const CLI_VERSION: string | undefined;
+
+declare const CLI_ENV_PROFILES:
+  | Record<
+      string,
+      {
+        oauthClientId: string;
+        oauthBaseUrl: string;
+        platformApiUrl: string;
+        backendApiUrl: string;
+      }
+    >
+  | undefined;

--- a/packages/cli-core/src/lib/config.test.ts
+++ b/packages/cli-core/src/lib/config.test.ts
@@ -37,7 +37,7 @@ describe("config", () => {
 
   test("writeConfig and readConfig roundtrip", async () => {
     const config = {
-      auth: { userId: "user_123" },
+      auth: { production: { userId: "user_123" } },
       profiles: {
         "/path/to/project": {
           workspaceId: "org_abc",
@@ -48,7 +48,19 @@ describe("config", () => {
     };
     await writeConfig(config);
     const result = await readConfig();
-    expect(result).toEqual(config);
+    expect(result.auth).toEqual(config.auth);
+    expect(result.profiles).toEqual(config.profiles);
+  });
+
+  test("readConfig migrates legacy auth format", async () => {
+    // Write old-format config directly
+    const legacyConfig = {
+      auth: { userId: "user_legacy" },
+      profiles: {},
+    };
+    await Bun.write(`${tempDir}/config.json`, JSON.stringify(legacyConfig));
+    const result = await readConfig();
+    expect(result.auth).toEqual({ production: { userId: "user_legacy" } });
   });
 
   test("setAuth and getAuth", async () => {

--- a/packages/cli-core/src/lib/config.ts
+++ b/packages/cli-core/src/lib/config.ts
@@ -1,11 +1,12 @@
 /**
  * Config file management for the Clerk CLI config file.
- * Stores auth identity and path-keyed project profiles.
+ * Stores auth identity (per environment) and path-keyed project profiles.
  */
 
 import { dirname, join } from "node:path";
 import { mkdir } from "node:fs/promises";
 import { CONFIG_FILE } from "./constants.ts";
+import { getCurrentEnvName } from "./environment.ts";
 import { getGitRepoIdentifier, getGitNormalizedRemote } from "./git.ts";
 import { CliError, ERROR_CODE } from "./errors.ts";
 
@@ -34,7 +35,8 @@ interface Profile {
 }
 
 interface ClerkConfig {
-  auth?: Auth;
+  environment?: string;
+  auth?: Record<string, Auth>;
   profiles: Record<string, Profile>;
 }
 
@@ -42,11 +44,35 @@ function defaultConfig(): ClerkConfig {
   return { profiles: {} };
 }
 
+/**
+ * Migrate legacy config format where `auth` was a bare `{ userId }` object
+ * into the new per-environment format `{ [envName]: { userId } }`.
+ */
+function migrateRawConfig(raw: Record<string, unknown>): ClerkConfig {
+  const config: ClerkConfig = {
+    environment: raw.environment as string | undefined,
+    profiles: (raw.profiles as Record<string, Profile>) ?? {},
+  };
+
+  if (raw.auth && typeof raw.auth === "object") {
+    const auth = raw.auth as Record<string, unknown>;
+    if (typeof auth.userId === "string") {
+      // Old format: bare Auth object → assign to production
+      config.auth = { production: { userId: auth.userId } };
+    } else {
+      config.auth = auth as Record<string, Auth>;
+    }
+  }
+
+  return config;
+}
+
 export async function readConfig(): Promise<ClerkConfig> {
   const file = Bun.file(configFile());
   if (!(await file.exists())) return defaultConfig();
   try {
-    return (await file.json()) as ClerkConfig;
+    const raw = (await file.json()) as Record<string, unknown>;
+    return migrateRawConfig(raw);
   } catch {
     return defaultConfig();
   }
@@ -59,18 +85,36 @@ export async function writeConfig(config: ClerkConfig): Promise<void> {
 
 export async function getAuth(): Promise<Auth | undefined> {
   const config = await readConfig();
-  return config.auth;
+  const envName = getCurrentEnvName();
+  return config.auth?.[envName];
 }
 
 export async function setAuth(auth: Auth): Promise<void> {
   const config = await readConfig();
-  config.auth = auth;
+  if (!config.auth) config.auth = {};
+  config.auth[getCurrentEnvName()] = auth;
   await writeConfig(config);
 }
 
 export async function clearAuth(): Promise<void> {
   const config = await readConfig();
-  delete config.auth;
+  if (config.auth) {
+    delete config.auth[getCurrentEnvName()];
+    if (Object.keys(config.auth).length === 0) {
+      delete config.auth;
+    }
+  }
+  await writeConfig(config);
+}
+
+export async function getEnvironment(): Promise<string | undefined> {
+  const config = await readConfig();
+  return config.environment;
+}
+
+export async function setEnvironment(envName: string): Promise<void> {
+  const config = await readConfig();
+  config.environment = envName;
   await writeConfig(config);
 }
 

--- a/packages/cli-core/src/lib/constants.ts
+++ b/packages/cli-core/src/lib/constants.ts
@@ -1,10 +1,15 @@
 /**
  * Shared constants for the Clerk CLI.
  * Centralizes configuration values that are used across multiple modules.
+ *
+ * Environment-dependent values (OAuth, API URLs) are resolved via functions
+ * so they reflect the active environment set by `clerk switch-env`.
+ * Process env vars always take highest priority for per-value overrides.
  */
 
 import { join } from "node:path";
 import envPaths from "env-paths";
+import { getCurrentEnv } from "./environment.ts";
 
 // ── File paths ──────────────────────────────────────────────────────────────
 
@@ -16,15 +21,17 @@ export const CREDENTIALS_FILE = join(clerkConfigDir ?? paths.data, "credentials"
 
 // ── OAuth ───────────────────────────────────────────────────────────────────
 
-const OAUTH_BASE_URL = process.env.CLERK_OAUTH_BASE_URL ?? "https://clerk.clerk.com";
-
-export const OAUTH = {
-  clientId: process.env.CLERK_OAUTH_CLIENT_ID ?? "ins_1lyWDZiobr600AKUeQDoSlrEmoM",
-  scopes: process.env.CLERK_OAUTH_SCOPES ?? "profile email",
-  authorizeUrl: new URL("/oauth/authorize", OAUTH_BASE_URL).href,
-  tokenUrl: new URL("/oauth/token", OAUTH_BASE_URL).href,
-  userinfoUrl: new URL("/oauth/userinfo", OAUTH_BASE_URL).href,
-} as const;
+export function getOAuthConfig() {
+  const env = getCurrentEnv();
+  const baseUrl = process.env.CLERK_OAUTH_BASE_URL ?? env.oauthBaseUrl;
+  return {
+    clientId: process.env.CLERK_OAUTH_CLIENT_ID ?? env.oauthClientId,
+    scopes: process.env.CLERK_OAUTH_SCOPES ?? "profile email",
+    authorizeUrl: new URL("/oauth/authorize", baseUrl).href,
+    tokenUrl: new URL("/oauth/token", baseUrl).href,
+    userinfoUrl: new URL("/oauth/userinfo", baseUrl).href,
+  };
+}
 
 // ── Auth server ─────────────────────────────────────────────────────────────
 
@@ -33,11 +40,15 @@ export const AUTH_TIMEOUT_MS = Number(process.env.CLERK_AUTH_TIMEOUT_MS) || 2 * 
 
 // ── Platform API ────────────────────────────────────────────────────────────
 
-export const PLAPI_BASE_URL = process.env.CLERK_PLATFORM_API_URL ?? "https://api.clerk.com";
+export function getPlapiBaseUrl(): string {
+  return process.env.CLERK_PLATFORM_API_URL ?? getCurrentEnv().platformApiUrl;
+}
 
 // ── Backend API ────────────────────────────────────────────────────────────
 
-export const BAPI_BASE_URL = process.env.CLERK_BACKEND_API_URL ?? "https://api.clerk.dev";
+export function getBapiBaseUrl(): string {
+  return process.env.CLERK_BACKEND_API_URL ?? getCurrentEnv().backendApiUrl;
+}
 
 // ── OpenAPI Spec ──────────────────────────────────────────────────────────
 

--- a/packages/cli-core/src/lib/constants.ts
+++ b/packages/cli-core/src/lib/constants.ts
@@ -9,8 +9,6 @@
 
 import { join } from "node:path";
 import envPaths from "env-paths";
-import { getCurrentEnv } from "./environment.ts";
-
 // ── File paths ──────────────────────────────────────────────────────────────
 
 const clerkConfigDir = process.env.CLERK_CONFIG_DIR;
@@ -19,36 +17,10 @@ const paths = envPaths("clerk-cli", { suffix: false });
 export const CONFIG_FILE = join(clerkConfigDir ?? paths.config, "config.json");
 export const CREDENTIALS_FILE = join(clerkConfigDir ?? paths.data, "credentials");
 
-// ── OAuth ───────────────────────────────────────────────────────────────────
-
-export function getOAuthConfig() {
-  const env = getCurrentEnv();
-  const baseUrl = process.env.CLERK_OAUTH_BASE_URL ?? env.oauthBaseUrl;
-  return {
-    clientId: process.env.CLERK_OAUTH_CLIENT_ID ?? env.oauthClientId,
-    scopes: process.env.CLERK_OAUTH_SCOPES ?? "profile email",
-    authorizeUrl: new URL("/oauth/authorize", baseUrl).href,
-    tokenUrl: new URL("/oauth/token", baseUrl).href,
-    userinfoUrl: new URL("/oauth/userinfo", baseUrl).href,
-  };
-}
-
 // ── Auth server ─────────────────────────────────────────────────────────────
 
 export const CALLBACK_PATH = "/callback";
 export const AUTH_TIMEOUT_MS = Number(process.env.CLERK_AUTH_TIMEOUT_MS) || 2 * 60 * 1000;
-
-// ── Platform API ────────────────────────────────────────────────────────────
-
-export function getPlapiBaseUrl(): string {
-  return process.env.CLERK_PLATFORM_API_URL ?? getCurrentEnv().platformApiUrl;
-}
-
-// ── Backend API ────────────────────────────────────────────────────────────
-
-export function getBapiBaseUrl(): string {
-  return process.env.CLERK_BACKEND_API_URL ?? getCurrentEnv().backendApiUrl;
-}
 
 // ── OpenAPI Spec ──────────────────────────────────────────────────────────
 

--- a/packages/cli-core/src/lib/credential-store.ts
+++ b/packages/cli-core/src/lib/credential-store.ts
@@ -1,14 +1,31 @@
 /**
  * Credential store for persisting the OAuth access token.
  * Uses platform keyring as primary (via @napi-rs/keyring), falls back to a plaintext file with chmod 600.
+ *
+ * Tokens are stored per-environment so switching environments preserves auth state.
+ * Keychain account: "oauth-access-token:<envName>"
+ * File fallback: "credentials.<envName>"
  */
 
 import { dirname } from "node:path";
 import { mkdir, chmod, unlink } from "node:fs/promises";
 import { CREDENTIALS_FILE } from "./constants.ts";
+import { getCurrentEnvName } from "./environment.ts";
 
 export const KEYCHAIN_SERVICE = "clerk-cli";
 export const KEYCHAIN_ACCOUNT = "oauth-access-token";
+
+function keychainAccount(): string {
+  const envName = getCurrentEnvName();
+  if (envName === "production") return KEYCHAIN_ACCOUNT;
+  return `${KEYCHAIN_ACCOUNT}:${envName}`;
+}
+
+function credentialsFile(): string {
+  const envName = getCurrentEnvName();
+  if (envName === "production") return CREDENTIALS_FILE;
+  return `${CREDENTIALS_FILE}.${envName}`;
+}
 
 let keyringModule: typeof import("@napi-rs/keyring") | null | undefined;
 
@@ -27,7 +44,7 @@ async function keyringStore(token: string): Promise<boolean> {
   const mod = await getKeyring();
   if (!mod) return false;
   try {
-    const entry = new mod.Entry(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT);
+    const entry = new mod.Entry(KEYCHAIN_SERVICE, keychainAccount());
     entry.setPassword(token);
     return true;
   } catch {
@@ -39,7 +56,7 @@ async function keyringGet(): Promise<string | null> {
   const mod = await getKeyring();
   if (!mod) return null;
   try {
-    const entry = new mod.Entry(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT);
+    const entry = new mod.Entry(KEYCHAIN_SERVICE, keychainAccount());
     return entry.getPassword();
   } catch {
     return null;
@@ -50,7 +67,7 @@ async function keyringDelete(): Promise<boolean> {
   const mod = await getKeyring();
   if (!mod) return false;
   try {
-    const entry = new mod.Entry(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT);
+    const entry = new mod.Entry(KEYCHAIN_SERVICE, keychainAccount());
     entry.deletePassword();
     return true;
   } catch {
@@ -59,13 +76,14 @@ async function keyringDelete(): Promise<boolean> {
 }
 
 async function fileStore(token: string): Promise<void> {
-  await mkdir(dirname(CREDENTIALS_FILE), { recursive: true });
-  await Bun.write(CREDENTIALS_FILE, token);
-  await chmod(CREDENTIALS_FILE, 0o600);
+  const file = credentialsFile();
+  await mkdir(dirname(file), { recursive: true });
+  await Bun.write(file, token);
+  await chmod(file, 0o600);
 }
 
 async function fileGet(): Promise<string | null> {
-  const file = Bun.file(CREDENTIALS_FILE);
+  const file = Bun.file(credentialsFile());
   if (!(await file.exists())) return null;
   const content = await file.text();
   return content.trim() || null;
@@ -73,7 +91,7 @@ async function fileGet(): Promise<string | null> {
 
 async function fileDelete(): Promise<void> {
   try {
-    await unlink(CREDENTIALS_FILE);
+    await unlink(credentialsFile());
   } catch {
     // File doesn't exist, nothing to delete
   }
@@ -99,8 +117,10 @@ export function _setTokenOverride(value: string | null | undefined): void {
 
 export async function getToken(): Promise<string | null> {
   if (tokenOverride !== undefined) return tokenOverride;
+
   const token = await keyringGet();
   if (token) return token;
+
   return fileGet();
 }
 

--- a/packages/cli-core/src/lib/environment.ts
+++ b/packages/cli-core/src/lib/environment.ts
@@ -88,3 +88,25 @@ export function getAvailableEnvs(): string[] {
 export function isValidEnv(name: string): boolean {
   return name in getProfiles();
 }
+
+// ── Derived config from the active environment profile ──────────────────────
+
+export function getOAuthConfig() {
+  const env = getCurrentEnv();
+  const baseUrl = process.env.CLERK_OAUTH_BASE_URL ?? env.oauthBaseUrl;
+  return {
+    clientId: process.env.CLERK_OAUTH_CLIENT_ID ?? env.oauthClientId,
+    scopes: process.env.CLERK_OAUTH_SCOPES ?? "profile email",
+    authorizeUrl: new URL("/oauth/authorize", baseUrl).href,
+    tokenUrl: new URL("/oauth/token", baseUrl).href,
+    userinfoUrl: new URL("/oauth/userinfo", baseUrl).href,
+  };
+}
+
+export function getPlapiBaseUrl(): string {
+  return process.env.CLERK_PLATFORM_API_URL ?? getCurrentEnv().platformApiUrl;
+}
+
+export function getBapiBaseUrl(): string {
+  return process.env.CLERK_BACKEND_API_URL ?? getCurrentEnv().backendApiUrl;
+}

--- a/packages/cli-core/src/lib/environment.ts
+++ b/packages/cli-core/src/lib/environment.ts
@@ -1,0 +1,90 @@
+/**
+ * Environment profile management for the Clerk CLI.
+ *
+ * Supports switching between Clerk infrastructure environments (e.g. production, staging).
+ * Environment profiles are injected at build time via CLI_ENV_PROFILES and contain
+ * the OAuth client ID, OAuth base URL, Platform API URL, and Backend API URL for each env.
+ *
+ * During local development (when CLI_ENV_PROFILES is not defined), profiles are loaded
+ * from .env-profiles.json at the repo root, falling back to hardcoded defaults.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface EnvProfileConfig {
+  oauthClientId: string;
+  oauthBaseUrl: string;
+  platformApiUrl: string;
+  backendApiUrl: string;
+}
+
+const DEFAULT_PROFILES: Record<string, EnvProfileConfig> = {
+  production: {
+    oauthClientId: "ins_1lyWDZiobr600AKUeQDoSlrEmoM",
+    oauthBaseUrl: "https://clerk.clerk.com",
+    platformApiUrl: "https://api.clerk.com",
+    backendApiUrl: "https://api.clerk.dev",
+  },
+};
+
+function loadFileProfiles(): Record<string, EnvProfileConfig> | undefined {
+  // Try repo root (cwd) first, then fall back to path relative to this source file
+  const candidates = [
+    join(process.cwd(), ".env-profiles.json"),
+    join(import.meta.dir, "..", "..", "..", "..", ".env-profiles.json"),
+  ];
+  for (const path of candidates) {
+    try {
+      const content = readFileSync(path, "utf-8");
+      return JSON.parse(content);
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
+
+function getProfiles(): Record<string, EnvProfileConfig> {
+  if (typeof CLI_ENV_PROFILES !== "undefined" && CLI_ENV_PROFILES) {
+    return CLI_ENV_PROFILES;
+  }
+  return loadFileProfiles() ?? DEFAULT_PROFILES;
+}
+
+let currentEnvName: string | undefined;
+
+/**
+ * Set the active environment. Called during CLI initialization from config,
+ * or by the switch-env command.
+ */
+export function setCurrentEnv(name: string): void {
+  const profiles = getProfiles();
+  if (!profiles[name]) {
+    const available = Object.keys(profiles).join(", ");
+    throw new Error(`Unknown environment "${name}". Available environments: ${available}`);
+  }
+  currentEnvName = name;
+}
+
+/** Get the name of the active environment. Defaults to "production". */
+export function getCurrentEnvName(): string {
+  return currentEnvName ?? "production";
+}
+
+/** Get the profile config for the active environment. */
+export function getCurrentEnv(): EnvProfileConfig {
+  const name = getCurrentEnvName();
+  const profiles = getProfiles();
+  return profiles[name] ?? profiles.production!;
+}
+
+/** List all available environment names. */
+export function getAvailableEnvs(): string[] {
+  return Object.keys(getProfiles());
+}
+
+/** Check if an environment name is valid. */
+export function isValidEnv(name: string): boolean {
+  return name in getProfiles();
+}

--- a/packages/cli-core/src/lib/plapi.ts
+++ b/packages/cli-core/src/lib/plapi.ts
@@ -3,7 +3,7 @@
  * Thin HTTP wrapper for Clerk's Platform API endpoints.
  */
 
-import { PLAPI_BASE_URL } from "./constants.ts";
+import { getPlapiBaseUrl } from "./constants.ts";
 import { getToken } from "./credential-store.ts";
 import { CliError, PlapiError, ERROR_CODE } from "./errors.ts";
 
@@ -53,7 +53,7 @@ export async function fetchInstanceConfigSchema(
   const token = await getAuthToken();
   const url = new URL(
     `/v1/platform/applications/${applicationId}/instances/${instanceId}/config/schema`,
-    PLAPI_BASE_URL,
+    getPlapiBaseUrl(),
   );
   if (keys?.length) {
     for (const key of keys) {
@@ -83,7 +83,7 @@ export async function fetchInstanceConfig(
   const token = await getAuthToken();
   const url = new URL(
     `/v1/platform/applications/${applicationId}/instances/${instanceId}/config`,
-    PLAPI_BASE_URL,
+    getPlapiBaseUrl(),
   );
   if (keys?.length) {
     for (const key of keys) {
@@ -120,7 +120,7 @@ export interface Application {
 
 export async function fetchApplication(applicationId: string): Promise<Application> {
   const token = await getAuthToken();
-  const url = new URL(`/v1/platform/applications/${applicationId}`, PLAPI_BASE_URL);
+  const url = new URL(`/v1/platform/applications/${applicationId}`, getPlapiBaseUrl());
   url.searchParams.set("include_secret_keys", "true");
   const response = await fetch(url, {
     headers: {
@@ -147,7 +147,7 @@ async function sendInstanceConfig(
   const token = await getAuthToken();
   const url = new URL(
     `/v1/platform/applications/${applicationId}/instances/${instanceId}/config`,
-    PLAPI_BASE_URL,
+    getPlapiBaseUrl(),
   );
   if (options?.destructive) {
     url.searchParams.set("destructive", "true");
@@ -186,7 +186,7 @@ export const patchInstanceConfig = (
 
 export async function listApplications(): Promise<Application[]> {
   const token = await getAuthToken();
-  const url = new URL("/v1/platform/applications", PLAPI_BASE_URL);
+  const url = new URL("/v1/platform/applications", getPlapiBaseUrl());
   const response = await fetch(url, {
     headers: {
       Authorization: `Bearer ${token}`,

--- a/packages/cli-core/src/lib/plapi.ts
+++ b/packages/cli-core/src/lib/plapi.ts
@@ -3,7 +3,7 @@
  * Thin HTTP wrapper for Clerk's Platform API endpoints.
  */
 
-import { getPlapiBaseUrl } from "./constants.ts";
+import { getPlapiBaseUrl } from "./environment.ts";
 import { getToken } from "./credential-store.ts";
 import { CliError, PlapiError, ERROR_CODE } from "./errors.ts";
 

--- a/packages/cli-core/src/lib/token-exchange.ts
+++ b/packages/cli-core/src/lib/token-exchange.ts
@@ -9,7 +9,7 @@
  *   CLERK_OAUTH_SCOPES=profile email
  */
 
-import { getOAuthConfig } from "./constants.ts";
+import { getOAuthConfig } from "./environment.ts";
 import { ApiError, withApiContext } from "./errors.ts";
 
 interface TokenResponse {

--- a/packages/cli-core/src/lib/token-exchange.ts
+++ b/packages/cli-core/src/lib/token-exchange.ts
@@ -9,10 +9,8 @@
  *   CLERK_OAUTH_SCOPES=profile email
  */
 
-import { OAUTH } from "./constants.ts";
+import { getOAuthConfig } from "./constants.ts";
 import { ApiError, withApiContext } from "./errors.ts";
-
-export const OAUTH_CONFIG = OAUTH;
 
 interface TokenResponse {
   access_token: string;
@@ -31,17 +29,18 @@ export async function exchangeCodeForToken(params: {
   codeVerifier: string;
   redirectUri: string;
 }): Promise<TokenResponse> {
+  const oauth = getOAuthConfig();
   const body = new URLSearchParams({
     grant_type: "authorization_code",
     code: params.code,
-    client_id: OAUTH_CONFIG.clientId,
+    client_id: oauth.clientId,
     code_verifier: params.codeVerifier,
     redirect_uri: params.redirectUri,
   });
 
   return withApiContext(
     (async () => {
-      const response = await fetch(OAUTH_CONFIG.tokenUrl, {
+      const response = await fetch(oauth.tokenUrl, {
         method: "POST",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
         body: body.toString(),
@@ -59,9 +58,10 @@ export async function exchangeCodeForToken(params: {
 }
 
 export async function fetchUserInfo(accessToken: string): Promise<UserInfo> {
+  const oauth = getOAuthConfig();
   return withApiContext(
     (async () => {
-      const response = await fetch(OAUTH_CONFIG.userinfoUrl, {
+      const response = await fetch(oauth.userinfoUrl, {
         headers: { Authorization: `Bearer ${accessToken}` },
       });
 

--- a/packages/cli-core/src/test/lib/setup.ts
+++ b/packages/cli-core/src/test/lib/setup.ts
@@ -172,13 +172,6 @@ mock.module(
         if (!token || token === "expired_token") throw new Error("Unauthorized");
         return { userId: "user_123", email: "test@example.com" };
       },
-      OAUTH_CONFIG: {
-        clientId: "test_client",
-        scopes: "profile email",
-        authorizeUrl: "https://test.clerk.com/oauth/authorize",
-        tokenUrl: "https://test.clerk.com/oauth/token",
-        userinfoUrl: "https://test.clerk.com/oauth/userinfo",
-      },
     }) satisfies typeof import("../../lib/token-exchange.ts"),
 );
 

--- a/packages/cli-core/src/test/stubs.ts
+++ b/packages/cli-core/src/test/stubs.ts
@@ -55,7 +55,6 @@ export const promptsStubs = {
 export const tokenExchangeStubs = {
   exchangeCodeForToken: async () => ({}),
   fetchUserInfo: async () => ({}),
-  OAUTH_CONFIG: {},
 };
 
 type FetchImpl = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -8,11 +8,26 @@ const { values } = parseArgs({
   options: {
     target: { type: "string" },
     version: { type: "string", default: "0.0.0-dev" },
+    "env-profiles": { type: "string" },
   },
 });
 
 const targetFilter = values.target;
 const version = values.version!;
+
+// Read environment profiles from a JSON file path (--env-profiles or CLI_ENV_PROFILES_FILE env var)
+let envProfilesJson: string | undefined;
+const envProfilesPath = values["env-profiles"] ?? process.env.CLI_ENV_PROFILES_FILE;
+if (envProfilesPath) {
+  const file = Bun.file(envProfilesPath);
+  if (!(await file.exists())) {
+    throw new Error(`Environment profiles file not found: ${envProfilesPath}`);
+  }
+  // Parse to validate, then re-stringify compactly for --define injection
+  const parsed = await file.json();
+  envProfilesJson = JSON.stringify(parsed);
+  console.log(`Loaded environment profiles from ${envProfilesPath}`);
+}
 
 const selectedTargets = targetFilter
   ? targets.filter((t) => t.bunTarget === targetFilter || t.name === targetFilter)
@@ -34,21 +49,23 @@ for (const target of selectedTargets) {
   await mkdir(outDir, { recursive: true });
 
   console.log(`Building ${target.name} (${target.bunTarget})...`);
-  const buildResult = Bun.spawnSync(
-    [
-      "bun",
-      "build",
-      "--compile",
-      "--no-compile-autoload-dotenv",
-      `--target=${target.bunTarget}`,
-      `--define`,
-      `CLI_VERSION="${version}"`,
-      "./packages/cli-core/src/cli.ts",
-      "--outfile",
-      outFile,
-    ],
-    { stdio: ["ignore", "pipe", "pipe"] },
-  );
+  const buildArgs = [
+    "bun",
+    "build",
+    "--compile",
+    "--no-compile-autoload-dotenv",
+    `--target=${target.bunTarget}`,
+    `--define`,
+    `CLI_VERSION="${version}"`,
+  ];
+
+  if (envProfilesJson) {
+    buildArgs.push("--define", `CLI_ENV_PROFILES=${envProfilesJson}`);
+  }
+
+  buildArgs.push("./packages/cli-core/src/cli.ts", "--outfile", outFile);
+
+  const buildResult = Bun.spawnSync(buildArgs, { stdio: ["ignore", "pipe", "pipe"] });
 
   if (buildResult.exitCode !== 0) {
     console.error(`  FAIL: ${buildResult.stderr.toString().trim()}`);

--- a/scripts/load-env-profiles.ts
+++ b/scripts/load-env-profiles.ts
@@ -1,0 +1,32 @@
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { $ } from "bun";
+
+const is1PasswordInstalled = await $`op --version`
+  .then((res) => res.exitCode === 0)
+  .catch(() => false);
+
+if (!is1PasswordInstalled) {
+  throw new Error("1Password CLI is not installed. Install it with `brew install 1password-cli`.");
+}
+
+const envItem = await $`op read 'op://Shared/CLI env profiles/.env-profiles.json'`
+  .then((res) => {
+    if (res.exitCode === 0) {
+      return res.stdout;
+    }
+
+    return null;
+  })
+  .catch(() => {
+    return null;
+  });
+
+if (!envItem) {
+  throw new Error(
+    "Failed to read from 1Password. Have you enabled the 1Password CLI in your 1Password settings? See https://developer.1password.com/docs/cli/get-started/#step-2-turn-on-the-1password-desktop-app-integration for more information.",
+  );
+}
+
+await writeFile(join(process.cwd(), ".env-profiles.json"), envItem);


### PR DESCRIPTION
## Summary

- Adds per-environment infrastructure profiles (`CLI_ENV_PROFILES` at build time, `.env-profiles.json` at repo root for local dev) so the CLI can target different Clerk backends (production, staging, etc.)
- Adds internal `clerk switch-env` command to switch the active environment, persisted in `~/.clerk/config.json`
- Stores auth tokens per-environment so switching back doesn't require re-authentication
- Prints a `[ENV]` banner to stderr when running against a non-production environment
- Adds `load-env-profiles` script to pull profiles from 1Password for local development

## Test plan

- [x] Run `bun test` — all existing tests pass
- [x] Run `clerk switch-env` — prints current environment and available options
- [x] Run `clerk switch-env staging` (with profiles loaded) — switches and persists
- [x] Verify `[STAGING]` banner appears on stderr for non-production environments
- [x] Verify stdout is not polluted by the env prefix (e.g. `clerk api /users | jq`)
- [x] Run `bun run scripts/load-env-profiles.ts` with 1Password CLI configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added switch-env command to list/change CLI environments; selection is persisted and the CLI shows a non-production banner.

* **Behavior Changes**
  * Credentials, OAuth, and API endpoints are now environment-scoped; existing config is migrated to per-environment format.

* **Documentation**
  * Added usage docs and examples for switch-env.

* **Chores**
  * Added tooling and a workspace script to load/inject environment profiles; .env-profiles.json is now ignored.

* **Tests**
  * Added and updated tests for environment-aware behavior and switch-env.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->