### PR TITLE
feat(init): bootstrap new project

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,14 @@ Commands:
 
 clerk init
   --framework <name>   Framework to set up (skips auto-detection)
+  --starter            Bootstrap a new project from a starter template
   --prompt             Output a prompt for an AI agent to integrate Clerk
   --yes                Skip confirmation prompts
   --no-skills          Skip the optional agent skills install prompt
   Examples:
     $ clerk init                       Auto-detect framework and set up Clerk
     $ clerk init --framework next      Set up for Next.js (skips detection)
+    $ clerk init --starter             Create a new project with Clerk
     $ clerk init --prompt              Output a setup prompt for an AI agent
     $ clerk init -y                    Skip all confirmation prompts
     $ clerk init --no-skills           Skip the agent skills install prompt

--- a/packages/cli-core/src/cli-program.ts
+++ b/packages/cli-core/src/cli-program.ts
@@ -82,6 +82,7 @@ export function createProgram() {
       ),
     )
     .option("--prompt", "Output a prompt for an AI agent to integrate Clerk")
+    .option("--starter", "Create a new project from a starter template")
     .option("-y, --yes", "Skip confirmation prompts")
     .option("--no-skills", "Skip the optional agent skills install prompt")
     .setExamples([
@@ -90,6 +91,7 @@ export function createProgram() {
         command: "clerk init --framework next",
         description: "Set up for Next.js (skips detection)",
       },
+      { command: "clerk init --starter", description: "Create a new project with Clerk" },
       { command: "clerk init --prompt", description: "Output a setup prompt for an AI agent" },
       { command: "clerk init -y", description: "Skip all confirmation prompts" },
       { command: "clerk init --no-skills", description: "Skip the agent skills install prompt" },

--- a/packages/cli-core/src/commands/init/README.md
+++ b/packages/cli-core/src/commands/init/README.md
@@ -7,6 +7,8 @@ Initializes Clerk in a project by authenticating the user, linking a Clerk appli
 ```sh
 clerk init
 clerk init --framework next
+clerk init --starter
+clerk init --starter --framework next
 clerk init --prompt
 clerk init -y
 clerk init --yes
@@ -15,12 +17,13 @@ clerk init --no-skills
 
 ## Options
 
-| Option               | Description                                                                                                                                                       |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--framework <name>` | Framework to set up (skips auto-detection). Valid values: `next`, `astro`, `nuxt`, `tanstack-start`, `react-router`, `vue`, `expo`, `react`, `express`, `fastify` |
-| `--prompt`           | Output a prompt for an AI agent to integrate Clerk, then exit                                                                                                     |
-| `-y, --yes`          | Skip confirmation prompts                                                                                                                                         |
-| `--no-skills`        | Skip the optional agent skills install prompt at the end of init                                                                                                  |
+| Option               | Description                                                                                                                                                                           |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--framework <name>` | Framework to set up (skips auto-detection). Valid values: `next`, `astro`, `nuxt`, `tanstack-start`, `react-router`, `vue`, `expo`, `react`, `javascript`, `js`, `express`, `fastify` |
+| `--starter`          | Bootstrap a new project from a starter template (runs the framework generator, installs deps, and scaffolds Clerk)                                                                    |
+| `--prompt`           | Output a prompt for an AI agent to integrate Clerk, then exit                                                                                                                         |
+| `-y, --yes`          | Skip confirmation prompts (also skips authentication after bootstrap, letting you connect your account later)                                                                         |
+| `--no-skills`        | Skip the optional agent skills install prompt at the end of init                                                                                                                      |
 
 ## Agent Mode
 
@@ -34,7 +37,7 @@ When running in agent mode (`--mode agent` or non-TTY), outputs a framework-spec
    - If already authenticated and linked: uses authenticated mode automatically
    - If authenticated but not linked: uses authenticated mode (runs `clerk link`)
    - If not authenticated: asks user — "Continue with temporary keys (connect your account later)" or "Log in to an existing Clerk account"
-   - With `--yes` and not authenticated: defaults to keyless mode
+   - With `--yes` and not authenticated: skips authentication (connect your account later)
 4. **Authenticated mode only**: authenticates via `clerk auth login` (skipped if already authenticated) and links the project via `clerk link` (skipped if already linked)
 5. Displays detected framework and variant
 6. Detects existing auth libraries (NextAuth, Auth0, Supabase, Firebase, Passport, Better Auth, Kinde) and shows migration guidance
@@ -47,7 +50,7 @@ When running in agent mode (`--mode agent` or non-TTY), outputs a framework-spec
 13. Scans for issues: hardcoded keys, leftover auth-library imports, stale API calls
 14. Prints a summary of created, modified, and skipped files with recommendations
 15. **Authenticated mode**: pulls development instance API keys via `clerk env pull`
-16. **Keyless mode**: prints instructions for keyless development and how to connect a Clerk account later
+16. **Unauthenticated mode**: prints instructions for development without API keys and how to connect a Clerk account later
 17. Optionally installs framework-specific Clerk agent skills via `npx skills add` (see [Agent skills install](#agent-skills-install))
 
 ## Framework Detection
@@ -64,6 +67,7 @@ Detects the project's framework from `package.json` dependencies (checked top-to
 | `vue`                   | Vue            | `@clerk/vue`                  | `VITE_CLERK_PUBLISHABLE_KEY`        |
 | `expo`                  | Expo           | `@clerk/expo`                 | `EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY` |
 | `react`                 | React          | `@clerk/react`                | `VITE_CLERK_PUBLISHABLE_KEY`        |
+| `vite`                  | JavaScript     | `@clerk/clerk-js`             | `VITE_CLERK_PUBLISHABLE_KEY`        |
 | `express`               | Express        | `@clerk/express`              | `CLERK_PUBLISHABLE_KEY`             |
 | `fastify`               | Fastify        | `@clerk/fastify`              | `CLERK_PUBLISHABLE_KEY`             |
 
@@ -71,7 +75,7 @@ Package manager is detected from lock files: `bun.lockb`/`bun.lock` → bun, `ya
 
 ## Scaffolding
 
-Scaffolding is supported for the first 8 frameworks above. Expo, Express, and Fastify are detected (SDK is installed, env vars are pulled) but scaffolding is not yet supported — users are directed to the Clerk docs.
+Scaffolding is supported for the first 9 frameworks above (through JavaScript/Vite). Expo, Express, and Fastify are detected (SDK is installed, env vars are pulled) but scaffolding is not yet supported — users are directed to the Clerk docs.
 
 All scaffolding is idempotent — files are skipped if they already contain Clerk setup.
 
@@ -150,6 +154,14 @@ Nuxt's module system auto-configures middleware and auto-imports components.
 | CREATE        | `src/views/sign-up.vue` | Sign-up page with `<SignUp />` component           |
 | MODIFY        | `src/router/index.ts`   | Add sign-in and sign-up routes (if router exists)  |
 | MODIFY        | `.env`                  | Add sign-in/sign-up route env vars (VITE\_ prefix) |
+
+### JavaScript (Vite)
+
+| Action | File             | Description                                     |
+| ------ | ---------------- | ----------------------------------------------- |
+| MODIFY | `src/main.ts/js` | Replace entry file with Clerk JS initialization |
+
+If no entry file is found, a post-instruction is printed pointing to the Clerk JS quickstart.
 
 ## Agent skills install
 

--- a/packages/cli-core/src/commands/init/bootstrap-registry.ts
+++ b/packages/cli-core/src/commands/init/bootstrap-registry.ts
@@ -1,0 +1,146 @@
+import type { ProjectContext } from "./frameworks/types.js";
+
+export type PackageManager = ProjectContext["packageManager"];
+
+export type BootstrapEntry = {
+  label: string;
+  dep: string;
+  defaultProjectName: string;
+  buildCommand(pm: PackageManager, projectName: string): string[];
+};
+
+const PM_RUNNERS: Record<PackageManager, string[]> = {
+  npm: ["npx"],
+  yarn: ["yarn", "dlx"],
+  pnpm: ["pnpm", "dlx"],
+  bun: ["bunx"],
+};
+
+function runner(pm: PackageManager): string[] {
+  return PM_RUNNERS[pm];
+}
+
+// WARNING: All generators are pinned to @latest. This means installs are non-deterministic
+// and upstream CLI changes can silently break bootstrap. If a generator changes its flags,
+// update the corresponding entry here and the matching test in bootstrap.test.ts.
+//
+// NOTE on package-manager forwarding: Only Nuxt (--packageManager) and TanStack (--package-manager)
+// accept an explicit PM flag. The others (create-next-app, create-vite, create-react-router,
+// create-astro) infer the PM from npm_config_user_agent, which is set automatically when run
+// via bunx/pnpm dlx/yarn dlx/npx. This works in practice since we run them via the selected
+// PM's runner, and our own installDependencies() step uses the correct PM regardless.
+export const BOOTSTRAP_REGISTRY: BootstrapEntry[] = [
+  {
+    label: "Next.js",
+    dep: "next",
+    defaultProjectName: "my-clerk-next-app",
+    buildCommand: (pm, name) => [
+      ...runner(pm),
+      "create-next-app@latest",
+      name,
+      "--yes",
+      "--skip-install",
+      "--disable-git",
+    ],
+  },
+  {
+    label: "React",
+    dep: "react",
+    defaultProjectName: "my-clerk-react-app",
+    buildCommand: (pm, name) => [
+      ...runner(pm),
+      "create-vite@latest",
+      name,
+      "--template",
+      "react-ts",
+    ],
+  },
+  {
+    label: "Vue",
+    dep: "vue",
+    defaultProjectName: "my-clerk-vue-app",
+    buildCommand: (pm, name) => [...runner(pm), "create-vite@latest", name, "--template", "vue-ts"],
+  },
+  {
+    label: "React Router",
+    dep: "react-router",
+    defaultProjectName: "my-clerk-react-router-app",
+    buildCommand: (pm, name) => [
+      ...runner(pm),
+      "create-react-router@latest",
+      name,
+      "--yes",
+      "--no-install",
+      "--no-git-init",
+    ],
+  },
+  {
+    label: "Astro",
+    dep: "astro",
+    defaultProjectName: "my-clerk-astro-app",
+    buildCommand: (pm, name) => [
+      ...runner(pm),
+      "create-astro@latest",
+      name,
+      "--yes",
+      "--no-install",
+      "--no-git",
+      "--skip-houston",
+    ],
+  },
+  {
+    label: "Nuxt",
+    dep: "nuxt",
+    defaultProjectName: "my-clerk-nuxt-app",
+    buildCommand: (pm, name) => [
+      ...runner(pm),
+      "create-nuxt@latest",
+      name,
+      "--template",
+      "minimal",
+      "--no-install",
+      "--no-gitInit",
+      // --no-modules suppresses the interactive modules prompt; --template minimal already
+      // implies a minimal setup, but both flags are kept for belt-and-suspenders safety.
+      "--no-modules",
+      "--packageManager",
+      pm,
+    ],
+  },
+  {
+    label: "TanStack Start",
+    dep: "@tanstack/react-start",
+    defaultProjectName: "my-clerk-tanstack-start-app",
+    buildCommand: (pm, name) => [
+      ...runner(pm),
+      "@tanstack/cli@latest",
+      "create",
+      name,
+      "--framework",
+      "react",
+      "--no-install",
+      "--no-git",
+      "--package-manager",
+      pm,
+    ],
+  },
+  {
+    label: "JavaScript",
+    dep: "vite",
+    defaultProjectName: "my-clerk-vite-app",
+    buildCommand: (pm, name) => [
+      ...runner(pm),
+      "create-vite@latest",
+      name,
+      "--template",
+      "vanilla",
+    ],
+  },
+];
+
+export const PM_INSTALL_COMMANDS: Record<PackageManager, string[]> = {
+  npm: ["npm", "install"],
+  yarn: ["yarn", "install"],
+  pnpm: ["pnpm", "install"],
+  bun: ["bun", "install"],
+};

--- a/packages/cli-core/src/commands/init/bootstrap.test.ts
+++ b/packages/cli-core/src/commands/init/bootstrap.test.ts
@@ -1,0 +1,126 @@
+import { test, expect, describe } from "bun:test";
+import { BOOTSTRAP_REGISTRY } from "./bootstrap-registry.ts";
+
+function entryFor(dep: string) {
+  const entry = BOOTSTRAP_REGISTRY.find((e) => e.dep === dep);
+  if (!entry) throw new Error(`No bootstrap entry for dep: ${dep}`);
+  return entry;
+}
+
+describe("BOOTSTRAP_REGISTRY", () => {
+  const packageManagers = ["npm", "yarn", "pnpm", "bun"] as const;
+
+  test("contains all 8 supported frameworks", () => {
+    expect(BOOTSTRAP_REGISTRY).toHaveLength(8);
+    const deps = BOOTSTRAP_REGISTRY.map((e) => e.dep);
+    expect(deps).toContain("next");
+    expect(deps).toContain("react");
+    expect(deps).toContain("vue");
+    expect(deps).toContain("react-router");
+    expect(deps).toContain("astro");
+    expect(deps).toContain("nuxt");
+    expect(deps).toContain("@tanstack/react-start");
+    expect(deps).toContain("vite");
+  });
+
+  test("each entry produces a non-empty string[] for all package managers", () => {
+    for (const entry of BOOTSTRAP_REGISTRY) {
+      for (const pm of packageManagers) {
+        const cmd = entry.buildCommand(pm, "test-app");
+        expect(cmd.length).toBeGreaterThan(0);
+        expect(cmd.every((arg) => typeof arg === "string")).toBe(true);
+      }
+    }
+  });
+
+  test("Next.js uses project name as target directory", () => {
+    const cmd = entryFor("next").buildCommand("bun", "my-cool-app");
+    expect(cmd[0]).toBe("bunx");
+    expect(cmd).toContain("create-next-app@latest");
+    expect(cmd).toContain("my-cool-app");
+    expect(cmd).toContain("--yes");
+    expect(cmd).toContain("--skip-install");
+    expect(cmd).toContain("--disable-git");
+
+    expect(entryFor("next").buildCommand("npm", "app")[0]).toBe("npx");
+  });
+
+  test("React uses project name as target directory", () => {
+    const cmd = entryFor("react").buildCommand("pnpm", "my-app");
+    expect(cmd).toContain("create-vite@latest");
+    expect(cmd).toContain("my-app");
+    expect(cmd).toContain("--template");
+    expect(cmd).toContain("react-ts");
+  });
+
+  test("Vue uses create-vite with vue-ts template", () => {
+    const cmd = entryFor("vue").buildCommand("npm", "my-vue");
+    expect(cmd).toContain("create-vite@latest");
+    expect(cmd).toContain("my-vue");
+    expect(cmd).toContain("vue-ts");
+  });
+
+  test("Nuxt uses create-nuxt with --no-modules to suppress interactive prompt", () => {
+    const cmd = entryFor("nuxt").buildCommand("bun", "my-nuxt");
+    expect(cmd).toContain("create-nuxt@latest");
+    expect(cmd).toContain("my-nuxt");
+    expect(cmd).toContain("--no-modules");
+    expect(cmd).toContain("--no-install");
+    expect(cmd).toContain("--no-gitInit");
+    expect(cmd).toContain("--packageManager");
+    expect(cmd).toContain("bun");
+  });
+
+  test("TanStack uses project name as positional arg", () => {
+    const cmd = entryFor("@tanstack/react-start").buildCommand("yarn", "my-app");
+    expect(cmd[0]).toBe("yarn");
+    expect(cmd[1]).toBe("dlx");
+    expect(cmd).toContain("@tanstack/cli@latest");
+    expect(cmd).toContain("create");
+    expect(cmd).toContain("my-app");
+    expect(cmd).toContain("--framework");
+    expect(cmd).toContain("react");
+    expect(cmd).toContain("--no-install");
+    expect(cmd).toContain("--no-git");
+  });
+
+  test("React Router uses project name as target", () => {
+    const cmd = entryFor("react-router").buildCommand("npm", "my-rr");
+    expect(cmd).toContain("create-react-router@latest");
+    expect(cmd).toContain("my-rr");
+    expect(cmd).toContain("--yes");
+    expect(cmd).toContain("--no-install");
+    expect(cmd).toContain("--no-git-init");
+  });
+
+  test("Astro uses --yes for basics template with --skip-houston", () => {
+    const cmd = entryFor("astro").buildCommand("bun", "my-astro");
+    expect(cmd).toContain("create-astro@latest");
+    expect(cmd).toContain("my-astro");
+    expect(cmd).toContain("--yes");
+    expect(cmd).toContain("--skip-houston");
+    expect(cmd).toContain("--no-install");
+    expect(cmd).toContain("--no-git");
+  });
+
+  test("JavaScript uses create-vite with vanilla template", () => {
+    const cmd = entryFor("vite").buildCommand("npm", "my-js-app");
+    expect(cmd).toContain("create-vite@latest");
+    expect(cmd).toContain("my-js-app");
+    expect(cmd).toContain("--template");
+    expect(cmd).toContain("vanilla");
+    expect(cmd).not.toContain("vanilla-ts");
+  });
+
+  test("yarn runner splits into two tokens", () => {
+    const cmd = entryFor("react").buildCommand("yarn", "app");
+    expect(cmd[0]).toBe("yarn");
+    expect(cmd[1]).toBe("dlx");
+  });
+
+  test("pnpm runner splits into two tokens", () => {
+    const cmd = entryFor("react").buildCommand("pnpm", "app");
+    expect(cmd[0]).toBe("pnpm");
+    expect(cmd[1]).toBe("dlx");
+  });
+});

--- a/packages/cli-core/src/commands/init/bootstrap.ts
+++ b/packages/cli-core/src/commands/init/bootstrap.ts
@@ -1,0 +1,168 @@
+import { join } from "node:path";
+import { search, confirm, input } from "@inquirer/prompts";
+import { cyan, yellow } from "../../lib/color.js";
+import { throwUserAbort, CliError } from "../../lib/errors.js";
+import type { FrameworkInfo } from "../../lib/framework.js";
+import { hasPackageJson } from "./context.js";
+import {
+  BOOTSTRAP_REGISTRY,
+  PM_INSTALL_COMMANDS,
+  type PackageManager,
+  type BootstrapEntry,
+} from "./bootstrap-registry.js";
+
+async function spawnInherited(args: string[], cwd: string): Promise<number> {
+  const proc = Bun.spawn(args, { cwd, stdout: "inherit", stderr: "inherit" });
+  return proc.exited;
+}
+
+function findEntry(dep: string) {
+  return BOOTSTRAP_REGISTRY.find((entry) => entry.dep === dep);
+}
+
+const FRAMEWORK_CHOICES = BOOTSTRAP_REGISTRY.map((entry) => ({
+  name: entry.label,
+  value: entry.dep,
+}));
+
+const PM_CHOICES: Array<{ name: string; value: PackageManager }> = [
+  { name: "bun", value: "bun" },
+  { name: "pnpm", value: "pnpm" },
+  { name: "yarn", value: "yarn" },
+  { name: "npm", value: "npm" },
+];
+
+function filterChoices<T extends { name: string }>(choices: T[], term: string | undefined): T[] {
+  if (!term) return choices;
+  const lower = term.toLowerCase();
+  return choices.filter((c) => c.name.toLowerCase().includes(lower));
+}
+
+async function pickFramework(frameworkOverride?: FrameworkInfo): Promise<BootstrapEntry> {
+  if (!frameworkOverride) {
+    const chosen = await search({
+      message: "Which framework?",
+      source: (term) => filterChoices(FRAMEWORK_CHOICES, term),
+    });
+    return findEntry(chosen)!;
+  }
+
+  const entry = findEntry(frameworkOverride.dep);
+  if (entry) return entry;
+
+  const supported = BOOTSTRAP_REGISTRY.map((e) => e.label).join(", ");
+  throw new CliError(
+    `Bootstrap is not supported for ${frameworkOverride.name}. Supported: ${supported}`,
+  );
+}
+
+async function pickPackageManager(): Promise<PackageManager> {
+  return search<PackageManager>({
+    message: "Which package manager?",
+    source: (term) => filterChoices(PM_CHOICES, term),
+  });
+}
+
+function defaultProjectName(entry: BootstrapEntry): string {
+  return entry.defaultProjectName;
+}
+
+async function askProjectName(entry: BootstrapEntry): Promise<string> {
+  const name = await input({
+    message: "Project name:",
+    default: defaultProjectName(entry),
+    validate: (value) => {
+      if (!value.trim()) return "Project name is required";
+      if (/[A-Z]/.test(value)) return "Project name must be lowercase";
+      if (/\s/.test(value)) return "Project name cannot contain spaces";
+      if (value.includes("/") || value.includes(".."))
+        return "Project name cannot contain path separators";
+      return true;
+    },
+  });
+  return name.trim();
+}
+
+async function generateProject(label: string, command: string[], cwd: string): Promise<void> {
+  console.log(`\nCreating ${cyan(label)} project...\n`);
+
+  const exitCode = await spawnInherited(command, cwd);
+  if (exitCode !== 0) {
+    throw new CliError(`Project generation failed (exit code ${exitCode}).`);
+  }
+}
+
+async function installDependencies(pm: PackageManager, cwd: string): Promise<void> {
+  console.log(`\nInstalling dependencies...\n`);
+
+  const exitCode = await spawnInherited(PM_INSTALL_COMMANDS[pm], cwd);
+  if (exitCode !== 0) {
+    console.log(
+      yellow(
+        `\nDependency installation failed. Run manually: ${PM_INSTALL_COMMANDS[pm].join(" ")}`,
+      ),
+    );
+  }
+}
+
+/**
+ * Warn if a package.json already exists (for --starter in non-blank dirs).
+ */
+export async function confirmOverwrite(cwd: string): Promise<void> {
+  if (!(await hasPackageJson(cwd))) return;
+
+  const proceed = await confirm({
+    message: "This directory already has a package.json. Proceed anyway?",
+    default: false,
+  });
+  if (!proceed) throwUserAbort();
+}
+
+export async function askSkipAuth(): Promise<boolean> {
+  return confirm({
+    message:
+      "Skip authentication for now? (you can connect your Clerk account later with `clerk login`)",
+    default: true,
+  });
+}
+
+export type BootstrapResult = {
+  projectDir: string;
+  projectName: string;
+  packageManager: PackageManager;
+};
+
+/**
+ * Interactive bootstrap flow.
+ * When skipConfirm is true (e.g. --starter flag), skips the "create a new one?" prompt.
+ * Returns bootstrap result on success, or null on failure.
+ */
+export async function promptAndBootstrap(
+  cwd: string,
+  frameworkOverride?: FrameworkInfo,
+  { skipConfirm = false } = {},
+): Promise<BootstrapResult> {
+  if (!skipConfirm) {
+    const wantBootstrap = await confirm({
+      message: "No project detected. Would you like to create a new one?",
+      default: true,
+    });
+    if (!wantBootstrap) throwUserAbort();
+  }
+
+  const entry = await pickFramework(frameworkOverride);
+  const pm = await pickPackageManager();
+  const projectName = await askProjectName(entry);
+  const projectDir = join(cwd, projectName);
+
+  await generateProject(entry.label, entry.buildCommand(pm, projectName), cwd);
+
+  if (!(await hasPackageJson(projectDir))) {
+    throw new CliError("Generator did not create a package.json.");
+  }
+
+  await installDependencies(pm, projectDir);
+
+  console.log();
+  return { projectDir, projectName, packageManager: pm };
+}

--- a/packages/cli-core/src/commands/init/context.ts
+++ b/packages/cli-core/src/commands/init/context.ts
@@ -35,6 +35,10 @@ async function detectPackageManager(cwd: string): Promise<ProjectContext["packag
 // Re-export for modules that import readDeps from context (e.g., format.ts)
 export { readDeps } from "../../lib/framework.js";
 
+export async function hasPackageJson(cwd: string): Promise<boolean> {
+  return fileExists(join(cwd, "package.json"));
+}
+
 export async function gatherContext(
   cwd: string,
   frameworkOverride?: FrameworkInfo,

--- a/packages/cli-core/src/commands/init/frameworks/helpers.ts
+++ b/packages/cli-core/src/commands/init/frameworks/helpers.ts
@@ -16,6 +16,7 @@ export {
   safeAddImport,
   insertAfterLastImport,
   wrapBodyWithProvider,
+  injectHeaderInProvider,
 } from "./transformations.js";
 
 export type AuthKind = "sign-in" | "sign-up";
@@ -198,8 +199,16 @@ function detectI18nMiddlewareImport(content: string): I18nMiddlewareLib | null {
 
 // ─── Middleware Content Generation ────────────────────────────────
 
-/** Next.js clerkMiddleware with route protection and matcher config. */
-export function nextjsMiddlewareContent(): string {
+/** Next.js clerkMiddleware — permissive (unauthenticated) or protective (default). */
+export function nextjsMiddlewareContent(keyless = false): string {
+  if (keyless) {
+    return `import { clerkMiddleware } from "@clerk/nextjs/server";
+
+export default clerkMiddleware();
+
+${nextjsMiddlewareConfig()}
+`;
+  }
   return `import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 
 ${nextjsPublicRouteMatcher()}
@@ -424,6 +433,7 @@ export async function scaffoldNextjsMiddleware(ctx: {
   typescript: boolean;
   deps?: Record<string, string>;
   middlewareBasename?: "proxy" | "middleware";
+  keyless?: boolean;
 }): Promise<FileAction> {
   const base = srcPrefix(ctx);
   const ext = scriptExt(ctx);
@@ -447,8 +457,10 @@ export async function scaffoldNextjsMiddleware(ctx: {
     return {
       path,
       type: "create",
-      content: nextjsMiddlewareContent(),
-      description: "Create Clerk middleware with route protection",
+      content: nextjsMiddlewareContent(ctx.keyless),
+      description: ctx.keyless
+        ? "Create Clerk middleware (permissive — connect your account later)"
+        : "Create Clerk middleware with route protection",
     };
   }
 

--- a/packages/cli-core/src/commands/init/frameworks/javascript.ts
+++ b/packages/cli-core/src/commands/init/frameworks/javascript.ts
@@ -1,0 +1,84 @@
+import { join } from "node:path";
+import { findFirstFile, scriptExt, srcPrefix } from "./helpers.js";
+import type { FileAction, FrameworkScaffold, ProjectContext, ScaffoldPlan } from "./types.js";
+
+async function findEntryFile(ctx: ProjectContext): Promise<string | null> {
+  const base = srcPrefix(ctx);
+  const ext = scriptExt(ctx);
+  return findFirstFile(ctx.cwd, [`${base}main.${ext}`]);
+}
+
+/**
+ * Generate Clerk JS initialization code following the official quickstart:
+ * https://clerk.com/docs/js-frontend/getting-started/quickstart
+ *
+ * Uses innerHTML to mount Clerk components into the DOM — this is safe because
+ * the content is a static string literal (no user input), matching the pattern
+ * from the official Clerk JS quickstart documentation.
+ */
+function clerkInitContent(typescript: boolean): string {
+  const castDiv = typescript ? " as HTMLDivElement" : "";
+  // Static template strings with no user input — safe for innerHTML
+  return `import { Clerk } from "@clerk/clerk-js";
+
+const publishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
+
+const clerk = new Clerk(publishableKey);
+await clerk.load();
+
+if (clerk.user) {
+  const div = document.getElementById("app")${castDiv};
+  div.innerHTML = '<div id="user-button"></div>';
+  clerk.mountUserButton(document.getElementById("user-button")${castDiv});
+} else {
+  const div = document.getElementById("app")${castDiv};
+  div.innerHTML = '<div id="sign-in"></div>';
+  clerk.mountSignIn(document.getElementById("sign-in")${castDiv});
+}
+`;
+}
+
+async function scaffoldEntry(ctx: ProjectContext): Promise<FileAction | null> {
+  const entryPath = await findEntryFile(ctx);
+  if (!entryPath) return null;
+
+  const content = await Bun.file(join(ctx.cwd, entryPath)).text();
+
+  if (content.includes("@clerk/clerk-js")) {
+    return { type: "skip", path: entryPath, skipReason: "Already has Clerk JS" };
+  }
+
+  return {
+    path: entryPath,
+    type: "modify",
+    content: clerkInitContent(ctx.typescript),
+    description: "Replace with Clerk JS initialization",
+  };
+}
+
+export const javascriptVite: FrameworkScaffold = {
+  name: "JavaScript (Vite)",
+  dep: "vite",
+
+  matches: (ctx) => ctx.framework.dep === "vite",
+
+  async scaffold(ctx: ProjectContext): Promise<ScaffoldPlan> {
+    const actions: FileAction[] = [];
+    const postInstructions: string[] = [];
+
+    const entryAction = await scaffoldEntry(ctx);
+    if (entryAction) {
+      actions.push(entryAction);
+    } else {
+      postInstructions.push(
+        "Initialize Clerk in your entry file (e.g., src/main.ts). See: https://clerk.com/docs/js-frontend/getting-started/quickstart",
+      );
+    }
+
+    postInstructions.push(
+      `Ensure ${ctx.framework.envVar} is set in your ${ctx.envFile} (pulled via \`clerk env pull\`)`,
+    );
+
+    return { actions, postInstructions };
+  },
+};

--- a/packages/cli-core/src/commands/init/frameworks/nextjs-app.test.ts
+++ b/packages/cli-core/src/commands/init/frameworks/nextjs-app.test.ts
@@ -519,3 +519,102 @@ export default wrapped;
   expect(mw.content).toContain("const middleware = wrapped");
   expect(mw.content).toContain("middleware(request)");
 });
+
+test("adds auth header in layout during bootstrap with Tailwind", async () => {
+  await mkdir(join(tempDir, "app"), { recursive: true });
+  await Bun.write(
+    join(tempDir, "app/layout.tsx"),
+    `export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}
+`,
+  );
+
+  const plan = await nextjsApp.scaffold(
+    makeCtx({ isBootstrap: true, deps: { tailwindcss: "4.0.0" } }),
+  );
+  const layout = findAction(plan.actions, "app/layout.tsx");
+
+  expect(layout.type).toBe("modify");
+  if (layout.type !== "modify") throw new Error("Expected modify action");
+
+  // Auth header components are present
+  expect(layout.content).toContain('<Show when="signed-out">');
+  expect(layout.content).toContain("<SignInButton />");
+  expect(layout.content).toContain("<SignUpButton />");
+  expect(layout.content).toContain('<Show when="signed-in">');
+  expect(layout.content).toContain("<UserButton />");
+
+  // Tailwind classes on header
+  expect(layout.content).toContain(
+    'className="flex h-16 items-center justify-end gap-4 border-b px-4"',
+  );
+
+  // All imports merged into a single @clerk/nextjs import
+  expect(layout.content).toContain("ClerkProvider");
+  expect(layout.content).toContain("Show");
+  expect(layout.content).toContain("SignInButton");
+  expect(layout.content).toContain("SignUpButton");
+  expect(layout.content).toContain("UserButton");
+
+  // Description mentions auth header
+  expect(layout.description).toContain("auth header");
+});
+
+test("does not add auth header for non-bootstrap init", async () => {
+  await mkdir(join(tempDir, "app"), { recursive: true });
+  await Bun.write(
+    join(tempDir, "app/layout.tsx"),
+    `export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}
+`,
+  );
+
+  const plan = await nextjsApp.scaffold(makeCtx());
+  const layout = findAction(plan.actions, "app/layout.tsx");
+
+  expect(layout.type).toBe("modify");
+  if (layout.type !== "modify") throw new Error("Expected modify action");
+
+  // Should have ClerkProvider but NOT the auth header
+  expect(layout.content).toContain("ClerkProvider");
+  expect(layout.content).not.toContain("<Show");
+  expect(layout.content).not.toContain("<SignInButton");
+  expect(layout.content).not.toContain("<UserButton");
+});
+
+test("uses plain styles for auth header when no Tailwind", async () => {
+  await mkdir(join(tempDir, "app"), { recursive: true });
+  await Bun.write(
+    join(tempDir, "app/layout.tsx"),
+    `export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}
+`,
+  );
+
+  const plan = await nextjsApp.scaffold(makeCtx({ isBootstrap: true, deps: {} }));
+  const layout = findAction(plan.actions, "app/layout.tsx");
+
+  expect(layout.type).toBe("modify");
+  if (layout.type !== "modify") throw new Error("Expected modify action");
+
+  // Plain styles instead of Tailwind
+  expect(layout.content).toContain("style={{");
+  expect(layout.content).toContain("justifyContent");
+  expect(layout.content).toContain("borderBottom");
+  expect(layout.content).not.toContain('className="flex');
+});

--- a/packages/cli-core/src/commands/init/frameworks/nextjs-app.ts
+++ b/packages/cli-core/src/commands/init/frameworks/nextjs-app.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import {
   authFileSpecs,
   hasTailwindStyles,
+  injectHeaderInProvider,
   jsxAuthPageContent,
   jsxExt,
   safeAddImport,
@@ -46,12 +47,22 @@ async function scaffoldLayout(ctx: ProjectContext): Promise<FileAction> {
     newContent = wrapBodyWithProvider(newContent, "ClerkProvider");
   }
 
+  if (ctx.isBootstrap && hasBody) {
+    newContent = safeAddImport(newContent, "@clerk/nextjs", "Show");
+    newContent = safeAddImport(newContent, "@clerk/nextjs", "SignInButton");
+    newContent = safeAddImport(newContent, "@clerk/nextjs", "SignUpButton");
+    newContent = safeAddImport(newContent, "@clerk/nextjs", "UserButton");
+    newContent = injectHeaderInProvider(newContent, hasTailwindStyles(ctx));
+  }
+
   return {
     path: ctx.layoutPath,
     type: "modify",
     content: newContent,
     description: hasBody
-      ? "Add ClerkProvider import and wrap body contents"
+      ? ctx.isBootstrap
+        ? "Add ClerkProvider, wrap body contents, and add auth header"
+        : "Add ClerkProvider import and wrap body contents"
       : "Add ClerkProvider import (manual wrapping needed)",
   };
 }

--- a/packages/cli-core/src/commands/init/frameworks/react-router.ts
+++ b/packages/cli-core/src/commands/init/frameworks/react-router.ts
@@ -396,7 +396,7 @@ export const reactRouter: FrameworkScaffold = {
 
     if (!rootAction) {
       postInstructions.push(
-        "Add ClerkProvider, clerkMiddleware(), and rootAuthLoader() to your app/root.tsx. See: https://clerk.com/docs/quickstarts/react-router",
+        "Add ClerkProvider, clerkMiddleware(), and rootAuthLoader() to your app/root.tsx. See: https://clerk.com/docs/react-router/getting-started/quickstart",
       );
     }
 

--- a/packages/cli-core/src/commands/init/frameworks/react.ts
+++ b/packages/cli-core/src/commands/init/frameworks/react.ts
@@ -65,7 +65,7 @@ export const reactVite: FrameworkScaffold = {
       actions.push(entryAction);
     } else {
       postInstructions.push(
-        `Wrap your app root with <ClerkProvider> from @clerk/react in your entry file (e.g., main.tsx). See: https://clerk.com/docs/quickstarts/react`,
+        `Wrap your app root with <ClerkProvider> from @clerk/react in your entry file (e.g., main.tsx). See: https://clerk.com/docs/react/getting-started/quickstart`,
       );
     }
 

--- a/packages/cli-core/src/commands/init/frameworks/transformations.ts
+++ b/packages/cli-core/src/commands/init/frameworks/transformations.ts
@@ -39,6 +39,38 @@ export function insertAfterLastImport(source: string, snippet: string): string {
   return source.slice(0, lineEnd + 1) + snippet + source.slice(lineEnd + 1);
 }
 
+/**
+ * Inject a navigation header with auth buttons inside `<ClerkProvider>`.
+ * Must be called AFTER `wrapBodyWithProvider` has already wrapped body contents.
+ */
+export function injectHeaderInProvider(content: string, tailwind: boolean): string {
+  const providerPattern = /^( *)<ClerkProvider>/m;
+  const match = providerPattern.exec(content);
+  if (!match) return content;
+
+  const [, indent] = match;
+  const innerIndent = indent + "  ";
+  const deepIndent = innerIndent + "  ";
+
+  const headerAttr = tailwind
+    ? `className="flex h-16 items-center justify-end gap-4 border-b px-4"`
+    : `style={{ display: "flex", height: "64px", alignItems: "center", justifyContent: "flex-end", gap: "16px", borderBottom: "1px solid #e5e7eb", padding: "0 16px" }}`;
+
+  const headerBlock = [
+    `${innerIndent}<header ${headerAttr}>`,
+    `${deepIndent}<Show when="signed-out">`,
+    `${deepIndent}  <SignInButton />`,
+    `${deepIndent}  <SignUpButton />`,
+    `${deepIndent}</Show>`,
+    `${deepIndent}<Show when="signed-in">`,
+    `${deepIndent}  <UserButton />`,
+    `${deepIndent}</Show>`,
+    `${innerIndent}</header>`,
+  ].join("\n");
+
+  return content.replace(providerPattern, `${indent}<ClerkProvider>\n${headerBlock}`);
+}
+
 /** Wrap the contents of a `<body>` tag with a provider component (e.g. `<ClerkProvider>`). */
 export function wrapBodyWithProvider(content: string, provider: string): string {
   const bodyPattern = /^( *)(<body[^>]*>)([\s\S]*?)(<\/body>)/m;

--- a/packages/cli-core/src/commands/init/frameworks/types.ts
+++ b/packages/cli-core/src/commands/init/frameworks/types.ts
@@ -17,6 +17,10 @@ export interface ProjectContext {
   middlewareBasename?: "proxy" | "middleware";
   /** i18n locale directory segment (e.g., "[locale]"). Set by enrichContext when detected. */
   i18nLocaleDir?: string;
+  /** When true, scaffold permissive middleware without route protection (keyless mode). */
+  keyless?: boolean;
+  /** When true, the project was created via bootstrap (empty repo). Scaffolders may add starter UI. */
+  isBootstrap?: boolean;
 }
 
 export type FileAction =

--- a/packages/cli-core/src/commands/init/index.test.ts
+++ b/packages/cli-core/src/commands/init/index.test.ts
@@ -1,8 +1,10 @@
 import { test, expect, describe, afterEach, spyOn } from "bun:test";
+import { configStubs, capturedOutput } from "../../test/lib/stubs.ts";
 
 // Pure spyOn approach — Bun's mock.module globally replaces modules for the
 // entire test run, which pollutes other test files (link, env/pull, config,
 // context, etc.) that import the same modules. spyOn restores cleanly.
+import * as loginMod from "../auth/login.ts";
 import * as linkMod from "../link/index.ts";
 import * as pullMod from "../env/pull.ts";
 import * as mode from "../../mode.ts";
@@ -15,26 +17,52 @@ import * as formatMod from "./format.ts";
 import * as scanMod from "./scan.ts";
 import * as heuristics from "./heuristics.ts";
 import * as skillsMod from "./skills.ts";
+import * as bootstrapMod from "./bootstrap.ts";
 import { init } from "./index.ts";
 
-describe("init command", () => {
+const FAKE_CTX = {
+  cwd: "/tmp/test",
+  framework: {
+    dep: "react",
+    name: "React",
+    sdk: "@clerk/react",
+    envVar: "VITE_CLERK_PUBLISHABLE_KEY",
+  },
+  typescript: true,
+  srcDir: false,
+  packageManager: "npm" as const,
+  existingClerk: true,
+  deps: { react: "^19.0.0" },
+  envFile: ".env",
+};
+
+const FAKE_BOOTSTRAP = {
+  projectDir: "/tmp/test/my-app",
+  projectName: "my-app",
+  packageManager: "npm" as const,
+};
+
+describe("init", () => {
   let spies: ReturnType<typeof spyOn>[];
 
   afterEach(() => {
-    for (const spy of spies) spy.mockRestore();
+    for (const s of spies) s.mockRestore();
   });
 
-  function setup(overrides: { email?: string | null } = {}) {
+  function setup(overrides: { email?: string | null; isAgent?: boolean } = {}) {
     const email = overrides.email ?? null;
+    const agent = overrides.isAgent ?? false;
 
     const gatherContextSpy = spyOn(context, "gatherContext").mockResolvedValue(null);
 
     spies = [
       spyOn(console, "log").mockImplementation(() => {}),
-      spyOn(mode, "isAgent").mockReturnValue(false),
+      spyOn(mode, "isAgent").mockReturnValue(agent),
+      spyOn(mode, "isHuman").mockReturnValue(!agent),
       spyOn(config, "resolveProfile").mockResolvedValue(undefined),
       spyOn(frameworkMod, "lookupFramework").mockReturnValue(null),
       gatherContextSpy,
+      spyOn(context, "hasPackageJson").mockResolvedValue(false),
       spyOn(scaffoldMod, "scaffold").mockResolvedValue({ actions: [], postInstructions: [] }),
       spyOn(scaffoldMod, "enrichProjectContext").mockResolvedValue(undefined),
       spyOn(previewMod, "previewPlan").mockReturnValue(undefined),
@@ -49,38 +77,157 @@ describe("init command", () => {
       spyOn(heuristics, "checkGitDirty").mockResolvedValue(false),
       spyOn(heuristics, "printOutro").mockReturnValue(undefined),
       spyOn(skillsMod, "installSkills").mockResolvedValue(undefined),
+      spyOn(loginMod, "login").mockResolvedValue(undefined as never),
       spyOn(linkMod, "link").mockResolvedValue(undefined),
       spyOn(pullMod, "pull").mockResolvedValue(undefined),
+      spyOn(bootstrapMod, "promptAndBootstrap").mockResolvedValue(FAKE_BOOTSTRAP),
+      spyOn(bootstrapMod, "confirmOverwrite").mockResolvedValue(undefined),
+      spyOn(bootstrapMod, "askSkipAuth").mockResolvedValue(false),
     ];
 
     return { gatherContextSpy };
   }
 
-  test("defaults to keyless mode when not authenticated", async () => {
+  function setupBootstrapSuccess() {
+    const gatherSpy =
+      spies.find((s) => s.getMockName?.() === "gatherContext") ?? spyOn(context, "gatherContext");
+    gatherSpy.mockResolvedValueOnce(null).mockResolvedValueOnce(FAKE_CTX);
+  }
+
+  test("suppresses auth next-steps when login runs during init", async () => {
     setup({ email: null });
+    spyOn(context, "gatherContext").mockResolvedValue(FAKE_CTX);
+    spyOn(heuristics, "getAuthenticatedEmail").mockResolvedValue(null);
+    spyOn(loginMod, "login").mockResolvedValue({
+      userId: "user_1",
+      email: "test@test.com",
+    } as never);
 
     await init({ yes: true });
 
-    expect(linkMod.link).not.toHaveBeenCalled();
-    expect(pullMod.pull).not.toHaveBeenCalled();
-    expect(heuristics.printKeylessInfo).toHaveBeenCalled();
+    expect(loginMod.login).toHaveBeenCalledWith({ showNextSteps: false });
+    expect(linkMod.link).toHaveBeenCalledWith({ skipIfLinked: true });
   });
 
-  test("links and pulls env when authenticated", async () => {
-    setup({ email: "test@test.com" });
+  test("agent mode prints guidance without auth/bootstrap", async () => {
+    setup({ isAgent: true });
+
+    await init({});
+
+    const output = capturedOutput(spies[0] as ReturnType<typeof spyOn>);
+    expect(output).toContain("clerk init -y");
+    expect(loginMod.login).not.toHaveBeenCalled();
+    expect(bootstrapMod.promptAndBootstrap).not.toHaveBeenCalled();
+  });
+
+  test("blank dir in human mode triggers bootstrap flow", async () => {
+    setup();
+    setupBootstrapSuccess();
+
+    await init({});
+
+    expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalled();
+    expect(bootstrapMod.askSkipAuth).toHaveBeenCalled();
+  });
+
+  test("-y flag skips auth prompt and defaults to unauthenticated mode", async () => {
+    setup();
+    setupBootstrapSuccess();
 
     await init({ yes: true });
 
-    expect(linkMod.link).toHaveBeenCalledWith({ skipIfLinked: true });
-    expect(pullMod.pull).toHaveBeenCalled();
-    expect(heuristics.printKeylessInfo).not.toHaveBeenCalled();
+    expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalled();
+    expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
+    expect(heuristics.getAuthenticatedEmail).not.toHaveBeenCalled();
+  });
+
+  test("blank dir bootstrap declined throws UserAbortError", async () => {
+    setup();
+    spyOn(bootstrapMod, "promptAndBootstrap").mockRejectedValue(
+      Object.assign(new Error(), { name: "UserAbortError" }),
+    );
+
+    await expect(init({})).rejects.toMatchObject({ name: "UserAbortError" });
+    expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalled();
+    expect(loginMod.login).not.toHaveBeenCalled();
+  });
+
+  test("non-empty unrecognized dir throws CliError without auth", async () => {
+    setup();
+    spyOn(context, "hasPackageJson").mockResolvedValue(true);
+
+    await expect(init({})).rejects.toThrow("Could not detect a framework");
+    expect(loginMod.login).not.toHaveBeenCalled();
+    expect(bootstrapMod.promptAndBootstrap).not.toHaveBeenCalled();
+  });
+
+  test("existing detected project skips bootstrap", async () => {
+    setup({ email: "test@test.com" });
+    spyOn(context, "gatherContext").mockResolvedValue(FAKE_CTX);
+    spyOn(config, "resolveProfile").mockResolvedValue({ profile: { appId: "app_123" } } as never);
+
+    await init({ yes: true });
+
+    expect(bootstrapMod.promptAndBootstrap).not.toHaveBeenCalled();
+    expect(context.hasPackageJson).not.toHaveBeenCalled();
+  });
+
+  test("passes frameworkOverride to bootstrap when provided", async () => {
+    const fwOverride = {
+      dep: "next",
+      name: "Next.js",
+      sdk: "@clerk/nextjs",
+      envVar: "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+    };
+    setup({ email: "test@test.com" });
+    spyOn(frameworkMod, "lookupFramework").mockReturnValue(fwOverride);
+    spyOn(config, "resolveProfile").mockResolvedValue({ profile: { appId: "app_123" } } as never);
+    setupBootstrapSuccess();
+
+    await init({ framework: "next", yes: true });
+
+    expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalledWith(expect.any(String), fwOverride, {
+      skipConfirm: true,
+    });
+  });
+
+  test("--starter skips detection and runs bootstrap with skipConfirm", async () => {
+    setup({ email: "test@test.com" });
+    spyOn(context, "gatherContext").mockResolvedValue(FAKE_CTX);
+    spyOn(config, "resolveProfile").mockResolvedValue({ profile: { appId: "app_123" } } as never);
+
+    await init({ starter: true, yes: true });
+
+    expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalledWith(expect.any(String), undefined, {
+      skipConfirm: true,
+    });
+    // --yes skips confirmOverwrite
+    expect(bootstrapMod.confirmOverwrite).not.toHaveBeenCalled();
+  });
+
+  test("--starter without -y calls confirmOverwrite", async () => {
+    setup({ email: "test@test.com" });
+    spyOn(context, "gatherContext").mockResolvedValue(FAKE_CTX);
+    spyOn(config, "resolveProfile").mockResolvedValue({ profile: { appId: "app_123" } } as never);
+
+    await init({ starter: true });
+
+    expect(bootstrapMod.confirmOverwrite).toHaveBeenCalledWith(expect.any(String));
+  });
+
+  test("--starter in agent mode prints guidance without bootstrap", async () => {
+    setup({ isAgent: true });
+
+    await init({ starter: true });
+
+    const output = capturedOutput(spies[0] as ReturnType<typeof spyOn>);
+    expect(output).toContain("clerk init -y");
+    expect(bootstrapMod.promptAndBootstrap).not.toHaveBeenCalled();
   });
 
   test("short-circuits env pull and skills install when already set up", async () => {
     const { gatherContextSpy } = setup({ email: "test@test.com" });
 
-    // Override the default null gatherContext with a minimal supported-framework
-    // context so detectAndInstall reaches the alreadySetUp path.
     gatherContextSpy.mockResolvedValueOnce({
       cwd: "/tmp/fake",
       framework: { name: "Next.js", dep: "next", sdk: "@clerk/nextjs", publishableKeyEnv: "x" },
@@ -93,7 +240,6 @@ describe("init command", () => {
 
     await init({ yes: true });
 
-    // Link still runs (it's before detectAndInstall); env pull and skills are skipped.
     expect(linkMod.link).toHaveBeenCalledWith({ skipIfLinked: true });
     expect(pullMod.pull).not.toHaveBeenCalled();
     expect(heuristics.printKeylessInfo).not.toHaveBeenCalled();

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -1,11 +1,13 @@
+import { login } from "../auth/login.js";
 import { link } from "../link/index.js";
 import { pull } from "../env/pull.js";
 import { isAgent } from "../../mode.js";
 import { dim, green, yellow, bold } from "../../lib/color.js";
-import { throwUserAbort } from "../../lib/errors.js";
-import { lookupFramework } from "../../lib/framework.js";
+import { throwUserAbort, CliError } from "../../lib/errors.js";
+import { lookupFramework, type FrameworkInfo } from "../../lib/framework.js";
 import { resolveProfile } from "../../lib/config.js";
-import { gatherContext } from "./context.js";
+import { printNextSteps } from "../../lib/next-steps.js";
+import { gatherContext, hasPackageJson } from "./context.js";
 import { scaffold, enrichProjectContext } from "./scaffold.js";
 import { previewPlan, previewAndConfirm } from "./preview.js";
 import { runFormatters } from "./format.js";
@@ -20,50 +22,63 @@ import {
 } from "./heuristics.js";
 import { installSkills } from "./skills.js";
 import { intro, outro, bar, withSpinner } from "../../lib/spinner.js";
+import {
+  promptAndBootstrap,
+  confirmOverwrite,
+  askSkipAuth,
+  type BootstrapResult,
+} from "./bootstrap.js";
 import type { ProjectContext } from "./frameworks/types.js";
 
-interface InitOptions {
+type InitOptions = {
   framework?: string;
   yes?: boolean;
   prompt?: boolean;
   skills?: boolean;
-}
+  starter?: boolean;
+};
 
 export async function init(options: InitOptions = {}) {
   const cwd = process.cwd();
 
-  // Commander validates --framework against FRAMEWORK_NAMES choices
   const frameworkOverride = options.framework
     ? (lookupFramework(options.framework) ?? undefined)
     : undefined;
-
-  intro("clerk init");
-
-  const ctx = await withSpinner("Detecting framework...", () =>
-    gatherContext(cwd, frameworkOverride),
-  );
-
-  // Populate framework-specific context (variant, layoutPath, middlewareBasename)
-  if (ctx) await enrichProjectContext(ctx);
 
   if (options.prompt || isAgent()) {
     console.log(
       "Run `clerk init -y` to automatically detect the framework, install the Clerk SDK, and scaffold authentication files without interactive prompts.",
     );
-    outro();
     return;
   }
 
-  bar();
-  const authenticated = await resolveAuth(cwd);
+  intro("clerk init");
 
-  if (authenticated) {
-    await link({ skipIfLinked: true });
+  const resolved = options.starter
+    ? await handleStarter(cwd, frameworkOverride, options.yes)
+    : await resolveProjectContext(cwd, frameworkOverride, options.yes);
+
+  if (!resolved) return;
+
+  const { ctx, bootstrap } = resolved;
+
+  if (bootstrap) {
+    ctx.isBootstrap = true;
+  }
+
+  await enrichProjectContext(ctx);
+
+  const keyless = bootstrap ? options.yes || (await askSkipAuth()) : false;
+  ctx.keyless = keyless;
+
+  if (!keyless) {
+    bar();
+    await authenticateAndLink(ctx.cwd);
   }
 
   // Short-circuit on a fully-clean re-run so env pull / skills prompt don't
   // execute when there's nothing to do.
-  const { alreadySetUp } = await detectAndInstall(cwd, ctx, options);
+  const { alreadySetUp } = await detectAndInstall(ctx.cwd, ctx, options);
 
   if (alreadySetUp) {
     console.log(green("\nClerk is already set up in this project."));
@@ -72,10 +87,14 @@ export async function init(options: InitOptions = {}) {
   }
 
   bar();
-  if (authenticated) {
+  if (!keyless) {
     await pull({});
   } else {
     printKeylessInfo();
+  }
+
+  if (bootstrap) {
+    printBootstrapNextSteps(bootstrap, keyless);
   }
 
   if (options.skills !== false) {
@@ -86,40 +105,113 @@ export async function init(options: InitOptions = {}) {
   outro("Done");
 }
 
-async function resolveAuth(cwd: string): Promise<boolean> {
-  const hasApiKey = Boolean(process.env.CLERK_PLATFORM_API_KEY);
-  const email = hasApiKey ? null : await getAuthenticatedEmail();
+type ResolvedContext = {
+  ctx: ProjectContext;
+  bootstrap: BootstrapResult | null;
+};
 
-  if (!hasApiKey && !email) return false;
+// --- Bootstrap paths ---
 
-  const profile = await resolveProfile(cwd);
-  const linkedInfo = profile ? ` · Linked to ${profile.profile.appId}` : "";
-  const authLabel = hasApiKey ? "Using API key" : `Logged in as ${email}`;
-  console.log(dim(`${authLabel}${linkedInfo}`));
-  return true;
+async function bootstrapAndDetect(
+  cwd: string,
+  frameworkOverride?: FrameworkInfo,
+  skipConfirm = false,
+): Promise<ResolvedContext> {
+  const bootstrap = await promptAndBootstrap(cwd, frameworkOverride, { skipConfirm });
+
+  const ctx = await gatherContext(bootstrap.projectDir);
+  if (!ctx) {
+    throw new CliError("Project generation did not produce a detectable framework.");
+  }
+  return { ctx, bootstrap };
 }
 
-/**
- * Run framework detection, SDK install, and scaffolding.
- *
- * Returns `alreadySetUp: true` only when the project has a supported
- * framework, the SDK is installed, all scaffold actions are skips, and there
- * are no postInstructions — i.e. a fully-clean re-run. The "no framework"
- * and "framework detected but unsupported" branches return `false` so the
- * caller still pulls env keys and offers the skills install.
- */
-async function detectAndInstall(
+async function handleStarter(
   cwd: string,
-  ctx: ProjectContext | null,
-  options: InitOptions,
-): Promise<{ alreadySetUp: boolean }> {
-  if (!ctx) {
-    console.log(
-      `Could not detect a framework. Install the appropriate Clerk SDK manually: ${dim("https://clerk.com/docs")}`,
-    );
-    return { alreadySetUp: false };
+  frameworkOverride?: FrameworkInfo,
+  skipConfirm = false,
+): Promise<ResolvedContext> {
+  if (!skipConfirm) {
+    await confirmOverwrite(cwd);
   }
 
+  return bootstrapAndDetect(cwd, frameworkOverride, true);
+}
+
+async function resolveProjectContext(
+  cwd: string,
+  frameworkOverride?: FrameworkInfo,
+  skipConfirm = false,
+): Promise<ResolvedContext> {
+  const ctx = await withSpinner("Detecting framework...", () =>
+    gatherContext(cwd, frameworkOverride),
+  );
+  if (ctx) return { ctx, bootstrap: null };
+
+  const isBlank = !(await hasPackageJson(cwd));
+
+  if (!isBlank) {
+    throw new CliError(
+      `Could not detect a framework. Install the appropriate Clerk SDK manually: https://clerk.com/docs`,
+    );
+  }
+
+  return bootstrapAndDetect(cwd, frameworkOverride, skipConfirm);
+}
+
+// --- Next steps ---
+
+function devCommand(pm: string): string {
+  return pm === "npm" ? "npm run dev" : `${pm} dev`;
+}
+
+function printBootstrapNextSteps(
+  { projectName, packageManager }: BootstrapResult,
+  keyless: boolean,
+): void {
+  const steps = [`cd ${projectName}`, devCommand(packageManager)];
+  if (keyless) {
+    steps.push("clerk login  (when you're ready to connect your Clerk account)");
+  }
+  printNextSteps(steps);
+}
+
+// --- Auth ---
+
+async function resolveAuthLabel(): Promise<string> {
+  const hasApiKey = Boolean(process.env.CLERK_PLATFORM_API_KEY);
+  if (hasApiKey) return "Using API key";
+
+  const email = await getAuthenticatedEmail();
+  if (email) return `Logged in as ${email}`;
+
+  await login({ showNextSteps: false });
+  return "";
+}
+
+async function authenticateAndLink(cwd: string): Promise<void> {
+  const label = await resolveAuthLabel();
+  const profile = await resolveProfile(cwd);
+
+  if (label && profile) {
+    console.log(dim(`${label} · Linked to ${profile.profile.appId}`));
+    return;
+  }
+
+  if (label) {
+    console.log(dim(label));
+  }
+
+  await link({ skipIfLinked: true });
+}
+
+// --- Detect & install ---
+
+async function detectAndInstall(
+  cwd: string,
+  ctx: ProjectContext,
+  options: InitOptions,
+): Promise<{ alreadySetUp: boolean }> {
   const variantLabel = ctx.variant ? ` (${ctx.variant})` : "";
   console.log(`\nDetected ${bold(ctx.framework.name)}${variantLabel}`);
 
@@ -171,7 +263,6 @@ async function scaffoldAndWrite(
   const writtenFiles = await writePlan(cwd, plan);
   await runFormatters(cwd, writtenFiles);
 
-  // Post-scaffold: scan for issues
   const findings = await withSpinner("Scanning for issues...", () =>
     scanForIssues(cwd, ctx.framework.dep),
   );

--- a/packages/cli-core/src/commands/init/prompts/index.ts
+++ b/packages/cli-core/src/commands/init/prompts/index.ts
@@ -77,6 +77,10 @@ const FRAMEWORK_PROMPTS: Record<string, FrameworkPromptInfo> = {
   },
   astro: { template: "astro", docsUrl: "https://clerk.com/docs/astro/getting-started/quickstart" },
   vue: { template: "vue", docsUrl: "https://clerk.com/docs/vue/getting-started/quickstart" },
+  vite: {
+    template: "generic-fallback",
+    docsUrl: "https://clerk.com/docs/js-frontend/getting-started/quickstart",
+  },
   expo: { template: "expo", docsUrl: "https://clerk.com/docs/expo/getting-started/quickstart" },
   express: {
     template: "express",

--- a/packages/cli-core/src/commands/init/scaffold.ts
+++ b/packages/cli-core/src/commands/init/scaffold.ts
@@ -6,6 +6,7 @@ import { nuxt } from "./frameworks/nuxt.js";
 import { tanstackStart } from "./frameworks/tanstack-start.js";
 import { astro } from "./frameworks/astro.js";
 import { vue } from "./frameworks/vue.js";
+import { javascriptVite } from "./frameworks/javascript.js";
 import { parseMajorVersion } from "./frameworks/helpers.js";
 import type { FrameworkScaffold, ProjectContext, ScaffoldPlan } from "./frameworks/types.js";
 
@@ -18,6 +19,7 @@ const SCAFFOLDERS = [
   tanstackStart,
   astro,
   vue,
+  javascriptVite,
 ] satisfies FrameworkScaffold[];
 
 /**

--- a/packages/cli-core/src/lib/framework.ts
+++ b/packages/cli-core/src/lib/framework.ts
@@ -77,6 +77,13 @@ export const FRAMEWORK_MAP: FrameworkInfo[] = [
     envFile: ".env.local",
   },
   {
+    dep: "vite",
+    name: "JavaScript",
+    sdk: "@clerk/clerk-js",
+    envVar: "VITE_CLERK_PUBLISHABLE_KEY",
+    envFile: ".env.local",
+  },
+  {
     dep: "express",
     name: "Express",
     sdk: "@clerk/express",
@@ -94,6 +101,8 @@ export const FRAMEWORK_MAP: FrameworkInfo[] = [
 
 const FRAMEWORK_ALIASES: Record<string, string> = {
   "tanstack-start": "@tanstack/react-start",
+  javascript: "vite",
+  js: "vite",
 };
 
 export function lookupFramework(name: string): FrameworkInfo | null {


### PR DESCRIPTION
## Summary

- When `clerk init` runs in a directory with no `package.json`, it now offers to bootstrap a new project with the user's chosen framework, install deps + Clerk SDK, pull env vars, and scaffold auth files — all in one command
- New `--starter` flag to explicitly trigger bootstrap (even in non-blank dirs, with a warning)
- After bootstrap, the user can choose **keyless mode** (skip auth, scaffold permissive middleware) or authenticate normally
- Refactors `authenticateAndLink` into `resolveAuthLabel` + linking — cleaner separation between resolving the auth display label (API key, email, or fresh login) and the linking step
- Moves the agent/prompt check before context resolution so blank directories in agent mode print the guidance message instead of a confusing "no package.json" error
- Reorders package manager choices to bun, pnpm, yarn, npm
- Fixes stale quickstart URLs in React and React Router post-instructions

### Supported frameworks
Next.js, React (Vite), Vue (Vite), React Router, Astro, Nuxt, TanStack Start

### UX flow
```
clerk init (in blank dir)
  → "No project detected. Would you like to create a new one?"
  → Pick framework (searchable)
  → Pick package manager (searchable, default order: bun, pnpm, yarn, npm)
  → Enter project name (default: my-clerk-{framework}-app)
  → Generator runs (e.g., create-next-app)
  → Dependencies installed
  → "Skip authentication and use keyless mode?"
  → Clerk SDK installed + files scaffolded
  → Next steps: cd my-clerk-next-app → bun dev
```

Or explicitly: `clerk init --starter --framework next`

### New files
- `bootstrap-registry.ts` — framework generator commands and package manager runners
- `bootstrap.ts` — interactive bootstrap orchestrator (prompts, project generation, dep install)
- `bootstrap.test.ts` — unit tests for the bootstrap flow

### Key changes to existing files
- `init/index.ts` — new `resolveProjectContext` / `handleStarter` paths, `resolveAuthLabel` extracted from `authenticateAndLink`, keyless/bootstrap wiring
- `init/context.ts` — new `hasPackageJson` helper
- `init/heuristics.ts` — `printOutro` refactored, `printKeylessInfo` added

## Test plan
- [x] Registry tests: all 7 frameworks, all 4 package managers, correct flags
- [x] Init flow tests: blank dir (human/agent), bootstrap success/decline, unrecognized dir, existing project, `--starter`, `--starter` agent mode, framework override
- [x] Manual smoke test: `cd $(mktemp -d) && clerk init --starter --framework next` with keyless mode
- [x] `bun run format` / `bun run lint` / `bun test` pass