### PR TITLE
feat(init): support keyless mode for zero-friction setup

### DIFF
--- a/packages/cli-core/src/commands/init/README.md
+++ b/packages/cli-core/src/commands/init/README.md
@@ -18,7 +18,7 @@ clerk init --yes
 | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--framework <name>` | Framework to set up (skips auto-detection). Valid values: `next`, `astro`, `nuxt`, `tanstack-start`, `react-router`, `vue`, `expo`, `react`, `express`, `fastify` |
 | `--prompt`           | Output a prompt for an AI agent to integrate Clerk, then exit                                                                                                     |
-| `-y, --yes`          | Skip confirmation prompts                                                                                                                                         |
+| `-y, --yes`          | Skip confirmation prompts. Defaults to keyless mode if not already authenticated and linked.                                                                      |
 
 ## Agent Mode
 
@@ -28,19 +28,24 @@ When running in agent mode (`--mode agent` or non-TTY), outputs a framework-spec
 
 1. Gathers project context (framework, router variant, TypeScript, `src/` directory, package manager)
 2. **Agent mode**: outputs a framework-specific prompt, then exits
-3. **Human mode**: authenticates via `clerk auth login` (skipped if already authenticated)
-4. Links the project via `clerk link` (skipped if already linked)
+3. **Human mode**: determines auth mode:
+   - If already authenticated and linked: uses authenticated mode automatically
+   - If authenticated but not linked: uses authenticated mode (runs `clerk link`)
+   - If not authenticated: asks user — "Continue with temporary keys" (keyless) or "Log in to an existing Clerk account"
+   - With `--yes` and not authenticated: defaults to keyless mode
+4. **Authenticated mode only**: authenticates via `clerk auth login` (skipped if already authenticated) and links the project via `clerk link` (skipped if already linked)
 5. Displays detected framework and variant
 6. Detects existing auth libraries (NextAuth, Auth0, Supabase, Firebase, Passport, Better Auth, Kinde) and shows migration guidance
 7. Installs the appropriate Clerk SDK (skips if already present)
-8. Pulls development instance API keys via `clerk env pull`
-9. Generates a scaffold plan for the detected framework
-10. Warns if the git working tree has uncommitted changes
-11. Previews planned file changes and asks for confirmation
-12. Writes scaffold files to disk
-13. Runs project formatters (Prettier/Biome) on generated files
-14. Scans for issues: hardcoded keys, leftover auth-library imports, stale API calls
-15. Prints a summary of created, modified, and skipped files with recommendations
+8. Generates a scaffold plan for the detected framework
+9. Warns if the git working tree has uncommitted changes
+10. Previews planned file changes and asks for confirmation
+11. Writes scaffold files to disk
+12. Runs project formatters (Prettier/Biome) on generated files
+13. Scans for issues: hardcoded keys, leftover auth-library imports, stale API calls
+14. Prints a summary of created, modified, and skipped files with recommendations
+15. **Authenticated mode**: pulls development instance API keys via `clerk env pull`
+16. **Keyless mode**: prints instructions for keyless development and how to connect a Clerk account later
 
 ## Framework Detection
 

--- a/packages/cli-core/src/commands/init/README.md
+++ b/packages/cli-core/src/commands/init/README.md
@@ -18,7 +18,7 @@ clerk init --yes
 | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--framework <name>` | Framework to set up (skips auto-detection). Valid values: `next`, `astro`, `nuxt`, `tanstack-start`, `react-router`, `vue`, `expo`, `react`, `express`, `fastify` |
 | `--prompt`           | Output a prompt for an AI agent to integrate Clerk, then exit                                                                                                     |
-| `-y, --yes`          | Skip confirmation prompts. Defaults to keyless mode if not already authenticated and linked.                                                                      |
+| `-y, --yes`          | Skip confirmation prompts                                                                                                                                         |
 
 ## Agent Mode
 
@@ -31,7 +31,7 @@ When running in agent mode (`--mode agent` or non-TTY), outputs a framework-spec
 3. **Human mode**: determines auth mode:
    - If already authenticated and linked: uses authenticated mode automatically
    - If authenticated but not linked: uses authenticated mode (runs `clerk link`)
