### PR TITLE
feat(auth): prompt for re-authentication when already logged in

### DIFF
--- a/packages/cli-core/src/commands/auth/README.md
+++ b/packages/cli-core/src/commands/auth/README.md
@@ -8,7 +8,7 @@ Manage authentication with Clerk.
 
 Authenticates the user via an OAuth 2.0 PKCE flow.
 
-1. Checks for an existing valid token and skips login if found
+1. Checks for an existing valid token — if found, prompts to re-authenticate (in agent mode, skips login silently)
 2. Generates PKCE parameters (code verifier, challenge, state)
 3. Starts a local HTTP callback server on `127.0.0.1`
 4. Opens the browser to the Clerk OAuth authorization URL

--- a/packages/cli-core/src/commands/auth/login.test.ts
+++ b/packages/cli-core/src/commands/auth/login.test.ts
@@ -8,6 +8,8 @@ const mockSetAuth = mock();
 const mockExchangeCodeForToken = mock();
 const mockFetchUserInfo = mock();
 const mockStartAuthServer = mock();
+const mockIsHuman = mock();
+const mockConfirm = mock();
 
 mock.module("../../lib/credential-store.ts", () => ({
   ...credentialStoreStubs,
@@ -51,6 +53,17 @@ mock.module("../../lib/auth-server.ts", () => ({
   startAuthServer: (...args: unknown[]) => mockStartAuthServer(...args),
 }));
 
+mock.module("../../mode.ts", () => ({
+  isHuman: (...args: unknown[]) => mockIsHuman(...args),
+  isAgent: () => !mockIsHuman(),
+  getMode: () => (mockIsHuman() ? "human" : "agent"),
+  setMode: () => {},
+}));
+
+mock.module("../../lib/prompts.ts", () => ({
+  confirm: (...args: unknown[]) => mockConfirm(...args),
+}));
+
 const { login } = await import("./login.ts");
 
 describe("login", () => {
@@ -65,6 +78,9 @@ describe("login", () => {
     mockExchangeCodeForToken.mockReset();
     mockFetchUserInfo.mockReset();
     mockStartAuthServer.mockReset();
+    mockIsHuman.mockReset();
+    mockConfirm.mockReset();
+    mockIsHuman.mockReturnValue(false);
     consoleSpy?.mockRestore();
     try {
       (Bun as any).spawn = origSpawn;
@@ -214,5 +230,76 @@ describe("login", () => {
 
     expect(result).toEqual({ userId: "user_brand_new", email: "brandnew@example.com" });
     expect(mockStartAuthServer).toHaveBeenCalled();
+  });
+
+  test("in agent mode, returns early without prompting when already authenticated", async () => {
+    mockIsHuman.mockReturnValue(false);
+    mockGetToken.mockResolvedValue("existing-token");
+    mockGetAuth.mockResolvedValue({ userId: "user_123" });
+    mockFetchUserInfo.mockResolvedValue({
+      userId: "user_123",
+      email: "agent@example.com",
+    });
+
+    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+    const result = await login();
+
+    expect(result).toEqual({ userId: "user_123", email: "agent@example.com" });
+    expect(consoleSpy).toHaveBeenCalledWith("Logged in as agent@example.com");
+    expect(mockConfirm).not.toHaveBeenCalled();
+    expect(mockStartAuthServer).not.toHaveBeenCalled();
+  });
+
+  test("in human mode, prompts and runs OAuth when user accepts re-auth", async () => {
+    mockIsHuman.mockReturnValue(true);
+    mockGetToken.mockResolvedValue("existing-token");
+    mockGetAuth.mockResolvedValue({ userId: "user_123" });
+    mockFetchUserInfo
+      .mockResolvedValueOnce({ userId: "user_123", email: "old@example.com" })
+      .mockResolvedValueOnce({ userId: "user_new", email: "new@example.com" });
+    mockConfirm.mockResolvedValue(true);
+    mockBunSpawn();
+
+    const mockServer = {
+      port: 54321,
+      waitForCallback: mock().mockResolvedValue({ code: "reauth-code" }),
+      stop: mock(),
+    };
+    mockStartAuthServer.mockReturnValue(mockServer);
+
+    mockExchangeCodeForToken.mockResolvedValue({
+      access_token: "new-token",
+      token_type: "Bearer",
+      expires_in: 3600,
+    });
+    mockStoreToken.mockResolvedValue(undefined);
+    mockSetAuth.mockResolvedValue(undefined);
+
+    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+    const result = await login();
+
+    expect(mockConfirm).toHaveBeenCalledWith({
+      message: "You're already logged in as old@example.com. Re-authenticate?",
+      default: false,
+    });
+    expect(result).toEqual({ userId: "user_new", email: "new@example.com" });
+    expect(mockStartAuthServer).toHaveBeenCalled();
+  });
+
+  test("in human mode, throws UserAbortError when user declines re-auth", async () => {
+    mockIsHuman.mockReturnValue(true);
+    mockGetToken.mockResolvedValue("existing-token");
+    mockGetAuth.mockResolvedValue({ userId: "user_123" });
+    mockFetchUserInfo.mockResolvedValue({
+      userId: "user_123",
+      email: "current@example.com",
+    });
+    mockConfirm.mockResolvedValue(false);
+
+    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+    await expect(login()).rejects.toThrow("User aborted");
+    expect(mockConfirm).toHaveBeenCalled();
+    expect(mockStartAuthServer).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli-core/src/commands/auth/login.ts
+++ b/packages/cli-core/src/commands/auth/login.ts
@@ -1,39 +1,48 @@
 import { printNextSteps } from "../../lib/next-steps.ts";
 import { generateCodeVerifier, generateCodeChallenge, generateState } from "../../lib/pkce.ts";
 import { startAuthServer } from "../../lib/auth-server.ts";
-import { exchangeCodeForToken, fetchUserInfo } from "../../lib/token-exchange.ts";
+import { exchangeCodeForToken, fetchUserInfo, type UserInfo } from "../../lib/token-exchange.ts";
 import { getOAuthConfig } from "../../lib/environment.ts";
 import { storeToken, getToken } from "../../lib/credential-store.ts";
 import { getAuth, setAuth } from "../../lib/config.ts";
 import { AUTH_TIMEOUT_MS, CALLBACK_PATH } from "../../lib/constants.ts";
+import { confirm } from "../../lib/prompts.ts";
+import { isHuman } from "../../mode.ts";
+import { throwUserAbort } from "../../lib/errors.ts";
 
-export async function login(): Promise<{ userId: string; email: string }> {
-  // Check if already authenticated
-  const existingToken = await getToken();
-  if (existingToken) {
-    const auth = await getAuth();
-    if (auth) {
-      try {
-        const userInfo = await fetchUserInfo(existingToken);
-        console.log(`Logged in as ${userInfo.email}`);
-        return userInfo;
-      } catch {
-        // Token expired or invalid — continue with fresh login
-      }
-    }
+const BROWSER_COMMANDS: Partial<Record<NodeJS.Platform, string>> = {
+  darwin: "open",
+  win32: "start",
+};
+
+async function getExistingSession(): Promise<UserInfo | null> {
+  const token = await getToken();
+  if (!token) return null;
+
+  const auth = await getAuth();
+  if (!auth) return null;
+
+  try {
+    return await fetchUserInfo(token);
+  } catch {
+    return null;
   }
+}
 
-  // Generate PKCE parameters
+function openBrowser(url: string) {
+  const command = BROWSER_COMMANDS[process.platform] ?? "xdg-open";
+  return Bun.spawn([command, url]);
+}
+
+async function performOAuthFlow(): Promise<UserInfo> {
   const codeVerifier = generateCodeVerifier();
   const codeChallenge = await generateCodeChallenge(codeVerifier);
   const state = generateState();
 
-  // Start local callback server
   const authServer = startAuthServer(state);
   // Use `http://127.0.0.1` (not localhost) so the backend permits any port https://datatracker.ietf.org/doc/html/rfc8252#section-7.3
   const redirectUri = `http://127.0.0.1:${authServer.port}${CALLBACK_PATH}`;
 
-  // Build authorization URL
   const oauth = getOAuthConfig();
   const authorizeUrl = new URL(oauth.authorizeUrl);
   authorizeUrl.searchParams.set("client_id", oauth.clientId);
@@ -44,36 +53,50 @@ export async function login(): Promise<{ userId: string; email: string }> {
   authorizeUrl.searchParams.set("code_challenge", codeChallenge);
   authorizeUrl.searchParams.set("code_challenge_method", "S256");
 
-  // Open browser (platform-aware)
-  const openCmd =
-    process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
-  const proc = Bun.spawn([openCmd, authorizeUrl.toString()]);
+  const proc = openBrowser(authorizeUrl.toString());
   await proc.exited;
 
-  // Wait for the OAuth callback
   const timeoutMinutes = Math.round(AUTH_TIMEOUT_MS / 60_000);
   console.log(`Waiting for authentication (timeout in ${timeoutMinutes}m)...`);
-  let callbackResult: { code: string };
-  try {
-    callbackResult = await authServer.waitForCallback();
-  } catch (error) {
+
+  const { code } = await authServer.waitForCallback().catch((error: unknown) => {
     authServer.stop();
     throw error;
-  }
+  });
 
-  // Exchange authorization code for access token
   const tokenResponse = await exchangeCodeForToken({
-    code: callbackResult.code,
+    code,
     codeVerifier,
     redirectUri,
   });
 
-  // Store the access token
   await storeToken(tokenResponse.access_token);
 
-  // Fetch user info and save to config
   const userInfo = await fetchUserInfo(tokenResponse.access_token);
   await setAuth({ userId: userInfo.userId });
+
+  return userInfo;
+}
+
+export async function login(): Promise<UserInfo> {
+  const existingSession = await getExistingSession();
+
+  if (existingSession && !isHuman()) {
+    console.log(`Logged in as ${existingSession.email}`);
+    return existingSession;
+  }
+
+  if (existingSession) {
+    const reauthenticate = await confirm({
+      message: `You're already logged in as ${existingSession.email}. Re-authenticate?`,
+      default: false,
+    });
+    if (!reauthenticate) {
+      throwUserAbort();
+    }
+  }
+
+  const userInfo = await performOAuthFlow();
 
   console.log(`Logged in as ${userInfo.email}`);
 

--- a/packages/cli-core/src/lib/token-exchange.ts
+++ b/packages/cli-core/src/lib/token-exchange.ts
@@ -19,7 +19,7 @@ interface TokenResponse {
   refresh_token?: string;
 }
 
-interface UserInfo {
+export interface UserInfo {
   userId: string;
   email: string;
 }


### PR DESCRIPTION
## Summary
- When a user runs `clerk auth login` with a valid session, show a confirmation prompt ("You're already logged in as X. Re-authenticate?") instead of silently returning
- In agent mode, preserves the existing behavior (logs and returns early)
- Refactors `login()` into small focused functions (`getExistingSession`, `openBrowser`, `performOAuthFlow`) and exports the `UserInfo` type from `token-exchange.ts`

## Test plan
- [x] Run `clerk auth login` when already authenticated — should see re-auth prompt
- [x] Decline the prompt — should exit cleanly (no error output)
- [x] Accept the prompt — should open browser for fresh OAuth flow
- [x] Run `clerk auth login` when not authenticated — should proceed directly to OAuth
- [x] Run in agent mode (`--mode agent`) when authenticated — should log and return silently (no prompt)

## Screenshots
- `clerk auth` when unauthenticated
<img width="597" height="163" alt="image" src="https://github.com/user-attachments/assets/58722a5e-a066-487d-b77c-d0ede1a5e6b0" />

- `clerk auth` when authenticated
<img width="634" height="183" alt="image" src="https://github.com/user-attachments/assets/23842229-63bb-482d-b7e6-0e996b3ca2b8" />

- `clerk auth --mode agent` when authenticated
<img width="655" height="77" alt="image" src="https://github.com/user-attachments/assets/77b38578-522a-470e-bf9b-8bb82e734dfa" />