### PR TITLE
fix(dx): remove trailing periods from CLI messages

### DIFF
--- a/packages/cli-core/src/commands/api/catalog.ts
+++ b/packages/cli-core/src/commands/api/catalog.ts
@@ -140,7 +140,7 @@ export async function loadCatalog(options: { platform?: boolean } = {}): Promise
   } catch (error) {
     // Fall back to stale cache
     if (cached) {
-      console.error("Warning: Unable to refresh API catalog, using cached version.");
+      console.error("Warning: Unable to refresh API catalog, using cached version");
       return cached;
     }
     throw new CliError(

--- a/packages/cli-core/src/commands/auth/logout.test.ts
+++ b/packages/cli-core/src/commands/auth/logout.test.ts
@@ -43,6 +43,6 @@ describe("logout", () => {
     consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     await logout();
 
-    expect(consoleSpy).toHaveBeenCalledWith("Logged out successfully.");
+    expect(consoleSpy).toHaveBeenCalledWith("Logged out successfully");
   });
 });

--- a/packages/cli-core/src/commands/auth/logout.ts
+++ b/packages/cli-core/src/commands/auth/logout.ts
@@ -4,5 +4,5 @@ import { clearAuth } from "../../lib/config.ts";
 export async function logout(): Promise<void> {
   await deleteToken();
   await clearAuth();
-  console.log("Logged out successfully.");
+  console.log("Logged out successfully");
 }

--- a/packages/cli-core/src/commands/config/push.test.ts
+++ b/packages/cli-core/src/commands/config/push.test.ts
@@ -418,7 +418,7 @@ describe("config push", () => {
     // Send a payload that matches the current config for the patched key
     await runConfigPatch({ json: '{"session":{"lifetime":604800}}', yes: true });
     expect(mutatingCallMade).toBe(false);
-    expect(errorSpy).toHaveBeenCalledWith("No changes detected.");
+    expect(errorSpy).toHaveBeenCalledWith("No changes detected");
   });
 
   test("put skips API call when payload matches current config", async () => {
@@ -439,7 +439,7 @@ describe("config push", () => {
       yes: true,
     });
     expect(mutatingCallMade).toBe(false);
-    expect(errorSpy).toHaveBeenCalledWith("No changes detected.");
+    expect(errorSpy).toHaveBeenCalledWith("No changes detected");
   });
 
   test("put detects no changes when current config has config_version (pull→put roundtrip)", async () => {
@@ -459,7 +459,7 @@ describe("config push", () => {
     // Simulate pull→put: payload includes config_version from the pull output
     await runConfigPut({ json: JSON.stringify(configWithVersion), yes: true });
     expect(mutatingCallMade).toBe(false);
-    expect(errorSpy).toHaveBeenCalledWith("No changes detected.");
+    expect(errorSpy).toHaveBeenCalledWith("No changes detected");
   });
 
   // --- Instance targeting ---
@@ -582,7 +582,7 @@ describe("config push", () => {
     });
 
     await runConfigPatch({ json: '{"a":1}', yes: true });
-    expect(errorSpy).toHaveBeenCalledWith("Config pushed successfully.");
+    expect(errorSpy).toHaveBeenCalledWith("Config pushed successfully");
   });
 
   // --- --json takes priority over --file ---

--- a/packages/cli-core/src/commands/config/push.ts
+++ b/packages/cli-core/src/commands/config/push.ts
@@ -91,7 +91,7 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
   const hasChanges = hasConfigChanges(currentConfig, configPayload, isPatch);
 
   if (!hasChanges) {
-    console.error("No changes detected.");
+    console.error("No changes detected");
     return;
   }
 
@@ -117,7 +117,7 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
       ),
   );
   console.log(JSON.stringify(result, null, 2));
-  console.error("Config pushed successfully.");
+  console.error("Config pushed successfully");
 }
 
 export async function readInput(options: { file?: string; json?: string }): Promise<string> {
@@ -140,7 +140,7 @@ export async function readInput(options: { file?: string; json?: string }): Prom
     }
     const text = Buffer.concat(chunks).toString("utf-8").trim();
     if (!text) {
-      throwUsageError("No input received from stdin.");
+      throwUsageError("No input received from stdin");
     }
     return text;
   }

