### PR TITLE
feat: add spinners to human-mode CLI commands

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "marseille",
@@ -23,6 +22,9 @@
     "packages/cli-core": {
       "name": "@clerk/cli-core",
       "version": "0.0.0",
+      "bin": {
+        "clerk": "./src/cli.ts",
+      },
       "dependencies": {
         "@commander-js/extra-typings": "^14.0.0",
         "@inquirer/prompts": "^8.2.0",

--- a/packages/cli-core/src/commands/api/catalog.ts
+++ b/packages/cli-core/src/commands/api/catalog.ts
@@ -8,6 +8,7 @@ import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { CLERK_CACHE_DIR, CACHE_TTL_MS, OPENAPI_SPEC_URLS } from "../../lib/constants.ts";
 import { CliError, ERROR_CODE } from "../../lib/errors.ts";
+import { withSpinner } from "../../lib/spinner.ts";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -125,13 +126,16 @@ export async function loadCatalog(options: { platform?: boolean } = {}): Promise
   // Fetch spec
   const url = platform ? OPENAPI_SPEC_URLS.platform : OPENAPI_SPEC_URLS.bapi;
   try {
-    const response = await fetch(url);
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
-    }
-    const yamlText = await response.text();
-    const catalog = parseSpec(yamlText);
-    await writeCache(platform, catalog);
+    const catalog = await withSpinner("Fetching API catalog...", async () => {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const yamlText = await response.text();
+      const parsed = parseSpec(yamlText);
+      await writeCache(platform, parsed);
+      return parsed;
+    });
     return catalog;
   } catch (error) {
     // Fall back to stale cache

--- a/packages/cli-core/src/commands/api/index.ts
+++ b/packages/cli-core/src/commands/api/index.ts
@@ -12,6 +12,7 @@ import {
 } from "../../lib/errors.ts";
 import { isHuman } from "../../mode.ts";
 import { confirm } from "../../lib/prompts.ts";
+import { withSpinner } from "../../lib/spinner.ts";
 
 export interface ApiOptions {
   method?: string;
@@ -86,13 +87,15 @@ export async function api(
 
   // 6. Execute request
   try {
-    const response = await bapiRequest({
-      method,
-      path: endpoint,
-      secretKey,
-      body: body ?? undefined,
-      baseUrl,
-    });
+    const response = await withSpinner("Executing request...", () =>
+      bapiRequest({
+        method,
+        path: endpoint,
+        secretKey,
+        body: body ?? undefined,
+        baseUrl,
+      }),
+    );
 
     if (options.include) {
       printHeaders(response.status, response.headers);

--- a/packages/cli-core/src/commands/apps/list.ts
+++ b/packages/cli-core/src/commands/apps/list.ts
@@ -2,6 +2,7 @@ import { listApplications, type Application } from "../../lib/plapi.ts";
 import { withApiContext } from "../../lib/errors.ts";
 import { isAgent } from "../../mode.ts";
 import { dim, cyan } from "../../lib/color.ts";
+import { withSpinner } from "../../lib/spinner.ts";
 
 interface AppsListOptions {
   json?: boolean;
@@ -36,7 +37,9 @@ function formatAppsTable(apps: Application[]): void {
 }
 
 export async function list(options: AppsListOptions = {}): Promise<void> {
-  const result = await withApiContext(listApplications(), "Failed to list applications");
+  const result = await withSpinner("Fetching applications...", () =>
+    withApiContext(listApplications(), "Failed to list applications"),
+  );
 
   if (options.json || isAgent()) {
     console.log(JSON.stringify(stripSecrets(result), null, 2));

--- a/packages/cli-core/src/commands/auth/login.ts
+++ b/packages/cli-core/src/commands/auth/login.ts
@@ -9,7 +9,7 @@ import { AUTH_TIMEOUT_MS, CALLBACK_PATH } from "../../lib/constants.ts";
 import { confirm } from "../../lib/prompts.ts";
 import { isHuman } from "../../mode.ts";
 import { throwUserAbort } from "../../lib/errors.ts";
-import { withSpinner } from "../../lib/spinner.ts";
+import { intro, outro, bar, withSpinner } from "../../lib/spinner.ts";
 
 const BROWSER_COMMANDS: Partial<Record<NodeJS.Platform, string>> = {
   darwin: "open",
@@ -89,6 +89,7 @@ async function performOAuthFlow(): Promise<UserInfo> {
 
 export async function login(options: LoginOptions = {}): Promise<UserInfo> {
   const { showNextSteps = true } = options;
+  intro("clerk login");
   const existingSession = await withSpinner("Checking session...", () => getExistingSession());
 
   if (existingSession && !isHuman()) {
@@ -108,6 +109,7 @@ export async function login(options: LoginOptions = {}): Promise<UserInfo> {
 
   const userInfo = await performOAuthFlow();
 
+  bar();
   console.log(`Logged in as ${userInfo.email}`);
 
   if (showNextSteps) {
@@ -117,5 +119,6 @@ export async function login(options: LoginOptions = {}): Promise<UserInfo> {
     ]);
   }
 
+  outro("Done");
   return userInfo;
 }

--- a/packages/cli-core/src/commands/auth/login.ts
+++ b/packages/cli-core/src/commands/auth/login.ts
@@ -103,6 +103,7 @@ export async function login(options: LoginOptions = {}): Promise<UserInfo> {
       default: false,
     });
     if (!reauthenticate) {
+      outro();
       throwUserAbort();
     }
   }

--- a/packages/cli-core/src/commands/auth/login.ts
+++ b/packages/cli-core/src/commands/auth/login.ts
@@ -1,4 +1,3 @@
-import { printNextSteps } from "../../lib/next-steps.ts";
 import { generateCodeVerifier, generateCodeChallenge, generateState } from "../../lib/pkce.ts";
 import { startAuthServer } from "../../lib/auth-server.ts";
 import { exchangeCodeForToken, fetchUserInfo, type UserInfo } from "../../lib/token-exchange.ts";
@@ -10,6 +9,7 @@ import { confirm } from "../../lib/prompts.ts";
 import { isHuman } from "../../mode.ts";
 import { throwUserAbort } from "../../lib/errors.ts";
 import { intro, outro, bar, withSpinner } from "../../lib/spinner.ts";
+import { NEXT_STEPS } from "../../lib/next-steps.ts";
 
 const BROWSER_COMMANDS: Partial<Record<NodeJS.Platform, string>> = {
   darwin: "open",
@@ -112,13 +112,6 @@ export async function login(options: LoginOptions = {}): Promise<UserInfo> {
   bar();
   console.log(`Logged in as ${userInfo.email}`);
 
-  if (showNextSteps) {
-    printNextSteps([
-      "Run `clerk init` to set up Clerk in your project",
-      "Run `clerk link` to connect an existing Clerk application",
-    ]);
-  }
-
-  outro("Done");
+  outro(showNextSteps ? NEXT_STEPS.LOGIN : "Done");
   return userInfo;
 }

--- a/packages/cli-core/src/commands/auth/login.ts
+++ b/packages/cli-core/src/commands/auth/login.ts
@@ -9,6 +9,7 @@ import { AUTH_TIMEOUT_MS, CALLBACK_PATH } from "../../lib/constants.ts";
 import { confirm } from "../../lib/prompts.ts";
 import { isHuman } from "../../mode.ts";
 import { throwUserAbort } from "../../lib/errors.ts";
+import { withSpinner } from "../../lib/spinner.ts";
 
 const BROWSER_COMMANDS: Partial<Record<NodeJS.Platform, string>> = {
   darwin: "open",
@@ -63,16 +64,20 @@ async function performOAuthFlow(): Promise<UserInfo> {
   const timeoutMinutes = Math.round(AUTH_TIMEOUT_MS / 60_000);
   console.log(`Waiting for authentication (timeout in ${timeoutMinutes}m)...`);
 
-  const { code } = await authServer.waitForCallback().catch((error: unknown) => {
-    authServer.stop();
-    throw error;
-  });
+  const { code } = await withSpinner("Waiting for authentication...", () =>
+    authServer.waitForCallback().catch((error: unknown) => {
+      authServer.stop();
+      throw error;
+    }),
+  );
 
-  const tokenResponse = await exchangeCodeForToken({
-    code,
-    codeVerifier,
-    redirectUri,
-  });
+  const tokenResponse = await withSpinner("Completing authentication...", () =>
+    exchangeCodeForToken({
+      code,
+      codeVerifier,
+      redirectUri,
+    }),
+  );
 
   await storeToken(tokenResponse.access_token);
 
@@ -84,7 +89,7 @@ async function performOAuthFlow(): Promise<UserInfo> {
 
 export async function login(options: LoginOptions = {}): Promise<UserInfo> {
   const { showNextSteps = true } = options;
-  const existingSession = await getExistingSession();
+  const existingSession = await withSpinner("Checking session...", () => getExistingSession());
 
   if (existingSession && !isHuman()) {
     console.log(`Logged in as ${existingSession.email}`);

--- a/packages/cli-core/src/commands/config/pull.test.ts
+++ b/packages/cli-core/src/commands/config/pull.test.ts
@@ -7,6 +7,13 @@ import { credentialStoreStubs, gitStubs, stubFetch } from "../../test/stubs.ts";
 
 mock.module("../../lib/credential-store.ts", () => credentialStoreStubs);
 mock.module("../../lib/git.ts", () => gitStubs);
+mock.module("../../lib/spinner.ts", () => ({
+  withSpinner: async (msg: string, fn: () => Promise<unknown>) => {
+    console.error(msg);
+    const result = await fn();
+    return result;
+  },
+}));
 
 describe("config pull", () => {
   const originalEnv = { ...process.env };
@@ -123,7 +130,9 @@ describe("config pull", () => {
     });
 
     await runConfigPull();
-    expect(errorSpy).toHaveBeenCalledWith("Pulling config from app_1 (development)...");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Pulling config from app_1 (development)"),
+    );
   });
 
   test("shows app name when stored in profile", async () => {
@@ -135,7 +144,9 @@ describe("config pull", () => {
     });
 
     await runConfigPull();
-    expect(errorSpy).toHaveBeenCalledWith("Pulling config from My SaaS App (development)...");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Pulling config from My SaaS App (development)"),
+    );
   });
 
   test("shows production label when --instance prod", async () => {
@@ -146,7 +157,9 @@ describe("config pull", () => {
     });
 
     await runConfigPull({ instance: "prod" });
-    expect(errorSpy).toHaveBeenCalledWith("Pulling config from app_1 (production)...");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Pulling config from app_1 (production)"),
+    );
   });
 
   test("uses development instance by default", async () => {

--- a/packages/cli-core/src/commands/config/pull.ts
+++ b/packages/cli-core/src/commands/config/pull.ts
@@ -1,6 +1,7 @@
 import { resolveAppContext } from "../../lib/config.ts";
 import { fetchInstanceConfig } from "../../lib/plapi.ts";
 import { withApiContext } from "../../lib/errors.ts";
+import { withSpinner } from "../../lib/spinner.ts";
 
 interface ConfigPullOptions {
   app?: string;
@@ -12,11 +13,13 @@ interface ConfigPullOptions {
 export async function configPull(options: ConfigPullOptions): Promise<void> {
   const ctx = await resolveAppContext(options);
 
-  console.error(`Pulling config from ${ctx.appLabel} (${ctx.instanceLabel})...`);
-
-  const config = await withApiContext(
-    fetchInstanceConfig(ctx.appId, ctx.instanceId, options.keys),
-    "Failed to fetch config",
+  const config = await withSpinner(
+    `Pulling config from ${ctx.appLabel} (${ctx.instanceLabel})...`,
+    () =>
+      withApiContext(
+        fetchInstanceConfig(ctx.appId, ctx.instanceId, options.keys),
+        "Failed to fetch config",
+      ),
   );
 
   const json = JSON.stringify(config, null, 2);

--- a/packages/cli-core/src/commands/config/push.test.ts
+++ b/packages/cli-core/src/commands/config/push.test.ts
@@ -9,6 +9,13 @@ import { printDiff, hasConfigChanges } from "./push.ts";
 mock.module("../../lib/credential-store.ts", () => credentialStoreStubs);
 mock.module("../../lib/git.ts", () => gitStubs);
 mock.module("@inquirer/prompts", () => promptsStubs);
+mock.module("../../lib/spinner.ts", () => ({
+  withSpinner: async (msg: string, fn: () => Promise<unknown>) => {
+    console.error(msg);
+    const result = await fn();
+    return result;
+  },
+}));
 
 describe("config push", () => {
   const originalEnv = { ...process.env };
@@ -246,7 +253,9 @@ describe("config push", () => {
     });
 
     await runConfigPatch({ json: '{"session":{"lifetime":3600}}', yes: true });
-    expect(errorSpy).toHaveBeenCalledWith("Updating config on app_1 (development)...");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Updating config on app_1 (development)"),
+    );
   });
 
   // --- PUT happy paths ---
@@ -277,7 +286,9 @@ describe("config push", () => {
     });
 
     await runConfigPut({ json: '{"session":{"lifetime":3600}}', yes: true });
-    expect(errorSpy).toHaveBeenCalledWith("Replacing config on app_1 (development)...");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Replacing config on app_1 (development)"),
+    );
   });
 
   // --- config_version stripping ---

--- a/packages/cli-core/src/commands/config/push.ts
+++ b/packages/cli-core/src/commands/config/push.ts
@@ -4,6 +4,7 @@ import { isHuman } from "../../mode.ts";
 import { throwUsageError, throwUserAbort, withApiContext, ERROR_CODE } from "../../lib/errors.ts";
 import { confirm } from "../../lib/prompts.ts";
 import { dim, bold, red, green } from "../../lib/color.ts";
+import { withSpinner } from "../../lib/spinner.ts";
 
 interface ConfigPushOptions {
   app?: string;
@@ -76,9 +77,11 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
     return;
   }
 
-  const currentConfig = await withApiContext(
-    fetchInstanceConfig(ctx.appId, ctx.instanceId),
-    "Failed to fetch current config",
+  const currentConfig = await withSpinner("Fetching current config...", () =>
+    withApiContext(
+      fetchInstanceConfig(ctx.appId, ctx.instanceId),
+      "Failed to fetch current config",
+    ),
   );
 
   // Strip config_version from current config to match the payload normalization above
@@ -105,11 +108,13 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
     }
   }
 
-  console.error(`${op.verb} config on ${ctx.appLabel} (${ctx.instanceLabel})...`);
-
-  const result = await withApiContext(
-    op.apiFn(ctx.appId, ctx.instanceId, configPayload, { destructive: options.destructive }),
-    "Failed to push config",
+  const result = await withSpinner(
+    `${op.verb} config on ${ctx.appLabel} (${ctx.instanceLabel})...`,
+    () =>
+      withApiContext(
+        op.apiFn(ctx.appId, ctx.instanceId, configPayload, { destructive: options.destructive }),
+        "Failed to push config",
+      ),
   );
   console.log(JSON.stringify(result, null, 2));
   console.error("Config pushed successfully.");

--- a/packages/cli-core/src/commands/deploy/index.ts
+++ b/packages/cli-core/src/commands/deploy/index.ts
@@ -1,7 +1,7 @@
 import { select, input, confirm, password } from "@inquirer/prompts";
 import { isAgent } from "../../mode.ts";
 import { dim, bold, cyan, green, blue, yellow } from "../../lib/color.ts";
-import { printNextSteps } from "../../lib/next-steps.ts";
+import { printNextSteps, NEXT_STEPS } from "../../lib/next-steps.ts";
 
 const DEPLOY_PROMPT = `You are deploying a Clerk application to production. Follow these steps:
 
@@ -246,8 +246,5 @@ export async function deploy(options: { debug?: boolean }) {
     ),
   );
 
-  printNextSteps([
-    "Run `clerk env pull --instance prod` to fetch production keys",
-    "Run `clerk doctor` to verify your setup",
-  ]);
+  printNextSteps(NEXT_STEPS.DEPLOY);
 }

--- a/packages/cli-core/src/commands/doctor/index.ts
+++ b/packages/cli-core/src/commands/doctor/index.ts
@@ -1,6 +1,7 @@
 import { isHuman } from "../../mode.ts";
 import { bold, green, red } from "../../lib/color.ts";
 import { CliError, ERROR_CODE } from "../../lib/errors.ts";
+import { withSpinner } from "../../lib/spinner.ts";
 import { createDoctorContext } from "./context.ts";
 import {
   checkLoggedIn,
@@ -60,7 +61,7 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
   }
 
   const ctx = createDoctorContext();
-  const allResults = await runChecks(ctx, options);
+  const allResults = await withSpinner("Running diagnostics...", () => runChecks(ctx, options));
 
   if (options.json) {
     const output = options.spotlight ? allResults.filter((r) => r.status !== "pass") : allResults;
@@ -104,15 +105,15 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
       }
 
       console.log("");
-      console.log(bold("Verifying fixes..."));
-      console.log("");
 
       const verifyCtx = createDoctorContext();
-      const verifyResults = await runChecks(verifyCtx, {
-        ...options,
-        fix: false,
-        spotlight: false,
-      });
+      const verifyResults = await withSpinner("Verifying fixes...", () =>
+        runChecks(verifyCtx, {
+          ...options,
+          fix: false,
+          spotlight: false,
+        }),
+      );
 
       const hasVerifyFailure = verifyResults.some((r) => r.status === "fail");
       if (hasVerifyFailure) {

--- a/packages/cli-core/src/commands/doctor/index.ts
+++ b/packages/cli-core/src/commands/doctor/index.ts
@@ -1,7 +1,7 @@
 import { isHuman } from "../../mode.ts";
 import { bold, green, red } from "../../lib/color.ts";
 import { CliError, ERROR_CODE } from "../../lib/errors.ts";
-import { withSpinner } from "../../lib/spinner.ts";
+import { intro, outro, bar, withSpinner } from "../../lib/spinner.ts";
 import { createDoctorContext } from "./context.ts";
 import {
   checkLoggedIn,
@@ -57,7 +57,7 @@ async function runChecks(ctx: DoctorContext, options: DoctorOptions): Promise<Ch
 
 export async function doctor(options: DoctorOptions = {}): Promise<void> {
   if (!options.json) {
-    console.log("");
+    intro("clerk doctor");
   }
 
   const ctx = createDoctorContext();
@@ -104,7 +104,7 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
         }
       }
 
-      console.log("");
+      bar();
 
       const verifyCtx = createDoctorContext();
       const verifyResults = await withSpinner("Verifying fixes...", () =>
@@ -121,6 +121,7 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
           code: ERROR_CODE.DOCTOR_FAILED,
         });
       }
+      outro("All checks passing");
       return;
     }
   }
@@ -131,4 +132,5 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
       code: ERROR_CODE.DOCTOR_FAILED,
     });
   }
+  outro("All checks passing");
 }

--- a/packages/cli-core/src/commands/env/pull.test.ts
+++ b/packages/cli-core/src/commands/env/pull.test.ts
@@ -7,9 +7,10 @@ import { credentialStoreStubs, gitStubs, configStubs, stubFetch } from "../../te
 mock.module("../../lib/credential-store.ts", () => credentialStoreStubs);
 mock.module("../../lib/git.ts", () => gitStubs);
 mock.module("../../lib/spinner.ts", () => ({
-  withSpinner: async (msg: string, fn: () => Promise<unknown>) => {
+  withSpinner: async (msg: string, fn: () => Promise<unknown>, doneMsg?: string) => {
     console.error(msg);
     const result = await fn();
+    if (doneMsg) console.error(doneMsg);
     return result;
   },
 }));
@@ -117,7 +118,6 @@ describe("env pull", () => {
   const originalCwd = process.cwd;
   let tempDir: string;
   let errorSpy: ReturnType<typeof spyOn>;
-  let logSpy: ReturnType<typeof spyOn>;
   let exitSpy: ReturnType<typeof spyOn>;
 
   const mockApplication = {
@@ -155,7 +155,6 @@ describe("env pull", () => {
     process.cwd = () => tempDir;
 
     errorSpy = spyOn(console, "error").mockImplementation(() => {});
-    logSpy = spyOn(console, "log").mockImplementation(() => {});
     exitSpy = spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit");
     });
@@ -169,7 +168,6 @@ describe("env pull", () => {
     process.cwd = originalCwd;
     globalThis.fetch = originalFetch;
     errorSpy.mockRestore();
-    logSpy.mockRestore();
     exitSpy.mockRestore();
     await rm(tempDir, { recursive: true, force: true });
   });
@@ -377,7 +375,7 @@ describe("env pull", () => {
     });
 
     await runEnvPull();
-    expect(logSpy).toHaveBeenCalledWith(
+    expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining("Environment variables written to"),
     );
   });

--- a/packages/cli-core/src/commands/env/pull.test.ts
+++ b/packages/cli-core/src/commands/env/pull.test.ts
@@ -6,6 +6,13 @@ import { credentialStoreStubs, gitStubs, configStubs, stubFetch } from "../../te
 
 mock.module("../../lib/credential-store.ts", () => credentialStoreStubs);
 mock.module("../../lib/git.ts", () => gitStubs);
+mock.module("../../lib/spinner.ts", () => ({
+  withSpinner: async (msg: string, fn: () => Promise<unknown>) => {
+    console.error(msg);
+    const result = await fn();
+    return result;
+  },
+}));
 
 type Profile = { workspaceId: string; appId: string; instances: Record<string, string> };
 const _profiles: Record<string, Profile> = {};
@@ -110,6 +117,7 @@ describe("env pull", () => {
   const originalCwd = process.cwd;
   let tempDir: string;
   let errorSpy: ReturnType<typeof spyOn>;
+  let logSpy: ReturnType<typeof spyOn>;
   let exitSpy: ReturnType<typeof spyOn>;
 
   const mockApplication = {
@@ -147,6 +155,7 @@ describe("env pull", () => {
     process.cwd = () => tempDir;
 
     errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    logSpy = spyOn(console, "log").mockImplementation(() => {});
     exitSpy = spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit");
     });
@@ -160,6 +169,7 @@ describe("env pull", () => {
     process.cwd = originalCwd;
     globalThis.fetch = originalFetch;
     errorSpy.mockRestore();
+    logSpy.mockRestore();
     exitSpy.mockRestore();
     await rm(tempDir, { recursive: true, force: true });
   });
@@ -354,7 +364,9 @@ describe("env pull", () => {
     });
 
     await runEnvPull();
-    expect(errorSpy).toHaveBeenCalledWith("Pulling env vars from development instance...");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Pulling env vars from development instance"),
+    );
   });
 
   test("shows written file in status message", async () => {
@@ -365,7 +377,7 @@ describe("env pull", () => {
     });
 
     await runEnvPull();
-    expect(errorSpy).toHaveBeenCalledWith(
+    expect(logSpy).toHaveBeenCalledWith(
       expect.stringContaining("Environment variables written to"),
     );
   });

--- a/packages/cli-core/src/commands/env/pull.test.ts
+++ b/packages/cli-core/src/commands/env/pull.test.ts
@@ -7,11 +7,9 @@ import { credentialStoreStubs, gitStubs, configStubs, stubFetch } from "../../te
 mock.module("../../lib/credential-store.ts", () => credentialStoreStubs);
 mock.module("../../lib/git.ts", () => gitStubs);
 mock.module("../../lib/spinner.ts", () => ({
-  withSpinner: async (msg: string, fn: () => Promise<unknown>, doneMsg?: string) => {
+  withSpinner: async (msg: string, fn: () => Promise<unknown>) => {
     console.error(msg);
-    const result = await fn();
-    if (doneMsg) console.error(doneMsg);
-    return result;
+    return fn();
   },
 }));
 
@@ -118,6 +116,7 @@ describe("env pull", () => {
   const originalCwd = process.cwd;
   let tempDir: string;
   let errorSpy: ReturnType<typeof spyOn>;
+  let logSpy: ReturnType<typeof spyOn>;
   let exitSpy: ReturnType<typeof spyOn>;
 
   const mockApplication = {
@@ -155,6 +154,7 @@ describe("env pull", () => {
     process.cwd = () => tempDir;
 
     errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    logSpy = spyOn(console, "log").mockImplementation(() => {});
     exitSpy = spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit");
     });
@@ -168,6 +168,7 @@ describe("env pull", () => {
     process.cwd = originalCwd;
     globalThis.fetch = originalFetch;
     errorSpy.mockRestore();
+    logSpy.mockRestore();
     exitSpy.mockRestore();
     await rm(tempDir, { recursive: true, force: true });
   });

--- a/packages/cli-core/src/commands/env/pull.ts
+++ b/packages/cli-core/src/commands/env/pull.ts
@@ -9,6 +9,7 @@ import {
 } from "../../lib/framework.ts";
 import { CliError, ERROR_CODE, withApiContext } from "../../lib/errors.ts";
 import { withSpinner } from "../../lib/spinner.ts";
+import { dim } from "../../lib/color.ts";
 
 interface EnvPullOptions {
   app?: string;
@@ -50,37 +51,35 @@ export async function pull(options: EnvPullOptions): Promise<void> {
   const targetFile = await resolveTargetFile(cwd, options.file, preferredEnvFile);
   const displayPath = options.file ?? targetFile.split("/").pop()!;
 
-  await withSpinner(
-    `Pulling env vars from ${ctx.instanceLabel} instance...`,
-    async () => {
-      const app = await withApiContext(fetchApplication(ctx.appId), "Failed to fetch API keys");
+  await withSpinner(`Pulling env vars from ${ctx.instanceLabel} instance...`, async () => {
+    const app = await withApiContext(fetchApplication(ctx.appId), "Failed to fetch API keys");
 
-      const matched = app.instances.find((i) => i.instance_id === ctx.instanceId);
-      if (!matched) {
-        throw new CliError(`Instance ${ctx.instanceId} not found in application response.`, {
-          code: ERROR_CODE.INSTANCE_NOT_FOUND,
-          docsUrl: "https://clerk.com/docs/guides/development/managing-environments",
-        });
-      }
+    const matched = app.instances.find((i) => i.instance_id === ctx.instanceId);
+    if (!matched) {
+      throw new CliError(`Instance ${ctx.instanceId} not found in application response.`, {
+        code: ERROR_CODE.INSTANCE_NOT_FOUND,
+        docsUrl: "https://clerk.com/docs/guides/development/managing-environments",
+      });
+    }
 
-      const publishableKeyName = await detectPublishableKeyName(cwd);
-      const secretKeyName = await detectSecretKeyName(cwd);
+    const publishableKeyName = await detectPublishableKeyName(cwd);
+    const secretKeyName = await detectSecretKeyName(cwd);
 
-      const file = Bun.file(targetFile);
-      const existingContent = (await file.exists()) ? await file.text() : "";
+    const file = Bun.file(targetFile);
+    const existingContent = (await file.exists()) ? await file.text() : "";
 
-      const lines = parseEnvFile(existingContent);
-      const vars: Record<string, string> = {
-        [publishableKeyName]: matched.publishable_key,
-      };
-      if (matched.secret_key) {
-        vars[secretKeyName] = matched.secret_key;
-      }
-      const merged = mergeEnvVars(lines, vars);
-      const output = serializeEnvFile(merged);
+    const lines = parseEnvFile(existingContent);
+    const vars: Record<string, string> = {
+      [publishableKeyName]: matched.publishable_key,
+    };
+    if (matched.secret_key) {
+      vars[secretKeyName] = matched.secret_key;
+    }
+    const merged = mergeEnvVars(lines, vars);
+    const output = serializeEnvFile(merged);
 
-      await Bun.write(targetFile, output);
-    },
-    `Environment variables written to ${displayPath}`,
-  );
+    await Bun.write(targetFile, output);
+  });
+
+  console.error(dim(`Environment variables written to ${displayPath}`));
 }

--- a/packages/cli-core/src/commands/env/pull.ts
+++ b/packages/cli-core/src/commands/env/pull.ts
@@ -45,40 +45,42 @@ async function resolveTargetFile(
 
 export async function pull(options: EnvPullOptions): Promise<void> {
   const ctx = await resolveAppContext(options);
-
-  const app = await withSpinner(`Pulling env vars from ${ctx.instanceLabel} instance...`, () =>
-    withApiContext(fetchApplication(ctx.appId), "Failed to fetch API keys"),
-  );
-
-  const matched = app.instances.find((i) => i.instance_id === ctx.instanceId);
-  if (!matched) {
-    throw new CliError(`Instance ${ctx.instanceId} not found in application response.`, {
-      code: ERROR_CODE.INSTANCE_NOT_FOUND,
-      docsUrl: "https://clerk.com/docs/guides/development/managing-environments",
-    });
-  }
-
   const cwd = process.cwd();
-  const publishableKeyName = await detectPublishableKeyName(cwd);
-  const secretKeyName = await detectSecretKeyName(cwd);
   const preferredEnvFile = await detectEnvFile(cwd);
   const targetFile = await resolveTargetFile(cwd, options.file, preferredEnvFile);
-
-  const file = Bun.file(targetFile);
-  const existingContent = (await file.exists()) ? await file.text() : "";
-
-  const lines = parseEnvFile(existingContent);
-  const vars: Record<string, string> = {
-    [publishableKeyName]: matched.publishable_key,
-  };
-  if (matched.secret_key) {
-    vars[secretKeyName] = matched.secret_key;
-  }
-  const merged = mergeEnvVars(lines, vars);
-  const output = serializeEnvFile(merged);
-
-  await Bun.write(targetFile, output);
-
   const displayPath = options.file ?? targetFile.split("/").pop()!;
-  console.log(`Environment variables written to ${displayPath}`);
+
+  await withSpinner(
+    `Pulling env vars from ${ctx.instanceLabel} instance...`,
+    async () => {
+      const app = await withApiContext(fetchApplication(ctx.appId), "Failed to fetch API keys");
+
+      const matched = app.instances.find((i) => i.instance_id === ctx.instanceId);
+      if (!matched) {
+        throw new CliError(`Instance ${ctx.instanceId} not found in application response.`, {
+          code: ERROR_CODE.INSTANCE_NOT_FOUND,
+          docsUrl: "https://clerk.com/docs/guides/development/managing-environments",
+        });
+      }
+
+      const publishableKeyName = await detectPublishableKeyName(cwd);
+      const secretKeyName = await detectSecretKeyName(cwd);
+
+      const file = Bun.file(targetFile);
+      const existingContent = (await file.exists()) ? await file.text() : "";
+
+      const lines = parseEnvFile(existingContent);
+      const vars: Record<string, string> = {
+        [publishableKeyName]: matched.publishable_key,
+      };
+      if (matched.secret_key) {
+        vars[secretKeyName] = matched.secret_key;
+      }
+      const merged = mergeEnvVars(lines, vars);
+      const output = serializeEnvFile(merged);
+
+      await Bun.write(targetFile, output);
+    },
+    `Environment variables written to ${displayPath}`,
+  );
 }

--- a/packages/cli-core/src/commands/env/pull.ts
+++ b/packages/cli-core/src/commands/env/pull.ts
@@ -8,6 +8,7 @@ import {
   detectEnvFile,
 } from "../../lib/framework.ts";
 import { CliError, ERROR_CODE, withApiContext } from "../../lib/errors.ts";
+import { withSpinner } from "../../lib/spinner.ts";
 
 interface EnvPullOptions {
   app?: string;
@@ -45,9 +46,9 @@ async function resolveTargetFile(
 export async function pull(options: EnvPullOptions): Promise<void> {
   const ctx = await resolveAppContext(options);
 
-  console.error(`Pulling env vars from ${ctx.instanceLabel} instance...`);
-
-  const app = await withApiContext(fetchApplication(ctx.appId), "Failed to fetch API keys");
+  const app = await withSpinner(`Pulling env vars from ${ctx.instanceLabel} instance...`, () =>
+    withApiContext(fetchApplication(ctx.appId), "Failed to fetch API keys"),
+  );
 
   const matched = app.instances.find((i) => i.instance_id === ctx.instanceId);
   if (!matched) {
@@ -79,5 +80,5 @@ export async function pull(options: EnvPullOptions): Promise<void> {
   await Bun.write(targetFile, output);
 
   const displayPath = options.file ?? targetFile.split("/").pop()!;
-  console.error(`Environment variables written to ${displayPath}`);
+  console.log(`Environment variables written to ${displayPath}`);
 }

--- a/packages/cli-core/src/commands/init/heuristics.ts
+++ b/packages/cli-core/src/commands/init/heuristics.ts
@@ -6,6 +6,7 @@ import { getToken } from "../../lib/credential-store.js";
 import { fetchUserInfo } from "../../lib/token-exchange.js";
 import { printFindings } from "./scan.js";
 import { pmInstallCommand } from "./prompts/index.js";
+import { withSpinner } from "../../lib/spinner.js";
 import type { FileAction, ProjectContext, ScaffoldPlan } from "./frameworks/types.js";
 import type { ScanFinding } from "./scan.js";
 
@@ -30,22 +31,24 @@ export async function installSdk(ctx: ProjectContext): Promise<void> {
 }
 
 export async function writePlan(cwd: string, plan: ScaffoldPlan): Promise<string[]> {
-  const written: string[] = [];
+  return withSpinner("Writing files...", async () => {
+    const written: string[] = [];
 
-  for (const action of plan.actions) {
-    if (action.type === "skip") continue;
+    for (const action of plan.actions) {
+      if (action.type === "skip") continue;
 
-    const fullPath = join(cwd, action.path);
+      const fullPath = join(cwd, action.path);
 
-    if (action.type === "create") {
-      await mkdir(dirname(fullPath), { recursive: true });
+      if (action.type === "create") {
+        await mkdir(dirname(fullPath), { recursive: true });
+      }
+
+      await Bun.write(fullPath, action.content);
+      written.push(action.path);
     }
 
-    await Bun.write(fullPath, action.content);
-    written.push(action.path);
-  }
-
-  return written;
+    return written;
+  });
 }
 
 export async function checkGitDirty(cwd: string): Promise<boolean> {

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -48,6 +48,7 @@ export async function init(options: InitOptions = {}) {
     console.log(
       "Run `clerk init -y` to automatically detect the framework, install the Clerk SDK, and scaffold authentication files without interactive prompts.",
     );
+    outro();
     return;
   }
 

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -18,7 +18,7 @@ import {
   printKeylessInfo,
   getAuthenticatedEmail,
 } from "./heuristics.js";
-import { withSpinner } from "../../lib/spinner.js";
+import { intro, outro, bar, withSpinner } from "../../lib/spinner.js";
 import type { ProjectContext } from "./frameworks/types.js";
 
 interface InitOptions {
@@ -34,6 +34,9 @@ export async function init(options: InitOptions = {}) {
   const frameworkOverride = options.framework
     ? (lookupFramework(options.framework) ?? undefined)
     : undefined;
+
+  intro("clerk init");
+
   const ctx = await withSpinner("Detecting framework...", () =>
     gatherContext(cwd, frameworkOverride),
   );
@@ -48,6 +51,7 @@ export async function init(options: InitOptions = {}) {
     return;
   }
 
+  bar();
   const authenticated = await resolveAuth(cwd);
 
   if (authenticated) {
@@ -56,12 +60,14 @@ export async function init(options: InitOptions = {}) {
 
   await detectAndInstall(cwd, ctx, options);
 
+  bar();
   if (authenticated) {
     await pull({});
-    return;
+  } else {
+    printKeylessInfo();
   }
 
-  printKeylessInfo();
+  outro("Done");
 }
 
 async function resolveAuth(cwd: string): Promise<boolean> {

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -18,6 +18,7 @@ import {
   printKeylessInfo,
   getAuthenticatedEmail,
 } from "./heuristics.js";
+import { withSpinner } from "../../lib/spinner.js";
 import type { ProjectContext } from "./frameworks/types.js";
 
 interface InitOptions {
@@ -33,7 +34,9 @@ export async function init(options: InitOptions = {}) {
   const frameworkOverride = options.framework
     ? (lookupFramework(options.framework) ?? undefined)
     : undefined;
-  const ctx = await gatherContext(cwd, frameworkOverride);
+  const ctx = await withSpinner("Detecting framework...", () =>
+    gatherContext(cwd, frameworkOverride),
+  );
 
   // Populate framework-specific context (variant, layoutPath, middlewareBasename)
   if (ctx) await enrichProjectContext(ctx);
@@ -138,6 +141,8 @@ async function scaffoldAndWrite(
   await runFormatters(cwd, writtenFiles);
 
   // Post-scaffold: scan for issues
-  const findings = await scanForIssues(cwd, ctx.framework.dep);
+  const findings = await withSpinner("Scanning for issues...", () =>
+    scanForIssues(cwd, ctx.framework.dep),
+  );
   printOutro(plan, findings);
 }

--- a/packages/cli-core/src/commands/link/index.test.ts
+++ b/packages/cli-core/src/commands/link/index.test.ts
@@ -81,6 +81,13 @@ mock.module("@inquirer/prompts", () => ({
   confirm: (...args: unknown[]) => mockConfirm(...args),
 }));
 
+mock.module("../../lib/spinner.ts", () => ({
+  intro: () => {},
+  outro: () => {},
+  bar: () => {},
+  withSpinner: async (_msg: string, fn: () => Promise<unknown>) => fn(),
+}));
+
 const { link } = await import("./index.ts");
 
 const mockApp = {

--- a/packages/cli-core/src/commands/link/index.ts
+++ b/packages/cli-core/src/commands/link/index.ts
@@ -8,7 +8,7 @@ import { setProfile, resolveProfile, moveProfile } from "../../lib/config.ts";
 import { autolink, findClerkKeys, matchKeyToApp } from "../../lib/autolink.ts";
 import { getGitRepoIdentifier, getGitRepoRoot, getGitNormalizedRemote } from "../../lib/git.ts";
 import { dim, cyan } from "../../lib/color.ts";
-import { printNextSteps } from "../../lib/next-steps.ts";
+import { printNextSteps, NEXT_STEPS } from "../../lib/next-steps.ts";
 import { CliError, ERROR_CODE } from "../../lib/errors.ts";
 import { withSpinner } from "../../lib/spinner.ts";
 
@@ -96,10 +96,7 @@ export async function link(options: LinkOptions = {}): Promise<void> {
   const label = app.name || app.application_id;
   console.log(`\nLinked to ${cyan(label)} in ${dim(displayPath)}`);
 
-  printNextSteps([
-    "Run `clerk env pull` to fetch your environment variables",
-    "Run `clerk doctor` to verify your setup",
-  ]);
+  printNextSteps(NEXT_STEPS.LINK);
 }
 
 async function ensureAuth() {

--- a/packages/cli-core/src/commands/link/index.ts
+++ b/packages/cli-core/src/commands/link/index.ts
@@ -10,6 +10,7 @@ import { getGitRepoIdentifier, getGitRepoRoot, getGitNormalizedRemote } from "..
 import { dim, cyan } from "../../lib/color.ts";
 import { printNextSteps } from "../../lib/next-steps.ts";
 import { CliError, ERROR_CODE } from "../../lib/errors.ts";
+import { withSpinner } from "../../lib/spinner.ts";
 
 const AGENT_PROMPT = `You are linking a Clerk application to the current project directory.
 
@@ -160,7 +161,7 @@ async function resolveApp(
   displayPath: string,
   detectKeys: boolean,
 ): Promise<Application> {
-  const apps = await listApplications();
+  const apps = await withSpinner("Fetching applications...", () => listApplications());
 
   if (apps.length === 0) {
     throw new CliError("No applications found. Create one at https://dashboard.clerk.com first.", {

--- a/packages/cli-core/src/commands/link/index.ts
+++ b/packages/cli-core/src/commands/link/index.ts
@@ -8,9 +8,9 @@ import { setProfile, resolveProfile, moveProfile } from "../../lib/config.ts";
 import { autolink, findClerkKeys, matchKeyToApp } from "../../lib/autolink.ts";
 import { getGitRepoIdentifier, getGitRepoRoot, getGitNormalizedRemote } from "../../lib/git.ts";
 import { dim, cyan } from "../../lib/color.ts";
-import { printNextSteps, NEXT_STEPS } from "../../lib/next-steps.ts";
+import { NEXT_STEPS } from "../../lib/next-steps.ts";
 import { CliError, ERROR_CODE } from "../../lib/errors.ts";
-import { withSpinner } from "../../lib/spinner.ts";
+import { intro, outro, withSpinner } from "../../lib/spinner.ts";
 
 const AGENT_PROMPT = `You are linking a Clerk application to the current project directory.
 
@@ -63,9 +63,14 @@ export async function link(options: LinkOptions = {}): Promise<void> {
     if (autolinked) return;
   }
 
+  intro("clerk link");
+
   if (existing) {
     const shouldRelink = await handleExistingProfile(existing, normalizedRemote, options);
-    if (!shouldRelink) return;
+    if (!shouldRelink) {
+      outro();
+      return;
+    }
   }
 
   await ensureAuth();
@@ -94,9 +99,9 @@ export async function link(options: LinkOptions = {}): Promise<void> {
   });
 
   const label = app.name || app.application_id;
-  console.log(`\nLinked to ${cyan(label)} in ${dim(displayPath)}`);
+  console.log(`Linked to ${cyan(label)} in ${dim(displayPath)}`);
 
-  printNextSteps(NEXT_STEPS.LINK);
+  outro(NEXT_STEPS.LINK);
 }
 
 async function ensureAuth() {

--- a/packages/cli-core/src/commands/whoami/index.ts
+++ b/packages/cli-core/src/commands/whoami/index.ts
@@ -1,5 +1,6 @@
 import { getToken } from "../../lib/credential-store.ts";
 import { fetchUserInfo } from "../../lib/token-exchange.ts";
+import { withSpinner } from "../../lib/spinner.ts";
 
 export async function whoami() {
   const token = await getToken();
@@ -9,7 +10,7 @@ export async function whoami() {
   }
 
   try {
-    const userInfo = await fetchUserInfo(token);
+    const userInfo = await withSpinner("Fetching account info...", () => fetchUserInfo(token));
     console.log(userInfo.email);
   } catch {
     console.log("Session expired. Run `clerk auth login` to re-authenticate.");

--- a/packages/cli-core/src/lib/next-steps.ts
+++ b/packages/cli-core/src/lib/next-steps.ts
@@ -1,14 +1,29 @@
 import { cyan, dimNeutral } from "./color.ts";
 import { isHuman } from "../mode.ts";
 
+export const NEXT_STEPS = {
+  LOGIN: [
+    "Run `clerk init` to set up Clerk in your project",
+    "Run `clerk link` to connect an existing Clerk application",
+  ],
+  LINK: [
+    "Run `clerk env pull` to fetch your environment variables",
+    "Run `clerk doctor` to verify your setup",
+  ],
+  DEPLOY: [
+    "Run `clerk env pull --instance prod` to fetch production keys",
+    "Run `clerk doctor` to verify your setup",
+  ],
+} as const;
+
 /**
  * Print contextual next-step suggestions after a successful command.
  * Only shown in human/interactive mode — agents get AGENT_PROMPT instead.
  */
-export function printNextSteps(steps: string[]): void {
+export function printNextSteps(steps: readonly string[]): void {
   if (!isHuman() || steps.length === 0) return;
-  console.error(`\n${dimNeutral("Next steps:")}`);
   for (const step of steps) {
-    console.error(`  ${cyan("\u2192")} ${step}`);
+    console.error(`   ${cyan("\u2192")} ${step}`);
   }
+  console.error();
 }

--- a/packages/cli-core/src/lib/spinner.ts
+++ b/packages/cli-core/src/lib/spinner.ts
@@ -3,21 +3,56 @@ import { isHuman } from "../mode.ts";
 const FRAMES = ["◒", "◐", "◓", "◑"];
 const INTERVAL = 80;
 
-function createSpinner(stream: NodeJS.WriteStream = process.stderr) {
-  const isInteractive = stream.isTTY && !process.env.CI;
+const S_BAR = "│";
+const S_BAR_START = "┌";
+const S_BAR_END = "└";
+const S_STEP_DONE = "◇";
+const S_STEP_ERROR = "■";
+
+const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
+const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;
+const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
+const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
+
+const stream = process.stderr;
+const isInteractive = () => stream.isTTY && !process.env.CI;
+
+/** Print intro bracket: ┌  title */
+export function intro(title?: string) {
+  if (!isHuman()) return;
+  const line = title ? `${dim(S_BAR_START)}  ${title}` : dim(S_BAR_START);
+  stream.write(`${line}\n`);
+}
+
+/** Print outro bracket: └  message */
+export function outro(message?: string) {
+  if (!isHuman()) return;
+  stream.write(`${dim(S_BAR)}\n`);
+  const line = message ? `${dim(S_BAR_END)}  ${message}` : dim(S_BAR_END);
+  stream.write(`${line}\n\n`);
+}
+
+/** Print a bar separator: │ */
+export function bar() {
+  if (!isHuman()) return;
+  stream.write(`${dim(S_BAR)}\n`);
+}
+
+function createSpinner() {
+  const interactive = isInteractive();
   let timer: ReturnType<typeof setInterval> | undefined;
   let frame = 0;
 
   return {
     start(message: string) {
-      if (!isInteractive) {
-        stream.write(`${message}\n`);
+      if (!interactive) {
+        stream.write(`${S_STEP_DONE}  ${message}\n`);
         return;
       }
       stream.write("\x1b[?25l"); // hide cursor
       timer = setInterval(() => {
-        const spinner = `\x1b[36m${FRAMES[frame++ % FRAMES.length]}\x1b[0m`;
-        stream.write(`\r\x1b[K${spinner} ${message}`);
+        const char = cyan(FRAMES[frame++ % FRAMES.length]);
+        stream.write(`\r\x1b[K${char}  ${message}`);
       }, INTERVAL);
     },
     stop(finalMessage?: string) {
@@ -25,12 +60,22 @@ function createSpinner(stream: NodeJS.WriteStream = process.stderr) {
         clearInterval(timer);
         timer = undefined;
       }
-      if (!isInteractive) return;
-      stream.write(`\r\x1b[K`); // clear line
+      if (!interactive) return;
+      stream.write(`\r\x1b[K`);
       if (finalMessage) {
-        stream.write(`${finalMessage}\n`);
+        stream.write(`${green(S_STEP_DONE)}  ${finalMessage}\n`);
       }
       stream.write("\x1b[?25h"); // show cursor
+    },
+    error(finalMessage?: string) {
+      if (timer) {
+        clearInterval(timer);
+        timer = undefined;
+      }
+      if (!interactive) return;
+      stream.write(`\r\x1b[K`);
+      stream.write(`${red(S_STEP_ERROR)}  ${finalMessage ?? "Failed"}\n`);
+      stream.write("\x1b[?25h");
     },
   };
 }
@@ -49,7 +94,7 @@ export async function withSpinner<T>(
     s.stop(doneMessage ?? message.replace(/\.{3}$/, ""));
     return result;
   } catch (error) {
-    s.stop("Failed");
+    s.error("Failed");
     throw error;
   }
 }

--- a/packages/cli-core/src/lib/spinner.ts
+++ b/packages/cli-core/src/lib/spinner.ts
@@ -1,0 +1,55 @@
+import { isHuman } from "../mode.ts";
+
+const FRAMES = ["◒", "◐", "◓", "◑"];
+const INTERVAL = 80;
+
+function createSpinner(stream: NodeJS.WriteStream = process.stderr) {
+  const isInteractive = stream.isTTY && !process.env.CI;
+  let timer: ReturnType<typeof setInterval> | undefined;
+  let frame = 0;
+
+  return {
+    start(message: string) {
+      if (!isInteractive) {
+        stream.write(`${message}\n`);
+        return;
+      }
+      stream.write("\x1b[?25l"); // hide cursor
+      timer = setInterval(() => {
+        const spinner = `\x1b[36m${FRAMES[frame++ % FRAMES.length]}\x1b[0m`;
+        stream.write(`\r\x1b[K${spinner} ${message}`);
+      }, INTERVAL);
+    },
+    stop(finalMessage?: string) {
+      if (timer) {
+        clearInterval(timer);
+        timer = undefined;
+      }
+      if (!isInteractive) return;
+      stream.write(`\r\x1b[K`); // clear line
+      if (finalMessage) {
+        stream.write(`${finalMessage}\n`);
+      }
+      stream.write("\x1b[?25h"); // show cursor
+    },
+  };
+}
+
+export async function withSpinner<T>(
+  message: string,
+  fn: () => Promise<T>,
+  doneMessage?: string,
+): Promise<T> {
+  if (!isHuman()) return fn();
+
+  const s = createSpinner();
+  s.start(message);
+  try {
+    const result = await fn();
+    s.stop(doneMessage ?? message.replace(/\.{3}$/, ""));
+    return result;
+  } catch (error) {
+    s.stop("Failed");
+    throw error;
+  }
+}

--- a/packages/cli-core/src/lib/spinner.ts
+++ b/packages/cli-core/src/lib/spinner.ts
@@ -58,13 +58,23 @@ export function intro(title?: string) {
   patchConsole();
 }
 
-/** Print outro bracket: └  message — restores normal console output. */
-export function outro(message?: string) {
+/** Print outro bracket: └  message — restores normal console output.
+ *  Pass a string[] to render as next steps after the bracket. */
+export function outro(messageOrSteps?: string | readonly string[]) {
   if (!isHuman()) return;
   unpatchConsole();
   stream.write(`${dim(S_BAR)}\n`);
-  const line = message ? `${dim(S_BAR_END)}  ${message}` : dim(S_BAR_END);
-  stream.write(`${line}\n\n`);
+
+  if (Array.isArray(messageOrSteps)) {
+    stream.write(`${dim(S_BAR_END)}  ${dim("Next steps")}\n`);
+    for (const step of messageOrSteps) {
+      stream.write(`   ${cyan("\u2192")} ${step}\n`);
+    }
+    stream.write("\n");
+  } else {
+    const label = messageOrSteps ?? "Done";
+    stream.write(`${dim(S_BAR_END)}  ${label}\n\n`);
+  }
 }
 
 /** Print a bar separator: │ */

--- a/packages/cli-core/src/lib/spinner.ts
+++ b/packages/cli-core/src/lib/spinner.ts
@@ -1,4 +1,5 @@
 import { isHuman } from "../mode.ts";
+import { dim, cyan, green, red } from "./color.ts";
 
 const FRAMES = ["◒", "◐", "◓", "◑"];
 const INTERVAL = 80;
@@ -9,24 +10,58 @@ const S_BAR_END = "└";
 const S_STEP_DONE = "◇";
 const S_STEP_ERROR = "■";
 
-const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
-const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;
-const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
-const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
-
 const stream = process.stderr;
 const isInteractive = () => stream.isTTY && !process.env.CI;
 
-/** Print intro bracket: ┌  title */
+// --- Console pipe (auto-prefix console.log/error with │ inside intro/outro flow) ---
+
+const _log = console.log;
+const _error = console.error;
+let flowDepth = 0;
+
+function pipedFn(original: typeof console.log): typeof console.log {
+  return (...args: unknown[]) => {
+    const msg = args.map((a) => (typeof a === "string" ? a : String(a))).join(" ");
+    if (!msg) {
+      stream.write(`${dim(S_BAR)}\n`);
+      return;
+    }
+    for (const line of msg.split("\n")) {
+      stream.write(`${dim(S_BAR)}  ${line}\n`);
+    }
+  };
+}
+
+function patchConsole() {
+  if (flowDepth === 0) {
+    console.log = pipedFn(_log);
+    console.error = pipedFn(_error);
+  }
+  flowDepth++;
+}
+
+function unpatchConsole() {
+  flowDepth = Math.max(0, flowDepth - 1);
+  if (flowDepth === 0) {
+    console.log = _log;
+    console.error = _error;
+  }
+}
+
+// --- Public API ---
+
+/** Print intro bracket: ┌  title — pipes all console output until outro(). */
 export function intro(title?: string) {
   if (!isHuman()) return;
   const line = title ? `${dim(S_BAR_START)}  ${title}` : dim(S_BAR_START);
   stream.write(`${line}\n`);
+  patchConsole();
 }
 
-/** Print outro bracket: └  message */
+/** Print outro bracket: └  message — restores normal console output. */
 export function outro(message?: string) {
   if (!isHuman()) return;
+  unpatchConsole();
   stream.write(`${dim(S_BAR)}\n`);
   const line = message ? `${dim(S_BAR_END)}  ${message}` : dim(S_BAR_END);
   stream.write(`${line}\n\n`);


### PR DESCRIPTION
## Summary

Closes [AIE-714](https://linear.app/clerk/issue/AIE-714/add-spinners-on-human-mode)

Zero visual feedback during async operations, users stare at a blank terminal. This adds spinners and a checkpoint flow to human-mode CLI commands.

### What changed

- **Custom spinner** (`lib/spinner.ts`) - zero dependencies, writes to stderr, no-op in agent mode, graceful non-TTY/CI fallback
- **Checkpoint flow** (`intro`/`outro`/`bar`) - clack-inspired visual pipeline for multi-step commands
- **Auto-pipe** - `console.log`/`console.error` auto-prefixed with `│` inside checkpoint flow, zero changes needed in command files
- **Centralized next steps** (`lib/next-steps.ts`) - `NEXT_STEPS.LOGIN`, `NEXT_STEPS.LINK`, `NEXT_STEPS.DEPLOY` constants, `outro(steps)` API renders them after `└`
- **Spinners on all async ops** - auth, init, env, link, apps, whoami, doctor, config, api
- **Dropped `@clack/prompts`** - replaced with ~140 lines of custom code per Carp's feedback

### Commands with checkpoint flow

| Command | Flow |
|---------|------|
| `clerk init` | `┌` framework detection, file writes, env pull, scan `└` |
| `clerk auth login` | `┌` session check, OAuth flow `└` |
| `clerk doctor` | `┌` diagnostics, fix prompts, re-verify `└` |
| `clerk link` | `┌` app selection, profile write `└` |

Single-spinner commands (`apps list`, `whoami`, `env pull`, etc.) just show `◇` on completion, no wrapping.

### Env pull dual output

Shows both the spinner message and the written-file confirmation:
```
◇  Pulling env vars from development instance
Environment variables written to .env.local
```

The "written to" message uses dimmed stderr so it's invisible in agent mode.

### Consistent cancel behavior

All checkpoint commands close the bracket cleanly on user cancel:
```
┌  clerk login
◇  Checking session
✔ Re-authenticate? No
│
└  Done
```

## Test plan

- [x] 720 tests pass (`bun test`)
- [x] Manual: `clerk init`, `clerk auth login`, `clerk doctor`, `clerk link` show checkpoint flow
- [x] Manual: `clerk apps list`, `clerk whoami`, `clerk env pull` show spinner
- [x] Manual: cancel flows close brackets consistently
- [x] Agent mode: no spinners (`CLERK_MODE=agent`)
- [ ] CI green