### PR TITLE
fix: Suppresses  next steps during init and link commands

### DIFF
--- a/packages/cli-core/src/commands/auth/login.test.ts
+++ b/packages/cli-core/src/commands/auth/login.test.ts
@@ -68,6 +68,7 @@ const { login } = await import("./login.ts");
 
 describe("login", () => {
   let consoleSpy: ReturnType<typeof spyOn>;
+  let consoleErrorSpy: ReturnType<typeof spyOn>;
   const origSpawn = Bun.spawn;
 
   afterEach(() => {
@@ -82,6 +83,7 @@ describe("login", () => {
     mockConfirm.mockReset();
     mockIsHuman.mockReturnValue(false);
     consoleSpy?.mockRestore();
+    consoleErrorSpy?.mockRestore();
     try {
       (Bun as any).spawn = origSpawn;
     } catch {
@@ -301,5 +303,40 @@ describe("login", () => {
     await expect(login()).rejects.toThrow("User aborted");
     expect(mockConfirm).toHaveBeenCalled();
     expect(mockStartAuthServer).not.toHaveBeenCalled();
+  });
+
+  test("suppresses auth next-steps when requested", async () => {
+    mockGetToken.mockResolvedValue(null);
+    mockBunSpawn();
+
+    const mockServer = {
+      port: 54321,
+      waitForCallback: mock().mockResolvedValue({ code: "fresh-auth-code" }),
+      stop: mock(),
+    };
+    mockStartAuthServer.mockReturnValue(mockServer);
+
+    mockExchangeCodeForToken.mockResolvedValue({
+      access_token: "new-access-token",
+      token_type: "Bearer",
+      expires_in: 3600,
+    });
+    mockStoreToken.mockResolvedValue(undefined);
+    mockFetchUserInfo.mockResolvedValue({
+      userId: "user_new",
+      email: "new@example.com",
+    });
+    mockSetAuth.mockResolvedValue(undefined);
+
+    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    await login({ showNextSteps: false });
+
+    expect(
+      consoleErrorSpy.mock.calls.some(
+        (c) => typeof c[0] === "string" && (c[0] as string).includes("Next steps:"),
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/cli-core/src/commands/auth/login.ts
+++ b/packages/cli-core/src/commands/auth/login.ts
@@ -15,6 +15,10 @@ const BROWSER_COMMANDS: Partial<Record<NodeJS.Platform, string>> = {
   win32: "start",
 };
 
+interface LoginOptions {
+  showNextSteps?: boolean;
+}
+
 async function getExistingSession(): Promise<UserInfo | null> {
   const token = await getToken();
   if (!token) return null;
@@ -78,7 +82,8 @@ async function performOAuthFlow(): Promise<UserInfo> {
   return userInfo;
 }
 
-export async function login(): Promise<UserInfo> {
+export async function login(options: LoginOptions = {}): Promise<UserInfo> {
+  const { showNextSteps = true } = options;
   const existingSession = await getExistingSession();
 
   if (existingSession && !isHuman()) {
@@ -100,10 +105,12 @@ export async function login(): Promise<UserInfo> {
 
   console.log(`Logged in as ${userInfo.email}`);
 
-  printNextSteps([
-    "Run `clerk link` to connect a Clerk application to this project",
-    "Run `clerk init` to set up Clerk in an existing project",
-  ]);
+  if (showNextSteps) {
+    printNextSteps([
+      "Run `clerk link` to connect a Clerk application to this project",
+      "Run `clerk init` to set up Clerk in an existing project",
+    ]);
+  }
 
   return userInfo;
 }

--- a/packages/cli-core/src/commands/init/index.test.ts
+++ b/packages/cli-core/src/commands/init/index.test.ts
@@ -1,0 +1,100 @@
+import { test, expect, describe, afterEach, mock, spyOn } from "bun:test";
+import { configStubs } from "../../test/stubs.ts";
+
+const mockLogin = mock();
+mock.module("../auth/login.js", () => ({
+  login: (...args: unknown[]) => mockLogin(...args),
+}));
+
+const mockLink = mock();
+mock.module("../link/index.js", () => ({
+  link: (...args: unknown[]) => mockLink(...args),
+}));
+
+mock.module("../env/pull.js", () => ({
+  pull: async () => {},
+}));
+
+const mockIsAgent = mock();
+mock.module("../../mode.js", () => ({
+  isAgent: (...args: unknown[]) => mockIsAgent(...args),
+  isHuman: () => true,
+  getMode: () => "human",
+  setMode: () => {},
+}));
+
+const mockLookupFramework = mock();
+mock.module("../../lib/framework.js", () => ({
+  lookupFramework: (...args: unknown[]) => mockLookupFramework(...args),
+}));
+
+const mockResolveProfile = mock();
+mock.module("../../lib/config.js", () => ({
+  ...configStubs,
+  resolveProfile: (...args: unknown[]) => mockResolveProfile(...args),
+}));
+
+const mockGatherContext = mock();
+mock.module("./context.js", () => ({
+  gatherContext: (...args: unknown[]) => mockGatherContext(...args),
+}));
+
+mock.module("./scaffold.js", () => ({
+  scaffold: async () => ({ actions: [], postInstructions: [] }),
+  enrichProjectContext: async () => {},
+}));
+
+mock.module("./preview.js", () => ({
+  previewPlan: () => {},
+  previewAndConfirm: async () => true,
+}));
+
+mock.module("./format.js", () => ({
+  runFormatters: async () => {},
+}));
+
+mock.module("./scan.js", () => ({
+  detectAuthLibraries: () => {},
+  scanForIssues: async () => [],
+}));
+
+const mockGetAuthenticatedEmail = mock();
+mock.module("./heuristics.js", () => ({
+  installSdk: async () => {},
+  writePlan: async () => [],
+  checkGitDirty: async () => false,
+  printOutro: () => {},
+  getAuthenticatedEmail: (...args: unknown[]) => mockGetAuthenticatedEmail(...args),
+}));
+
+const { init } = await import("./index.ts");
+
+describe("init next-steps ordering", () => {
+  let consoleSpy: ReturnType<typeof spyOn>;
+
+  afterEach(() => {
+    mockLogin.mockReset();
+    mockLink.mockReset();
+    mockIsAgent.mockReset();
+    mockLookupFramework.mockReset();
+    mockResolveProfile.mockReset();
+    mockGatherContext.mockReset();
+    mockGetAuthenticatedEmail.mockReset();
+    consoleSpy?.mockRestore();
+  });
+
+  test("suppresses auth next-steps when login runs during init", async () => {
+    mockIsAgent.mockReturnValue(false);
+    mockGatherContext.mockResolvedValue(null);
+    mockGetAuthenticatedEmail.mockResolvedValue(null);
+    mockResolveProfile.mockResolvedValue(undefined);
+    mockLogin.mockResolvedValue({ userId: "user_1", email: "test@test.com" });
+    mockLink.mockResolvedValue(undefined);
+    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+    await init({ yes: true });
+
+    expect(mockLogin).toHaveBeenCalledWith({ showNextSteps: false });
+    expect(mockLink).toHaveBeenCalledWith({ skipIfLinked: true });
+  });
+});

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -68,7 +68,7 @@ async function authenticateAndLink(cwd: string): Promise<void> {
   }
 
   // Not authenticated — full flow
-  await login();
+  await login({ showNextSteps: false });
   await link({ skipIfLinked: true });
 }
 

--- a/packages/cli-core/src/commands/link/index.test.ts
+++ b/packages/cli-core/src/commands/link/index.test.ts
@@ -217,6 +217,18 @@ describe("link", () => {
 
       expect(mockLogin).not.toHaveBeenCalled();
     });
+
+    test("suppresses auth next-steps when login runs during link", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockGetToken.mockResolvedValue(null);
+      mockLogin.mockResolvedValue({ userId: "user_1", email: "test@test.com" });
+      mockFetchApplication.mockResolvedValue(mockApp);
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await link({ app: "app_123" });
+
+      expect(mockLogin).toHaveBeenCalledWith({ showNextSteps: false });
+    });
   });
 
   describe("app selection", () => {

--- a/packages/cli-core/src/commands/link/index.ts
+++ b/packages/cli-core/src/commands/link/index.ts
@@ -105,7 +105,7 @@ async function ensureAuth() {
   const token = await getToken();
   if (!token) {
     console.log("Not logged in. Authenticating first...");
-    await login();
+    await login({ showNextSteps: false });
   }
 }
 


### PR DESCRIPTION
Ensures next steps are not buried within init/link command outputs

<details><summary>BEFORE</summary>
<p>

clerk link
[STAGING]
Not logged in. Authenticating first...
Waiting for authentication (timeout in 2m)...
Logged in as alex.carpenter@clerk.dev
Next steps:
  → Run `clerk link` to connect a Clerk application to this project
  → Run `clerk init` to set up Clerk in an existing project
? Select a Clerk application to link (repo: clerk-cli-test)
  Paddy Banned Admin Test (app_3BOxy2jHK46tx4kMTEn52yG16qf)
❯ My Application (app_3AlrLZItmYLWVqcVoffIQQWFlS5)
  Cool Beans (app_2y6G9HHVI3H8c1CcHBwiuReW75I)
  Paddy Demo App 1 (app_36wM09wnoKcP41iWVvFZlUf4G5l)
  clerk-js Sandbox (app_3AaGPUx1IpoCyNjCbuiRUHDLNQ0)
  Proration Testbed (app_2wNIgqGucsKNeKINHHLiUWuHSGk)
  basic testbed (app_2vElYQy1yz9i8vcFZbWGYizr6tL)

</p>
</details> 

<details><summary>AFTER</summary>
<p>

clerk link
[STAGING]
Not logged in. Authenticating first...
Waiting for authentication (timeout in 2m)...
Logged in as alex.carpenter@clerk.dev
? Select a Clerk application to link (repo: clerk-cli-test)
  Paddy Banned Admin Test (app_3BOxy2jHK46tx4kMTEn52yG16qf)
❯ My Application (app_3AlrLZItmYLWVqcVoffIQQWFlS5)
  Cool Beans (app_2y6G9HHVI3H8c1CcHBwiuReW75I)
  Paddy Demo App 1 (app_36wM09wnoKcP41iWVvFZlUf4G5l)
  clerk-js Sandbox (app_3AaGPUx1IpoCyNjCbuiRUHDLNQ0)
  Proration Testbed (app_2wNIgqGucsKNeKINHHLiUWuHSGk)
  basic testbed (app_2vElYQy1yz9i8vcFZbWGYizr6tL)
Linked to My Application in /Users/alex/Repos/cli
Next steps:
  → Run `clerk env pull` to fetch your environment variables
  → Run `clerk doctor` to verify your setup

</p>
</details> 