### PR TITLE
feat(completion): add examples, tutorial, and better missing-shell error

### DIFF
--- a/packages/cli-core/src/cli-program.ts
+++ b/packages/cli-core/src/cli-program.ts
@@ -364,7 +364,7 @@ Examples:
     .command("completion")
     .description("Generate shell autocompletion script")
     .addArgument(
-      createArgument("<shell>", `Shell type (${SUPPORTED_SHELLS.join(", ")})`).choices(
+      createArgument("[shell]", `Shell type (${SUPPORTED_SHELLS.join(", ")})`).choices(
         SUPPORTED_SHELLS,
       ),
     )
@@ -372,9 +372,29 @@ Examples:
       "after",
       `
 Examples:
-  $ clerk completion bash       # Output bash completion script
-  $ clerk completion zsh        # Output zsh completion script
-  $ eval "$(clerk completion bash)"  # Enable completions in current session`,
+  $ clerk completion bash              Output bash completion script
+  $ clerk completion zsh               Output zsh completion script
+  $ clerk completion fish              Output fish completion script
+  $ clerk completion powershell        Output PowerShell completion script
+
+Tutorial — enable completions for your shell:
+
+  Bash:
+    $ eval "$(clerk completion bash)"                          # Current session only
+    $ clerk completion bash > /etc/bash_completion.d/clerk     # Permanent (Linux)
+    $ echo 'eval "$(clerk completion bash)"' >> ~/.bashrc      # Permanent (append)
+
+  Zsh:
+    $ eval "$(clerk completion zsh)"                           # Current session only
+    $ mkdir -p ~/.zfunc && clerk completion zsh > ~/.zfunc/_clerk  # Permanent
+    # Then add to ~/.zshrc: fpath=(~/.zfunc $fpath); autoload -Uz compinit && compinit
+
+  Fish:
+    $ clerk completion fish > ~/.config/fish/completions/clerk.fish  # Auto-discovered
+
+  PowerShell:
+    $ clerk completion powershell | Out-String | Invoke-Expression  # Current session
+    $ clerk completion powershell >> $PROFILE                       # Permanent`,
     )
     .action(completion);
 

--- a/packages/cli-core/src/commands/completion/index.test.ts
+++ b/packages/cli-core/src/commands/completion/index.test.ts
@@ -3,6 +3,8 @@ import { generate as generateBash } from "./shells/bash.ts";
 import { generate as generateZsh } from "./shells/zsh.ts";
 import { generate as generateFish } from "./shells/fish.ts";
 import { generate as generatePowershell } from "./shells/powershell.ts";
+import { completion } from "./index.ts";
+import { CliError } from "../../lib/errors.ts";
 
 const BINARY = "clerk";
 
@@ -12,6 +14,18 @@ const SHELLS = [
   { name: "fish", generate: generateFish },
   { name: "powershell", generate: generatePowershell },
 ];
