### PR TITLE
fix(ci): pass secrets to build-binaries workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
       version: ${{ needs.versioning.outputs.version }}
       ref: ${{ github.sha }}
       artifact-prefix: clerk
+    secrets: inherit
 
   smoke-test:
     needs: [versioning, build]
@@ -141,6 +142,7 @@ jobs:
       version: ${{ needs.canary-version.outputs.version }}
       ref: ${{ github.sha }}
       artifact-prefix: clerk-canary
+    secrets: inherit
 
   canary-smoke-test:
     needs: [canary-version, canary-build]


### PR DESCRIPTION
## Summary
- Add `secrets: inherit` to both the release `build` and `canary-build` jobs so `ENV_PROFILES` is available in the `build-binaries` reusable workflow.

## Test plan
- [ ] Trigger a canary release and verify the build succeeds with env profiles embedded
- [ ] Verify a production release build also picks up the secret

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configuration to properly inherit required environment credentials for stable and canary release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->