### PR TITLE
fix(release): use correct asset filenames in GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,8 @@ jobs:
           for dir in dist/artifacts/clerk-*/; do
             target=${dir#dist/artifacts/clerk-} && target=${target%/}
             ext=""; [[ "$target" == win32-* ]] && ext=".exe"
-            gh release upload "$tag" "${dir}clerk${ext}#clerk-${target}${ext}" --clobber
+            cp "${dir}clerk${ext}" "${dir}clerk-${target}${ext}"
+            gh release upload "$tag" "${dir}clerk-${target}${ext}" --clobber
           done
 
   # ─── Canary release ────────────────────────────────────────────────
@@ -181,7 +182,8 @@ jobs:
           for dir in dist/artifacts/clerk-canary-*/; do
             target=${dir#dist/artifacts/clerk-canary-} && target=${target%/}
             ext=""; [[ "$target" == win32-* ]] && ext=".exe"
-            gh release upload "$tag" "${dir}clerk${ext}#clerk-${target}${ext}" \
+            cp "${dir}clerk${ext}" "${dir}clerk-${target}${ext}"
+            gh release upload "$tag" "${dir}clerk-${target}${ext}" \
               --repo "$GH_REPO" --clobber
           done
 


### PR DESCRIPTION
## Summary

- The `gh release upload` `file#label` syntax sets a display **label**, not the asset **filename**. Every platform was uploading a file literally named `clerk`, so `--clobber` caused them to overwrite each other — leaving only one binary per release.
- Fixes both stable and canary upload steps by copying the binary to the platform-specific name (e.g. `clerk-darwin-arm64`) before uploading, so each target gets a distinct downloadable asset.
- This fixes the 404 when running `install.sh --canary` (or any channel), since the install script expects assets named `clerk-<target>`.

## Test plan

- [ ] Build locally, create a throwaway GitHub release, run the upload loop, and verify `gh release view` shows per-platform asset names
- [ ] Run `install.sh --version <test-tag>` and confirm it downloads successfully
- [ ] Verify next canary release from `main` has all platform binaries

```
# 1. Build for your platform
bun run scripts/build.ts --target=darwin-arm64

# 2. Create a test release
gh release create v0.0.0-test --repo clerk/cli-new --prerelease --title "test" --notes "test"

# 3. Simulate the upload (mirroring the fixed workflow logic)
dir="dist/artifacts/darwin-arm64/"
cp "${dir}clerk" "${dir}clerk-darwin-arm64"
gh release upload v0.0.0-test "${dir}clerk-darwin-arm64" --repo clerk/cli-new

# 4. Verify the asset name is correct
gh release view v0.0.0-test --repo clerk/cli-new --json assets --jq '.assets[].name'
# Should show: clerk-darwin-arm64  (not just "clerk")

# 5. Test the install script
./install.sh --version v0.0.0-test

# 6. Clean up
gh release delete v0.0.0-test --repo clerk/cli-new --yes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release artifact upload process to include platform and version information in binary filenames for both stable and canary releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->