-   - If not authenticated: asks user — "Continue with temporary keys" (keyless) or "Log in to an existing Clerk account"
+   - If not authenticated: asks user — "Continue with temporary keys (connect your account later)" or "Log in to an existing Clerk account"
    - With `--yes` and not authenticated: defaults to keyless mode
 4. **Authenticated mode only**: authenticates via `clerk auth login` (skipped if already authenticated) and links the project via `clerk link` (skipped if already linked)
 5. Displays detected framework and variant

--- a/packages/cli-core/src/commands/init/heuristics.ts
+++ b/packages/cli-core/src/commands/init/heuristics.ts
@@ -101,3 +101,16 @@ export async function getAuthenticatedEmail(): Promise<string | null> {
     return null;
   }
 }
+
+export function printKeylessInfo(): void {
+  console.log(
+    dim("\n  Your app will work immediately — Clerk generates temporary dev keys automatically."),
+  );
+  console.log(
+    dim(`  Look for the ${bold('"Configure your application"')} banner to claim your account.\n`),
+  );
+  console.log(dim("  To connect a Clerk account later:"));
+  console.log(dim("    clerk auth login"));
+  console.log(dim("    clerk link"));
+  console.log(dim("    clerk env pull"));
+}

--- a/packages/cli-core/src/commands/init/heuristics.ts
+++ b/packages/cli-core/src/commands/init/heuristics.ts
@@ -6,7 +6,7 @@ import { getToken } from "../../lib/credential-store.js";
 import { fetchUserInfo } from "../../lib/token-exchange.js";
 import { printFindings } from "./scan.js";
 import { pmInstallCommand } from "./prompts/index.js";
-import type { ProjectContext, ScaffoldPlan } from "./frameworks/types.js";
+import type { FileAction, ProjectContext, ScaffoldPlan } from "./frameworks/types.js";
 import type { ScanFinding } from "./scan.js";
 
 export async function installSdk(ctx: ProjectContext): Promise<void> {
@@ -63,27 +63,21 @@ export async function checkGitDirty(cwd: string): Promise<boolean> {
   }
 }
 
