### PR TITLE
feat(init): enable non-interactive init and app creation

### DIFF
--- a/packages/cli-core/src/cli-program.ts
+++ b/packages/cli-core/src/cli-program.ts
@@ -65,6 +65,9 @@ export function createProgram() {
         FRAMEWORK_NAMES,
       ),
     )
+    .option("--app <id>", "Application ID (skips login/link, enables non-interactive mode)")
+    .option("--instance <id>", "Instance to target (dev, prod, or instance ID; used with --app)")
+    .option("--create-app <name>", "Create a new Clerk application with this name")
     .option("--prompt", "Output a prompt for an AI agent to integrate Clerk")
     .option("-y, --yes", "Skip confirmation prompts")
     .addHelpText(
@@ -73,6 +76,8 @@ export function createProgram() {
 Examples:
   $ clerk init                       Auto-detect framework and set up Clerk
   $ clerk init --framework next      Set up for Next.js (skips detection)
+  $ clerk init --app app_123         Non-interactive init with a specific app
+  $ clerk init --create-app "My App" Create a new app and initialize
   $ clerk init --prompt              Output a setup prompt for an AI agent
   $ clerk init -y                    Skip all confirmation prompts`,
     )
@@ -131,12 +136,14 @@ Examples:
     .command("link")
     .description("Link this project to a Clerk application")
     .option("--app <id>", "Application ID to link (skips interactive picker)")
+    .option("--create-app <name>", "Create a new Clerk application and link it")
     .addHelpText(
       "after",
       `
 Examples:
   $ clerk link                       Pick an app interactively
-  $ clerk link --app app_abc123      Link directly by application ID`,
+  $ clerk link --app app_abc123      Link directly by application ID
+  $ clerk link --create-app "My App" Create a new app and link it`,
     )
     .action(link);
 

--- a/packages/cli-core/src/commands/init/README.md
+++ b/packages/cli-core/src/commands/init/README.md
@@ -10,30 +10,47 @@ clerk init --framework next
 clerk init --prompt
 clerk init -y
 clerk init --yes
+clerk init --app app_123 --framework next
+clerk init --app app_123 --instance dev --framework next
+clerk init --create-app "My App" --framework next
+CLERK_PLATFORM_API_KEY=ak_... clerk init --app app_123 --framework next
 ```
 
 ## Options
 
-| Option               | Description                                                                                                                                                       |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--framework <name>` | Framework to set up (skips auto-detection). Valid values: `next`, `astro`, `nuxt`, `tanstack-start`, `react-router`, `vue`, `expo`, `react`, `express`, `fastify` |
-| `--prompt`           | Output a prompt for an AI agent to integrate Clerk, then exit                                                                                                     |
-| `-y, --yes`          | Skip confirmation prompts                                                                                                                                         |
+| Option                | Description                                                                                                                                                       |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--framework <name>`  | Framework to set up (skips auto-detection). Valid values: `next`, `astro`, `nuxt`, `tanstack-start`, `react-router`, `vue`, `expo`, `react`, `express`, `fastify` |
+| `--prompt`            | Output a prompt for an AI agent to integrate Clerk, then exit                                                                                                     |
+| `-y, --yes`           | Skip confirmation prompts                                                                                                                                         |
+| `--app <id>`          | Application ID. Skips login/link prompts, enables non-interactive mode (implies `--yes`). Authenticates via existing OAuth token or `CLERK_PLATFORM_API_KEY`      |
+| `--instance <id>`     | Instance to target (`dev`, `prod`, or full instance ID). Used with `--app` to select which instance's environment variables to pull                               |
+| `--create-app <name>` | Create a new Clerk application with this name                                                                                                                     |
 
 ## Agent Mode
 
-When running in agent mode (`--mode agent` or non-TTY), outputs a framework-specific prompt with exact file paths and code snippets, then exits without modifying the project.
+When running in agent mode (`--mode agent` or non-TTY), outputs a framework-specific prompt with exact file paths and code snippets, then exits without modifying the project. However, when `--app` or `--create-app` is provided in agent mode, the command performs actual scaffolding instead of outputting a prompt.
+
+## Non-Interactive / Agent Usage
+
+```sh
+clerk init --app app_123 --framework next
+clerk init --app app_123 --instance dev --framework next
+clerk init --create-app "My App" --framework next
+CLERK_PLATFORM_API_KEY=ak_... clerk init --app app_123 --framework next
+```
 
 ## Flow
 
 1. Gathers project context (framework, router variant, TypeScript, `src/` directory, package manager)
-2. **Agent mode**: outputs a framework-specific prompt, then exits
+2. **Agent mode**: outputs a framework-specific prompt, then exits (unless `--app` or `--create-app` is provided, in which case scaffolding proceeds)
 3. **Human mode**: determines auth mode:
-   - If already authenticated and linked: uses authenticated mode automatically
+   - If already authenticated (via `CLERK_PLATFORM_API_KEY` or OAuth token) and linked: uses authenticated mode automatically
    - If authenticated but not linked: uses authenticated mode (runs `clerk link`)
-   - If not authenticated: asks user — "Continue with temporary keys (connect your account later)" or "Log in to an existing Clerk account"
+   - If `--app` is provided: skips login/link entirely (authenticates via existing OAuth token or `CLERK_PLATFORM_API_KEY`)
+   - If not authenticated: defaults to keyless mode
    - With `--yes` and not authenticated: defaults to keyless mode
-4. **Authenticated mode only**: authenticates via `clerk auth login` (skipped if already authenticated) and links the project via `clerk link` (skipped if already linked)
+4. **Authenticated mode only**: links the project via `clerk link` (skipped if already linked; when `--create-app` is provided, creates a new app during this step)
 5. Displays detected framework and variant
 6. Detects existing auth libraries (NextAuth, Auth0, Supabase, Firebase, Passport, Better Auth, Kinde) and shows migration guidance
 7. Installs the appropriate Clerk SDK (skips if already present)

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -20,14 +20,14 @@ import {
 } from "./heuristics.js";
 import type { ProjectContext } from "./frameworks/types.js";
 
-interface InitOptions {
+type InitOptions = {
   framework?: string;
   yes?: boolean;
   prompt?: boolean;
   app?: string;
   instance?: string;
   createApp?: string;
-}
+};
 
 export async function init(options: InitOptions = {}) {
   const cwd = process.cwd();

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -2,8 +2,8 @@ import { link } from "../link/index.js";
 import { pull } from "../env/pull.js";
 import { isAgent } from "../../mode.js";
 import { dim, green, yellow, bold } from "../../lib/color.js";
-import { throwUserAbort } from "../../lib/errors.js";
-import { lookupFramework } from "../../lib/framework.js";
+import { throwUserAbort, throwUsageError } from "../../lib/errors.js";
+import { lookupFramework, type FrameworkInfo } from "../../lib/framework.js";
 import { resolveProfile } from "../../lib/config.js";
 import { gatherContext } from "./context.js";
 import { scaffold, enrichProjectContext } from "./scaffold.js";
@@ -30,6 +30,10 @@ type InitOptions = {
 };
 
 export async function init(options: InitOptions = {}) {
+  if (options.app && options.createApp) {
+    throwUsageError("Cannot use --app and --create-app together.");
+  }
+
   const cwd = process.cwd();
 
   // Commander validates --framework against FRAMEWORK_NAMES choices

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -3,7 +3,7 @@ import { pull } from "../env/pull.js";
 import { isAgent } from "../../mode.js";
 import { dim, green, yellow, bold } from "../../lib/color.js";
 import { throwUserAbort, throwUsageError } from "../../lib/errors.js";
-import { lookupFramework, type FrameworkInfo } from "../../lib/framework.js";
+import { lookupFramework } from "../../lib/framework.js";
 import { resolveProfile } from "../../lib/config.js";
 import { gatherContext } from "./context.js";
 import { scaffold, enrichProjectContext } from "./scaffold.js";

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -24,6 +24,9 @@ interface InitOptions {
   framework?: string;
   yes?: boolean;
   prompt?: boolean;
+  app?: string;
+  instance?: string;
+  createApp?: string;
 }
 
 export async function init(options: InitOptions = {}) {
@@ -38,23 +41,34 @@ export async function init(options: InitOptions = {}) {
   // Populate framework-specific context (variant, layoutPath, middlewareBasename)
   if (ctx) await enrichProjectContext(ctx);
 
-  if (options.prompt || isAgent()) {
+  // In agent mode, output a hint unless --app/--create-app is provided (which means: actually scaffold)
+  const nonInteractive = options.app || options.createApp;
+  if ((options.prompt || isAgent()) && !nonInteractive) {
     console.log(
       "Run `clerk init -y` to automatically detect the framework, install the Clerk SDK, and scaffold authentication files without interactive prompts.",
     );
     return;
   }
 
-  const authenticated = await resolveAuth(cwd);
+  let authenticated: boolean;
 
-  if (authenticated) {
-    await link({ skipIfLinked: true });
+  // --app bypasses auth+link entirely; API calls authenticate via token/env var
+  if (options.app) {
+    authenticated = true;
+  } else {
+    authenticated = await resolveAuth(cwd);
+    if (authenticated) {
+      await link({
+        skipIfLinked: !options.createApp,
+        ...(options.createApp ? { createApp: options.createApp } : {}),
+      });
+    }
   }
 
   await detectAndInstall(cwd, ctx, options);
 
   if (authenticated) {
-    await pull({});
+    await pull({ app: options.app, instance: options.instance });
     return;
   }
 
@@ -127,7 +141,8 @@ async function scaffoldAndWrite(
     console.log(dim("Consider committing first so you can review what clerk init creates.\n"));
   }
 
-  if (options.yes) {
+  // --app implies non-interactive mode (skip confirmation like --yes)
+  if (options.yes || options.app) {
     previewPlan(plan);
   } else {
     const proceed = await previewAndConfirm(plan);

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -34,6 +34,10 @@ export async function init(options: InitOptions = {}) {
     throwUsageError("Cannot use --app and --create-app together.");
   }
 
+  if (options.instance && !options.app) {
+    throwUsageError("--instance requires --app.");
+  }
+
   const cwd = process.cwd();
 
   // Commander validates --framework against FRAMEWORK_NAMES choices
@@ -145,8 +149,8 @@ async function scaffoldAndWrite(
     console.log(dim("Consider committing first so you can review what clerk init creates.\n"));
   }
 
-  // --app implies non-interactive mode (skip confirmation like --yes)
-  if (options.yes || options.app) {
+  // --app/--create-app imply non-interactive mode (skip confirmation like --yes)
+  if (options.yes || options.app || options.createApp) {
     previewPlan(plan);
   } else {
     const proceed = await previewAndConfirm(plan);

--- a/packages/cli-core/src/commands/link/README.md
+++ b/packages/cli-core/src/commands/link/README.md
@@ -8,15 +8,17 @@ automatically shared across all clones and worktrees of the same repository.
 ## Usage
 
 ```sh
-clerk link                    # Interactive app picker
-clerk link --app app_abc123   # Link directly by app ID
+clerk link                              # Interactive app picker
+clerk link --app app_abc123             # Link directly by app ID
+clerk link --create-app "My App"        # Create a new app and link it
 ```
 
 ## Options
 
-| Flag         | Description                                       |
-| ------------ | ------------------------------------------------- |
-| `--app <id>` | Application ID to link (skips interactive picker) |
+| Flag                  | Description                                               |
+| --------------------- | --------------------------------------------------------- |
+| `--app <id>`          | Application ID to link (skips interactive picker)         |
+| `--create-app <name>` | Create a new Clerk application with this name and link it |
 
 ## Agent Mode
 
@@ -37,7 +39,7 @@ interactive flow.
 7. If a key matches an application, suggests it: "We found \<app\>. Link to this application?"
    - If the user confirms (default), links to the detected app
    - If the user declines, falls through to the interactive picker
-8. If no match, presents a searchable picker (type to filter by name)
+8. If no match, presents a searchable picker (type to filter by name) with a "+ Create new application" option at the bottom. When selected, prompts for a name and creates the app via the API. If the user has zero apps, the picker shows only the "Create new" option
 9. Stores the profile in the config file keyed by the normalized remote URL
 10. Falls back to git-common-dir or the current directory path if no remote is configured
 
@@ -72,3 +74,4 @@ Detected publishable keys are matched against all applications returned by
 | ------ | ----------------------------------- | ------------------------------------------------ |
 | `GET`  | `/v1/platform/applications`         | List all applications for the authenticated user |
 | `GET`  | `/v1/platform/applications/{appId}` | Fetch application details with instance IDs      |
+| `POST` | `/v1/platform/applications`         | Create a new application                         |

--- a/packages/cli-core/src/commands/link/index.test.ts
+++ b/packages/cli-core/src/commands/link/index.test.ts
@@ -34,9 +34,11 @@ mock.module("../auth/login.ts", () => ({
 
 const mockListApplications = mock();
 const mockFetchApplication = mock();
+const mockCreateApplication = mock();
 mock.module("../../lib/plapi.ts", () => ({
   listApplications: (...args: unknown[]) => mockListApplications(...args),
   fetchApplication: (...args: unknown[]) => mockFetchApplication(...args),
+  createApplication: (...args: unknown[]) => mockCreateApplication(...args),
   PlapiError: class PlapiError extends Error {},
   fetchInstanceConfig: async () => ({}),
   putInstanceConfig: async () => ({}),
@@ -75,10 +77,12 @@ mock.module("../../lib/git.ts", () => ({
 
 const mockSearch = mock();
 const mockConfirm = mock();
+const mockInput = mock();
 mock.module("@inquirer/prompts", () => ({
   ...promptsStubs,
   search: (...args: unknown[]) => mockSearch(...args),
   confirm: (...args: unknown[]) => mockConfirm(...args),
+  input: (...args: unknown[]) => mockInput(...args),
 }));
 
 const { link } = await import("./index.ts");
@@ -111,6 +115,7 @@ describe("link", () => {
     mockLogin.mockReset();
     mockListApplications.mockReset();
     mockFetchApplication.mockReset();
+    mockCreateApplication.mockReset();
     mockSetProfile.mockReset();
     mockResolveProfile.mockReset();
     mockResolveProfile.mockResolvedValue(undefined);
@@ -129,6 +134,7 @@ describe("link", () => {
     mockGetGitNormalizedRemote.mockResolvedValue("github.com/org/repo");
     mockSearch.mockReset();
     mockConfirm.mockReset();
+    mockInput.mockReset();
     consoleSpy?.mockRestore();
   });
 
@@ -294,7 +300,7 @@ describe("link", () => {
       mockSearch.mockImplementation(
         async (config: { source: (term: string | undefined) => unknown[] }) => {
           const results = config.source(undefined);
-          expect(results).toHaveLength(2);
+          expect(results).toHaveLength(3); // 2 apps + "Create new"
           return "app_a";
         },
       );
@@ -374,12 +380,37 @@ describe("link", () => {
       await link();
     });
 
-    test("exits when no apps found", async () => {
+    test("shows picker with create option when no apps found", async () => {
       mockIsAgent.mockReturnValue(false);
       mockGetToken.mockResolvedValue("token");
       mockListApplications.mockResolvedValue([]);
+      mockSearch.mockResolvedValue("__create_new__");
+      mockInput.mockResolvedValue("My New App");
+      mockCreateApplication.mockResolvedValue({
+        application_id: "app_new",
+        name: "My New App",
+        instances: [
+          { instance_id: "ins_dev", environment_type: "development", publishable_key: "pk_test" },
+        ],
+      });
+      mockFetchApplication.mockResolvedValue({
+        application_id: "app_new",
+        name: "My New App",
+        instances: [
+          {
+            instance_id: "ins_dev",
+            environment_type: "development",
+            secret_key: "sk_test",
+            publishable_key: "pk_test",
+          },
+        ],
+      });
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await expect(link()).rejects.toThrow("No applications found");
+      await link();
+
+      expect(mockSearch).toHaveBeenCalled();
+      expect(mockCreateApplication).toHaveBeenCalledWith("My New App");
     });
   });
 

--- a/packages/cli-core/src/commands/link/index.test.ts
+++ b/packages/cli-core/src/commands/link/index.test.ts
@@ -160,6 +160,46 @@ describe("link", () => {
       expect(mockGetToken).not.toHaveBeenCalled();
       expect(mockListApplications).not.toHaveBeenCalled();
     });
+
+    test("bypasses agent prompt when --app is provided", async () => {
+      mockIsAgent.mockReturnValue(true);
+      mockGetToken.mockResolvedValue("token");
+      mockFetchApplication.mockResolvedValue(mockApp);
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link({ app: "app_123" });
+
+      expect(mockFetchApplication).toHaveBeenCalledWith("app_123");
+      expect(mockSetProfile).toHaveBeenCalled();
+    });
+
+    test("bypasses agent prompt when --create-app is provided", async () => {
+      mockIsAgent.mockReturnValue(true);
+      mockGetToken.mockResolvedValue("token");
+      mockCreateApplication.mockResolvedValue({
+        application_id: "app_new",
+        name: "Agent App",
+        instances: [],
+      });
+      mockFetchApplication.mockResolvedValue({
+        application_id: "app_new",
+        name: "Agent App",
+        instances: [
+          {
+            instance_id: "ins_dev",
+            environment_type: "development",
+            secret_key: "sk_test",
+            publishable_key: "pk_test",
+          },
+        ],
+      });
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link({ createApp: "Agent App" });
+
+      expect(mockCreateApplication).toHaveBeenCalledWith("Agent App");
+      expect(mockSetProfile).toHaveBeenCalled();
+    });
   });
 
   describe("already linked", () => {
@@ -333,11 +373,12 @@ describe("link", () => {
           source: (term: string | undefined) => { name: string; value: string }[];
         }) => {
           const results = config.source("my");
-          expect(results).toHaveLength(1);
+          expect(results).toHaveLength(2); // "My App" + pinned "Create new"
           expect(results[0]!.value).toBe("app_a");
 
           const noMatch = config.source("zzz");
-          expect(noMatch).toHaveLength(0);
+          expect(noMatch).toHaveLength(1); // only pinned "Create new"
+          expect(noMatch[0]!.value).toBe("__create_new__");
 
           return "app_a";
         },
@@ -370,7 +411,7 @@ describe("link", () => {
           source: (term: string | undefined) => { name: string; value: string }[];
         }) => {
           const results = config.source("abc");
-          expect(results).toHaveLength(1);
+          expect(results).toHaveLength(2); // "app_abc" + pinned "Create new"
           expect(results[0]!.value).toBe("app_abc");
           return "app_abc";
         },
@@ -378,6 +419,19 @@ describe("link", () => {
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
       await link();
+    });
+
+    test("rejects --app and --create-app used together", async () => {
+      await expect(link({ app: "app_123", createApp: "My App" })).rejects.toThrow(
+        "Cannot use --app and --create-app together",
+      );
+    });
+
+    test("throws when --create-app name is empty", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockGetToken.mockResolvedValue("token");
+
+      await expect(link({ createApp: "  " })).rejects.toThrow("Application name cannot be empty");
     });
 
     test("shows picker with create option when no apps found", async () => {
@@ -411,6 +465,47 @@ describe("link", () => {
 
       expect(mockSearch).toHaveBeenCalled();
       expect(mockCreateApplication).toHaveBeenCalledWith("My New App");
+      expect(mockSetProfile).toHaveBeenCalledWith(
+        "github.com/org/repo",
+        expect.objectContaining({
+          appId: "app_new",
+          appName: "My New App",
+        }),
+      );
+    });
+
+    test("--create-app skips re-link prompt on already-linked project", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockGetToken.mockResolvedValue("token");
+      mockResolveProfile.mockResolvedValue({
+        path: "github.com/org/repo",
+        profile: { workspaceId: "", appId: "app_existing", instances: { development: "ins_1" } },
+      });
+      mockCreateApplication.mockResolvedValue({
+        application_id: "app_new",
+        name: "New App",
+        instances: [],
+      });
+      mockFetchApplication.mockResolvedValue({
+        application_id: "app_new",
+        name: "New App",
+        instances: [
+          {
+            instance_id: "ins_dev",
+            environment_type: "development",
+            secret_key: "sk_test",
+            publishable_key: "pk_test",
+          },
+        ],
+      });
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link({ createApp: "New App" });
+
+      // Should NOT prompt for re-link confirmation
+      expect(mockConfirm).not.toHaveBeenCalled();
+      expect(mockCreateApplication).toHaveBeenCalledWith("New App");
+      expect(mockSetProfile).toHaveBeenCalled();
     });
   });
 

--- a/packages/cli-core/src/commands/link/index.ts
+++ b/packages/cli-core/src/commands/link/index.ts
@@ -14,7 +14,7 @@ import { autolink, findClerkKeys, matchKeyToApp } from "../../lib/autolink.ts";
 import { getGitRepoIdentifier, getGitRepoRoot, getGitNormalizedRemote } from "../../lib/git.ts";
 import { dim, cyan } from "../../lib/color.ts";
 import { printNextSteps } from "../../lib/next-steps.ts";
-import { CliError, ERROR_CODE } from "../../lib/errors.ts";
+import { CliError, ERROR_CODE, throwUsageError } from "../../lib/errors.ts";
 
 const AGENT_PROMPT = `You are linking a Clerk application to the current project directory.
 
@@ -48,7 +48,11 @@ function appLabel(app: Application): string {
 }
 
 export async function link(options: LinkOptions = {}): Promise<void> {
-  if (isAgent()) {
+  if (options.app && options.createApp) {
+    throwUsageError("Cannot use --app and --create-app together.");
+  }
+
+  if (isAgent() && !options.app && !options.createApp) {
     console.log(AGENT_PROMPT);
     return;
   }
@@ -72,7 +76,7 @@ export async function link(options: LinkOptions = {}): Promise<void> {
     if (autolinked) return;
   }
 
-  if (existing) {
+  if (existing && !options.createApp) {
     const shouldRelink = await handleExistingProfile(existing, normalizedRemote, options);
     if (!shouldRelink) return;
   }
@@ -208,17 +212,15 @@ async function resolveApp(
 }
 
 async function pickOrCreateApp(apps: Application[], displayPath: string): Promise<Application> {
-  const choices = [
-    ...apps.map((a) => ({ name: appLabel(a), value: a.application_id })),
-    { name: dim("+ Create a new application"), value: CREATE_NEW_APP },
-  ];
+  const appChoices = apps.map((a) => ({ name: appLabel(a), value: a.application_id }));
+  const createChoice = { name: dim("+ Create a new application"), value: CREATE_NEW_APP };
 
   const selectedId = await search({
     message: `Select a Clerk application to link ${dim(`(repo: ${basename(displayPath)})`)}`,
     source: (term) => {
-      if (!term) return choices;
+      if (!term) return [...appChoices, createChoice];
       const lower = term.toLowerCase();
-      return choices.filter((c) => c.name.toLowerCase().includes(lower));
+      return [...appChoices.filter((c) => c.name.toLowerCase().includes(lower)), createChoice];
     },
   });
 

--- a/packages/cli-core/src/commands/link/index.ts
+++ b/packages/cli-core/src/commands/link/index.ts
@@ -175,7 +175,9 @@ async function resolveApplication(
 }
 
 async function createAndFetchApp(name: string): Promise<Application> {
-  const created = await createApplication(name);
+  const trimmed = name.trim();
+  if (!trimmed) throw new CliError("Application name cannot be empty.");
+  const created = await createApplication(trimmed);
   console.log(`\nCreated ${cyan(created.name ?? created.application_id)}`);
   return fetchApplication(created.application_id);
 }
@@ -231,6 +233,5 @@ async function pickOrCreateApp(apps: Application[], displayPath: string): Promis
   }
 
   const name = await input({ message: "Application name:" });
-  if (!name.trim()) throw new CliError("Application name cannot be empty.");
-  return createAndFetchApp(name.trim());
+  return createAndFetchApp(name);
 }

--- a/packages/cli-core/src/commands/link/index.ts
+++ b/packages/cli-core/src/commands/link/index.ts
@@ -1,9 +1,14 @@
 import { basename } from "node:path";
-import { search, confirm } from "@inquirer/prompts";
+import { search, confirm, input } from "@inquirer/prompts";
 import { isAgent } from "../../mode.ts";
 import { getToken } from "../../lib/credential-store.ts";
 import { login } from "../auth/login.ts";
-import { listApplications, fetchApplication, type Application } from "../../lib/plapi.ts";
+import {
+  listApplications,
+  fetchApplication,
+  createApplication,
+  type Application,
+} from "../../lib/plapi.ts";
 import { setProfile, resolveProfile, moveProfile } from "../../lib/config.ts";
 import { autolink, findClerkKeys, matchKeyToApp } from "../../lib/autolink.ts";
 import { getGitRepoIdentifier, getGitRepoRoot, getGitNormalizedRemote } from "../../lib/git.ts";
@@ -18,6 +23,7 @@ const AGENT_PROMPT = `You are linking a Clerk application to the current project
 1. Ensure the user is authenticated. If not, run \`clerk auth login\` first.
 2. Determine which application to link:
    - If the user provides an app ID: \`clerk link --app <app_id>\`
+   - To create a new application: \`clerk link --create-app "My App"\`
    - Otherwise, list available applications with \`GET /v1/platform/applications\` and ask the user to select one.
 3. The link is stored in ~/.clerk/config.json as a profile keyed by the git repository root (shared across worktrees).
 
@@ -26,10 +32,14 @@ const AGENT_PROMPT = `You are linking a Clerk application to the current project
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
 | GET | /v1/platform/applications | List all applications |
-| GET | /v1/platform/applications/{appId} | Fetch application with instance details |`;
+| GET | /v1/platform/applications/{appId} | Fetch application with instance details |
+| POST | /v1/platform/applications | Create a new application |`;
+
+const CREATE_NEW_APP = "__create_new__" as const;
 
 interface LinkOptions {
   app?: string;
+  createApp?: string;
   skipIfLinked?: boolean;
 }
 
@@ -71,7 +81,9 @@ export async function link(options: LinkOptions = {}): Promise<void> {
 
   const app = options.app
     ? await fetchApplication(options.app)
-    : await resolveApp(cwd, displayPath, !existing);
+    : options.createApp
+      ? await createAndFetchApp(options.createApp)
+      : await resolveApp(cwd, displayPath, !existing);
 
   const devInstance = app.instances.find((i) => i.environment_type === "development");
   const prodInstance = app.instances.find((i) => i.environment_type === "production");
@@ -155,6 +167,12 @@ async function handleExistingProfile(
   return confirm({ message: "Re-link to a different application?", default: false });
 }
 
+async function createAndFetchApp(name: string): Promise<Application> {
+  const created = await createApplication(name);
+  console.log(`\nCreated ${cyan(created.name ?? created.application_id)}`);
+  return fetchApplication(created.application_id);
+}
+
 async function resolveApp(
   cwd: string,
   displayPath: string,
@@ -162,13 +180,7 @@ async function resolveApp(
 ): Promise<Application> {
   const apps = await listApplications();
 
-  if (apps.length === 0) {
-    throw new CliError("No applications found. Create one at https://dashboard.clerk.com first.", {
-      code: ERROR_CODE.APP_NOT_FOUND,
-    });
-  }
-
-  if (detectKeys) {
+  if (apps.length > 0 && detectKeys) {
     const detectedKeys = await findClerkKeys(cwd);
     const match = detectedKeys.length > 0 ? matchKeyToApp(detectedKeys, apps) : undefined;
 
@@ -183,14 +195,14 @@ async function resolveApp(
     }
   }
 
-  return pickApp(apps, displayPath);
+  return pickOrCreateApp(apps, displayPath);
 }
 
-async function pickApp(apps: Application[], displayPath: string): Promise<Application> {
-  const choices = apps.map((a) => ({
-    name: appLabel(a),
-    value: a.application_id,
-  }));
+async function pickOrCreateApp(apps: Application[], displayPath: string): Promise<Application> {
+  const choices = [
+    ...apps.map((a) => ({ name: appLabel(a), value: a.application_id })),
+    { name: dim("+ Create a new application"), value: CREATE_NEW_APP },
+  ];
 
   const selectedId = await search({
     message: `Select a Clerk application to link ${dim(`(repo: ${basename(displayPath)})`)}`,
@@ -201,11 +213,17 @@ async function pickApp(apps: Application[], displayPath: string): Promise<Applic
     },
   });
 
-  const found = apps.find((a) => a.application_id === selectedId);
-  if (!found) {
-    throw new CliError("Selected application not found.", {
-      code: ERROR_CODE.APP_NOT_FOUND,
-    });
+  if (selectedId !== CREATE_NEW_APP) {
+    const found = apps.find((a) => a.application_id === selectedId);
+    if (!found) {
+      throw new CliError("Selected application not found.", {
+        code: ERROR_CODE.APP_NOT_FOUND,
+      });
+    }
+    return found;
   }
-  return found;
+
+  const name = await input({ message: "Application name:" });
+  if (!name.trim()) throw new CliError("Application name cannot be empty.");
+  return createAndFetchApp(name.trim());
 }

--- a/packages/cli-core/src/commands/link/index.ts
+++ b/packages/cli-core/src/commands/link/index.ts
@@ -37,11 +37,11 @@ const AGENT_PROMPT = `You are linking a Clerk application to the current project
 
 const CREATE_NEW_APP = "__create_new__" as const;
 
-interface LinkOptions {
+type LinkOptions = {
   app?: string;
   createApp?: string;
   skipIfLinked?: boolean;
-}
+};
 
 function appLabel(app: Application): string {
   return app.name ? `${app.name} (${app.application_id})` : app.application_id;
@@ -79,11 +79,7 @@ export async function link(options: LinkOptions = {}): Promise<void> {
 
   await ensureAuth();
 
-  const app = options.app
-    ? await fetchApplication(options.app)
-    : options.createApp
-      ? await createAndFetchApp(options.createApp)
-      : await resolveApp(cwd, displayPath, !existing);
+  const app = await resolveApplication(options, cwd, displayPath, !existing);
 
   const devInstance = app.instances.find((i) => i.environment_type === "development");
   const prodInstance = app.instances.find((i) => i.environment_type === "production");
@@ -165,6 +161,17 @@ async function handleExistingProfile(
   }
 
   return confirm({ message: "Re-link to a different application?", default: false });
+}
+
+async function resolveApplication(
+  options: LinkOptions,
+  cwd: string,
+  displayPath: string,
+  detectKeys: boolean,
+): Promise<Application> {
+  if (options.app) return fetchApplication(options.app);
+  if (options.createApp) return createAndFetchApp(options.createApp);
+  return resolveApp(cwd, displayPath, detectKeys);
 }
 
 async function createAndFetchApp(name: string): Promise<Application> {

--- a/packages/cli-core/src/lib/plapi.test.ts
+++ b/packages/cli-core/src/lib/plapi.test.ts
@@ -13,6 +13,7 @@ const {
   putInstanceConfig,
   patchInstanceConfig,
   listApplications,
+  createApplication,
 } = await import("./plapi.ts");
 const { PlapiError } = await import("./errors.ts");
 
@@ -318,6 +319,76 @@ describe("plapi", () => {
       } catch (error) {
         expect(error).toBeInstanceOf(PlapiError);
         expect((error as PlapiError).status).toBe(403);
+      }
+    });
+  });
+
+  describe("createApplication", () => {
+    test("sends POST method with correct URL and body", async () => {
+      let capturedMethod = "";
+      let capturedUrl = "";
+      let capturedBody = "";
+      const mockApp = {
+        application_id: "app_new",
+        name: "My New App",
+        instances: [],
+      };
+      stubFetch(async (input, init) => {
+        capturedUrl = input.toString();
+        capturedMethod = init?.method ?? "GET";
+        capturedBody = init?.body as string;
+        return new Response(JSON.stringify(mockApp), { status: 200 });
+      });
+
+      const result = await createApplication("My New App");
+      expect(capturedMethod).toBe("POST");
+      expect(capturedUrl).toBe("https://api.clerk.com/v1/platform/applications");
+      expect(JSON.parse(capturedBody)).toEqual({ name: "My New App" });
+      expect(result).toEqual(mockApp);
+    });
+
+    test("sends Content-Type and Authorization headers", async () => {
+      let capturedHeaders: Headers | undefined;
+      stubFetch(async (_input, init) => {
+        capturedHeaders = new Headers(init?.headers);
+        return new Response(JSON.stringify({ application_id: "app_1", instances: [] }), {
+          status: 200,
+        });
+      });
+
+      await createApplication("Test App");
+      expect(capturedHeaders?.get("Authorization")).toBe("Bearer test_key_123");
+      expect(capturedHeaders?.get("Content-Type")).toBe("application/json");
+      expect(capturedHeaders?.get("Accept")).toBe("application/json");
+    });
+
+    test("returns parsed Application object", async () => {
+      const mockApp = {
+        application_id: "app_created",
+        name: "Created App",
+        instances: [
+          {
+            instance_id: "ins_dev",
+            environment_type: "development",
+            publishable_key: "pk_test_new",
+          },
+        ],
+      };
+      stubFetch(async () => new Response(JSON.stringify(mockApp), { status: 200 }));
+
+      const result = await createApplication("Created App");
+      expect(result).toEqual(mockApp);
+    });
+
+    test("throws PlapiError on non-2xx response", async () => {
+      stubFetch(async () => new Response("Bad Request", { status: 400 }));
+
+      try {
+        await createApplication("Bad App");
+        expect(true).toBe(false);
+      } catch (error) {
+        expect(error).toBeInstanceOf(PlapiError);
+        expect((error as PlapiError).status).toBe(400);
       }
     });
   });

--- a/packages/cli-core/src/lib/plapi.test.ts
+++ b/packages/cli-core/src/lib/plapi.test.ts
@@ -16,6 +16,7 @@ const {
   createApplication,
 } = await import("./plapi.ts");
 const { PlapiError } = await import("./errors.ts");
+type PlapiErrorInstance = InstanceType<typeof PlapiError>;
 
 describe("plapi", () => {
   const originalEnv = { ...process.env };
@@ -105,8 +106,8 @@ describe("plapi", () => {
       expect(true).toBe(false); // should not reach
     } catch (error) {
       expect(error).toBeInstanceOf(PlapiError);
-      expect((error as PlapiError).status).toBe(404);
-      expect((error as PlapiError).body).toBe("Not Found");
+      expect((error as PlapiErrorInstance).status).toBe(404);
+      expect((error as PlapiErrorInstance).body).toBe("Not Found");
     }
   });
 
@@ -179,7 +180,7 @@ describe("plapi", () => {
         expect(true).toBe(false);
       } catch (error) {
         expect(error).toBeInstanceOf(PlapiError);
-        expect((error as PlapiError).status).toBe(400);
+        expect((error as PlapiErrorInstance).status).toBe(400);
       }
     });
   });
@@ -241,7 +242,7 @@ describe("plapi", () => {
         expect(true).toBe(false);
       } catch (error) {
         expect(error).toBeInstanceOf(PlapiError);
-        expect((error as PlapiError).status).toBe(422);
+        expect((error as PlapiErrorInstance).status).toBe(422);
       }
     });
   });
@@ -282,7 +283,7 @@ describe("plapi", () => {
         expect(true).toBe(false);
       } catch (error) {
         expect(error).toBeInstanceOf(PlapiError);
-        expect((error as PlapiError).status).toBe(404);
+        expect((error as PlapiErrorInstance).status).toBe(404);
       }
     });
   });
@@ -318,7 +319,7 @@ describe("plapi", () => {
         expect(true).toBe(false);
       } catch (error) {
         expect(error).toBeInstanceOf(PlapiError);
-        expect((error as PlapiError).status).toBe(403);
+        expect((error as PlapiErrorInstance).status).toBe(403);
       }
     });
   });
@@ -388,7 +389,7 @@ describe("plapi", () => {
         expect(true).toBe(false);
       } catch (error) {
         expect(error).toBeInstanceOf(PlapiError);
-        expect((error as PlapiError).status).toBe(400);
+        expect((error as PlapiErrorInstance).status).toBe(400);
       }
     });
   });

--- a/packages/cli-core/src/lib/plapi.ts
+++ b/packages/cli-core/src/lib/plapi.ts
@@ -184,6 +184,27 @@ export const patchInstanceConfig = (
   options?: { destructive?: boolean },
 ) => sendInstanceConfig("PATCH", applicationId, instanceId, config, options);
 
+export async function createApplication(name: string): Promise<Application> {
+  const token = await getAuthToken();
+  const url = new URL("/v1/platform/applications", getPlapiBaseUrl());
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({ name }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new PlapiError(response.status, body);
+  }
+
+  return response.json() as Promise<Application>;
+}
+
 export async function listApplications(): Promise<Application[]> {
   const token = await getAuthToken();
   const url = new URL("/v1/platform/applications", getPlapiBaseUrl());

--- a/packages/cli-core/src/test/integration/agent-mode.test.ts
+++ b/packages/cli-core/src/test/integration/agent-mode.test.ts
@@ -4,9 +4,17 @@
  */
 
 import { test, expect } from "bun:test";
-import { useIntegrationTestHarness, http, clerk } from "../lib/setup.ts";
+import { join } from "node:path";
+import {
+  useIntegrationTestHarness,
+  http,
+  clerk,
+  getInstance,
+  parseEnvFile,
+  MOCK_APP,
+} from "../lib/setup.ts";
 
-useIntegrationTestHarness();
+const h = useIntegrationTestHarness();
 
 test("init outputs structured agent prompt without API calls", async () => {
   const { stdout } = await clerk("--mode", "agent", "init");
@@ -26,4 +34,74 @@ test("unlink outputs structured agent prompt without API calls", async () => {
   expect(stdout).toContain("unlinking a Clerk application");
   expect(stdout).toContain("## Steps");
   expect(http.requests.length).toBe(0);
+});
+
+test("init --app in agent mode scaffolds instead of outputting prompt", async () => {
+  // Write package.json so framework detection works and SDK install is skipped
+  await Bun.write(
+    join(h.tempDir, "package.json"),
+    JSON.stringify({
+      name: "test-project",
+      dependencies: { next: "15.0.0", "@clerk/nextjs": "6.0.0" },
+    }),
+  );
+
+  http.mock({
+    [`/applications/${MOCK_APP.application_id}`]: MOCK_APP,
+  });
+
+  const { stdout, stderr } = await clerk(
+    "--mode",
+    "agent",
+    "init",
+    "--app",
+    MOCK_APP.application_id,
+  );
+
+  // Should NOT output the agent prompt — it should actually scaffold
+  expect(stdout).not.toContain("# Add Clerk Authentication");
+  // Should pull env vars (this is part of the scaffold flow)
+  expect(stderr).toContain("Pulling env vars");
+});
+
+test("init --app --instance prod uses production keys in .env.local", async () => {
+  const prodInstance = getInstance(MOCK_APP, "production");
+
+  await Bun.write(
+    join(h.tempDir, "package.json"),
+    JSON.stringify({
+      name: "test-project",
+      dependencies: { next: "15.0.0", "@clerk/nextjs": "6.0.0" },
+    }),
+  );
+
+  http.mock({
+    [`/applications/${MOCK_APP.application_id}`]: MOCK_APP,
+  });
+
+  await clerk("--mode", "agent", "init", "--app", MOCK_APP.application_id, "--instance", "prod");
+
+  const envContent = await Bun.file(join(h.tempDir, ".env.local")).text();
+  const env = parseEnvFile(envContent, ".env.local");
+  expect(env.get("NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY")).toBe(prodInstance.publishable_key);
+  expect(env.get("CLERK_SECRET_KEY")).toBe(prodInstance.secret_key);
+});
+
+test("init --app in human mode skips login/link", async () => {
+  await Bun.write(
+    join(h.tempDir, "package.json"),
+    JSON.stringify({
+      name: "test-project",
+      dependencies: { next: "15.0.0", "@clerk/nextjs": "6.0.0" },
+    }),
+  );
+
+  http.mock({
+    [`/applications/${MOCK_APP.application_id}`]: MOCK_APP,
+  });
+
+  const { stdout } = await clerk("--mode", "human", "init", "--app", MOCK_APP.application_id);
+
+  // Should NOT show "Logged in as" since --app skips authenticateAndLink
+  expect(stdout).not.toContain("Logged in as");
 });

--- a/packages/cli-core/src/test/integration/agent-mode.test.ts
+++ b/packages/cli-core/src/test/integration/agent-mode.test.ts
@@ -64,7 +64,7 @@ test("init --app in agent mode scaffolds instead of outputting prompt", async ()
   expect(stderr).toContain("Pulling env vars");
 });
 
-test("init --app --instance prod uses production keys in .env.local", async () => {
+test("init --app --instance prod uses production keys in .env", async () => {
   const prodInstance = getInstance(MOCK_APP, "production");
 
   await Bun.write(
@@ -81,8 +81,8 @@ test("init --app --instance prod uses production keys in .env.local", async () =
 
   await clerk("--mode", "agent", "init", "--app", MOCK_APP.application_id, "--instance", "prod");
 
-  const envContent = await Bun.file(join(h.tempDir, ".env.local")).text();
-  const env = parseEnvFile(envContent, ".env.local");
+  const envContent = await Bun.file(join(h.tempDir, ".env")).text();
+  const env = parseEnvFile(envContent, ".env");
   expect(env.get("NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY")).toBe(prodInstance.publishable_key);
   expect(env.get("CLERK_SECRET_KEY")).toBe(prodInstance.secret_key);
 });

--- a/packages/cli-core/src/test/integration/create-app.test.ts
+++ b/packages/cli-core/src/test/integration/create-app.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Create-app flow
+ * Tests `clerk link --create-app` which creates a new application via POST
+ * and then fetches it to populate the profile.
+ */
+
+import { test, expect } from "bun:test";
+import { useIntegrationTestHarness, http, readConfig, clerk, MOCK_APP } from "../lib/setup.ts";
+import type { Application } from "../../lib/plapi.ts";
+
+useIntegrationTestHarness();
+
+/** Minimal response from POST /v1/platform/applications (no secret keys). */
+const CREATED_APP: Application = {
+  application_id: MOCK_APP.application_id,
+  name: "My App",
+  instances: [],
+};
+
+test("link --create-app posts to /applications and stores profile", async () => {
+  const requests: Array<{ method: string; url: string; body: string | null }> = [];
+
+  http.stub(async (url, init) => {
+    const method = init?.method ?? "GET";
+    const body = (init?.body as string) ?? null;
+    requests.push({ method, url, body });
+
+    // POST /v1/platform/applications — create
+    if (method === "POST" && url.includes("/v1/platform/applications")) {
+      return new Response(JSON.stringify(CREATED_APP), { status: 200 });
+    }
+
+    // GET /v1/platform/applications/<id> — fetch with secret keys
+    if (method === "GET" && url.includes(`/applications/${MOCK_APP.application_id}`)) {
+      return new Response(JSON.stringify(MOCK_APP), { status: 200 });
+    }
+
+    throw new Error(`Unexpected request: ${method} ${url}`);
+  });
+
+  await clerk("--mode", "human", "link", "--create-app", "My App");
+
+  // Verify the POST was made with the correct body
+  const postReq = requests.find((r) => r.method === "POST");
+  expect(postReq).toBeDefined();
+  expect(postReq!.url).toContain("/v1/platform/applications");
+  expect(JSON.parse(postReq!.body!)).toEqual({ name: "My App" });
+
+  // Verify a follow-up GET fetched the full application
+  const getReq = requests.find(
+    (r) => r.method === "GET" && r.url.includes(`/applications/${MOCK_APP.application_id}`),
+  );
+  expect(getReq).toBeDefined();
+
+  // Verify config was written
+  const config = await readConfig();
+  const profile = config.profiles["github.com/test/project"];
+  expect(profile).toBeDefined();
+  expect(profile!.appId).toBe(MOCK_APP.application_id);
+  expect(profile!.appName).toBe(MOCK_APP.name);
+});


### PR DESCRIPTION
## Summary

- **`--app <id>` on `init`**: Bypasses login/link prompts and enables fully non-interactive mode (implies `--yes`). Authenticates via existing OAuth token or `CLERK_PLATFORM_API_KEY`.
- **`--instance <id>` on `init`**: Selects which instance's env vars to pull (used with `--app`).
- **`--create-app <name>` on `init` and `link`**: Creates a new Clerk application via `POST /v1/platform/applications`, then links it.
- **"+ Create a new application"** option added to the interactive app picker in `link` (and `init` which calls `link`). When no apps exist, the picker shows only the create option instead of throwing an error.

### Usage examples

```sh
# Non-interactive (for CI/agents)
clerk init --app app_123 --framework next
clerk init --app app_123 --instance prod --framework next
CLERK_PLATFORM_API_KEY=ak_... clerk init --app app_123

# Create a new app
clerk init --create-app "My App" --framework next
clerk link --create-app "My App"

# Interactive: picker now has "+ Create new" at the bottom
clerk init
clerk link
```

## Test plan

- [ ] `bun run format` passes
- [ ] `bun run lint` passes (0 errors, 1 pre-existing warning)
- [ ] `bun test` passes (713 pass, 2 pre-existing flaky failures in `api command`)
- [ ] Integration tests verify `--app` scaffolds in agent mode instead of outputting prompt
- [ ] Integration tests verify `--instance prod` pulls production keys
- [ ] Integration test verifies `--create-app` POSTs to the API and stores profile
- [ ] Unit tests verify `createApplication` sends correct POST request
- [ ] Existing link tests updated for new picker choices (2 apps + create = 3 choices)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--app <id>` and `--instance <id>` to `clerk init` for non-interactive setup
  * Added `--create-app <name>` to `clerk init` and `clerk link` to create apps during commands
  * Linking now supports creating and selecting a new application inline

* **Documentation**
  * Updated CLI docs and examples for `--app`, `--instance`, and `--create-app`
  * Added Non-Interactive / Agent usage guidance

* **Tests**
  * Added and expanded tests covering create-app flows, agent-mode, and linking behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->