+
+describe("completion()", () => {
+  test("throws a helpful error when shell is not provided", () => {
+    expect(() => completion()).toThrow(CliError);
+    expect(() => completion()).toThrow(/Missing required shell argument/);
+  });
+
+  test("throws a helpful error for unsupported shells", () => {
+    expect(() => completion("nushell")).toThrow(CliError);
+    expect(() => completion("nushell")).toThrow(/Unsupported shell: nushell/);
+  });
+});
 
 describe("shell script generators", () => {
   describe.each(SHELLS)("$name", ({ generate }) => {

--- a/packages/cli-core/src/commands/completion/index.ts
+++ b/packages/cli-core/src/commands/completion/index.ts
@@ -21,7 +21,22 @@ function isSupportedShell(shell: string): shell is SupportedShell {
   return (SUPPORTED_SHELLS as readonly string[]).includes(shell);
 }
 
-export function completion(shell: string): void {
+export function completion(shell?: string): void {
+  if (!shell) {
+    throwUsageError(
+      `Missing required shell argument. Supported shells: ${SUPPORTED_SHELLS.join(", ")}
+
+Usage:
+  $ clerk completion <shell>
+
+Examples:
+  $ clerk completion bash              Output bash completion script
+  $ clerk completion zsh               Output zsh completion script
+  $ eval "$(clerk completion bash)"    Enable completions in current session
+
+Run 'clerk completion --help' for full setup instructions.`,
+    );
+  }
   if (!isSupportedShell(shell)) {
     throwUsageError(`Unsupported shell: ${shell}. Supported: ${SUPPORTED_SHELLS.join(", ")}`);
   }


### PR DESCRIPTION
## Summary
- Expanded `clerk completion --help` with examples for all 4 shells (bash, zsh, fish, powershell) and a per-shell setup tutorial showing temporary and permanent installation
- Improved the error when running `clerk completion` without a shell argument — now shows supported shells, usage, and examples instead of Commander's generic "missing required argument"
- Added tests for missing and unsupported shell arguments

## Test plan
- [x] Run `bun run dev completion` — should show the new helpful error message
- [x] Run `bun run dev completion --help` — should show examples for all shells and the setup tutorial
- [x] Run `bun run dev completion bash` — should still output the bash completion script
- [x] Run `bun test packages/cli-core/src/commands/completion/` — all tests pass

## Screenshots
### Without args
- before
```sh
clerk completion
error: missing required argument 'shell'
```

- after
```sh
bun run ./src/cli.ts completion
error: Missing required shell argument. Supported shells: bash, zsh, fish, powershell

Usage:
  $ clerk completion <shell>

Examples:
  $ clerk completion bash              Output bash completion script
  $ clerk completion zsh               Output zsh completion script
  $ eval "$(clerk completion bash)"    Enable completions in current session

Run 'clerk completion --help' for full setup instructions.
```
<img width="881" height="258" alt="image" src="https://github.com/user-attachments/assets/dddfbf08-b6c5-4571-a86a-4541aa384f60" />

### `--help`

- before
```sh
clerk completion --help
Usage: clerk completion [options] <shell>

Generate shell autocompletion script

Arguments:
  shell       Shell type (bash, zsh, fish, powershell) (choices: "bash", "zsh", "fish", "powershell")

Options:
  -h, --help  display help for command

Examples:
  $ clerk completion bash       # Output bash completion script
  $ clerk completion zsh        # Output zsh completion script
  $ eval "$(clerk completion bash)"  # Enable completions in current session
```

- after
```sh
bun run ./src/cli.ts completion --help
Usage: clerk completion [options] [shell]

Generate shell autocompletion script

Arguments:
  shell       Shell type (bash, zsh, fish, powershell) (choices: "bash", "zsh", "fish", "powershell")

Options:
  -h, --help  display help for command

Examples:
  $ clerk completion bash              Output bash completion script
  $ clerk completion zsh               Output zsh completion script
  $ clerk completion fish              Output fish completion script
  $ clerk completion powershell        Output PowerShell completion script

Tutorial — enable completions for your shell:

  Bash:
    $ eval "$(clerk completion bash)"                          # Current session only
    $ clerk completion bash > /etc/bash_completion.d/clerk     # Permanent (Linux)
    $ echo 'eval "$(clerk completion bash)"' >> ~/.bashrc      # Permanent (append)

  Zsh:
    $ eval "$(clerk completion zsh)"                           # Current session only
    $ mkdir -p ~/.zfunc && clerk completion zsh > ~/.zfunc/_clerk  # Permanent
    # Then add to ~/.zshrc: fpath=(~/.zfunc $fpath); autoload -Uz compinit && compinit

  Fish:
    $ clerk completion fish > ~/.config/fish/completions/clerk.fish  # Auto-discovered

  PowerShell:
    $ clerk completion powershell | Out-String | Invoke-Expression  # Current session
    $ clerk completion powershell >> $PROFILE                       # Permanent
```

<img width="955" height="667" alt="image" src="https://github.com/user-attachments/assets/6caba669-3c68-4b93-a312-ea67262ced23" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The completion command now accepts an optional shell argument and provides improved messaging when not specified.

* **Documentation**
  * Expanded help with examples and step-by-step enablement for Bash, Zsh, Fish, and PowerShell (current-session and persistent options).

* **Bug Fixes**
  * Clearer error when an unsupported shell is requested.

* **Tests**
  * Added unit tests covering missing and unsupported shell error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->