-export function printOutro(plan: ScaffoldPlan, findings: ScanFinding[]): void {
-  const created = plan.actions.filter((a) => a.type === "create");
-  const modified = plan.actions.filter((a) => a.type === "modify");
-  const skipped = plan.actions.filter((a) => a.type === "skip");
+function formatAction(action: FileAction): string {
+  if (action.type === "create") return `  ${green("+")} ${action.path}`;
+  if (action.type === "modify") return `  ${yellow("~")} ${action.path}`;
+  return `  ${dim("-")} ${dim(action.path)} ${dim(`(${action.skipReason})`)}`;
+}
 
+export function printOutro(plan: ScaffoldPlan, findings: ScanFinding[]): void {
   console.log(bold(green("\n✓ Clerk has been set up in your project!\n")));
 
-  for (const a of created) {
-    console.log(`  ${green("+")} ${a.path}`);
-  }
-  for (const a of modified) {
-    console.log(`  ${yellow("~")} ${a.path}`);
-  }
-  for (const a of skipped) {
-    console.log(`  ${dim("-")} ${dim(a.path)} ${dim(`(${a.skipReason})`)}`);
+  for (const action of plan.actions) {
+    console.log(formatAction(action));
   }
 
   printNextSteps(plan.postInstructions);
-
   printFindings(findings);
-
   console.log();
 }
 
@@ -103,14 +97,13 @@ export async function getAuthenticatedEmail(): Promise<string | null> {
 }
 
 export function printKeylessInfo(): void {
-  console.log(
-    dim("\n  Your app will work immediately — Clerk generates temporary dev keys automatically."),
-  );
-  console.log(
-    dim(`  Look for the ${bold('"Configure your application"')} banner to claim your account.\n`),
-  );
-  console.log(dim("  To connect a Clerk account later:"));
-  console.log(dim("    clerk auth login"));
-  console.log(dim("    clerk link"));
-  console.log(dim("    clerk env pull"));
+  const lines = [
+    "\n  Your app will work immediately — Clerk generates temporary dev keys automatically.",
+    `  Look for the ${bold('"Configure your application"')} banner to claim your account.\n`,
+    "  To connect a Clerk account later:",
+    "    clerk auth login",
+    "    clerk link",
+    "    clerk env pull",
+  ];
+  console.log(lines.map(dim).join("\n"));
 }

--- a/packages/cli-core/src/commands/init/index.test.ts
+++ b/packages/cli-core/src/commands/init/index.test.ts
@@ -1,100 +1,66 @@
-import { test, expect, describe, afterEach, mock, spyOn } from "bun:test";
-import { configStubs } from "../../test/stubs.ts";
+import { test, expect, describe, afterEach, spyOn } from "bun:test";
 
-const mockLogin = mock();
-mock.module("../auth/login.js", () => ({
-  login: (...args: unknown[]) => mockLogin(...args),
-}));
+// Use spyOn exclusively — Bun's mock.module pollutes the global module registry
+// and breaks other test files that import the same modules.
+import * as linkMod from "../link/index.ts";
+import * as pullMod from "../env/pull.ts";
+import * as context from "./context.ts";
+import * as scaffoldMod from "./scaffold.ts";
+import * as scanMod from "./scan.ts";
+import * as heuristics from "./heuristics.ts";
+import * as mode from "../../mode.ts";
+import * as framework from "../../lib/framework.ts";
+import * as config from "../../lib/config.ts";
+import { init } from "./index.ts";
 
-const mockLink = mock();
-mock.module("../link/index.js", () => ({
-  link: (...args: unknown[]) => mockLink(...args),
-}));
-
-mock.module("../env/pull.js", () => ({
-  pull: async () => {},
-}));
-
-const mockIsAgent = mock();
-mock.module("../../mode.js", () => ({
-  isAgent: (...args: unknown[]) => mockIsAgent(...args),
-  isHuman: () => true,
-  getMode: () => "human",
-  setMode: () => {},
-}));
-
-const mockLookupFramework = mock();
-mock.module("../../lib/framework.js", () => ({
-  lookupFramework: (...args: unknown[]) => mockLookupFramework(...args),
-}));
-
-const mockResolveProfile = mock();
-mock.module("../../lib/config.js", () => ({
-  ...configStubs,
-  resolveProfile: (...args: unknown[]) => mockResolveProfile(...args),
-}));
-
-const mockGatherContext = mock();
-mock.module("./context.js", () => ({
-  gatherContext: (...args: unknown[]) => mockGatherContext(...args),
-}));
-
-mock.module("./scaffold.js", () => ({
-  scaffold: async () => ({ actions: [], postInstructions: [] }),
-  enrichProjectContext: async () => {},
-}));
-
-mock.module("./preview.js", () => ({
-  previewPlan: () => {},
-  previewAndConfirm: async () => true,
-}));
-
-mock.module("./format.js", () => ({
-  runFormatters: async () => {},
-}));
-
-mock.module("./scan.js", () => ({
-  detectAuthLibraries: () => {},
-  scanForIssues: async () => [],
-}));
-
-const mockGetAuthenticatedEmail = mock();
-mock.module("./heuristics.js", () => ({
-  installSdk: async () => {},
-  writePlan: async () => [],
-  checkGitDirty: async () => false,
-  printOutro: () => {},
-  getAuthenticatedEmail: (...args: unknown[]) => mockGetAuthenticatedEmail(...args),
-}));
-
-const { init } = await import("./index.ts");
-
-describe("init next-steps ordering", () => {
-  let consoleSpy: ReturnType<typeof spyOn>;
+describe("init command", () => {
+  let spies: ReturnType<typeof spyOn>[];
 
   afterEach(() => {
-    mockLogin.mockReset();
-    mockLink.mockReset();
-    mockIsAgent.mockReset();
-    mockLookupFramework.mockReset();
-    mockResolveProfile.mockReset();
-    mockGatherContext.mockReset();
-    mockGetAuthenticatedEmail.mockReset();
-    consoleSpy?.mockRestore();
+    for (const spy of spies) spy.mockRestore();
   });
 
-  test("suppresses auth next-steps when login runs during init", async () => {
-    mockIsAgent.mockReturnValue(false);
-    mockGatherContext.mockResolvedValue(null);
-    mockGetAuthenticatedEmail.mockResolvedValue(null);
-    mockResolveProfile.mockResolvedValue(undefined);
-    mockLogin.mockResolvedValue({ userId: "user_1", email: "test@test.com" });
-    mockLink.mockResolvedValue(undefined);
-    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+  function setupMocks(overrides: { email?: string | null } = {}) {
+    const email = overrides.email ?? null;
+
+    spies = [
+      spyOn(console, "log").mockImplementation(() => {}),
+      spyOn(mode, "isAgent").mockReturnValue(false),
+      spyOn(framework, "lookupFramework").mockReturnValue(undefined),
+      spyOn(config, "resolveProfile").mockResolvedValue(undefined),
+      spyOn(context, "gatherContext").mockResolvedValue(null),
+      spyOn(scaffoldMod, "scaffold").mockResolvedValue({ actions: [], postInstructions: [] }),
+      spyOn(scaffoldMod, "enrichProjectContext").mockResolvedValue(undefined),
+      spyOn(scanMod, "detectAuthLibraries").mockReturnValue(undefined),
+      spyOn(scanMod, "scanForIssues").mockResolvedValue([]),
+      spyOn(heuristics, "installSdk").mockResolvedValue(undefined),
+      spyOn(heuristics, "writePlan").mockResolvedValue([]),
+      spyOn(heuristics, "checkGitDirty").mockResolvedValue(false),
+      spyOn(heuristics, "printOutro").mockReturnValue(undefined),
+      spyOn(heuristics, "printKeylessInfo").mockReturnValue(undefined),
+      spyOn(heuristics, "getAuthenticatedEmail").mockResolvedValue(email),
+      spyOn(linkMod, "link").mockResolvedValue(undefined),
+      spyOn(pullMod, "pull").mockResolvedValue(undefined),
+    ];
+  }
+
+  test("defaults to keyless mode when not authenticated", async () => {
+    setupMocks({ email: null });
 
     await init({ yes: true });
 
-    expect(mockLogin).toHaveBeenCalledWith({ showNextSteps: false });
-    expect(mockLink).toHaveBeenCalledWith({ skipIfLinked: true });
+    expect(linkMod.link).not.toHaveBeenCalled();
+    expect(pullMod.pull).not.toHaveBeenCalled();
+    expect(heuristics.printKeylessInfo).toHaveBeenCalled();
+  });
+
+  test("links and pulls env when authenticated", async () => {
+    setupMocks({ email: "test@test.com" });
+
+    await init({ yes: true });
+
+    expect(linkMod.link).toHaveBeenCalledWith({ skipIfLinked: true });
+    expect(pullMod.pull).toHaveBeenCalled();
+    expect(heuristics.printKeylessInfo).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli-core/src/commands/init/index.test.ts
+++ b/packages/cli-core/src/commands/init/index.test.ts
@@ -1,16 +1,19 @@
 import { test, expect, describe, afterEach, spyOn } from "bun:test";
 
-// Use spyOn exclusively — Bun's mock.module pollutes the global module registry
-// and breaks other test files that import the same modules.
+// Pure spyOn approach — Bun's mock.module globally replaces modules for the
+// entire test run, which pollutes other test files (link, env/pull, config,
+// context, etc.) that import the same modules. spyOn restores cleanly.
 import * as linkMod from "../link/index.ts";
 import * as pullMod from "../env/pull.ts";
+import * as mode from "../../mode.ts";
+import * as config from "../../lib/config.ts";
+import * as frameworkMod from "../../lib/framework.ts";
 import * as context from "./context.ts";
 import * as scaffoldMod from "./scaffold.ts";
+import * as previewMod from "./preview.ts";
+import * as formatMod from "./format.ts";
 import * as scanMod from "./scan.ts";
 import * as heuristics from "./heuristics.ts";
-import * as mode from "../../mode.ts";
-import * as framework from "../../lib/framework.ts";
-import * as config from "../../lib/config.ts";
 import { init } from "./index.ts";
 
 describe("init command", () => {
@@ -20,32 +23,35 @@ describe("init command", () => {
     for (const spy of spies) spy.mockRestore();
   });
 
-  function setupMocks(overrides: { email?: string | null } = {}) {
+  function setup(overrides: { email?: string | null } = {}) {
     const email = overrides.email ?? null;
 
     spies = [
       spyOn(console, "log").mockImplementation(() => {}),
       spyOn(mode, "isAgent").mockReturnValue(false),
-      spyOn(framework, "lookupFramework").mockReturnValue(undefined),
       spyOn(config, "resolveProfile").mockResolvedValue(undefined),
+      spyOn(frameworkMod, "lookupFramework").mockReturnValue(null),
       spyOn(context, "gatherContext").mockResolvedValue(null),
       spyOn(scaffoldMod, "scaffold").mockResolvedValue({ actions: [], postInstructions: [] }),
       spyOn(scaffoldMod, "enrichProjectContext").mockResolvedValue(undefined),
+      spyOn(previewMod, "previewPlan").mockReturnValue(undefined),
+      spyOn(previewMod, "previewAndConfirm").mockResolvedValue(true),
+      spyOn(formatMod, "runFormatters").mockResolvedValue(undefined),
       spyOn(scanMod, "detectAuthLibraries").mockReturnValue(undefined),
       spyOn(scanMod, "scanForIssues").mockResolvedValue([]),
+      spyOn(heuristics, "getAuthenticatedEmail").mockResolvedValue(email),
+      spyOn(heuristics, "printKeylessInfo").mockReturnValue(undefined),
       spyOn(heuristics, "installSdk").mockResolvedValue(undefined),
       spyOn(heuristics, "writePlan").mockResolvedValue([]),
       spyOn(heuristics, "checkGitDirty").mockResolvedValue(false),
       spyOn(heuristics, "printOutro").mockReturnValue(undefined),
-      spyOn(heuristics, "printKeylessInfo").mockReturnValue(undefined),
-      spyOn(heuristics, "getAuthenticatedEmail").mockResolvedValue(email),
       spyOn(linkMod, "link").mockResolvedValue(undefined),
       spyOn(pullMod, "pull").mockResolvedValue(undefined),
     ];
   }
 
   test("defaults to keyless mode when not authenticated", async () => {
-    setupMocks({ email: null });
+    setup({ email: null });
 
     await init({ yes: true });
 
@@ -55,7 +61,7 @@ describe("init command", () => {
   });
 
   test("links and pulls env when authenticated", async () => {
-    setupMocks({ email: "test@test.com" });
+    setup({ email: "test@test.com" });
 
     await init({ yes: true });
 

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -1,10 +1,11 @@
+import { select } from "@inquirer/prompts";
 import { login } from "../auth/login.js";
 import { link } from "../link/index.js";
 import { pull } from "../env/pull.js";
 import { isAgent } from "../../mode.js";
 import { dim, green, yellow, bold } from "../../lib/color.js";
 import { throwUserAbort } from "../../lib/errors.js";
-import { lookupFramework, type FrameworkInfo } from "../../lib/framework.js";
+import { lookupFramework } from "../../lib/framework.js";
 import { resolveProfile } from "../../lib/config.js";
 import { gatherContext } from "./context.js";
 import { scaffold, enrichProjectContext } from "./scaffold.js";
@@ -16,24 +17,31 @@ import {
   writePlan,
   checkGitDirty,
   printOutro,
+  printKeylessInfo,
   getAuthenticatedEmail,
 } from "./heuristics.js";
 import type { ProjectContext } from "./frameworks/types.js";
 
-interface InitOptions {
+type AuthMode = "keyless" | "authenticated";
+
+type AuthResolution = {
+  mode: AuthMode;
+  email: string | null;
+};
+
+type InitOptions = {
   framework?: string;
   yes?: boolean;
   prompt?: boolean;
-}
+};
 
 export async function init(options: InitOptions = {}) {
   const cwd = process.cwd();
 
   // Commander validates --framework against FRAMEWORK_NAMES choices
-  let frameworkOverride: FrameworkInfo | undefined;
-  if (options.framework) {
-    frameworkOverride = lookupFramework(options.framework) ?? undefined;
-  }
+  const frameworkOverride = options.framework
+    ? (lookupFramework(options.framework) ?? undefined)
+    : undefined;
   const ctx = await gatherContext(cwd, frameworkOverride);
 
   // Populate framework-specific context (variant, layoutPath, middlewareBasename)
@@ -46,42 +54,54 @@ export async function init(options: InitOptions = {}) {
     return;
   }
 
-  await authenticateAndLink(cwd);
-  await detectAndInstall(cwd, ctx, options);
+  const { mode, email } = await resolveAuthMode(cwd, options.yes);
+
+  if (mode === "authenticated") {
+    await ensureAuthenticated(email);
+  }
+
+  await detectAndInstall(cwd, ctx, options, mode);
 }
 
-async function authenticateAndLink(cwd: string): Promise<void> {
-  // If Platform API key is set, skip OAuth entirely
+async function resolveAuthMode(cwd: string, yes?: boolean): Promise<AuthResolution> {
+  // Platform API key — skip OAuth entirely
   const hasApiKey = Boolean(process.env.CLERK_PLATFORM_API_KEY);
-  const profile = await resolveProfile(cwd);
-
-  if (hasApiKey && profile) {
-    console.log(dim(`Using API key · Linked to ${profile.profile.appId}`));
-    return;
-  }
 
   if (hasApiKey) {
-    await link({ skipIfLinked: true });
-    return;
+    const profile = await resolveProfile(cwd);
+    if (profile) {
+      console.log(dim(`Using API key · Linked to ${profile.profile.appId}`));
+    }
+    return { mode: "authenticated", email: null };
   }
 
-  // Check if fully ready (authenticated + linked)
   const email = await getAuthenticatedEmail();
 
-  if (email && profile) {
-    console.log(dim(`Logged in as ${email} · Linked to ${profile.profile.appId}`));
-    return;
-  }
-
-  // Authenticated but not linked
   if (email) {
-    console.log(dim(`Logged in as ${email}`));
-    await link({ skipIfLinked: true });
-    return;
+    const profile = await resolveProfile(cwd);
+    const linkedInfo = profile ? ` · Linked to ${profile.profile.appId}` : "";
+    console.log(dim(`Logged in as ${email}${linkedInfo}`));
+    return { mode: "authenticated", email };
   }
 
-  // Not authenticated — full flow
-  await login({ showNextSteps: false });
+  // Not authenticated + --yes flag: default to keyless (fastest path, no browser)
+  if (yes) return { mode: "keyless", email: null };
+
+  const mode = await select<AuthMode>({
+    message: "How would you like to set up Clerk?",
+    choices: [
+      { name: "Continue with temporary keys (connect your account later)", value: "keyless" },
+      { name: "Log in to an existing Clerk account", value: "authenticated" },
+    ],
+  });
+
+  return { mode, email: null };
+}
+
+async function ensureAuthenticated(email: string | null): Promise<void> {
+  if (!email) {
+    await login({ showNextSteps: false });
+  }
   await link({ skipIfLinked: true });
 }
 
@@ -89,6 +109,7 @@ async function detectAndInstall(
   cwd: string,
   ctx: ProjectContext | null,
   options: InitOptions,
+  authMode: AuthMode,
 ): Promise<void> {
   if (!ctx) {
     console.log(
@@ -100,9 +121,7 @@ async function detectAndInstall(
   const variantLabel = ctx.variant ? ` (${ctx.variant})` : "";
   console.log(`\nDetected ${bold(ctx.framework.name)}${variantLabel}`);
 
-  // Pre-scaffold: detect existing auth libraries
   detectAuthLibraries(ctx.deps);
-
   console.log();
 
   if (ctx.existingClerk) {
@@ -111,8 +130,14 @@ async function detectAndInstall(
     await installSdk(ctx);
   }
 
-  await pull({});
   await scaffoldAndWrite(cwd, ctx, options);
+
+  if (authMode === "authenticated") {
+    await pull({});
+    return;
+  }
+
+  printKeylessInfo();
 }
 
 async function scaffoldAndWrite(

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -20,11 +20,11 @@ import {
 } from "./heuristics.js";
 import type { ProjectContext } from "./frameworks/types.js";
 
-type InitOptions = {
+interface InitOptions {
   framework?: string;
   yes?: boolean;
   prompt?: boolean;
-};
+}
 
 export async function init(options: InitOptions = {}) {
   const cwd = process.cwd();

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -1,5 +1,3 @@
-import { select } from "@inquirer/prompts";
-import { login } from "../auth/login.js";
 import { link } from "../link/index.js";
 import { pull } from "../env/pull.js";
 import { isAgent } from "../../mode.js";
@@ -21,13 +19,6 @@ import {
   getAuthenticatedEmail,
 } from "./heuristics.js";
 import type { ProjectContext } from "./frameworks/types.js";
-
-type AuthMode = "keyless" | "authenticated";
-
-type AuthResolution = {
-  mode: AuthMode;
-  email: string | null;
-};
 
 type InitOptions = {
   framework?: string;
@@ -54,62 +45,39 @@ export async function init(options: InitOptions = {}) {
     return;
   }
 
-  const { mode, email } = await resolveAuthMode(cwd, options.yes);
+  const authenticated = await resolveAuth(cwd);
 
-  if (mode === "authenticated") {
-    await ensureAuthenticated(email);
+  if (authenticated) {
+    await link({ skipIfLinked: true });
   }
 
-  await detectAndInstall(cwd, ctx, options, mode);
+  await detectAndInstall(cwd, ctx, options);
+
+  if (authenticated) {
+    await pull({});
+    return;
+  }
+
+  printKeylessInfo();
 }
 
-async function resolveAuthMode(cwd: string, yes?: boolean): Promise<AuthResolution> {
-  // Platform API key — skip OAuth entirely
+async function resolveAuth(cwd: string): Promise<boolean> {
   const hasApiKey = Boolean(process.env.CLERK_PLATFORM_API_KEY);
+  const email = hasApiKey ? null : await getAuthenticatedEmail();
 
-  if (hasApiKey) {
-    const profile = await resolveProfile(cwd);
-    if (profile) {
-      console.log(dim(`Using API key · Linked to ${profile.profile.appId}`));
-    }
-    return { mode: "authenticated", email: null };
-  }
+  if (!hasApiKey && !email) return false;
 
-  const email = await getAuthenticatedEmail();
-
-  if (email) {
-    const profile = await resolveProfile(cwd);
-    const linkedInfo = profile ? ` · Linked to ${profile.profile.appId}` : "";
-    console.log(dim(`Logged in as ${email}${linkedInfo}`));
-    return { mode: "authenticated", email };
-  }
-
-  // Not authenticated + --yes flag: default to keyless (fastest path, no browser)
-  if (yes) return { mode: "keyless", email: null };
-
-  const mode = await select<AuthMode>({
-    message: "How would you like to set up Clerk?",
-    choices: [
-      { name: "Continue with temporary keys (connect your account later)", value: "keyless" },
-      { name: "Log in to an existing Clerk account", value: "authenticated" },
-    ],
-  });
-
-  return { mode, email: null };
-}
-
-async function ensureAuthenticated(email: string | null): Promise<void> {
-  if (!email) {
-    await login({ showNextSteps: false });
-  }
-  await link({ skipIfLinked: true });
+  const profile = await resolveProfile(cwd);
+  const linkedInfo = profile ? ` · Linked to ${profile.profile.appId}` : "";
+  const authLabel = hasApiKey ? "Using API key" : `Logged in as ${email}`;
+  console.log(dim(`${authLabel}${linkedInfo}`));
+  return true;
 }
 
 async function detectAndInstall(
   cwd: string,
   ctx: ProjectContext | null,
   options: InitOptions,
-  authMode: AuthMode,
 ): Promise<void> {
   if (!ctx) {
     console.log(
@@ -131,13 +99,6 @@ async function detectAndInstall(
   }
 
   await scaffoldAndWrite(cwd, ctx, options);
-
-  if (authMode === "authenticated") {
-    await pull({});
-    return;
-  }
-
-  printKeylessInfo();
 }
 
 async function scaffoldAndWrite(


### PR DESCRIPTION
## Summary

- Allow `clerk init` to work **without a Clerk account** by leveraging Clerk's keyless mode (SDK auto-generates temporary dev keys)
- When unauthenticated, prompt users to choose: "Continue with temporary keys" or "Log in to an existing Clerk account"
- Move `env pull` to **after scaffolding** so project files are set up before pulling API keys
- `--yes` flag defaults to keyless mode when not already authenticated (fastest path)

## Test plan

- [ ] Run `clerk init` without auth → prompt appears with keyless/login choices
- [ ] Select "Continue with temporary keys" → SDK installs, files scaffold, keyless info prints, no env pull
- [ ] Select "Log in" → OAuth flow → link → scaffold → env pull at end
- [ ] Run `clerk init` when already authenticated + linked → no prompt, authenticated flow
- [ ] Run `clerk init -y` without auth → keyless mode automatically
- [ ] Run `clerk init -y` when already auth+linked → authenticated mode
- [ ] Run `clerk init --prompt` → unchanged agent mode behavior
- [ ] `bun test` passes (705/707, 2 pre-existing failures in api/index.test.ts)
- [ ] `bun run lint` passes
- [ ] `bun run format` passes