### PR TITLE
fix(dx): reorder login next-steps, add top-level login/logout aliases

### DIFF
--- a/packages/cli-core/src/cli-program.ts
+++ b/packages/cli-core/src/cli-program.ts
@@ -116,6 +116,18 @@ Examples:
     .action(logout);
 
   program
+    .command("login", { hidden: true })
+    .description("Log in to your Clerk account")
+    .action(async () => {
+      await login();
+    });
+
+  program
+    .command("logout", { hidden: true })
+    .description("Log out of your Clerk account")
+    .action(logout);
+
+  program
     .command("link")
     .description("Link this project to a Clerk application")
     .option("--app <id>", "Application ID to link (skips interactive picker)")

--- a/packages/cli-core/src/commands/auth/login.ts
+++ b/packages/cli-core/src/commands/auth/login.ts
@@ -107,8 +107,8 @@ export async function login(options: LoginOptions = {}): Promise<UserInfo> {
 
   if (showNextSteps) {
     printNextSteps([
-      "Run `clerk link` to connect a Clerk application to this project",
-      "Run `clerk init` to set up Clerk in an existing project",
+      "Run `clerk init` to set up Clerk in your project",
+      "Run `clerk link` to connect an existing Clerk application",
     ]);
   }
 


### PR DESCRIPTION
## Summary

Two small DX improvements from internal testing feedback (#proj-clerk-cli):

1. **Reorder next-steps after `clerk auth login`**: `clerk init` first (it calls `link` internally), `clerk link` second
2. **Add hidden `clerk login` / `clerk logout` top-level aliases**: matches Wrangler, Vercel CLI, gh CLI conventions

### Next-steps output (after login)
```
Logged in as user@clerk.dev

Next steps:
  → Run `clerk init` to set up Clerk in your project
  → Run `clerk link` to connect an existing Clerk application
```

### Alias works, hidden from help
```
$ clerk login --help
Usage: clerk login [options]
Log in to your Clerk account

$ clerk --help
# login/logout NOT listed (hidden)
```

Closes AIE-727, AIE-737, AIE-736

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new `clerk login` and `clerk logout` commands for simplified authentication workflows.

* **Improvements**
  * Enhanced login setup instructions with clearer guidance on project initialization and application connection steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->