--- a/packages/cli-core/src/commands/doctor/index.ts
+++ b/packages/cli-core/src/commands/doctor/index.ts
@@ -117,7 +117,7 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 
       const hasVerifyFailure = verifyResults.some((r) => r.status === "fail");
       if (hasVerifyFailure) {
-        throw new CliError("Some checks still failing after auto-fix.", {
+        throw new CliError("Some checks still failing after auto-fix", {
           code: ERROR_CODE.DOCTOR_FAILED,
         });
       }
@@ -128,7 +128,7 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 
   const hasFailure = allResults.some((r) => r.status === "fail");
   if (hasFailure) {
-    throw new CliError("Doctor found issues with your Clerk integration.", {
+    throw new CliError("Doctor found issues with your Clerk integration", {
       code: ERROR_CODE.DOCTOR_FAILED,
     });
   }

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -133,7 +133,7 @@ async function scaffoldAndWrite(
   }
 
   if (await checkGitDirty(cwd)) {
-    console.log(yellow("Warning: You have uncommitted changes."));
+    console.log(yellow("Warning: You have uncommitted changes"));
     console.log(dim("Consider committing first so you can review what clerk init creates.\n"));
   }
 

--- a/packages/cli-core/src/commands/link/index.ts
+++ b/packages/cli-core/src/commands/link/index.ts
@@ -83,7 +83,7 @@ export async function link(options: LinkOptions = {}): Promise<void> {
   const prodInstance = app.instances.find((i) => i.environment_type === "production");
 
   if (!devInstance) {
-    throw new CliError("Application has no development instance.", {
+    throw new CliError("Application has no development instance", {
       code: ERROR_CODE.INSTANCE_NOT_FOUND,
     });
   }
@@ -206,7 +206,7 @@ async function pickApp(apps: Application[], displayPath: string): Promise<Applic
 
   const found = apps.find((a) => a.application_id === selectedId);
   if (!found) {
-    throw new CliError("Selected application not found.", {
+    throw new CliError("Selected application not found", {
       code: ERROR_CODE.APP_NOT_FOUND,
     });
   }

--- a/packages/cli-core/src/commands/unlink/index.ts
+++ b/packages/cli-core/src/commands/unlink/index.ts
@@ -34,7 +34,7 @@ export async function unlink(options: UnlinkOptions = {}): Promise<void> {
   const existing = await resolveProfile(cwd);
 
   if (!existing) {
-    throw new CliError("This directory is not linked to a Clerk application.", {
+    throw new CliError("This directory is not linked to a Clerk application", {
       code: ERROR_CODE.NOT_LINKED,
     });
   }

--- a/packages/cli-core/src/commands/whoami/index.ts
+++ b/packages/cli-core/src/commands/whoami/index.ts
@@ -5,7 +5,7 @@ import { withSpinner } from "../../lib/spinner.ts";
 export async function whoami() {
   const token = await getToken();
   if (!token) {
-    console.log("Not logged in. Run `clerk auth login` to authenticate.");
+    console.log("Not logged in. Run `clerk auth login` to authenticate");
     return;
   }
 
@@ -13,7 +13,7 @@ export async function whoami() {
     const userInfo = await withSpinner("Fetching account info...", () => fetchUserInfo(token));
     console.log(userInfo.email);
   } catch {
-    console.log("Session expired. Run `clerk auth login` to re-authenticate.");
+    console.log("Session expired. Run `clerk auth login` to re-authenticate");
     return;
   }
 }

--- a/packages/cli-core/src/lib/plapi.ts
+++ b/packages/cli-core/src/lib/plapi.ts
@@ -39,7 +39,7 @@ export async function getAuthToken(): Promise<string> {
   const oauthToken = await getToken();
   if (oauthToken) return oauthToken;
 
-  throw new CliError("Not authenticated. Run `clerk auth login` or set CLERK_PLATFORM_API_KEY.", {
+  throw new CliError("Not authenticated. Run `clerk auth login` or set CLERK_PLATFORM_API_KEY", {
     code: ERROR_CODE.AUTH_REQUIRED,
     docsUrl: "https://clerk.com/docs/guides/development/clerk-environment-variables",
   });


### PR DESCRIPTION
## Summary
- Remove trailing periods from all user-facing CLI messages (console output and error strings) to follow CLI convention
- Update corresponding test assertions to match the new strings
- 14 strings updated across 9 source files, 5 test assertions updated across 2 test files

## Test plan
- [x] `bun test` passes (732/735 — 3 pre-existing failures unrelated to this change)
- [x] Pre-commit hooks (oxfmt, oxlint) pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized CLI command output formatting by removing trailing periods from user-facing messages, including success notifications, error messages, and warnings across all commands for consistent presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->