### PR TITLE
fix(init): replace <NuxtWelcome /> with <NuxtPage /> in Nuxt scaffold

### DIFF
--- a/packages/cli-core/src/commands/init/frameworks/nuxt.ts
+++ b/packages/cli-core/src/commands/init/frameworks/nuxt.ts
@@ -1,7 +1,9 @@
+import { join } from "node:path";
 import { parseModule } from "magicast";
 import {
   authComponentName,
   authFileSpecs,
+  findFirstFile,
   hasTailwindStyles,
   htmlAuthComponentMarkup,
   indentBlock,
@@ -53,6 +55,32 @@ function scaffoldConfig(ctx: ProjectContext): Promise<FileAction> {
   });
 }
 
+/**
+ * Ensure app.vue has `<NuxtPage />` so file-based routing works.
+ * The minimal Nuxt template uses `<NuxtWelcome />` without a router
+ * outlet, which means pages/ routes never render.
+ */
+async function scaffoldAppVue(ctx: ProjectContext): Promise<FileAction | null> {
+  const appPath = await findFirstFile(ctx.cwd, ["app/app.vue", "app.vue"]);
+  if (!appPath) return null;
+
+  const content = await Bun.file(join(ctx.cwd, appPath)).text();
+
+  if (content.includes("<NuxtPage")) {
+    return { type: "skip", path: appPath, skipReason: "Already has <NuxtPage />" };
+  }
+
+  if (!content.includes("<NuxtWelcome")) return null;
+
+  const updated = content.replace(/<NuxtWelcome\s*\/?>/, "<NuxtPage />");
+  return {
+    path: appPath,
+    type: "modify",
+    content: updated,
+    description: "Replace <NuxtWelcome /> with <NuxtPage /> for file-based routing",
+  };
+}
+
 export const nuxt: FrameworkScaffold = {
   name: "Nuxt",
   dep: "nuxt",
@@ -62,8 +90,9 @@ export const nuxt: FrameworkScaffold = {
 
   async scaffold(ctx: ProjectContext): Promise<ScaffoldPlan> {
     const tailwind = hasTailwindStyles(ctx);
-    const [configAction, authActions, envAction] = await Promise.all([
+    const [configAction, appVueAction, authActions, envAction] = await Promise.all([
       scaffoldConfig(ctx),
+      scaffoldAppVue(ctx),
       scaffoldAuthFiles(
         ctx.cwd,
         authFileSpecs({
@@ -75,9 +104,21 @@ export const nuxt: FrameworkScaffold = {
       scaffoldEnvVars(ctx, SIGN_ROUTE_ENV_VARS.nuxt),
     ]);
 
-    const postInstructions = [
+    const actions = [configAction, appVueAction, ...authActions, envAction].filter(
+      (action): action is FileAction => action !== null,
+    );
+
+    const postInstructions: string[] = [];
+
+    if (!appVueAction) {
+      postInstructions.push(
+        "Ensure your app.vue (or app/app.vue) includes <NuxtPage /> so file-based routes render",
+      );
+    }
+
+    postInstructions.push(
       'Use <Show when="signed-in"> and <Show when="signed-out"> components in your app.vue for conditional rendering (auto-imported)',
-    ];
+    );
 
     if (ctx.deps["@nuxtjs/i18n"]) {
       postInstructions.push(
@@ -85,9 +126,6 @@ export const nuxt: FrameworkScaffold = {
       );
     }
 
-    return {
-      actions: [configAction, ...authActions, envAction],
-      postInstructions,
-    };
+    return { actions, postInstructions };
   },
 };


### PR DESCRIPTION
## Summary

- Replace `<NuxtWelcome />` with `<NuxtPage />` in `app.vue` during `clerk init` so file-based routing works
- The default Nuxt starter uses `<NuxtWelcome />` without a router outlet, which means pages added by the scaffolder never render
- Adds a post-instruction hint if `app.vue` couldn't be found or patched automatically

## Test plan

- [ ] `bun run test` passes
- [ ] `bun run lint` passes
- [ ] Run `clerk init` in a fresh Nuxt project and verify `app.vue` is patched
- [ ] Run `clerk init` in a Nuxt project that already has `<NuxtPage />` and verify it's skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nuxt project initialization now automatically handles application component configuration updates when needed, streamlining the setup experience.
  * Added intelligent post-initialization guidance that provides users with clear instructions when manual configuration steps are required.
  * Improved scaffolding process to ensure consistent setup of application components across new Nuxt projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->