### PR TITLE
chore: Update repository name from cli-new to cli

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@
 
 set -euo pipefail
 
-REPO="clerk/cli-new"
+REPO="clerk/cli"
 BINARY_NAME="clerk"
 INSTALL_DIR="${CLERK_INSTALL_DIR:-}"
 CHANNEL=""


### PR DESCRIPTION
Mirror the new repo name so install works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the installation script to source the CLI binary from the updated repository location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->