### PR TITLE
chore: Adjust version flags to be -v and --version

### DIFF
--- a/packages/cli-core/src/cli-program.ts
+++ b/packages/cli-core/src/cli-program.ts
@@ -27,7 +27,7 @@ export function createProgram() {
   const program = new Command()
     .name("clerk")
     .description("Clerk CLI")
-    .version(typeof CLI_VERSION !== "undefined" ? CLI_VERSION : "0.0.0-dev")
+    .version(typeof CLI_VERSION !== "undefined" ? CLI_VERSION : "0.0.0-dev", "-v, --version")
     .option(
       "--mode <mode>",
       "Force interaction mode (human or agent). Defaults to auto-detect based on TTY.",
@@ -569,7 +569,12 @@ function outputJsonError(
   errors?: ApiErrorEntry[],
 ): void {
   const payload: {
-    error: { code: string; message: string; docsUrl?: string; errors?: ApiErrorEntry[] };
+    error: {
+      code: string;
+      message: string;
+      docsUrl?: string;
+      errors?: ApiErrorEntry[];
+    };
   } = {
     error: { code, message },
   };


### PR DESCRIPTION
I'm used to expecting `clerk -v` and `clerk --version` to work, instead of `clerk -V` and `clerk --version`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CLI version option to properly support `-v` and `--version` flags for retrieving version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->