### PR TITLE
refactor(log): introduce structured log utility with proper stdout/stderr semantics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,73 @@ When creating or modifying a command, evaluate whether it needs an agent mode. C
 
 `README.md` at the project root contains the CLI help output. When commands are added, removed, or their options change, update the help output in `README.md` to stay in sync. You can regenerate it by running `bun run dev -- --help`.
 
+## Logging
+
+All output goes through the `log` object from `packages/cli-core/src/lib/log.ts`. **Never use `console.log`, `console.error`, or `process.stderr.write` directly** — use `log.*` methods so output respects log levels, throttling, and test capture.
+
+```ts
+import { log } from "../../lib/log.ts";
+```
+
+### Which method to use
+
+| Method          | Stream     | When to use                                     |
+| --------------- | ---------- | ----------------------------------------------- |
+| `log.data()`    | **stdout** | Pipeable output (JSON, lists, machine-readable) |
+| `log.info()`    | stderr     | Status messages                                 |
+| `log.success()` | stderr     | Completion confirmations (green)                |
+| `log.warn()`    | stderr     | Warnings (yellow)                               |
+| `log.error()`   | stderr     | Errors (red, auto-prefixed `error: `)           |
+| `log.debug()`   | stderr     | Diagnostic info, only with `--verbose`          |
+| `log.raw()`     | stderr     | Machine-readable JSON for agent mode            |
+| `log.blank()`   | stderr     | Blank line                                      |
+
+`log.data()` writes to **stdout** — this is what gets piped (e.g., `clerk apps list | jq`). Everything else writes to **stderr** as UI for humans. Never mix these.
+
+### Debug logging
+
+`log.debug()` is gated by `--verbose`. Use for diagnostic details (request URLs, timing, intermediate state):
+
+```ts
+log.debug(`Fetching instance ${instanceId}…`);
+```
+
+### Tagged loggers
+
+`log.withTag()` adds scoped context in complex flows:
+
+```ts
+const apiLog = log.withTag("api");
+apiLog.info("Fetching config…"); // [api] Fetching config…
+```
+
+### Inline highlighting
+
+Backtick-wrapped text auto-highlights in cyan:
+
+```ts
+log.info("Linked to `my-app` on `development`");
+```
+
+### Testing log output
+
+Use `captureLog()` from `packages/cli-core/src/test/lib/stubs.ts`:
+
+```ts
+import { captureLog } from "../../test/lib/stubs.ts";
+
+let captured: ReturnType<typeof captureLog>;
+beforeEach(() => {
+  captured = captureLog();
+});
+
+test("outputs result", async () => {
+  await captured.run(() => myCommand());
+  expect(captured.out).toContain("expected stdout"); // log.data()
+  expect(captured.err).toContain("expected stderr"); // log.info/warn/etc.
+});
+```
+
 ## Error Handling
 
 All error classes and helpers live in `packages/cli-core/src/lib/errors.ts`. The global error handler in `packages/cli-core/src/cli.ts` catches thrown errors and formats them for the user. **Never call `console.error` + `process.exit` directly in commands** — throw an error instead and let the global handler deal with output and exit codes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,17 +134,13 @@ log.info("Linked to `my-app` on `development`");
 
 ### Testing log output
 
-Use `captureLog()` from `packages/cli-core/src/test/lib/stubs.ts`:
+Use `captureLog()` from `packages/cli-core/src/test/lib/stubs.ts`. Capture is scoped via `AsyncLocalStorage` — no teardown needed:
 
 ```ts
 import { captureLog } from "../../test/lib/stubs.ts";
 
-let captured: ReturnType<typeof captureLog>;
-beforeEach(() => {
-  captured = captureLog();
-});
-
 test("outputs result", async () => {
+  const captured = captureLog();
   await captured.run(() => myCommand());
   expect(captured.out).toContain("expected stdout"); // log.data()
   expect(captured.err).toContain("expected stderr"); // log.info/warn/etc.

--- a/packages/cli-core/src/cli-program.ts
+++ b/packages/cli-core/src/cli-program.ts
@@ -1,4 +1,5 @@
 import { Command, createOption, createArgument } from "@commander-js/extra-typings";
+import { setLogLevel } from "./lib/log.ts";
 import { setMode, type Mode } from "./mode.ts";
 import { init } from "./commands/init/index.ts";
 import { login } from "./commands/auth/login.ts";
@@ -48,10 +49,13 @@ export function createProgram() {
       "--mode <mode>",
       "Force interaction mode (human or agent). Defaults to auto-detect based on TTY.",
     )
-    .option("--verbose", "Show detailed error output");
+    .option("--verbose", "Show detailed output (enables debug messages)");
 
   program.hook("preAction", async () => {
     const opts = program.opts();
+    if (opts.verbose) {
+      setLogLevel("debug");
+    }
     if (opts.mode) {
       if (opts.mode !== "human" && opts.mode !== "agent") {
         throwUsageError(`Invalid mode "${opts.mode}". Must be "human" or "agent".`);

--- a/packages/cli-core/src/cli-program.ts
+++ b/packages/cli-core/src/cli-program.ts
@@ -52,6 +52,9 @@ export function createProgram() {
     .option("--verbose", "Show detailed output (enables debug messages)");
 
   program.hook("preAction", async () => {
+    // Reset log level at the start of each command invocation so a previous
+    // --verbose or --debug flag doesn't leak into subsequent runs.
+    setLogLevel("info");
     const opts = program.opts();
     if (opts.verbose) {
       setLogLevel("debug");

--- a/packages/cli-core/src/cli-program.ts
+++ b/packages/cli-core/src/cli-program.ts
@@ -29,8 +29,8 @@ import {
 } from "./lib/errors.ts";
 import { clerkHelpConfig } from "./lib/help.ts";
 import { ExitPromptError } from "@inquirer/core";
-import { red } from "./lib/color.ts";
 import { isAgent } from "./mode.ts";
+import { log } from "./lib/log.ts";
 
 export function createProgram() {
   const program = new Command()
@@ -535,10 +535,10 @@ export async function runProgram(
         outputJsonError(error.code, error.message, error.docsUrl);
       } else {
         if (error.message) {
-          console.error(red(`error: ${error.message}`));
+          log.error(error.message);
         }
         if (error.docsUrl) {
-          console.error(`\nFor more information, see: ${error.docsUrl}`);
+          log.info(`\nFor more information, see: ${error.docsUrl}`);
         }
       }
       process.exit(error.exitCode);
@@ -557,9 +557,9 @@ export async function runProgram(
           apiErrors,
         );
       } else {
-        console.error(red(`error: ${prefix} (${error.status}): ${detail}`));
+        log.error(`${prefix} (${error.status}): ${detail}`);
         if (verbose && error instanceof PlapiError && error.url) {
-          console.error(`       URL: ${error.url}`);
+          log.error(`       URL: ${error.url}`);
         }
       }
       process.exit(EXIT_CODE.GENERAL);
@@ -569,7 +569,7 @@ export async function runProgram(
       if (isAgent()) {
         outputJsonError("unexpected_error", error.message);
       } else {
-        console.error(red(`error: ${error.message}`));
+        log.error(error.message);
       }
       process.exit(EXIT_CODE.GENERAL);
     }
@@ -577,7 +577,7 @@ export async function runProgram(
     if (isAgent()) {
       outputJsonError("unexpected_error", "An unexpected error occurred");
     } else {
-      console.error(red("error: An unexpected error occurred"));
+      log.error("An unexpected error occurred");
     }
     process.exit(EXIT_CODE.GENERAL);
   }
@@ -608,7 +608,7 @@ function outputJsonError(
   };
   if (docsUrl) payload.error.docsUrl = docsUrl;
   if (errors?.length) payload.error.errors = errors;
-  console.error(JSON.stringify(payload));
+  log.raw(JSON.stringify(payload));
 }
 
 /** Extract the error code from a Clerk API JSON response body, if present. */

--- a/packages/cli-core/src/commands/api/catalog.test.ts
+++ b/packages/cli-core/src/commands/api/catalog.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe, beforeEach, afterEach, spyOn } from "bun:test";
-import { stubFetch } from "../../test/lib/stubs.ts";
+import { captureLog, stubFetch } from "../../test/lib/stubs.ts";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -179,14 +179,17 @@ describe("loadCatalog", () => {
   const originalFetch = globalThis.fetch;
   let tempDir: string;
   let errorSpy: ReturnType<typeof spyOn>;
+  let captured: ReturnType<typeof captureLog>;
 
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), "clerk-catalog-test-"));
     _setCacheDir(tempDir);
     errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    captured = captureLog();
   });
 
   afterEach(async () => {
+    captured.teardown();
     _setCacheDir(undefined);
     globalThis.fetch = originalFetch;
     errorSpy.mockRestore();
@@ -254,7 +257,7 @@ describe("loadCatalog", () => {
 
     const catalog = await loadCatalog();
     expect(catalog.endpoints.length).toBe(6);
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("Unable to refresh"));
+    expect(captured.err).toContain("Unable to refresh");
   });
 
   test("errors when offline with no cache", async () => {

--- a/packages/cli-core/src/commands/api/catalog.test.ts
+++ b/packages/cli-core/src/commands/api/catalog.test.ts
@@ -196,6 +196,10 @@ describe("loadCatalog", () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
+  function runLoadCatalog(options?: Parameters<typeof loadCatalog>[0]) {
+    return captured.run(() => loadCatalog(options));
+  }
+
   test("fetches and caches on first load", async () => {
     let fetchCalled = false;
     stubFetch(async () => {
@@ -203,7 +207,7 @@ describe("loadCatalog", () => {
       return new Response(MINIMAL_SPEC, { status: 200 });
     });
 
-    const catalog = await loadCatalog();
+    const catalog = await runLoadCatalog();
     expect(fetchCalled).toBe(true);
     expect(catalog.endpoints.length).toBe(6);
 
@@ -224,7 +228,7 @@ describe("loadCatalog", () => {
       return new Response(MINIMAL_SPEC, { status: 200 });
     });
 
-    const catalog = await loadCatalog();
+    const catalog = await runLoadCatalog();
     expect(fetchCalled).toBe(false);
     expect(catalog.endpoints.length).toBe(6);
   });
@@ -241,7 +245,7 @@ describe("loadCatalog", () => {
       return new Response(MINIMAL_SPEC, { status: 200 });
     });
 
-    await loadCatalog();
+    await runLoadCatalog();
     expect(fetchCalled).toBe(true);
   });
 
@@ -255,7 +259,7 @@ describe("loadCatalog", () => {
       throw new Error("Network error");
     });
 
-    const catalog = await loadCatalog();
+    const catalog = await runLoadCatalog();
     expect(catalog.endpoints.length).toBe(6);
     expect(captured.err).toContain("Unable to refresh");
   });
@@ -265,7 +269,7 @@ describe("loadCatalog", () => {
       throw new Error("Network error");
     });
 
-    await expect(loadCatalog()).rejects.toThrow("Unable to fetch API catalog");
+    await expect(runLoadCatalog()).rejects.toThrow("Unable to fetch API catalog");
   });
 
   test("uses platform URL when platform flag set", async () => {
@@ -275,7 +279,7 @@ describe("loadCatalog", () => {
       return new Response(MINIMAL_SPEC, { status: 200 });
     });
 
-    await loadCatalog({ platform: true });
+    await runLoadCatalog({ platform: true });
     expect(capturedUrl).toContain("platform");
 
     // Cache uses platform filename

--- a/packages/cli-core/src/commands/api/catalog.ts
+++ b/packages/cli-core/src/commands/api/catalog.ts
@@ -9,6 +9,7 @@ import { join } from "node:path";
 import { CLERK_CACHE_DIR, CACHE_TTL_MS, OPENAPI_SPEC_URLS } from "../../lib/constants.ts";
 import { CliError, ERROR_CODE } from "../../lib/errors.ts";
 import { withSpinner } from "../../lib/spinner.ts";
+import { log } from "../../lib/log.ts";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -140,7 +141,7 @@ export async function loadCatalog(options: { platform?: boolean } = {}): Promise
   } catch (error) {
     // Fall back to stale cache
     if (cached) {
-      console.error("Warning: Unable to refresh API catalog, using cached version");
+      log.warn("Unable to refresh API catalog, using cached version");
       return cached;
     }
     throw new CliError(

--- a/packages/cli-core/src/commands/api/index.test.ts
+++ b/packages/cli-core/src/commands/api/index.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
+  captureLog,
   credentialStoreStubs,
   gitStubs,
   configStubs,
@@ -125,6 +126,7 @@ describe("api command", () => {
   let logSpy: ReturnType<typeof spyOn>;
   let errorSpy: ReturnType<typeof spyOn>;
   let exitSpy: ReturnType<typeof spyOn>;
+  let captured: ReturnType<typeof captureLog>;
 
   const mockUsers = { data: [{ id: "user_1", email: "test@example.com" }] };
 
@@ -149,11 +151,13 @@ describe("api command", () => {
     exitSpy = spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit");
     });
+    captured = captureLog();
 
     stubFetch(async () => new Response(JSON.stringify(mockUsers), { status: 200 }));
   });
 
   afterEach(async () => {
+    captured.teardown();
     _setConfigDir(undefined);
     process.env = { ...originalEnv };
     globalThis.fetch = originalFetch;
@@ -191,7 +195,7 @@ describe("api command", () => {
     expect(capturedUrl).toContain("/v1/users");
     expect(capturedMethod).toBe("GET");
     expect(capturedHeaders?.get("Authorization")).toBe("Bearer sk_test_123");
-    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(mockUsers, null, 2));
+    expect(captured.out).toContain(JSON.stringify(mockUsers, null, 2));
   });
 
   test("defaults to GET when no body provided", async () => {
@@ -279,8 +283,8 @@ describe("api command", () => {
     );
 
     await runApi("/users", { include: true });
-    expect(errorSpy).toHaveBeenCalledWith("HTTP 200");
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("x-request-id: req_123"));
+    expect(captured.err).toContain("HTTP 200");
+    expect(captured.err).toContain("x-request-id: req_123");
   });
 
   // --- --dry-run option ---
@@ -294,12 +298,12 @@ describe("api command", () => {
 
     await runApi("/users", { dryRun: true });
     expect(fetchCalled).toBe(false);
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("[dry-run] GET"));
+    expect(captured.err).toContain("[dry-run] GET");
   });
 
   test("--dry-run shows body when present", async () => {
     await runApi("/users", { dryRun: true, data: '{"email":"a@b.com"}' });
-    expect(logSpy).toHaveBeenCalledWith(JSON.stringify({ email: "a@b.com" }, null, 2));
+    expect(captured.out).toContain(JSON.stringify({ email: "a@b.com" }, null, 2));
   });
 
   // --- --secret-key override ---
@@ -426,7 +430,7 @@ describe("api command", () => {
 
     await runApi("/users/bad_id");
     expect(process.exitCode).toBe(1);
-    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(errorBody, null, 2));
+    expect(captured.out).toContain(JSON.stringify(errorBody, null, 2));
   });
 
   test("--include shows headers on error responses too", async () => {
@@ -440,8 +444,8 @@ describe("api command", () => {
 
     await runApi("/users", { include: true });
     expect(process.exitCode).toBe(1);
-    expect(errorSpy).toHaveBeenCalledWith("HTTP 400");
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("x-request-id: req_err"));
+    expect(captured.err).toContain("HTTP 400");
+    expect(captured.err).toContain("x-request-id: req_err");
   });
 
   // --- -d takes priority over --file ---

--- a/packages/cli-core/src/commands/api/index.test.ts
+++ b/packages/cli-core/src/commands/api/index.test.ts
@@ -175,7 +175,7 @@ describe("api command", () => {
 
   async function runApi(endpoint: string, options: Record<string, unknown> = {}) {
     const { api } = await import("./index.ts");
-    return api(endpoint, undefined, options);
+    return captured.run(() => api(endpoint, undefined, options));
   }
 
   // --- GET requests ---

--- a/packages/cli-core/src/commands/api/index.ts
+++ b/packages/cli-core/src/commands/api/index.ts
@@ -13,6 +13,7 @@ import {
 import { isHuman } from "../../mode.ts";
 import { confirm } from "../../lib/prompts.ts";
 import { withSpinner } from "../../lib/spinner.ts";
+import { log } from "../../lib/log.ts";
 
 export interface ApiOptions {
   method?: string;
@@ -66,7 +67,7 @@ export async function api(
 
   // 4. Dry run
   if (options.dryRun) {
-    console.error(`[dry-run] ${method} ${baseUrl}${normalizePath(endpoint)}`);
+    log.info(`[dry-run] ${method} ${baseUrl}${normalizePath(endpoint)}`);
     if (body) {
       prettyPrint(body);
     }
@@ -75,7 +76,7 @@ export async function api(
 
   // 5. Confirmation for mutating methods
   if (MUTATING_METHODS.has(method) && isHuman() && !options.yes) {
-    console.error(`\nAbout to ${method} ${endpoint}`);
+    log.info(`\nAbout to ${method} ${endpoint}`);
     if (body) {
       prettyPrintToStderr(body);
     }
@@ -194,35 +195,35 @@ function normalizePath(path: string): string {
 }
 
 function printHeaders(status: number, headers: Headers): void {
-  console.error(`HTTP ${status}`);
+  log.raw(`HTTP ${status}`);
   headers.forEach((value, key) => {
-    console.error(`${key}: ${value}`);
+    log.raw(`${key}: ${value}`);
   });
-  console.error("");
+  log.blank();
 }
 
 function printBody(body: unknown): void {
   if (typeof body === "string") {
-    console.log(body);
+    log.data(body);
   } else {
-    console.log(JSON.stringify(body, null, 2));
+    log.data(JSON.stringify(body, null, 2));
   }
 }
 
 /** Pretty-print a string as JSON to stdout if possible, otherwise print raw. */
 function prettyPrint(text: string): void {
   try {
-    console.log(JSON.stringify(JSON.parse(text), null, 2));
+    log.data(JSON.stringify(JSON.parse(text), null, 2));
   } catch {
-    console.log(text);
+    log.data(text);
   }
 }
 
 /** Pretty-print a string as JSON to stderr if possible, otherwise print raw. */
 function prettyPrintToStderr(text: string): void {
   try {
-    console.error(JSON.stringify(JSON.parse(text), null, 2));
+    log.raw(JSON.stringify(JSON.parse(text), null, 2));
   } catch {
-    console.error(text);
+    log.raw(text);
   }
 }

--- a/packages/cli-core/src/commands/api/interactive.test.ts
+++ b/packages/cli-core/src/commands/api/interactive.test.ts
@@ -2,7 +2,7 @@ import { test, expect, describe, beforeEach, afterEach, spyOn, mock } from "bun:
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { promptsStubs, stubFetch } from "../../test/lib/stubs.ts";
+import { captureLog, promptsStubs, stubFetch } from "../../test/lib/stubs.ts";
 
 let _mode = "human";
 mock.module("../../mode.ts", () => ({
@@ -68,6 +68,7 @@ describe("apiInteractive", () => {
   let errorSpy: ReturnType<typeof spyOn>;
   let logSpy: ReturnType<typeof spyOn>;
   let exitSpy: ReturnType<typeof spyOn>;
+  let captured: ReturnType<typeof captureLog>;
   const originalFetch = globalThis.fetch;
   const originalIsTTY = process.stdin.isTTY;
 
@@ -95,6 +96,7 @@ describe("apiInteractive", () => {
     exitSpy = spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit");
     });
+    captured = captureLog();
     // Capture fetch calls from the real api handler
     stubFetch(async (input, init) => {
       fetchCalls.push({ url: input.toString(), method: init?.method ?? "GET" });
@@ -109,6 +111,7 @@ describe("apiInteractive", () => {
   });
 
   afterEach(async () => {
+    captured.teardown();
     _setCacheDir(undefined);
     process.env = { ...originalEnv };
     globalThis.fetch = originalFetch;
@@ -128,9 +131,7 @@ describe("apiInteractive", () => {
     const { apiInteractive } = await import("./interactive.ts");
 
     await apiInteractive({});
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Interactive mode requires a TTY"),
-    );
+    expect(captured.err).toContain("Interactive mode requires a TTY");
     setMode("human");
   });
 

--- a/packages/cli-core/src/commands/api/interactive.test.ts
+++ b/packages/cli-core/src/commands/api/interactive.test.ts
@@ -126,19 +126,20 @@ describe("apiInteractive", () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
+  async function runApiInteractive(options: Record<string, unknown> = {}) {
+    const { apiInteractive } = await import("./interactive.ts");
+    return captured.run(() => apiInteractive(options));
+  }
+
   test("shows help and returns in agent mode", async () => {
     setMode("agent");
-    const { apiInteractive } = await import("./interactive.ts");
-
-    await apiInteractive({});
+    await runApiInteractive({});
     expect(captured.err).toContain("Interactive mode requires a TTY");
     setMode("human");
   });
 
   test("completes full flow for GET endpoint (no body, no params)", async () => {
     setMode("human");
-    const { apiInteractive } = await import("./interactive.ts");
-
     // Step 1: select tag "Users"
     selectResponses.push("Users");
     // Step 2: select endpoint GET /users
@@ -154,7 +155,7 @@ describe("apiInteractive", () => {
     // Step 5: confirm execution
     confirmResponses.push(true);
 
-    await apiInteractive({});
+    await runApiInteractive({});
 
     expect(fetchCalls.length).toBe(1);
     expect(fetchCalls[0].url).toContain("/v1/users");
@@ -163,8 +164,6 @@ describe("apiInteractive", () => {
 
   test("prompts for path parameters", async () => {
     setMode("human");
-    const { apiInteractive } = await import("./interactive.ts");
-
     selectResponses.push("Users");
     selectResponses.push({
       method: "GET",
@@ -178,7 +177,7 @@ describe("apiInteractive", () => {
     inputResponses.push("user_abc123");
     confirmResponses.push(true);
 
-    await apiInteractive({});
+    await runApiInteractive({});
 
     expect(fetchCalls.length).toBe(1);
     expect(fetchCalls[0].url).toContain("/v1/users/user_abc123");
@@ -186,8 +185,6 @@ describe("apiInteractive", () => {
 
   test("aborts when user declines confirmation", async () => {
     setMode("human");
-    const { apiInteractive } = await import("./interactive.ts");
-
     selectResponses.push("Users");
     selectResponses.push({
       method: "GET",
@@ -200,7 +197,7 @@ describe("apiInteractive", () => {
     });
     confirmResponses.push(false); // decline
 
-    await expect(apiInteractive({})).rejects.toThrow("User aborted");
+    await expect(runApiInteractive({})).rejects.toThrow("User aborted");
 
     expect(fetchCalls.length).toBe(0);
   });

--- a/packages/cli-core/src/commands/api/interactive.ts
+++ b/packages/cli-core/src/commands/api/interactive.ts
@@ -7,10 +7,11 @@ import { isHuman } from "../../mode.ts";
 import { loadCatalog, endpointsByTag, type EndpointInfo } from "./catalog.ts";
 import type { ApiOptions } from "./index.ts";
 import { throwUserAbort } from "../../lib/errors.ts";
+import { log } from "../../lib/log.ts";
 
 export async function apiInteractive(options: ApiOptions): Promise<void> {
   if (!isHuman()) {
-    console.error(
+    log.info(
       "Interactive mode requires a TTY.\n\n" +
         "Usage:\n" +
         "  clerk api <endpoint>        Make an API request\n" +
@@ -82,12 +83,12 @@ export async function apiInteractive(options: ApiOptions): Promise<void> {
   }
 
   // 6. Preview and confirm
-  console.error(`\n${endpoint.method} ${resolvedPath}`);
+  log.info(`\n${endpoint.method} ${resolvedPath}`);
   if (body) {
     try {
-      console.error(JSON.stringify(JSON.parse(body), null, 2));
+      log.raw(JSON.stringify(JSON.parse(body), null, 2));
     } catch {
-      console.error(body);
+      log.raw(body);
     }
   }
 

--- a/packages/cli-core/src/commands/api/ls.test.ts
+++ b/packages/cli-core/src/commands/api/ls.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { parseSpec, _setCacheDir } from "./catalog.ts";
-import { stubFetch } from "../../test/lib/stubs.ts";
+import { captureLog, stubFetch } from "../../test/lib/stubs.ts";
 import { apiLs } from "./ls.ts";
 
 const MINIMAL_SPEC = `
@@ -45,6 +45,7 @@ describe("apiLs", () => {
   let tempDir: string;
   let logSpy: ReturnType<typeof spyOn>;
   let errorSpy: ReturnType<typeof spyOn>;
+  let captured: ReturnType<typeof captureLog>;
   const originalFetch = globalThis.fetch;
 
   beforeEach(async () => {
@@ -58,12 +59,14 @@ describe("apiLs", () => {
 
     logSpy = spyOn(console, "log").mockImplementation(() => {});
     errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    captured = captureLog();
     stubFetch(async () => {
       throw new Error("Should not fetch");
     });
   });
 
   afterEach(async () => {
+    captured.teardown();
     _setCacheDir(undefined);
     globalThis.fetch = originalFetch;
     logSpy.mockRestore();
@@ -74,34 +77,28 @@ describe("apiLs", () => {
   test("prints all endpoints in table format", async () => {
     await apiLs(undefined, {});
 
-    expect(logSpy).toHaveBeenCalledTimes(4);
-    // Check that each line contains method, path, and summary
-    const firstCall = logSpy.mock.calls[0][0] as string;
-    expect(firstCall).toContain("GET");
-    expect(firstCall).toContain("/users");
-    expect(firstCall).toContain("List all users");
+    // Check that output contains method, path, and summary
+    expect(captured.out).toContain("GET");
+    expect(captured.out).toContain("/users");
+    expect(captured.out).toContain("List all users");
 
     // Footer
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("4 endpoints"));
+    expect(captured.err).toContain("4 endpoints");
   });
 
   test("filters endpoints by keyword", async () => {
     await apiLs("organizations", {});
 
-    expect(logSpy).toHaveBeenCalledTimes(1);
-    const line = logSpy.mock.calls[0][0] as string;
-    expect(line).toContain("/organizations");
+    expect(captured.out).toContain("/organizations");
 
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('1 endpoint matching "organizations"'),
-    );
+    expect(captured.err).toContain('1 endpoint matching "organizations"');
   });
 
   test("shows message when no matches", async () => {
     await apiLs("zzzzz", {});
 
-    expect(logSpy).not.toHaveBeenCalled();
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('No endpoints matching "zzzzz"'));
+    expect(captured.out).toBe("");
+    expect(captured.err).toContain('No endpoints matching "zzzzz"');
   });
 
   test("uses platform catalog when --platform set", async () => {
@@ -111,6 +108,6 @@ describe("apiLs", () => {
     await Bun.write(join(tempDir, "plapi-catalog.json"), JSON.stringify(cached));
 
     await apiLs(undefined, { platform: true });
-    expect(logSpy).toHaveBeenCalled();
+    expect(captured.out).not.toBe("");
   });
 });

--- a/packages/cli-core/src/commands/api/ls.test.ts
+++ b/packages/cli-core/src/commands/api/ls.test.ts
@@ -74,8 +74,12 @@ describe("apiLs", () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
+  function runApiLs(filter: string | undefined, options: Parameters<typeof apiLs>[1]) {
+    return captured.run(() => apiLs(filter, options));
+  }
+
   test("prints all endpoints in table format", async () => {
-    await apiLs(undefined, {});
+    await runApiLs(undefined, {});
 
     // Check that output contains method, path, and summary
     expect(captured.out).toContain("GET");
@@ -87,7 +91,7 @@ describe("apiLs", () => {
   });
 
   test("filters endpoints by keyword", async () => {
-    await apiLs("organizations", {});
+    await runApiLs("organizations", {});
 
     expect(captured.out).toContain("/organizations");
 
@@ -95,7 +99,7 @@ describe("apiLs", () => {
   });
 
   test("shows message when no matches", async () => {
-    await apiLs("zzzzz", {});
+    await runApiLs("zzzzz", {});
 
     expect(captured.out).toBe("");
     expect(captured.err).toContain('No endpoints matching "zzzzz"');
@@ -107,7 +111,7 @@ describe("apiLs", () => {
     cached.fetchedAt = Date.now();
     await Bun.write(join(tempDir, "plapi-catalog.json"), JSON.stringify(cached));
 
-    await apiLs(undefined, { platform: true });
+    await runApiLs(undefined, { platform: true });
     expect(captured.out).not.toBe("");
   });
 });

--- a/packages/cli-core/src/commands/api/ls.ts
+++ b/packages/cli-core/src/commands/api/ls.ts
@@ -3,6 +3,7 @@
  */
 
 import { loadCatalog, filterEndpoints, type EndpointInfo } from "./catalog.ts";
+import { log } from "../../lib/log.ts";
 
 export async function apiLs(
   filter: string | undefined,
@@ -12,7 +13,7 @@ export async function apiLs(
   const endpoints = filterEndpoints(catalog, filter);
 
   if (endpoints.length === 0) {
-    console.error(
+    log.info(
       filter
         ? `No endpoints matching "${filter}". Try a broader search term.`
         : "No endpoints found.",
@@ -25,7 +26,7 @@ export async function apiLs(
   const label = filter
     ? `${endpoints.length} endpoint${endpoints.length === 1 ? "" : "s"} matching "${filter}"`
     : `${endpoints.length} endpoint${endpoints.length === 1 ? "" : "s"}`;
-  console.error(`\n${label}`);
+  log.info(`\n${label}`);
 }
 
 function printTable(endpoints: EndpointInfo[]): void {
@@ -35,6 +36,6 @@ function printTable(endpoints: EndpointInfo[]): void {
   for (const ep of endpoints) {
     const method = ep.method.padEnd(methodWidth);
     const path = ep.path.padEnd(pathWidth);
-    console.log(`${method}${path}${ep.summary}`);
+    log.data(`${method}${path}${ep.summary}`);
   }
 }

--- a/packages/cli-core/src/commands/apps/create.test.ts
+++ b/packages/cli-core/src/commands/apps/create.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe, beforeEach, afterEach, mock, spyOn } from "bun:test";
-import { capturedOutput } from "../../test/lib/stubs.ts";
+import { captureLog } from "../../test/lib/stubs.ts";
 
 const mockCreateApplication = mock();
 const mockFetchApplication = mock();
@@ -41,6 +41,7 @@ const mockApp = {
 describe("apps create", () => {
   let logSpy: ReturnType<typeof spyOn>;
   let errorSpy: ReturnType<typeof spyOn>;
+  let captured: ReturnType<typeof captureLog>;
 
   beforeEach(() => {
     mockIsAgent.mockReturnValue(false);
@@ -51,9 +52,11 @@ describe("apps create", () => {
     mockFetchApplication.mockResolvedValue(mockApp);
     logSpy = spyOn(console, "log").mockImplementation(() => {});
     errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    captured = captureLog();
   });
 
   afterEach(() => {
+    captured.teardown();
     mockCreateApplication.mockReset();
     mockFetchApplication.mockReset();
     mockIsAgent.mockReset();
@@ -61,8 +64,12 @@ describe("apps create", () => {
     errorSpy.mockRestore();
   });
 
+  function runCreate(name: string, options?: Parameters<typeof create>[1]) {
+    return captured.run(() => create(name, options));
+  }
+
   test("calls createApplication then fetchApplication", async () => {
-    await create("My SaaS App");
+    await runCreate("My SaaS App");
 
     expect(mockCreateApplication).toHaveBeenCalledWith("My SaaS App");
     expect(mockFetchApplication).toHaveBeenCalledWith("app_abc123");
@@ -70,12 +77,11 @@ describe("apps create", () => {
 
   describe("human output", () => {
     test("shows created app name and id", async () => {
-      await create("My SaaS App");
+      await runCreate("My SaaS App");
 
-      const output = capturedOutput(logSpy);
-      expect(output).toContain("Created");
-      expect(output).toContain("My SaaS App");
-      expect(output).toContain("app_abc123");
+      expect(captured.err).toContain("Created");
+      expect(captured.err).toContain("My SaaS App");
+      expect(captured.err).toContain("app_abc123");
     });
 
     test("falls back to app id when name is absent", async () => {
@@ -87,35 +93,31 @@ describe("apps create", () => {
         ],
       });
 
-      await create("Some Name");
+      await runCreate("Some Name");
 
-      const output = capturedOutput(logSpy);
-      expect(output).toContain("app_noname");
+      expect(captured.err).toContain("app_noname");
     });
 
     test("does not show secret keys", async () => {
-      await create("My SaaS App");
+      await runCreate("My SaaS App");
 
-      const output = capturedOutput(logSpy);
-      expect(output).not.toContain("sk_test_xxx");
-      expect(output).not.toContain("sk_live_xxx");
+      expect(captured.err).not.toContain("sk_test_xxx");
+      expect(captured.err).not.toContain("sk_live_xxx");
     });
 
     test("shows next steps on stderr", async () => {
-      await create("My SaaS App");
+      await runCreate("My SaaS App");
 
-      const output = capturedOutput(errorSpy);
-      expect(output).toContain("clerk link");
-      expect(output).toContain("clerk env pull");
+      expect(captured.err).toContain("clerk link");
+      expect(captured.err).toContain("clerk env pull");
     });
   });
 
   describe("JSON output", () => {
     test("outputs JSON when --json flag is set", async () => {
-      await create("My SaaS App", { json: true });
+      await runCreate("My SaaS App", { json: true });
 
-      const output = capturedOutput(logSpy);
-      const parsed = JSON.parse(output);
+      const parsed = JSON.parse(captured.out);
       expect(parsed.application_id).toBe("app_abc123");
       expect(parsed.name).toBe("My SaaS App");
       expect(parsed.instances).toHaveLength(2);
@@ -124,28 +126,25 @@ describe("apps create", () => {
     test("outputs JSON in agent mode", async () => {
       mockIsAgent.mockReturnValue(true);
 
-      await create("My SaaS App");
+      await runCreate("My SaaS App");
 
-      const output = capturedOutput(logSpy);
-      const parsed = JSON.parse(output);
+      const parsed = JSON.parse(captured.out);
       expect(parsed.application_id).toBe("app_abc123");
     });
 
     test("does not show next steps", async () => {
       mockIsAgent.mockReturnValue(true);
 
-      await create("My SaaS App");
+      await runCreate("My SaaS App");
 
-      const output = capturedOutput(errorSpy);
-      expect(output).not.toContain("clerk link");
-      expect(output).not.toContain("clerk env pull");
+      expect(captured.err).not.toContain("clerk link");
+      expect(captured.err).not.toContain("clerk env pull");
     });
 
     test("strips secret_key from JSON", async () => {
-      await create("My SaaS App", { json: true });
+      await runCreate("My SaaS App", { json: true });
 
-      const output = capturedOutput(logSpy);
-      const parsed = JSON.parse(output);
+      const parsed = JSON.parse(captured.out);
       for (const instance of parsed.instances) {
         expect(instance).not.toHaveProperty("secret_key");
         expect(instance).toHaveProperty("publishable_key");

--- a/packages/cli-core/src/commands/apps/create.ts
+++ b/packages/cli-core/src/commands/apps/create.ts
@@ -4,6 +4,7 @@ import { dim, cyan } from "../../lib/color.ts";
 import { withSpinner } from "../../lib/spinner.ts";
 import { printNextSteps, NEXT_STEPS } from "../../lib/next-steps.ts";
 import { stripSecrets, displayName, printJson, type AppsOptions } from "./shared.ts";
+import { log } from "../../lib/log.ts";
 
 export async function create(name: string, options: AppsOptions = {}): Promise<void> {
   const app = await withSpinner("Creating application...", async () => {
@@ -13,6 +14,6 @@ export async function create(name: string, options: AppsOptions = {}): Promise<v
 
   if (printJson(stripSecrets(app), options)) return;
 
-  console.log(`Created ${cyan(displayName(app))} ${dim(app.application_id)}`);
+  log.info(`Created ${cyan(displayName(app))} ${dim(app.application_id)}`);
   printNextSteps(NEXT_STEPS.CREATE);
 }

--- a/packages/cli-core/src/commands/apps/list.test.ts
+++ b/packages/cli-core/src/commands/apps/list.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe, beforeEach, afterEach, mock, spyOn } from "bun:test";
-import { capturedOutput, captureLog } from "../../test/lib/stubs.ts";
+import { captureLog } from "../../test/lib/stubs.ts";
 
 const mockListApplications = mock();
 mock.module("../../lib/plapi.ts", () => ({
@@ -69,11 +69,15 @@ describe("apps list", () => {
     errorSpy.mockRestore();
   });
 
+  function runList(options: Parameters<typeof list>[0] = {}) {
+    return captured.run(() => list(options));
+  }
+
   describe("compact table (default)", () => {
     test("lists apps with name, id, and environments", async () => {
       mockListApplications.mockResolvedValue(mockApps);
 
-      await list();
+      await runList();
 
       expect(captured.out).toContain("My SaaS App");
       expect(captured.out).toContain("app_abc123");
@@ -92,7 +96,7 @@ describe("apps list", () => {
         },
       ]);
 
-      await list();
+      await runList();
 
       expect(captured.out).toContain("app_noname");
     });
@@ -100,7 +104,7 @@ describe("apps list", () => {
     test("does not show secret keys", async () => {
       mockListApplications.mockResolvedValue(mockApps);
 
-      await list();
+      await runList();
 
       expect(captured.out).not.toContain("sk_test_xxx");
       expect(captured.out).not.toContain("sk_live_xxx");
@@ -109,7 +113,7 @@ describe("apps list", () => {
     test("shows count summary on stderr", async () => {
       mockListApplications.mockResolvedValue(mockApps);
 
-      await list();
+      await runList();
 
       expect(captured.err).toContain("2 applications");
     });
@@ -117,7 +121,7 @@ describe("apps list", () => {
     test("shows singular count for one app", async () => {
       mockListApplications.mockResolvedValue([mockApps[0]]);
 
-      await list();
+      await runList();
 
       expect(captured.err).toContain("1 application");
       expect(captured.err).not.toContain("1 applications");
@@ -128,7 +132,7 @@ describe("apps list", () => {
     test("outputs JSON when --json flag is set", async () => {
       mockListApplications.mockResolvedValue(mockApps);
 
-      await list({ json: true });
+      await runList({ json: true });
 
       const parsed = JSON.parse(captured.out);
       expect(parsed).toHaveLength(2);
@@ -140,7 +144,7 @@ describe("apps list", () => {
       mockIsAgent.mockReturnValue(true);
       mockListApplications.mockResolvedValue(mockApps);
 
-      await list();
+      await runList();
 
       const parsed = JSON.parse(captured.out);
       expect(parsed).toHaveLength(2);
@@ -149,7 +153,7 @@ describe("apps list", () => {
     test("strips secret_key from JSON", async () => {
       mockListApplications.mockResolvedValue(mockApps);
 
-      await list({ json: true });
+      await runList({ json: true });
 
       expect(captured.out).not.toContain("sk_test_xxx");
       expect(captured.out).not.toContain("sk_live_xxx");
@@ -161,7 +165,7 @@ describe("apps list", () => {
     test("shows helpful message when no apps found", async () => {
       mockListApplications.mockResolvedValue([]);
 
-      await list();
+      await runList();
 
       expect(captured.out).toContain("No applications found");
       expect(captured.out).toContain("dashboard.clerk.com");
@@ -170,7 +174,7 @@ describe("apps list", () => {
     test("outputs empty JSON array when --json flag is set", async () => {
       mockListApplications.mockResolvedValue([]);
 
-      await list({ json: true });
+      await runList({ json: true });
 
       const parsed = JSON.parse(captured.out);
       expect(parsed).toEqual([]);
@@ -180,7 +184,7 @@ describe("apps list", () => {
       mockIsAgent.mockReturnValue(true);
       mockListApplications.mockResolvedValue([]);
 
-      await list();
+      await runList();
 
       const parsed = JSON.parse(captured.out);
       expect(parsed).toEqual([]);

--- a/packages/cli-core/src/commands/apps/list.test.ts
+++ b/packages/cli-core/src/commands/apps/list.test.ts
@@ -167,8 +167,8 @@ describe("apps list", () => {
 
       await runList();
 
-      expect(captured.out).toContain("No applications found");
-      expect(captured.out).toContain("dashboard.clerk.com");
+      expect(captured.err).toContain("No applications found");
+      expect(captured.err).toContain("dashboard.clerk.com");
     });
 
     test("outputs empty JSON array when --json flag is set", async () => {

--- a/packages/cli-core/src/commands/apps/list.test.ts
+++ b/packages/cli-core/src/commands/apps/list.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe, beforeEach, afterEach, mock, spyOn } from "bun:test";
-import { capturedOutput } from "../../test/lib/stubs.ts";
+import { capturedOutput, captureLog } from "../../test/lib/stubs.ts";
 
 const mockListApplications = mock();
 mock.module("../../lib/plapi.ts", () => ({
@@ -52,14 +52,17 @@ const mockApps = [
 describe("apps list", () => {
   let logSpy: ReturnType<typeof spyOn>;
   let errorSpy: ReturnType<typeof spyOn>;
+  let captured: ReturnType<typeof captureLog>;
 
   beforeEach(() => {
     mockIsAgent.mockReturnValue(false);
     logSpy = spyOn(console, "log").mockImplementation(() => {});
     errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    captured = captureLog();
   });
 
   afterEach(() => {
+    captured.teardown();
     mockListApplications.mockReset();
     mockIsAgent.mockReset();
     logSpy.mockRestore();
@@ -72,12 +75,11 @@ describe("apps list", () => {
 
       await list();
 
-      const output = capturedOutput(logSpy);
-      expect(output).toContain("My SaaS App");
-      expect(output).toContain("app_abc123");
-      expect(output).toContain("development, production");
-      expect(output).toContain("Side Project");
-      expect(output).toContain("app_xyz789");
+      expect(captured.out).toContain("My SaaS App");
+      expect(captured.out).toContain("app_abc123");
+      expect(captured.out).toContain("development, production");
+      expect(captured.out).toContain("Side Project");
+      expect(captured.out).toContain("app_xyz789");
     });
 
     test("shows app id as name when name is absent", async () => {
@@ -92,8 +94,7 @@ describe("apps list", () => {
 
       await list();
 
-      const output = capturedOutput(logSpy);
-      expect(output).toContain("app_noname");
+      expect(captured.out).toContain("app_noname");
     });
 
     test("does not show secret keys", async () => {
@@ -101,9 +102,8 @@ describe("apps list", () => {
 
       await list();
 
-      const output = capturedOutput(logSpy);
-      expect(output).not.toContain("sk_test_xxx");
-      expect(output).not.toContain("sk_live_xxx");
+      expect(captured.out).not.toContain("sk_test_xxx");
+      expect(captured.out).not.toContain("sk_live_xxx");
     });
 
     test("shows count summary on stderr", async () => {
@@ -111,8 +111,7 @@ describe("apps list", () => {
 
       await list();
 
-      const summary = capturedOutput(errorSpy);
-      expect(summary).toContain("2 applications");
+      expect(captured.err).toContain("2 applications");
     });
 
     test("shows singular count for one app", async () => {
@@ -120,9 +119,8 @@ describe("apps list", () => {
 
       await list();
 
-      const summary = capturedOutput(errorSpy);
-      expect(summary).toContain("1 application");
-      expect(summary).not.toContain("1 applications");
+      expect(captured.err).toContain("1 application");
+      expect(captured.err).not.toContain("1 applications");
     });
   });
 
@@ -132,8 +130,7 @@ describe("apps list", () => {
 
       await list({ json: true });
 
-      const output = capturedOutput(logSpy);
-      const parsed = JSON.parse(output);
+      const parsed = JSON.parse(captured.out);
       expect(parsed).toHaveLength(2);
       expect(parsed[0].application_id).toBe("app_abc123");
       expect(parsed[0].name).toBe("My SaaS App");
@@ -145,8 +142,7 @@ describe("apps list", () => {
 
       await list();
 
-      const output = capturedOutput(logSpy);
-      const parsed = JSON.parse(output);
+      const parsed = JSON.parse(captured.out);
       expect(parsed).toHaveLength(2);
     });
 
@@ -155,10 +151,9 @@ describe("apps list", () => {
 
       await list({ json: true });
 
-      const output = capturedOutput(logSpy);
-      expect(output).not.toContain("sk_test_xxx");
-      expect(output).not.toContain("sk_live_xxx");
-      expect(output).not.toContain("secret_key");
+      expect(captured.out).not.toContain("sk_test_xxx");
+      expect(captured.out).not.toContain("sk_live_xxx");
+      expect(captured.out).not.toContain("secret_key");
     });
   });
 
@@ -168,9 +163,8 @@ describe("apps list", () => {
 
       await list();
 
-      const output = capturedOutput(logSpy);
-      expect(output).toContain("No applications found");
-      expect(output).toContain("dashboard.clerk.com");
+      expect(captured.out).toContain("No applications found");
+      expect(captured.out).toContain("dashboard.clerk.com");
     });
 
     test("outputs empty JSON array when --json flag is set", async () => {
@@ -178,8 +172,7 @@ describe("apps list", () => {
 
       await list({ json: true });
 
-      const output = capturedOutput(logSpy);
-      const parsed = JSON.parse(output);
+      const parsed = JSON.parse(captured.out);
       expect(parsed).toEqual([]);
     });
 
@@ -189,8 +182,7 @@ describe("apps list", () => {
 
       await list();
 
-      const output = capturedOutput(logSpy);
-      const parsed = JSON.parse(output);
+      const parsed = JSON.parse(captured.out);
       expect(parsed).toEqual([]);
     });
   });

--- a/packages/cli-core/src/commands/apps/list.ts
+++ b/packages/cli-core/src/commands/apps/list.ts
@@ -32,7 +32,7 @@ export async function list(options: AppsOptions = {}): Promise<void> {
   if (printJson(result.map(stripSecrets), options)) return;
 
   if (result.length === 0) {
-    log.data("No applications found. Create one at https://dashboard.clerk.com");
+    log.warn("No applications found. Create one at https://dashboard.clerk.com");
     return;
   }
 

--- a/packages/cli-core/src/commands/apps/list.ts
+++ b/packages/cli-core/src/commands/apps/list.ts
@@ -3,6 +3,7 @@ import { withApiContext } from "../../lib/errors.ts";
 import { dim, cyan } from "../../lib/color.ts";
 import { withSpinner } from "../../lib/spinner.ts";
 import { stripSecrets, displayName, printJson, type AppsOptions } from "./shared.ts";
+import { log } from "../../lib/log.ts";
 
 const COLUMN_PADDING = 2;
 
@@ -13,13 +14,13 @@ function formatAppsTable(apps: Application[]): void {
     Math.max("APP ID".length, ...apps.map((a) => a.application_id.length)) + COLUMN_PADDING;
 
   const header = `${"NAME".padEnd(nameWidth)}${"APP ID".padEnd(idWidth)}ENVIRONMENTS`;
-  console.log(dim(header));
+  log.data(dim(header));
 
   for (const app of apps) {
     const name = displayName(app).padEnd(nameWidth);
     const id = dim(app.application_id.padEnd(idWidth));
     const envs = app.instances.map((i) => i.environment_type).join(", ");
-    console.log(`${cyan(name)}${id}${envs}`);
+    log.data(`${cyan(name)}${id}${envs}`);
   }
 }
 
@@ -31,12 +32,12 @@ export async function list(options: AppsOptions = {}): Promise<void> {
   if (printJson(result.map(stripSecrets), options)) return;
 
   if (result.length === 0) {
-    console.log("No applications found. Create one at https://dashboard.clerk.com");
+    log.data("No applications found. Create one at https://dashboard.clerk.com");
     return;
   }
 
   formatAppsTable(result);
 
   const count = result.length;
-  console.error(`\n${count} application${count === 1 ? "" : "s"}`);
+  log.info(`\n${count} application${count === 1 ? "" : "s"}`);
 }

--- a/packages/cli-core/src/commands/apps/shared.ts
+++ b/packages/cli-core/src/commands/apps/shared.ts
@@ -1,5 +1,6 @@
 import type { Application } from "../../lib/plapi.ts";
 import { isAgent } from "../../mode.ts";
+import { log } from "../../lib/log.ts";
 
 export type AppsOptions = {
   json?: boolean;
@@ -16,6 +17,6 @@ export const displayName = (app: Application) => app.name ?? app.application_id;
 
 export function printJson(data: unknown, options: AppsOptions = {}): boolean {
   if (!options.json && !isAgent()) return false;
-  console.log(JSON.stringify(data, null, 2));
+  log.data(JSON.stringify(data, null, 2));
   return true;
 }

--- a/packages/cli-core/src/commands/auth/login.test.ts
+++ b/packages/cli-core/src/commands/auth/login.test.ts
@@ -97,6 +97,10 @@ describe("login", () => {
     }
   });
 
+  function runLogin(options?: Parameters<typeof login>[0]) {
+    return captured.run(() => login(options));
+  }
+
   function mockBunSpawn() {
     try {
       (Bun as any).spawn = mock(() => ({ exited: Promise.resolve(0) }));
@@ -114,7 +118,7 @@ describe("login", () => {
     });
 
     consoleSpy = spyOn(console, "log").mockImplementation(() => {});
-    const result = await login();
+    const result = await runLogin();
 
     expect(result).toEqual({ userId: "user_123", email: "existing@example.com" });
     expect(captured.out).toContain("Logged in as existing@example.com");
@@ -145,7 +149,7 @@ describe("login", () => {
     mockSetAuth.mockResolvedValue(undefined);
 
     consoleSpy = spyOn(console, "log").mockImplementation(() => {});
-    const result = await login();
+    const result = await runLogin();
 
     expect(result).toEqual({ userId: "user_new", email: "new@example.com" });
     expect(mockStartAuthServer).toHaveBeenCalledWith("test-state-value");
@@ -183,7 +187,7 @@ describe("login", () => {
     mockSetAuth.mockResolvedValue(undefined);
 
     consoleSpy = spyOn(console, "log").mockImplementation(() => {});
-    const result = await login();
+    const result = await runLogin();
 
     expect(result).toEqual({ userId: "user_refreshed", email: "refreshed@example.com" });
     expect(mockStartAuthServer).toHaveBeenCalled();
@@ -205,7 +209,7 @@ describe("login", () => {
 
     consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-    await expect(login()).rejects.toThrow("Authentication timed out");
+    await expect(runLogin()).rejects.toThrow("Authentication timed out");
     expect(mockServer.stop).toHaveBeenCalled();
   });
 
@@ -234,7 +238,7 @@ describe("login", () => {
     mockSetAuth.mockResolvedValue(undefined);
 
     consoleSpy = spyOn(console, "log").mockImplementation(() => {});
-    const result = await login();
+    const result = await runLogin();
 
     expect(result).toEqual({ userId: "user_brand_new", email: "brandnew@example.com" });
     expect(mockStartAuthServer).toHaveBeenCalled();
@@ -250,7 +254,7 @@ describe("login", () => {
     });
 
     consoleSpy = spyOn(console, "log").mockImplementation(() => {});
-    const result = await login();
+    const result = await runLogin();
 
     expect(result).toEqual({ userId: "user_123", email: "agent@example.com" });
     expect(captured.out).toContain("Logged in as agent@example.com");
@@ -284,7 +288,7 @@ describe("login", () => {
     mockSetAuth.mockResolvedValue(undefined);
 
     consoleSpy = spyOn(console, "log").mockImplementation(() => {});
-    const result = await login();
+    const result = await runLogin();
 
     expect(mockConfirm).toHaveBeenCalledWith({
       message: "You're already logged in as old@example.com. Re-authenticate?",
@@ -306,7 +310,7 @@ describe("login", () => {
 
     consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-    await expect(login()).rejects.toThrow("User aborted");
+    await expect(runLogin()).rejects.toThrow("User aborted");
     expect(mockConfirm).toHaveBeenCalled();
     expect(mockStartAuthServer).not.toHaveBeenCalled();
   });
@@ -337,7 +341,7 @@ describe("login", () => {
     consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
 
-    await login({ showNextSteps: false });
+    await runLogin({ showNextSteps: false });
 
     expect(captured.err).not.toContain("Next steps:");
   });

--- a/packages/cli-core/src/commands/auth/login.test.ts
+++ b/packages/cli-core/src/commands/auth/login.test.ts
@@ -121,7 +121,7 @@ describe("login", () => {
     const result = await runLogin();
 
     expect(result).toEqual({ userId: "user_123", email: "existing@example.com" });
-    expect(captured.out).toContain("Logged in as existing@example.com");
+    expect(captured.err).toContain("Logged in as existing@example.com");
     expect(mockStartAuthServer).not.toHaveBeenCalled();
   });
 
@@ -160,7 +160,7 @@ describe("login", () => {
     });
     expect(mockStoreToken).toHaveBeenCalledWith("new-access-token");
     expect(mockSetAuth).toHaveBeenCalledWith({ userId: "user_new" });
-    expect(captured.out).toContain("Logged in as new@example.com");
+    expect(captured.err).toContain("Logged in as new@example.com");
   });
 
   test("re-authenticates when existing token is expired", async () => {
@@ -257,7 +257,7 @@ describe("login", () => {
     const result = await runLogin();
 
     expect(result).toEqual({ userId: "user_123", email: "agent@example.com" });
-    expect(captured.out).toContain("Logged in as agent@example.com");
+    expect(captured.err).toContain("Logged in as agent@example.com");
     expect(mockConfirm).not.toHaveBeenCalled();
     expect(mockStartAuthServer).not.toHaveBeenCalled();
   });

--- a/packages/cli-core/src/commands/auth/login.test.ts
+++ b/packages/cli-core/src/commands/auth/login.test.ts
@@ -1,5 +1,5 @@
-import { test, expect, describe, afterEach, mock, spyOn } from "bun:test";
-import { credentialStoreStubs, configStubs } from "../../test/lib/stubs.ts";
+import { test, expect, describe, beforeEach, afterEach, mock, spyOn } from "bun:test";
+import { captureLog, credentialStoreStubs, configStubs } from "../../test/lib/stubs.ts";
 
 const mockGetToken = mock();
 const mockStoreToken = mock();
@@ -69,9 +69,15 @@ const { login } = await import("./login.ts");
 describe("login", () => {
   let consoleSpy: ReturnType<typeof spyOn>;
   let consoleErrorSpy: ReturnType<typeof spyOn>;
+  let captured: ReturnType<typeof captureLog>;
   const origSpawn = Bun.spawn;
 
+  beforeEach(() => {
+    captured = captureLog();
+  });
+
   afterEach(() => {
+    captured.teardown();
     mockGetToken.mockReset();
     mockStoreToken.mockReset();
     mockGetAuth.mockReset();
@@ -111,7 +117,7 @@ describe("login", () => {
     const result = await login();
 
     expect(result).toEqual({ userId: "user_123", email: "existing@example.com" });
-    expect(consoleSpy).toHaveBeenCalledWith("Logged in as existing@example.com");
+    expect(captured.out).toContain("Logged in as existing@example.com");
     expect(mockStartAuthServer).not.toHaveBeenCalled();
   });
 
@@ -150,7 +156,7 @@ describe("login", () => {
     });
     expect(mockStoreToken).toHaveBeenCalledWith("new-access-token");
     expect(mockSetAuth).toHaveBeenCalledWith({ userId: "user_new" });
-    expect(consoleSpy).toHaveBeenCalledWith("Logged in as new@example.com");
+    expect(captured.out).toContain("Logged in as new@example.com");
   });
 
   test("re-authenticates when existing token is expired", async () => {
@@ -247,7 +253,7 @@ describe("login", () => {
     const result = await login();
 
     expect(result).toEqual({ userId: "user_123", email: "agent@example.com" });
-    expect(consoleSpy).toHaveBeenCalledWith("Logged in as agent@example.com");
+    expect(captured.out).toContain("Logged in as agent@example.com");
     expect(mockConfirm).not.toHaveBeenCalled();
     expect(mockStartAuthServer).not.toHaveBeenCalled();
   });
@@ -333,10 +339,6 @@ describe("login", () => {
 
     await login({ showNextSteps: false });
 
-    expect(
-      consoleErrorSpy.mock.calls.some(
-        (c) => typeof c[0] === "string" && (c[0] as string).includes("Next steps:"),
-      ),
-    ).toBe(false);
+    expect(captured.err).not.toContain("Next steps:");
   });
 });

--- a/packages/cli-core/src/commands/auth/login.ts
+++ b/packages/cli-core/src/commands/auth/login.ts
@@ -93,7 +93,7 @@ export async function login(options: LoginOptions = {}): Promise<UserInfo> {
   const existingSession = await withSpinner("Checking session...", () => getExistingSession());
 
   if (existingSession && !isHuman()) {
-    log.info(`Logged in as ${existingSession.email}`);
+    log.success(`Logged in as ${existingSession.email}`);
     return existingSession;
   }
 
@@ -111,7 +111,7 @@ export async function login(options: LoginOptions = {}): Promise<UserInfo> {
   const userInfo = await performOAuthFlow();
 
   bar();
-  log.info(`Logged in as ${userInfo.email}`);
+  log.success(`Logged in as ${userInfo.email}`);
 
   outro(showNextSteps ? NEXT_STEPS.LOGIN : "Done");
   return userInfo;

--- a/packages/cli-core/src/commands/auth/login.ts
+++ b/packages/cli-core/src/commands/auth/login.ts
@@ -12,6 +12,7 @@ import { intro, outro, bar, withSpinner } from "../../lib/spinner.ts";
 import { NEXT_STEPS } from "../../lib/next-steps.ts";
 import { openBrowser } from "../../lib/open.ts";
 import { cyan, dim } from "../../lib/color.ts";
+import { log } from "../../lib/log.ts";
 
 interface LoginOptions {
   showNextSteps?: boolean;
@@ -55,13 +56,13 @@ async function performOAuthFlow(): Promise<UserInfo> {
   const urlString = authorizeUrl.toString();
   const result = await openBrowser(urlString);
   if (!result.ok) {
-    console.log(
+    log.warn(
       `\nCould not open your browser automatically. Open this URL to continue:\n  ${cyan(urlString)}\n${dim("(Reason: " + result.reason + ")")}\n`,
     );
   }
 
   const timeoutMinutes = Math.round(AUTH_TIMEOUT_MS / 60_000);
-  console.log(`Waiting for authentication (timeout in ${timeoutMinutes}m)...`);
+  log.data(`Waiting for authentication (timeout in ${timeoutMinutes}m)...`);
 
   const { code } = await withSpinner("Waiting for authentication...", () =>
     authServer.waitForCallback().catch((error: unknown) => {
@@ -92,7 +93,7 @@ export async function login(options: LoginOptions = {}): Promise<UserInfo> {
   const existingSession = await withSpinner("Checking session...", () => getExistingSession());
 
   if (existingSession && !isHuman()) {
-    console.log(`Logged in as ${existingSession.email}`);
+    log.data(`Logged in as ${existingSession.email}`);
     return existingSession;
   }
 
@@ -110,7 +111,7 @@ export async function login(options: LoginOptions = {}): Promise<UserInfo> {
   const userInfo = await performOAuthFlow();
 
   bar();
-  console.log(`Logged in as ${userInfo.email}`);
+  log.data(`Logged in as ${userInfo.email}`);
 
   outro(showNextSteps ? NEXT_STEPS.LOGIN : "Done");
   return userInfo;

--- a/packages/cli-core/src/commands/auth/login.ts
+++ b/packages/cli-core/src/commands/auth/login.ts
@@ -62,7 +62,7 @@ async function performOAuthFlow(): Promise<UserInfo> {
   }
 
   const timeoutMinutes = Math.round(AUTH_TIMEOUT_MS / 60_000);
-  log.data(`Waiting for authentication (timeout in ${timeoutMinutes}m)...`);
+  log.info(`Waiting for authentication (timeout in ${timeoutMinutes}m)...`);
 
   const { code } = await withSpinner("Waiting for authentication...", () =>
     authServer.waitForCallback().catch((error: unknown) => {
@@ -93,7 +93,7 @@ export async function login(options: LoginOptions = {}): Promise<UserInfo> {
   const existingSession = await withSpinner("Checking session...", () => getExistingSession());
 
   if (existingSession && !isHuman()) {
-    log.data(`Logged in as ${existingSession.email}`);
+    log.info(`Logged in as ${existingSession.email}`);
     return existingSession;
   }
 
@@ -111,7 +111,7 @@ export async function login(options: LoginOptions = {}): Promise<UserInfo> {
   const userInfo = await performOAuthFlow();
 
   bar();
-  log.data(`Logged in as ${userInfo.email}`);
+  log.info(`Logged in as ${userInfo.email}`);
 
   outro(showNextSteps ? NEXT_STEPS.LOGIN : "Done");
   return userInfo;

--- a/packages/cli-core/src/commands/auth/logout.test.ts
+++ b/packages/cli-core/src/commands/auth/logout.test.ts
@@ -31,12 +31,16 @@ describe("logout", () => {
     consoleSpy?.mockRestore();
   });
 
+  function runLogout() {
+    return captured.run(() => logout());
+  }
+
   test("deletes token and clears auth config", async () => {
     mockDeleteToken.mockResolvedValue(undefined);
     mockClearAuth.mockResolvedValue(undefined);
 
     consoleSpy = spyOn(console, "log").mockImplementation(() => {});
-    await logout();
+    await runLogout();
 
     expect(mockDeleteToken).toHaveBeenCalledTimes(1);
     expect(mockClearAuth).toHaveBeenCalledTimes(1);
@@ -47,7 +51,7 @@ describe("logout", () => {
     mockClearAuth.mockResolvedValue(undefined);
 
     consoleSpy = spyOn(console, "log").mockImplementation(() => {});
-    await logout();
+    await runLogout();
 
     expect(captured.out).toContain("Logged out successfully");
   });

--- a/packages/cli-core/src/commands/auth/logout.test.ts
+++ b/packages/cli-core/src/commands/auth/logout.test.ts
@@ -53,6 +53,6 @@ describe("logout", () => {
     consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     await runLogout();
 
-    expect(captured.out).toContain("Logged out successfully");
+    expect(captured.err).toContain("Logged out successfully");
   });
 });

--- a/packages/cli-core/src/commands/auth/logout.test.ts
+++ b/packages/cli-core/src/commands/auth/logout.test.ts
@@ -1,5 +1,5 @@
-import { test, expect, describe, afterEach, mock, spyOn } from "bun:test";
-import { credentialStoreStubs, configStubs } from "../../test/lib/stubs.ts";
+import { test, expect, describe, beforeEach, afterEach, mock, spyOn } from "bun:test";
+import { captureLog, credentialStoreStubs, configStubs } from "../../test/lib/stubs.ts";
 
 const mockDeleteToken = mock();
 const mockClearAuth = mock();
@@ -18,8 +18,14 @@ const { logout } = await import("./logout.ts");
 
 describe("logout", () => {
   let consoleSpy: ReturnType<typeof spyOn>;
+  let captured: ReturnType<typeof captureLog>;
+
+  beforeEach(() => {
+    captured = captureLog();
+  });
 
   afterEach(() => {
+    captured.teardown();
     mockDeleteToken.mockReset();
     mockClearAuth.mockReset();
     consoleSpy?.mockRestore();
@@ -43,6 +49,6 @@ describe("logout", () => {
     consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     await logout();
 
-    expect(consoleSpy).toHaveBeenCalledWith("Logged out successfully");
+    expect(captured.out).toContain("Logged out successfully");
   });
 });

--- a/packages/cli-core/src/commands/auth/logout.ts
+++ b/packages/cli-core/src/commands/auth/logout.ts
@@ -5,5 +5,5 @@ import { log } from "../../lib/log.ts";
 export async function logout(): Promise<void> {
   await deleteToken();
   await clearAuth();
-  log.data("Logged out successfully");
+  log.success("Logged out successfully");
 }

--- a/packages/cli-core/src/commands/auth/logout.ts
+++ b/packages/cli-core/src/commands/auth/logout.ts
@@ -1,8 +1,9 @@
 import { deleteToken } from "../../lib/credential-store.ts";
 import { clearAuth } from "../../lib/config.ts";
+import { log } from "../../lib/log.ts";
 
 export async function logout(): Promise<void> {
   await deleteToken();
   await clearAuth();
-  console.log("Logged out successfully");
+  log.data("Logged out successfully");
 }

--- a/packages/cli-core/src/commands/config/pull.test.ts
+++ b/packages/cli-core/src/commands/config/pull.test.ts
@@ -61,7 +61,7 @@ describe("config pull", () => {
     options: { app?: string; instance?: string; output?: string; keys?: string[] } = {},
   ) {
     const { configPull } = await import("./pull.ts");
-    return configPull(options);
+    return captured.run(() => configPull(options));
   }
 
   test("errors when no profile is linked", async () => {

--- a/packages/cli-core/src/commands/config/pull.test.ts
+++ b/packages/cli-core/src/commands/config/pull.test.ts
@@ -3,15 +3,15 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { _setConfigDir, setProfile } from "../../lib/config.ts";
-import { credentialStoreStubs, gitStubs, stubFetch } from "../../test/lib/stubs.ts";
+import { captureLog, credentialStoreStubs, gitStubs, stubFetch } from "../../test/lib/stubs.ts";
 
 mock.module("../../lib/credential-store.ts", () => credentialStoreStubs);
 mock.module("../../lib/git.ts", () => gitStubs);
 mock.module("../../lib/spinner.ts", () => ({
   withSpinner: async (msg: string, fn: () => Promise<unknown>) => {
-    console.error(msg);
-    const result = await fn();
-    return result;
+    const { log } = await import("../../lib/log.ts");
+    log.info(msg);
+    return fn();
   },
 }));
 
@@ -22,6 +22,7 @@ describe("config pull", () => {
   let logSpy: ReturnType<typeof spyOn>;
   let errorSpy: ReturnType<typeof spyOn>;
   let exitSpy: ReturnType<typeof spyOn>;
+  let captured: ReturnType<typeof captureLog>;
 
   const mockConfig = {
     session: { lifetime: 604800 },
@@ -39,11 +40,13 @@ describe("config pull", () => {
     exitSpy = spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit");
     });
+    captured = captureLog();
 
     stubFetch(async () => new Response(JSON.stringify(mockConfig), { status: 200 }));
   });
 
   afterEach(async () => {
+    captured.teardown();
     _setConfigDir(undefined);
     process.env = { ...originalEnv };
     globalThis.fetch = originalFetch;
@@ -84,7 +87,7 @@ describe("config pull", () => {
     });
 
     await runConfigPull();
-    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(mockConfig, null, 2));
+    expect(captured.out).toContain(JSON.stringify(mockConfig, null, 2));
   });
 
   test("supports --app without a linked profile", async () => {
@@ -105,7 +108,7 @@ describe("config pull", () => {
     });
 
     await runConfigPull({ app: "app_1" });
-    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(mockConfig, null, 2));
+    expect(captured.out).toContain(JSON.stringify(mockConfig, null, 2));
   });
 
   test("writes config to file with --output", async () => {
@@ -119,7 +122,7 @@ describe("config pull", () => {
     await runConfigPull({ output: outFile });
     const written = await Bun.file(outFile).json();
     expect(written).toEqual(mockConfig);
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("Config written to"));
+    expect(captured.err).toContain("Config written to");
   });
 
   test("shows which environment is being pulled", async () => {
@@ -130,9 +133,7 @@ describe("config pull", () => {
     });
 
     await runConfigPull();
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Pulling config from app_1 (development)"),
-    );
+    expect(captured.err).toContain("Pulling config from app_1 (development)");
   });
 
   test("shows app name when stored in profile", async () => {
@@ -144,9 +145,7 @@ describe("config pull", () => {
     });
 
     await runConfigPull();
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Pulling config from My SaaS App (development)"),
-    );
+    expect(captured.err).toContain("Pulling config from My SaaS App (development)");
   });
 
   test("shows production label when --instance prod", async () => {
@@ -157,9 +156,7 @@ describe("config pull", () => {
     });
 
     await runConfigPull({ instance: "prod" });
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Pulling config from app_1 (production)"),
-    );
+    expect(captured.err).toContain("Pulling config from app_1 (production)");
   });
 
   test("uses development instance by default", async () => {
@@ -240,7 +237,7 @@ describe("config pull", () => {
 
     await runConfigPull({ keys: ["session"] });
     expect(requestedUrl).toContain("keys=session");
-    expect(logSpy).toHaveBeenCalledWith(JSON.stringify({ session: { lifetime: 604800 } }, null, 2));
+    expect(captured.out).toContain(JSON.stringify({ session: { lifetime: 604800 } }, null, 2));
   });
 
   test("--keys passes multiple keys as repeated query params", async () => {

--- a/packages/cli-core/src/commands/config/pull.ts
+++ b/packages/cli-core/src/commands/config/pull.ts
@@ -2,6 +2,7 @@ import { resolveAppContext } from "../../lib/config.ts";
 import { fetchInstanceConfig } from "../../lib/plapi.ts";
 import { withApiContext } from "../../lib/errors.ts";
 import { withSpinner } from "../../lib/spinner.ts";
+import { log } from "../../lib/log.ts";
 
 interface ConfigPullOptions {
   app?: string;
@@ -26,8 +27,8 @@ export async function configPull(options: ConfigPullOptions): Promise<void> {
 
   if (options.output) {
     await Bun.write(options.output, json + "\n");
-    console.error(`Config written to ${options.output}`);
+    log.info(`Config written to ${options.output}`);
   } else {
-    console.log(json);
+    log.data(json);
   }
 }

--- a/packages/cli-core/src/commands/config/pull.ts
+++ b/packages/cli-core/src/commands/config/pull.ts
@@ -27,7 +27,7 @@ export async function configPull(options: ConfigPullOptions): Promise<void> {
 
   if (options.output) {
     await Bun.write(options.output, json + "\n");
-    log.info(`Config written to ${options.output}`);
+    log.success(`Config written to ${options.output}`);
   } else {
     log.data(json);
   }

--- a/packages/cli-core/src/commands/config/push.test.ts
+++ b/packages/cli-core/src/commands/config/push.test.ts
@@ -83,7 +83,7 @@ describe("config push", () => {
     } = {},
   ) {
     const { configPatch } = await import("./push.ts");
-    return configPatch(options);
+    return captured.run(() => configPatch(options));
   }
 
   async function runConfigPut(
@@ -98,7 +98,7 @@ describe("config push", () => {
     } = {},
   ) {
     const { configPut } = await import("./push.ts");
-    return configPut(options);
+    return captured.run(() => configPut(options));
   }
 
   // --- Shared error cases ---
@@ -616,10 +616,11 @@ describe("config push", () => {
 
 describe("printDiff", () => {
   let captured: ReturnType<typeof captureLog>;
+  const ANSI_ESCAPE_PATTERN = new RegExp(String.raw`\u001b\[[0-9;]*m`, "g");
 
   /** Return captured stderr lines with ANSI codes stripped. */
   function lines(): string[] {
-    return captured.stderr.map((l) => l.replace(/\x1b\[[0-9;]*m/g, ""));
+    return captured.stderr.map((l) => l.replace(ANSI_ESCAPE_PATTERN, ""));
   }
 
   beforeEach(() => {
@@ -634,7 +635,7 @@ describe("printDiff", () => {
     const current = { session: { lifetime: 604800, cookie: "__session" } };
     const patch = { session: { lifetime: 3600 } };
 
-    printDiff(current, patch, true);
+    captured.run(() => printDiff(current, patch, true));
 
     expect(lines()).toEqual(["  session:", "    lifetime:", "      - 604800", "      + 3600"]);
   });
@@ -643,7 +644,7 @@ describe("printDiff", () => {
     const current = { session: { lifetime: 3600 }, sign_up: { mode: "public" } };
     const patch = { session: { lifetime: 3600 } };
 
-    printDiff(current, patch, true);
+    captured.run(() => printDiff(current, patch, true));
 
     expect(lines()).toEqual([]);
   });
@@ -652,7 +653,7 @@ describe("printDiff", () => {
     const current = {};
     const patch = { session: { lifetime: 3600 } };
 
-    printDiff(current, patch, true);
+    captured.run(() => printDiff(current, patch, true));
 
     expect(lines()).toEqual(["  session:", '    + {"lifetime":3600}']);
   });
@@ -661,7 +662,7 @@ describe("printDiff", () => {
     const current = { session: { lifetime: 604800 }, sign_up: { mode: "public" } };
     const patch = { session: { lifetime: 3600 } };
 
-    printDiff(current, patch, true);
+    captured.run(() => printDiff(current, patch, true));
 
     // sign_up should not appear
     expect(lines().some((l) => l.includes("sign_up"))).toBe(false);
@@ -671,7 +672,7 @@ describe("printDiff", () => {
     const current = { session: { lifetime: 604800 }, sign_up: { mode: "public" } };
     const payload = { session: { lifetime: 604800 } };
 
-    printDiff(current, payload, false);
+    captured.run(() => printDiff(current, payload, false));
 
     // session is unchanged, sign_up is being removed
     expect(lines().some((l) => l.includes("sign_up"))).toBe(true);
@@ -682,7 +683,7 @@ describe("printDiff", () => {
     const current = { session: { lifetime: 604800 } };
     const payload = { session: { lifetime: 3600 } };
 
-    printDiff(current, payload, false);
+    captured.run(() => printDiff(current, payload, false));
 
     expect(lines()).toContainEqual(expect.stringContaining("- 604800"));
     expect(lines()).toContainEqual(expect.stringContaining("+ 3600"));
@@ -692,7 +693,7 @@ describe("printDiff", () => {
     const current = { a: { b: { c: { d: 1 } } } };
     const patch = { a: { b: { c: { d: 2 } } } };
 
-    printDiff(current, patch, true);
+    captured.run(() => printDiff(current, patch, true));
 
     expect(lines()).toEqual(["  a:", "    b.c.d:", "      - 1", "      + 2"]);
   });
@@ -701,7 +702,7 @@ describe("printDiff", () => {
     const current = { allowed: { origins: ["a.com", "b.com"] } };
     const patch = { allowed: { origins: ["a.com", "c.com"] } };
 
-    printDiff(current, patch, true);
+    captured.run(() => printDiff(current, patch, true));
 
     expect(lines()).toContainEqual(expect.stringContaining('- ["a.com","b.com"]'));
     expect(lines()).toContainEqual(expect.stringContaining('+ ["a.com","c.com"]'));

--- a/packages/cli-core/src/commands/config/push.test.ts
+++ b/packages/cli-core/src/commands/config/push.test.ts
@@ -3,18 +3,20 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { _setConfigDir, setProfile } from "../../lib/config.ts";
-import { credentialStoreStubs, gitStubs, promptsStubs, stubFetch } from "../../test/lib/stubs.ts";
+import {
+  captureLog,
+  credentialStoreStubs,
+  gitStubs,
+  promptsStubs,
+  stubFetch,
+} from "../../test/lib/stubs.ts";
 import { printDiff, hasConfigChanges } from "./push.ts";
 
 mock.module("../../lib/credential-store.ts", () => credentialStoreStubs);
 mock.module("../../lib/git.ts", () => gitStubs);
 mock.module("@inquirer/prompts", () => promptsStubs);
 mock.module("../../lib/spinner.ts", () => ({
-  withSpinner: async (msg: string, fn: () => Promise<unknown>) => {
-    console.error(msg);
-    const result = await fn();
-    return result;
-  },
+  withSpinner: async (_msg: string, fn: () => Promise<unknown>) => fn(),
 }));
 
 describe("config push", () => {
@@ -24,6 +26,7 @@ describe("config push", () => {
   let logSpy: ReturnType<typeof spyOn>;
   let errorSpy: ReturnType<typeof spyOn>;
   let exitSpy: ReturnType<typeof spyOn>;
+  let captured: ReturnType<typeof captureLog>;
 
   const mockResponse = {
     session: { lifetime: 3600 },
@@ -48,6 +51,7 @@ describe("config push", () => {
     exitSpy = spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit");
     });
+    captured = captureLog();
 
     stubFetch(async (_input, init) => {
       const isGet = !init?.method || init.method === "GET";
@@ -57,6 +61,7 @@ describe("config push", () => {
   });
 
   afterEach(async () => {
+    captured.teardown();
     _setConfigDir(undefined);
     process.env = { ...originalEnv };
     globalThis.fetch = originalFetch;
@@ -242,7 +247,7 @@ describe("config push", () => {
     });
 
     await runConfigPatch({ json: '{"session":{"lifetime":3600}}', yes: true });
-    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(mockResponse, null, 2));
+    expect(captured.out).toContain(JSON.stringify(mockResponse, null, 2));
   });
 
   test("patch shows 'Updating' label", async () => {
@@ -253,9 +258,7 @@ describe("config push", () => {
     });
 
     await runConfigPatch({ json: '{"session":{"lifetime":3600}}', yes: true });
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Updating config on app_1 (development)"),
-    );
+    expect(captured.err).toContain("Updating config on app_1 (development)");
   });
 
   // --- PUT happy paths ---
@@ -286,9 +289,7 @@ describe("config push", () => {
     });
 
     await runConfigPut({ json: '{"session":{"lifetime":3600}}', yes: true });
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Replacing config on app_1 (development)"),
-    );
+    expect(captured.err).toContain("Replacing config on app_1 (development)");
   });
 
   // --- config_version stripping ---
@@ -418,7 +419,7 @@ describe("config push", () => {
     // Send a payload that matches the current config for the patched key
     await runConfigPatch({ json: '{"session":{"lifetime":604800}}', yes: true });
     expect(mutatingCallMade).toBe(false);
-    expect(errorSpy).toHaveBeenCalledWith("No changes detected");
+    expect(captured.err).toContain("No changes detected");
   });
 
   test("put skips API call when payload matches current config", async () => {
@@ -439,7 +440,7 @@ describe("config push", () => {
       yes: true,
     });
     expect(mutatingCallMade).toBe(false);
-    expect(errorSpy).toHaveBeenCalledWith("No changes detected");
+    expect(captured.err).toContain("No changes detected");
   });
 
   test("put detects no changes when current config has config_version (pull→put roundtrip)", async () => {
@@ -459,7 +460,7 @@ describe("config push", () => {
     // Simulate pull→put: payload includes config_version from the pull output
     await runConfigPut({ json: JSON.stringify(configWithVersion), yes: true });
     expect(mutatingCallMade).toBe(false);
-    expect(errorSpy).toHaveBeenCalledWith("No changes detected");
+    expect(captured.err).toContain("No changes detected");
   });
 
   // --- Instance targeting ---
@@ -542,8 +543,8 @@ describe("config push", () => {
       dryRun: true,
     });
     expect(fetchCalled).toBe(false);
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("[dry-run]"));
-    expect(logSpy).toHaveBeenCalledWith(JSON.stringify({ session: { lifetime: 3600 } }, null, 2));
+    expect(captured.err).toContain("[dry-run]");
+    expect(captured.out).toContain(JSON.stringify({ session: { lifetime: 3600 } }, null, 2));
   });
 
   test("dry-run for put shows PUT method", async () => {
@@ -554,7 +555,7 @@ describe("config push", () => {
     });
 
     await runConfigPut({ json: '{"a":1}', dryRun: true });
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("[dry-run] Would PUT"));
+    expect(captured.err).toContain("[dry-run] Would PUT");
   });
 
   // --- API error handling ---
@@ -582,7 +583,7 @@ describe("config push", () => {
     });
 
     await runConfigPatch({ json: '{"a":1}', yes: true });
-    expect(errorSpy).toHaveBeenCalledWith("Config pushed successfully");
+    expect(captured.err).toContain("Config pushed successfully");
   });
 
   // --- --json takes priority over --file ---
@@ -614,19 +615,19 @@ describe("config push", () => {
 });
 
 describe("printDiff", () => {
-  let errorSpy: ReturnType<typeof spyOn>;
-  let lines: string[];
+  let captured: ReturnType<typeof captureLog>;
+
+  /** Return captured stderr lines with ANSI codes stripped. */
+  function lines(): string[] {
+    return captured.stderr.map((l) => l.replace(/\x1b\[[0-9;]*m/g, ""));
+  }
 
   beforeEach(() => {
-    lines = [];
-    errorSpy = spyOn(console, "error").mockImplementation((...args: unknown[]) => {
-      // Strip ANSI codes for easier assertion
-      lines.push(String(args[0]).replace(/\x1b\[[0-9;]*m/g, ""));
-    });
+    captured = captureLog();
   });
 
   afterEach(() => {
-    errorSpy.mockRestore();
+    captured.teardown();
   });
 
   test("patch mode: shows only changed leaf values", () => {
@@ -635,7 +636,7 @@ describe("printDiff", () => {
 
     printDiff(current, patch, true);
 
-    expect(lines).toEqual(["  session:", "    lifetime:", "      - 604800", "      + 3600"]);
+    expect(lines()).toEqual(["  session:", "    lifetime:", "      - 604800", "      + 3600"]);
   });
 
   test("patch mode: skips unchanged keys", () => {
@@ -644,7 +645,7 @@ describe("printDiff", () => {
 
     printDiff(current, patch, true);
 
-    expect(lines).toEqual([]);
+    expect(lines()).toEqual([]);
   });
 
   test("patch mode: shows new keys being added", () => {
@@ -653,7 +654,7 @@ describe("printDiff", () => {
 
     printDiff(current, patch, true);
 
-    expect(lines).toEqual(["  session:", '    + {"lifetime":3600}']);
+    expect(lines()).toEqual(["  session:", '    + {"lifetime":3600}']);
   });
 
   test("patch mode: ignores keys not in patch", () => {
@@ -663,7 +664,7 @@ describe("printDiff", () => {
     printDiff(current, patch, true);
 
     // sign_up should not appear
-    expect(lines.some((l) => l.includes("sign_up"))).toBe(false);
+    expect(lines().some((l) => l.includes("sign_up"))).toBe(false);
   });
 
   test("put mode: shows removed keys", () => {
@@ -673,8 +674,8 @@ describe("printDiff", () => {
     printDiff(current, payload, false);
 
     // session is unchanged, sign_up is being removed
-    expect(lines.some((l) => l.includes("sign_up"))).toBe(true);
-    expect(lines.some((l) => l.includes("- {"))).toBe(true);
+    expect(lines().some((l) => l.includes("sign_up"))).toBe(true);
+    expect(lines().some((l) => l.includes("- {"))).toBe(true);
   });
 
   test("put mode: shows both old and new for changed values", () => {
@@ -683,8 +684,8 @@ describe("printDiff", () => {
 
     printDiff(current, payload, false);
 
-    expect(lines).toContainEqual(expect.stringContaining("- 604800"));
-    expect(lines).toContainEqual(expect.stringContaining("+ 3600"));
+    expect(lines()).toContainEqual(expect.stringContaining("- 604800"));
+    expect(lines()).toContainEqual(expect.stringContaining("+ 3600"));
   });
 
   test("handles deeply nested changes", () => {
@@ -693,7 +694,7 @@ describe("printDiff", () => {
 
     printDiff(current, patch, true);
 
-    expect(lines).toEqual(["  a:", "    b.c.d:", "      - 1", "      + 2"]);
+    expect(lines()).toEqual(["  a:", "    b.c.d:", "      - 1", "      + 2"]);
   });
 
   test("handles array value changes", () => {
@@ -702,8 +703,8 @@ describe("printDiff", () => {
 
     printDiff(current, patch, true);
 
-    expect(lines).toContainEqual(expect.stringContaining('- ["a.com","b.com"]'));
-    expect(lines).toContainEqual(expect.stringContaining('+ ["a.com","c.com"]'));
+    expect(lines()).toContainEqual(expect.stringContaining('- ["a.com","b.com"]'));
+    expect(lines()).toContainEqual(expect.stringContaining('+ ["a.com","c.com"]'));
   });
 });
 

--- a/packages/cli-core/src/commands/config/push.ts
+++ b/packages/cli-core/src/commands/config/push.ts
@@ -5,6 +5,7 @@ import { throwUsageError, throwUserAbort, withApiContext, ERROR_CODE } from "../
 import { confirm } from "../../lib/prompts.ts";
 import { dim, bold, red, green } from "../../lib/color.ts";
 import { withSpinner } from "../../lib/spinner.ts";
+import { log } from "../../lib/log.ts";
 
 interface ConfigPushOptions {
   app?: string;
@@ -72,8 +73,8 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
   delete configPayload.config_version;
 
   if (options.dryRun) {
-    console.error(`[dry-run] Would ${op.method} config on ${ctx.appLabel} (${ctx.instanceLabel}):`);
-    console.log(JSON.stringify(configPayload, null, 2));
+    log.info(`[dry-run] Would ${op.method} config on ${ctx.appLabel} (${ctx.instanceLabel}):`);
+    log.data(JSON.stringify(configPayload, null, 2));
     return;
   }
 
@@ -91,16 +92,16 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
   const hasChanges = hasConfigChanges(currentConfig, configPayload, isPatch);
 
   if (!hasChanges) {
-    console.error("No changes detected");
+    log.info("No changes detected");
     return;
   }
 
-  console.error(`\n${op.verb} config on ${ctx.appLabel} (${ctx.instanceLabel}):\n`);
+  log.info(`\n${op.verb} config on ${ctx.appLabel} (${ctx.instanceLabel}):\n`);
   printDiff(currentConfig, configPayload, isPatch);
 
   if (isHuman() && !options.yes) {
     if (op.warning) {
-      console.error(`\nWARNING: ${op.warning}`);
+      log.warn(`${op.warning}`);
     }
     const ok = await confirm({ message: "Proceed?" });
     if (!ok) {
@@ -116,8 +117,8 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
         "Failed to push config",
       ),
   );
-  console.log(JSON.stringify(result, null, 2));
-  console.error("Config pushed successfully");
+  log.data(JSON.stringify(result, null, 2));
+  log.info("Config pushed successfully");
 }
 
 export async function readInput(options: { file?: string; json?: string }): Promise<string> {
@@ -251,20 +252,20 @@ export function printDiff(
     collectChanges(current[key], payload[key], "", changes, patchMode);
     if (changes.length === 0) continue;
 
-    console.error(`  ${key}:`);
+    log.raw(`  ${key}:`);
     for (const { path, oldVal, newVal } of changes) {
       if (path) {
-        console.error(`    ${path}:`);
+        log.raw(`    ${path}:`);
       }
       const indent = path ? "      " : "    ";
       const useColor = isHuman();
       if (oldVal !== undefined) {
         const line = `${indent}- ${JSON.stringify(oldVal)}`;
-        console.error(useColor ? dim(red(line)) : line);
+        log.raw(useColor ? dim(red(line)) : line);
       }
       if (newVal !== undefined) {
         const line = `${indent}+ ${JSON.stringify(newVal)}`;
-        console.error(useColor ? bold(green(line)) : line);
+        log.raw(useColor ? bold(green(line)) : line);
       }
     }
   }

--- a/packages/cli-core/src/commands/config/push.ts
+++ b/packages/cli-core/src/commands/config/push.ts
@@ -118,7 +118,7 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
       ),
   );
   log.data(JSON.stringify(result, null, 2));
-  log.info("Config pushed successfully");
+  log.success("Config pushed successfully");
 }
 
 export async function readInput(options: { file?: string; json?: string }): Promise<string> {

--- a/packages/cli-core/src/commands/config/schema.test.ts
+++ b/packages/cli-core/src/commands/config/schema.test.ts
@@ -58,7 +58,7 @@ describe("config schema", () => {
     options: { app?: string; instance?: string; output?: string; keys?: string[] } = {},
   ) {
     const { configSchema } = await import("./schema.ts");
-    return configSchema(options);
+    return captured.run(() => configSchema(options));
   }
 
   test("errors when no profile is linked", async () => {

--- a/packages/cli-core/src/commands/config/schema.test.ts
+++ b/packages/cli-core/src/commands/config/schema.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { _setConfigDir, setProfile } from "../../lib/config.ts";
-import { credentialStoreStubs, gitStubs, stubFetch } from "../../test/lib/stubs.ts";
+import { credentialStoreStubs, gitStubs, stubFetch, captureLog } from "../../test/lib/stubs.ts";
 
 mock.module("../../lib/credential-store.ts", () => credentialStoreStubs);
 mock.module("../../lib/git.ts", () => gitStubs);
@@ -15,6 +15,7 @@ describe("config schema", () => {
   let logSpy: ReturnType<typeof spyOn>;
   let errorSpy: ReturnType<typeof spyOn>;
   let exitSpy: ReturnType<typeof spyOn>;
+  let captured: ReturnType<typeof captureLog>;
 
   const mockSchema = {
     type: "object",
@@ -37,11 +38,13 @@ describe("config schema", () => {
     exitSpy = spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit");
     });
+    captured = captureLog();
 
     stubFetch(async () => new Response(JSON.stringify(mockSchema), { status: 200 }));
   });
 
   afterEach(async () => {
+    captured.teardown();
     _setConfigDir(undefined);
     process.env = { ...originalEnv };
     globalThis.fetch = originalFetch;
@@ -81,7 +84,7 @@ describe("config schema", () => {
     });
 
     await runConfigSchema();
-    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(mockSchema, null, 2));
+    expect(captured.out).toBe(JSON.stringify(mockSchema, null, 2));
   });
 
   test("supports --app without a linked profile", async () => {
@@ -102,7 +105,7 @@ describe("config schema", () => {
     });
 
     await runConfigSchema({ app: "app_1" });
-    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(mockSchema, null, 2));
+    expect(captured.out).toBe(JSON.stringify(mockSchema, null, 2));
   });
 
   test("writes schema to file with --output", async () => {
@@ -116,7 +119,7 @@ describe("config schema", () => {
     await runConfigSchema({ output: outFile });
     const written = await Bun.file(outFile).json();
     expect(written).toEqual(mockSchema);
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("Schema written to"));
+    expect(captured.err).toContain("Schema written to");
   });
 
   test("shows which environment is being pulled", async () => {
@@ -127,7 +130,7 @@ describe("config schema", () => {
     });
 
     await runConfigSchema();
-    expect(errorSpy).toHaveBeenCalledWith("Pulling config schema from app_1 (development)...");
+    expect(captured.err).toContain("Pulling config schema from app_1 (development)...");
   });
 
   test("shows production label when --instance prod", async () => {
@@ -138,7 +141,7 @@ describe("config schema", () => {
     });
 
     await runConfigSchema({ instance: "prod" });
-    expect(errorSpy).toHaveBeenCalledWith("Pulling config schema from app_1 (production)...");
+    expect(captured.err).toContain("Pulling config schema from app_1 (production)...");
   });
 
   test("uses development instance by default", async () => {

--- a/packages/cli-core/src/commands/config/schema.ts
+++ b/packages/cli-core/src/commands/config/schema.ts
@@ -1,6 +1,7 @@
 import { resolveAppContext } from "../../lib/config.ts";
 import { fetchInstanceConfigSchema } from "../../lib/plapi.ts";
 import { withApiContext } from "../../lib/errors.ts";
+import { log } from "../../lib/log.ts";
 
 interface ConfigSchemaOptions {
   app?: string;
@@ -12,8 +13,7 @@ interface ConfigSchemaOptions {
 export async function configSchema(options: ConfigSchemaOptions): Promise<void> {
   const ctx = await resolveAppContext(options);
 
-  // Use `console.error` for informational messages so stdout is just the JSON response.
-  console.error(`Pulling config schema from ${ctx.appLabel} (${ctx.instanceLabel})...`);
+  log.info(`Pulling config schema from ${ctx.appLabel} (${ctx.instanceLabel})...`);
 
   const schema = await withApiContext(
     fetchInstanceConfigSchema(ctx.appId, ctx.instanceId, options.keys),
@@ -24,8 +24,8 @@ export async function configSchema(options: ConfigSchemaOptions): Promise<void> 
 
   if (options.output) {
     await Bun.write(options.output, json + "\n");
-    console.error(`Schema written to ${options.output}`);
+    log.info(`Schema written to ${options.output}`);
   } else {
-    console.log(json);
+    log.data(json);
   }
 }

--- a/packages/cli-core/src/commands/config/schema.ts
+++ b/packages/cli-core/src/commands/config/schema.ts
@@ -24,7 +24,7 @@ export async function configSchema(options: ConfigSchemaOptions): Promise<void> 
 
   if (options.output) {
     await Bun.write(options.output, json + "\n");
-    log.info(`Schema written to ${options.output}`);
+    log.success(`Schema written to ${options.output}`);
   } else {
     log.data(json);
   }

--- a/packages/cli-core/src/commands/deploy/index.test.ts
+++ b/packages/cli-core/src/commands/deploy/index.test.ts
@@ -49,12 +49,16 @@ describe("deploy", () => {
     consoleSpy?.mockRestore();
   });
 
+  function runDeploy(options: Parameters<typeof deploy>[0]) {
+    return captured.run(() => deploy(options));
+  }
+
   describe("agent mode", () => {
     test("outputs deploy prompt and returns", async () => {
       mockIsAgent.mockReturnValue(true);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await deploy({});
+      await runDeploy({});
 
       expect(captured.out).toContain("deploying a Clerk application to production");
     });
@@ -63,7 +67,7 @@ describe("deploy", () => {
       mockIsAgent.mockReturnValue(true);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await deploy({});
+      await runDeploy({});
 
       const output = captured.out;
       expect(output).toContain("Prerequisites");
@@ -78,7 +82,7 @@ describe("deploy", () => {
       mockIsAgent.mockReturnValue(true);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await deploy({});
+      await runDeploy({});
 
       const output = captured.out;
       expect(output).toContain("/v1/platform/applications");
@@ -90,7 +94,7 @@ describe("deploy", () => {
       mockIsAgent.mockReturnValue(true);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await deploy({});
+      await runDeploy({});
 
       const output = captured.out;
       expect(output).toContain("accounts.{domain}/v1/oauth_callback");
@@ -100,7 +104,7 @@ describe("deploy", () => {
       mockIsAgent.mockReturnValue(true);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await deploy({ debug: true });
+      await runDeploy({ debug: true });
 
       expect(mockSelect).not.toHaveBeenCalled();
       expect(mockInput).not.toHaveBeenCalled();
@@ -122,7 +126,7 @@ describe("deploy", () => {
       mockHumanFlow();
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await deploy({});
+      await runDeploy({});
 
       const allOutput = captured.out;
       expect(allOutput).not.toContain("deploying a Clerk application to production");
@@ -132,7 +136,7 @@ describe("deploy", () => {
       mockHumanFlow();
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await deploy({});
+      await runDeploy({});
 
       const allOutput = captured.out;
       expect(allOutput).toContain("[mock]");

--- a/packages/cli-core/src/commands/deploy/index.test.ts
+++ b/packages/cli-core/src/commands/deploy/index.test.ts
@@ -1,5 +1,5 @@
-import { test, expect, describe, afterEach, mock, spyOn } from "bun:test";
-import { capturedOutput, promptsStubs } from "../../test/lib/stubs.ts";
+import { test, expect, describe, beforeEach, afterEach, mock, spyOn } from "bun:test";
+import { captureLog, promptsStubs } from "../../test/lib/stubs.ts";
 
 const mockIsAgent = mock();
 let _modeOverride: string | undefined;
@@ -32,8 +32,14 @@ const { deploy } = await import("./index.ts");
 
 describe("deploy", () => {
   let consoleSpy: ReturnType<typeof spyOn>;
+  let captured: ReturnType<typeof captureLog>;
+
+  beforeEach(() => {
+    captured = captureLog();
+  });
 
   afterEach(() => {
+    captured.teardown();
     _modeOverride = undefined;
     mockIsAgent.mockReset();
     mockSelect.mockReset();
@@ -50,9 +56,7 @@ describe("deploy", () => {
 
       await deploy({});
 
-      expect(consoleSpy).toHaveBeenCalledTimes(1);
-      const output = consoleSpy.mock.calls[0][0] as string;
-      expect(output).toContain("deploying a Clerk application to production");
+      expect(captured.out).toContain("deploying a Clerk application to production");
     });
 
     test("prompt includes all deployment steps", async () => {
@@ -61,7 +65,7 @@ describe("deploy", () => {
 
       await deploy({});
 
-      const output = consoleSpy.mock.calls[0][0] as string;
+      const output = captured.out;
       expect(output).toContain("Prerequisites");
       expect(output).toContain("Verify Subscription Compatibility");
       expect(output).toContain("Choose a Production Domain");
@@ -76,7 +80,7 @@ describe("deploy", () => {
 
       await deploy({});
 
-      const output = consoleSpy.mock.calls[0][0] as string;
+      const output = captured.out;
       expect(output).toContain("/v1/platform/applications");
       expect(output).toContain("instances/production/config");
       expect(output).toContain("instances/development/config");
@@ -88,7 +92,7 @@ describe("deploy", () => {
 
       await deploy({});
 
-      const output = consoleSpy.mock.calls[0][0] as string;
+      const output = captured.out;
       expect(output).toContain("accounts.{domain}/v1/oauth_callback");
     });
 
@@ -120,7 +124,7 @@ describe("deploy", () => {
 
       await deploy({});
 
-      const allOutput = capturedOutput(consoleSpy);
+      const allOutput = captured.out;
       expect(allOutput).not.toContain("deploying a Clerk application to production");
     });
 
@@ -130,7 +134,7 @@ describe("deploy", () => {
 
       await deploy({});
 
-      const allOutput = capturedOutput(consoleSpy);
+      const allOutput = captured.out;
       expect(allOutput).toContain("[mock]");
     });
   });

--- a/packages/cli-core/src/commands/deploy/index.ts
+++ b/packages/cli-core/src/commands/deploy/index.ts
@@ -90,37 +90,38 @@ export async function deploy(options: { debug?: boolean }) {
     log.data(DEPLOY_PROMPT);
     return;
   }
-  const debug = options.debug
-    ? (...args: unknown[]) => log.data(`[debug] ${args.join(" ")}`)
-    : () => {};
+  if (options.debug) {
+    const { setLogLevel } = await import("../../lib/log.ts");
+    setLogLevel("debug");
+  }
 
   log.data("[mock] This command uses mocked data and is not yet wired up to real APIs.\n");
 
-  debug("Checking for authenticated user and linked application...");
+  log.debug("Checking for authenticated user and linked application...");
 
   // Mock state — will be replaced with real lookups
   const user = { id: "user_abc123", email: "kyle@clerk.dev" };
   const application = { id: "app_xyz789", name: "my-saas-app" };
 
-  debug(`Found authenticated user: ${user.email} (${user.id})`);
-  debug(`Found linked application: ${application.name} (${application.id})`);
+  log.debug(`Found authenticated user: ${user.email} (${user.id})`);
+  log.debug(`Found linked application: ${application.name} (${application.id})`);
 
-  debug("Checking for production instance...");
-  debug("No production instance found.");
+  log.debug("Checking for production instance...");
+  log.debug("No production instance found.");
 
   // Mock state — check subscription vs dev instance features
-  debug("Checking development instance features against subscription...");
+  log.debug("Checking development instance features against subscription...");
   const devFeatures = ["email_auth", "social_oauth"];
   const subscriptionFeatures = ["email_auth", "social_oauth"];
   const unsupported = devFeatures.filter((f) => !subscriptionFeatures.includes(f));
 
   if (unsupported.length > 0) {
-    debug(`Found features not covered by subscription: ${unsupported.join(", ")}`);
-    debug("User must upgrade their plan before deploying.");
+    log.debug(`Found features not covered by subscription: ${unsupported.join(", ")}`);
+    log.debug("User must upgrade their plan before deploying.");
     return;
   }
 
-  debug("All development features are covered by subscription.");
+  log.debug("All development features are covered by subscription.");
 
   const domainChoice = await select({
     message: "How would you like to set up your production domain?",
@@ -142,40 +143,40 @@ export async function deploy(options: { debug?: boolean }) {
     domain = await input({
       message: "Enter your domain:",
     });
-    debug(`User provided custom domain: ${domain}`);
+    log.debug(`User provided custom domain: ${domain}`);
   } else {
     // Mock generated subdomain
     const generatedSubdomain = "sincere-chinchilla-87.clerk.app";
     domain = generatedSubdomain;
-    debug(`Using Clerk-provided subdomain: ${domain}`);
+    log.debug(`Using Clerk-provided subdomain: ${domain}`);
   }
 
-  debug("Creating production instance...");
-  debug(`Production instance created with domain: ${domain}`);
+  log.debug("Creating production instance...");
+  log.debug(`Production instance created with domain: ${domain}`);
 
   // DNS setup for custom domains
   if (domainChoice === "custom-domain") {
-    debug(`Looking up DNS provider for ${domain}...`);
+    log.debug(`Looking up DNS provider for ${domain}...`);
 
     // Mock state — DNS lookup and Domain Connect check
     const dnsProvider = { name: "Cloudflare", supportsDomainConnect: true };
-    debug(`DNS hosted by: ${dnsProvider.name}`);
-    debug(`Checking Domain Connect support for ${dnsProvider.name}...`);
-    debug(`${dnsProvider.name} supports Domain Connect.`);
+    log.debug(`DNS hosted by: ${dnsProvider.name}`);
+    log.debug(`Checking Domain Connect support for ${dnsProvider.name}...`);
+    log.debug(`${dnsProvider.name} supports Domain Connect.`);
 
     const domainConnectUrl = `https://domainconnect.${dnsProvider.name.toLowerCase()}.com/v2/domainTemplates/providers/clerk.com/services/clerk-production/apply?domain=${domain}`;
-    debug(`Composed Domain Connect URL: ${domainConnectUrl}`);
+    log.debug(`Composed Domain Connect URL: ${domainConnectUrl}`);
 
     await confirm({
       message: `We can automatically configure DNS for ${domain} via ${dnsProvider.name}. Open browser to continue?`,
       default: true,
     });
 
-    debug("Opening Domain Connect flow in browser...");
+    log.debug("Opening Domain Connect flow in browser...");
   }
 
   // Check dev instance settings that require production credentials
-  debug("Checking development instance settings for production requirements...");
+  log.debug("Checking development instance settings for production requirements...");
 
   // Mock state — dev instance has Google OAuth enabled
   const devSettings = {
@@ -183,7 +184,7 @@ export async function deploy(options: { debug?: boolean }) {
   };
 
   if (devSettings.socialProviders.length > 0) {
-    debug(
+    log.debug(
       `Found social providers requiring production credentials: ${devSettings.socialProviders.join(", ")}`,
     );
 
@@ -216,7 +217,7 @@ export async function deploy(options: { debug?: boolean }) {
         log.data(`    ${cyan(`https://accounts.${domain}/v1/oauth_callback`)}`);
         log.data("");
 
-        debug(`Opening ${displayName} OAuth setup guide in browser...`);
+        log.debug(`Opening ${displayName} OAuth setup guide in browser...`);
         const openResult = await openBrowser(docsUrl);
         if (!openResult.ok) {
           log.info(dim(`(Could not open browser automatically, visit ${docsUrl})`));
@@ -233,13 +234,13 @@ export async function deploy(options: { debug?: boolean }) {
         message: `${displayName} OAuth Client Secret:`,
       });
 
-      debug(`Received ${displayName} credentials (client ID: ${clientId.slice(0, 8)}...)`);
+      log.debug(`Received ${displayName} credentials (client ID: ${clientId.slice(0, 8)}...)`);
     }
 
-    debug("All social provider credentials collected.");
+    log.debug("All social provider credentials collected.");
   }
 
-  debug("Deploy complete.");
+  log.debug("Deploy complete.");
 
   log.data(
     `\n${bold(green(`Your production application is set up and ready at ${blue(`https://${domain}`)}`))}`,

--- a/packages/cli-core/src/commands/deploy/index.ts
+++ b/packages/cli-core/src/commands/deploy/index.ts
@@ -1,8 +1,9 @@
 import { select, input, confirm, password } from "@inquirer/prompts";
 import { isAgent } from "../../mode.ts";
-import { dim, bold, cyan, green, blue, yellow } from "../../lib/color.ts";
+import { dim, bold, cyan, green, blue } from "../../lib/color.ts";
 import { printNextSteps, NEXT_STEPS } from "../../lib/next-steps.ts";
 import { openBrowser } from "../../lib/open.ts";
+import { log } from "../../lib/log.ts";
 
 const DEPLOY_PROMPT = `You are deploying a Clerk application to production. Follow these steps:
 
@@ -86,14 +87,14 @@ Refer to the Clerk Platform API docs for detailed request/response schemas.`;
 
 export async function deploy(options: { debug?: boolean }) {
   if (isAgent()) {
-    console.log(DEPLOY_PROMPT);
+    log.data(DEPLOY_PROMPT);
     return;
   }
-  const debug = options.debug ? (...args: unknown[]) => console.log("[debug]", ...args) : () => {};
+  const debug = options.debug
+    ? (...args: unknown[]) => log.data(`[debug] ${args.join(" ")}`)
+    : () => {};
 
-  console.log(
-    yellow("[mock] This command uses mocked data and is not yet wired up to real APIs.") + "\n",
-  );
+  log.data("[mock] This command uses mocked data and is not yet wired up to real APIs.\n");
 
   debug("Checking for authenticated user and linked application...");
 
@@ -205,23 +206,23 @@ export async function deploy(options: { debug?: boolean }) {
       });
 
       if (credentialChoice === "walkthrough") {
-        console.log(
+        log.data(
           `\n${bold(`When configuring your ${displayName} OAuth app, use these values:`)}\n`,
         );
-        console.log(`  ${dim("Authorized JavaScript origins:")}`);
-        console.log(`    ${cyan(`https://${domain}`)}`);
-        console.log(`    ${cyan(`https://www.${domain}`)}`);
-        console.log(`\n  ${dim("Authorized redirect URI:")}`);
-        console.log(`    ${cyan(`https://accounts.${domain}/v1/oauth_callback`)}`);
-        console.log();
+        log.data(`  ${dim("Authorized JavaScript origins:")}`);
+        log.data(`    ${cyan(`https://${domain}`)}`);
+        log.data(`    ${cyan(`https://www.${domain}`)}`);
+        log.data(`\n  ${dim("Authorized redirect URI:")}`);
+        log.data(`    ${cyan(`https://accounts.${domain}/v1/oauth_callback`)}`);
+        log.data("");
 
         debug(`Opening ${displayName} OAuth setup guide in browser...`);
         const openResult = await openBrowser(docsUrl);
         if (!openResult.ok) {
-          console.log(dim(`(Could not open browser automatically, visit ${docsUrl})`));
+          log.info(dim(`(Could not open browser automatically, visit ${docsUrl})`));
         }
 
-        console.log("Once you've created your credentials, enter them below:\n");
+        log.data("Once you've created your credentials, enter them below:\n");
       }
 
       const clientId = await input({
@@ -240,10 +241,10 @@ export async function deploy(options: { debug?: boolean }) {
 
   debug("Deploy complete.");
 
-  console.log(
+  log.data(
     `\n${bold(green(`Your production application is set up and ready at ${blue(`https://${domain}`)}`))}`,
   );
-  console.log(
+  log.data(
     dim(
       "If your application is not loading correctly, you may need to redeploy with your updated Clerk secret keys.",
     ),

--- a/packages/cli-core/src/commands/doctor/index.ts
+++ b/packages/cli-core/src/commands/doctor/index.ts
@@ -29,8 +29,8 @@ const CHECKS: CheckFn[] = [
   checkShellCompletion,
 ];
 
-async function runChecks(ctx: DoctorContext, options: DoctorOptions): Promise<CheckResult[]> {
-  const results = await Promise.all(
+async function runChecks(ctx: DoctorContext): Promise<CheckResult[]> {
+  return Promise.all(
     CHECKS.map(async (check) => {
       try {
         return await check(ctx);
@@ -43,17 +43,15 @@ async function runChecks(ctx: DoctorContext, options: DoctorOptions): Promise<Ch
       }
     }),
   );
+}
 
-  if (!options.json) {
-    for (const result of results) {
-      if (!options.spotlight || result.status !== "pass") {
-        log.info(formatCheckResult(result, options.verbose ?? false));
-      }
+function printResults(results: CheckResult[], options: DoctorOptions): void {
+  for (const result of results) {
+    if (!options.spotlight || result.status !== "pass") {
+      log.info(formatCheckResult(result, options.verbose ?? false));
     }
-    log.blank();
   }
-
-  return results;
+  log.blank();
 }
 
 export async function doctor(options: DoctorOptions = {}): Promise<void> {
@@ -62,7 +60,11 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
   }
 
   const ctx = createDoctorContext();
-  const allResults = await withSpinner("Running diagnostics...", () => runChecks(ctx, options));
+  const allResults = await withSpinner("Running diagnostics...", () => runChecks(ctx));
+
+  if (!options.json) {
+    printResults(allResults, options);
+  }
 
   if (options.json) {
     const output = options.spotlight ? allResults.filter((r) => r.status !== "pass") : allResults;
@@ -108,13 +110,8 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
       bar();
 
       const verifyCtx = createDoctorContext();
-      const verifyResults = await withSpinner("Verifying fixes...", () =>
-        runChecks(verifyCtx, {
-          ...options,
-          fix: false,
-          spotlight: false,
-        }),
-      );
+      const verifyResults = await withSpinner("Verifying fixes...", () => runChecks(verifyCtx));
+      printResults(verifyResults, { ...options, fix: false, spotlight: false });
 
       const hasVerifyFailure = verifyResults.some((r) => r.status === "fail");
       if (hasVerifyFailure) {

--- a/packages/cli-core/src/commands/doctor/index.ts
+++ b/packages/cli-core/src/commands/doctor/index.ts
@@ -1,5 +1,6 @@
 import { isHuman } from "../../mode.ts";
 import { bold, green, red } from "../../lib/color.ts";
+import { log } from "../../lib/log.ts";
 import { CliError, ERROR_CODE } from "../../lib/errors.ts";
 import { intro, outro, bar, withSpinner } from "../../lib/spinner.ts";
 import { createDoctorContext } from "./context.ts";
@@ -46,10 +47,10 @@ async function runChecks(ctx: DoctorContext, options: DoctorOptions): Promise<Ch
   if (!options.json) {
     for (const result of results) {
       if (!options.spotlight || result.status !== "pass") {
-        console.log(formatCheckResult(result, options.verbose ?? false));
+        log.info(formatCheckResult(result, options.verbose ?? false));
       }
     }
-    console.log("");
+    log.blank();
   }
 
   return results;
@@ -65,7 +66,7 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
 
   if (options.json) {
     const output = options.spotlight ? allResults.filter((r) => r.status !== "pass") : allResults;
-    console.log(formatJson(output));
+    log.data(formatJson(output));
   }
 
   if (options.fix && !options.json && isHuman()) {
@@ -80,9 +81,9 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
     });
 
     if (uniqueFixable.length > 0) {
-      console.log("");
-      console.log(bold("Auto-fix"));
-      console.log("");
+      log.blank();
+      log.info(bold("Auto-fix"));
+      log.blank();
 
       const { confirm } = await import("@inquirer/prompts");
 
@@ -97,9 +98,9 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
         if (proceed) {
           try {
             await fix.run();
-            console.log(`  ${green("✓")} ${result.name} fixed`);
+            log.info(`  ${green("✓")} ${result.name} fixed`);
           } catch (error) {
-            console.log(`  ${red("✗")} Fix failed: ${errorMessage(error)}`);
+            log.info(`  ${red("✗")} Fix failed: ${errorMessage(error)}`);
           }
         }
       }

--- a/packages/cli-core/src/commands/env/pull.test.ts
+++ b/packages/cli-core/src/commands/env/pull.test.ts
@@ -184,7 +184,7 @@ describe("env pull", () => {
 
   async function runEnvPull(options: { app?: string; instance?: string; file?: string } = {}) {
     const { pull } = await import("./pull.ts");
-    return pull(options);
+    return captured.run(() => pull(options));
   }
 
   test("errors when no profile is linked", async () => {

--- a/packages/cli-core/src/commands/env/pull.test.ts
+++ b/packages/cli-core/src/commands/env/pull.test.ts
@@ -2,7 +2,13 @@ import { test, expect, describe, beforeEach, afterEach, spyOn, mock } from "bun:
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { credentialStoreStubs, gitStubs, configStubs, stubFetch } from "../../test/lib/stubs.ts";
+import {
+  credentialStoreStubs,
+  gitStubs,
+  configStubs,
+  stubFetch,
+  captureLog,
+} from "../../test/lib/stubs.ts";
 
 mock.module("../../lib/credential-store.ts", () => credentialStoreStubs);
 mock.module("../../lib/git.ts", () => gitStubs);
@@ -118,6 +124,7 @@ describe("env pull", () => {
   let errorSpy: ReturnType<typeof spyOn>;
   let logSpy: ReturnType<typeof spyOn>;
   let exitSpy: ReturnType<typeof spyOn>;
+  let captured: ReturnType<typeof captureLog>;
 
   const mockApplication = {
     application_id: "app_1",
@@ -158,11 +165,13 @@ describe("env pull", () => {
     exitSpy = spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit");
     });
+    captured = captureLog();
 
     stubFetch(async () => new Response(JSON.stringify(mockApplication), { status: 200 }));
   });
 
   afterEach(async () => {
+    captured.teardown();
     _setConfigDir(undefined);
     process.env = { ...originalEnv };
     process.cwd = originalCwd;
@@ -408,9 +417,7 @@ describe("env pull", () => {
     });
 
     await runEnvPull();
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Environment variables written to"),
-    );
+    expect(captured.err).toContain("Environment variables written to");
   });
 
   test("errors when instance not found in API response", async () => {

--- a/packages/cli-core/src/commands/env/pull.ts
+++ b/packages/cli-core/src/commands/env/pull.ts
@@ -9,7 +9,6 @@ import {
 } from "../../lib/framework.ts";
 import { CliError, ERROR_CODE, withApiContext } from "../../lib/errors.ts";
 import { withSpinner } from "../../lib/spinner.ts";
-import { dim } from "../../lib/color.ts";
 import { log } from "../../lib/log.ts";
 
 const DEV_LOCAL_ENV_FILE = ".env.development.local";
@@ -86,5 +85,5 @@ export async function pull(options: EnvPullOptions): Promise<void> {
     await Bun.write(targetFile, output);
   });
 
-  log.info(dim(`Environment variables written to ${displayPath}`));
+  log.info(`Environment variables written to ${displayPath}`);
 }

--- a/packages/cli-core/src/commands/env/pull.ts
+++ b/packages/cli-core/src/commands/env/pull.ts
@@ -10,6 +10,7 @@ import {
 import { CliError, ERROR_CODE, withApiContext } from "../../lib/errors.ts";
 import { withSpinner } from "../../lib/spinner.ts";
 import { dim } from "../../lib/color.ts";
+import { log } from "../../lib/log.ts";
 
 const DEV_LOCAL_ENV_FILE = ".env.development.local";
 
@@ -85,5 +86,5 @@ export async function pull(options: EnvPullOptions): Promise<void> {
     await Bun.write(targetFile, output);
   });
 
-  console.error(dim(`Environment variables written to ${displayPath}`));
+  log.info(dim(`Environment variables written to ${displayPath}`));
 }

--- a/packages/cli-core/src/commands/init/heuristics.ts
+++ b/packages/cli-core/src/commands/init/heuristics.ts
@@ -2,6 +2,7 @@ import { join, dirname } from "node:path";
 import { mkdir } from "node:fs/promises";
 import { dim, cyan, green, yellow, bold } from "../../lib/color.js";
 import { printNextSteps } from "../../lib/next-steps.js";
+import { log } from "../../lib/log.js";
 import { getToken } from "../../lib/credential-store.js";
 import { fetchUserInfo } from "../../lib/token-exchange.js";
 import { printFindings } from "./scan.js";
@@ -18,16 +19,14 @@ export async function installSdk(ctx: ProjectContext): Promise<void> {
   // only have npm). Fail fast with a useful message rather than a raw ENOENT.
   const pmBinary = addCmd.split(" ")[0];
   if (Bun.which(pmBinary) === null) {
-    console.log(
-      yellow(
-        `${pmBinary} is not installed but the project's lockfile suggests it. ` +
-          `Install ${pmBinary} or run \`${addCmd} ${ctx.framework.sdk}\` manually with another package manager.`,
-      ),
+    log.warn(
+      `${pmBinary} is not installed but the project's lockfile suggests it. ` +
+        `Install ${pmBinary} or run \`${addCmd} ${ctx.framework.sdk}\` manually with another package manager.`,
     );
     return;
   }
 
-  console.log(`Installing ${cyan(ctx.framework.sdk)} for ${ctx.framework.name}...`);
+  log.info(`Installing ${cyan(ctx.framework.sdk)} for ${ctx.framework.name}...`);
 
   // try/catch covers the TOCTOU window between Bun.which and spawn.
   let exitCode: number;
@@ -40,19 +39,15 @@ export async function installSdk(ctx: ProjectContext): Promise<void> {
     exitCode = await proc.exited;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    console.log(
-      yellow(
-        `Failed to spawn ${addCmd}: ${message}. You can install manually: ${addCmd} ${ctx.framework.sdk}`,
-      ),
+    log.warn(
+      `Failed to spawn ${addCmd}: ${message}. You can install manually: ${addCmd} ${ctx.framework.sdk}`,
     );
     return;
   }
 
   if (exitCode !== 0) {
-    console.log(
-      yellow(
-        `Failed to install ${ctx.framework.sdk}. You can install it manually: ${addCmd} ${ctx.framework.sdk}`,
-      ),
+    log.warn(
+      `Failed to install ${ctx.framework.sdk}. You can install it manually: ${addCmd} ${ctx.framework.sdk}`,
     );
   }
 }
@@ -100,15 +95,15 @@ function formatAction(action: FileAction): string {
 }
 
 export function printOutro(plan: ScaffoldPlan, findings: ScanFinding[]): void {
-  console.log(bold(green("\n✓ Clerk has been set up in your project\n")));
+  log.info(bold(green("\n✓ Clerk has been set up in your project\n")));
 
   for (const action of plan.actions) {
-    console.log(formatAction(action));
+    log.info(formatAction(action));
   }
 
   printNextSteps(plan.postInstructions);
   printFindings(findings);
-  console.log();
+  log.blank();
 }
 
 /**
@@ -135,5 +130,5 @@ export function printKeylessInfo(): void {
     "    clerk link",
     "    clerk env pull",
   ];
-  console.log(lines.map(dim).join("\n"));
+  log.info(lines.map(dim).join("\n"));
 }

--- a/packages/cli-core/src/commands/init/index.test.ts
+++ b/packages/cli-core/src/commands/init/index.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe, afterEach, spyOn } from "bun:test";
-import { captureLog, configStubs, capturedOutput } from "../../test/lib/stubs.ts";
+import { captureLog } from "../../test/lib/stubs.ts";
 
 // Pure spyOn approach — Bun's mock.module globally replaces modules for the
 // entire test run, which pollutes other test files (link, env/pull, config,
@@ -89,7 +89,7 @@ describe("init", () => {
       spyOn(bootstrapMod, "askSkipAuth").mockResolvedValue(false),
     ];
 
-    return { gatherContextSpy };
+    return { gatherContextSpy, captured };
   }
 
   function setupBootstrapSuccess() {
@@ -114,12 +114,11 @@ describe("init", () => {
   });
 
   test("agent mode prints guidance without auth/bootstrap", async () => {
-    setup({ isAgent: true });
+    const { captured } = setup({ isAgent: true });
 
-    await init({});
+    await captured.run(() => init({}));
 
-    const output = capturedOutput(spies[0] as ReturnType<typeof spyOn>);
-    expect(output).toContain("clerk init -y");
+    expect(captured.out).toContain("clerk init -y");
     expect(loginMod.login).not.toHaveBeenCalled();
     expect(bootstrapMod.promptAndBootstrap).not.toHaveBeenCalled();
   });
@@ -220,12 +219,11 @@ describe("init", () => {
   });
 
   test("--starter in agent mode prints guidance without bootstrap", async () => {
-    setup({ isAgent: true });
+    const { captured } = setup({ isAgent: true });
 
-    await init({ starter: true });
+    await captured.run(() => init({ starter: true }));
 
-    const output = capturedOutput(spies[0] as ReturnType<typeof spyOn>);
-    expect(output).toContain("clerk init -y");
+    expect(captured.out).toContain("clerk init -y");
     expect(bootstrapMod.promptAndBootstrap).not.toHaveBeenCalled();
   });
 

--- a/packages/cli-core/src/commands/init/index.test.ts
+++ b/packages/cli-core/src/commands/init/index.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe, afterEach, spyOn } from "bun:test";
-import { configStubs, capturedOutput } from "../../test/lib/stubs.ts";
+import { captureLog, configStubs, capturedOutput } from "../../test/lib/stubs.ts";
 
 // Pure spyOn approach — Bun's mock.module globally replaces modules for the
 // entire test run, which pollutes other test files (link, env/pull, config,
@@ -44,14 +44,18 @@ const FAKE_BOOTSTRAP = {
 
 describe("init", () => {
   let spies: ReturnType<typeof spyOn>[];
+  let captured: ReturnType<typeof captureLog>;
 
   afterEach(() => {
+    captured.teardown();
     for (const s of spies) s.mockRestore();
   });
 
   function setup(overrides: { email?: string | null; isAgent?: boolean } = {}) {
     const email = overrides.email ?? null;
     const agent = overrides.isAgent ?? false;
+
+    captured = captureLog();
 
     const gatherContextSpy = spyOn(context, "gatherContext").mockResolvedValue(null);
 

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -2,10 +2,11 @@ import { login } from "../auth/login.js";
 import { link } from "../link/index.js";
 import { pull } from "../env/pull.js";
 import { isAgent } from "../../mode.js";
-import { dim, green, yellow, bold } from "../../lib/color.js";
+import { dim, bold } from "../../lib/color.js";
 import { throwUserAbort, CliError } from "../../lib/errors.js";
 import { lookupFramework, type FrameworkInfo } from "../../lib/framework.js";
 import { resolveProfile } from "../../lib/config.js";
+import { log } from "../../lib/log.js";
 import { printNextSteps } from "../../lib/next-steps.js";
 import { gatherContext, hasPackageJson } from "./context.js";
 import { scaffold, enrichProjectContext } from "./scaffold.js";
@@ -46,7 +47,7 @@ export async function init(options: InitOptions = {}) {
     : undefined;
 
   if (options.prompt || isAgent()) {
-    console.log(
+    log.data(
       "Run `clerk init -y` to automatically detect the framework, install the Clerk SDK, and scaffold authentication files without interactive prompts.",
     );
     return;
@@ -81,7 +82,7 @@ export async function init(options: InitOptions = {}) {
   const { alreadySetUp } = await detectAndInstall(ctx.cwd, ctx, options);
 
   if (alreadySetUp) {
-    console.log(green("\nClerk is already set up in this project."));
+    log.success("\nClerk is already set up in this project.");
     outro("Done");
     return;
   }
@@ -194,12 +195,12 @@ async function authenticateAndLink(cwd: string): Promise<void> {
   const profile = await resolveProfile(cwd);
 
   if (label && profile) {
-    console.log(dim(`${label} · Linked to ${profile.profile.appId}`));
+    log.info(dim(`${label} · Linked to ${profile.profile.appId}`));
     return;
   }
 
   if (label) {
-    console.log(dim(label));
+    log.info(dim(label));
   }
 
   await link({ skipIfLinked: true });
@@ -213,13 +214,13 @@ async function detectAndInstall(
   options: InitOptions,
 ): Promise<{ alreadySetUp: boolean }> {
   const variantLabel = ctx.variant ? ` (${ctx.variant})` : "";
-  console.log(`\nDetected ${bold(ctx.framework.name)}${variantLabel}`);
+  log.info(`\nDetected ${bold(ctx.framework.name)}${variantLabel}`);
 
   detectAuthLibraries(ctx.deps);
-  console.log();
+  log.blank();
 
   if (ctx.existingClerk) {
-    console.log(dim(`${ctx.framework.sdk} is already installed`));
+    log.info(dim(`${ctx.framework.sdk} is already installed`));
   } else {
     await installSdk(ctx);
   }
@@ -241,16 +242,16 @@ async function scaffoldAndWrite(
   }
 
   if (!hasChanges) {
-    console.log(dim("\nNo files to scaffold, but:"));
+    log.info(dim("\nNo files to scaffold, but:"));
     for (const instr of plan.postInstructions) {
-      console.log(dim(`  • ${instr}`));
+      log.info(dim(`  • ${instr}`));
     }
     return { alreadySetUp: false };
   }
 
   if (await checkGitDirty(cwd)) {
-    console.log(yellow("Warning: You have uncommitted changes"));
-    console.log(dim("Consider committing first so you can review what clerk init creates.\n"));
+    log.warn("You have uncommitted changes");
+    log.info(dim("Consider committing first so you can review what clerk init creates.\n"));
   }
 
   if (options.yes) {

--- a/packages/cli-core/src/commands/init/preview.ts
+++ b/packages/cli-core/src/commands/init/preview.ts
@@ -1,5 +1,6 @@
 import { confirm } from "@inquirer/prompts";
 import { cyan, dim, green, yellow } from "../../lib/color.js";
+import { log } from "../../lib/log.js";
 import type { FileAction, ScaffoldPlan } from "./frameworks/types.js";
 
 function formatAction(action: FileAction): string {
@@ -14,20 +15,20 @@ function formatAction(action: FileAction): string {
 }
 
 export function previewPlan(plan: ScaffoldPlan): void {
-  console.log("\nclerk init will make the following changes:\n");
+  log.info("\nclerk init will make the following changes:\n");
 
   for (const action of plan.actions) {
-    console.log(formatAction(action));
+    log.info(formatAction(action));
   }
 
   if (plan.postInstructions.length > 0) {
-    console.log(dim("\n  After scaffolding, you'll need to:"));
+    log.info(dim("\n  After scaffolding, you'll need to:"));
     for (const instr of plan.postInstructions) {
-      console.log(dim(`  • ${instr}`));
+      log.info(dim(`  • ${instr}`));
     }
   }
 
-  console.log();
+  log.blank();
 }
 
 export async function previewAndConfirm(plan: ScaffoldPlan): Promise<boolean> {

--- a/packages/cli-core/src/commands/init/scan.test.ts
+++ b/packages/cli-core/src/commands/init/scan.test.ts
@@ -1,4 +1,5 @@
 import { test, expect, describe, beforeEach, afterEach, spyOn } from "bun:test";
+import { captureLog } from "../../test/stubs.ts";
 import { join } from "node:path";
 import { mkdtemp, rm, mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -6,74 +7,77 @@ import { detectAuthLibraries, scanForIssues } from "./scan.ts";
 
 describe("detectAuthLibraries", () => {
   let consoleSpy: ReturnType<typeof spyOn>;
+  let captured: ReturnType<typeof captureLog>;
 
   beforeEach(() => {
+    captured = captureLog();
     consoleSpy = spyOn(console, "log").mockImplementation(() => {});
   });
 
   afterEach(() => {
+    captured.teardown();
     consoleSpy.mockRestore();
   });
 
   test("detects NextAuth", () => {
     detectAuthLibraries({ "next-auth": "5.0.0", next: "15.0.0" });
-    const output = consoleSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    const output = captured.out;
     expect(output).toContain("NextAuth");
     expect(output).toContain("clerk.com/docs/migrations/nextauth");
   });
 
   test("detects Auth0 via @auth0/nextjs-auth0", () => {
     detectAuthLibraries({ "@auth0/nextjs-auth0": "3.0.0" });
-    const output = consoleSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    const output = captured.out;
     expect(output).toContain("Auth0");
   });
 
   test("detects Auth0 via auth0 package", () => {
     detectAuthLibraries({ auth0: "4.0.0" });
-    const output = consoleSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    const output = captured.out;
     expect(output).toContain("Auth0");
   });
 
   test("detects Supabase Auth via @supabase/ssr", () => {
     detectAuthLibraries({ "@supabase/ssr": "0.5.0" });
-    const output = consoleSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    const output = captured.out;
     expect(output).toContain("Supabase Auth");
   });
 
   test("detects Firebase", () => {
     detectAuthLibraries({ firebase: "11.0.0" });
-    const output = consoleSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    const output = captured.out;
     expect(output).toContain("Firebase");
   });
 
   test("detects Passport.js", () => {
     detectAuthLibraries({ passport: "0.7.0" });
-    const output = consoleSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    const output = captured.out;
     expect(output).toContain("Passport.js");
   });
 
   test("detects Better Auth", () => {
     detectAuthLibraries({ "better-auth": "1.0.0" });
-    const output = consoleSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    const output = captured.out;
     expect(output).toContain("Better Auth");
   });
 
   test("detects Kinde", () => {
     detectAuthLibraries({ "@kinde-oss/kinde-auth-nextjs": "2.0.0" });
-    const output = consoleSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    const output = captured.out;
     expect(output).toContain("Kinde");
   });
 
   test("detects multiple auth libraries", () => {
     detectAuthLibraries({ "next-auth": "5.0.0", firebase: "11.0.0" });
-    const output = consoleSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    const output = captured.out;
     expect(output).toContain("NextAuth");
     expect(output).toContain("Firebase");
   });
 
   test("does not warn when no auth library found", () => {
     detectAuthLibraries({ react: "19.0.0", next: "15.0.0" });
-    expect(consoleSpy).not.toHaveBeenCalled();
+    expect(captured.out).toBe("");
   });
 });
 

--- a/packages/cli-core/src/commands/init/scan.test.ts
+++ b/packages/cli-core/src/commands/init/scan.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe, beforeEach, afterEach, spyOn } from "bun:test";
-import { captureLog } from "../../test/stubs.ts";
+import { captureLog } from "../../test/lib/stubs.ts";
 import { join } from "node:path";
 import { mkdtemp, rm, mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";

--- a/packages/cli-core/src/commands/init/scan.test.ts
+++ b/packages/cli-core/src/commands/init/scan.test.ts
@@ -19,64 +19,68 @@ describe("detectAuthLibraries", () => {
     consoleSpy.mockRestore();
   });
 
+  function runDetectAuthLibraries(deps: Parameters<typeof detectAuthLibraries>[0]) {
+    return captured.run(() => detectAuthLibraries(deps));
+  }
+
   test("detects NextAuth", () => {
-    detectAuthLibraries({ "next-auth": "5.0.0", next: "15.0.0" });
+    runDetectAuthLibraries({ "next-auth": "5.0.0", next: "15.0.0" });
     const output = captured.out;
     expect(output).toContain("NextAuth");
     expect(output).toContain("clerk.com/docs/migrations/nextauth");
   });
 
   test("detects Auth0 via @auth0/nextjs-auth0", () => {
-    detectAuthLibraries({ "@auth0/nextjs-auth0": "3.0.0" });
+    runDetectAuthLibraries({ "@auth0/nextjs-auth0": "3.0.0" });
     const output = captured.out;
     expect(output).toContain("Auth0");
   });
 
   test("detects Auth0 via auth0 package", () => {
-    detectAuthLibraries({ auth0: "4.0.0" });
+    runDetectAuthLibraries({ auth0: "4.0.0" });
     const output = captured.out;
     expect(output).toContain("Auth0");
   });
 
   test("detects Supabase Auth via @supabase/ssr", () => {
-    detectAuthLibraries({ "@supabase/ssr": "0.5.0" });
+    runDetectAuthLibraries({ "@supabase/ssr": "0.5.0" });
     const output = captured.out;
     expect(output).toContain("Supabase Auth");
   });
 
   test("detects Firebase", () => {
-    detectAuthLibraries({ firebase: "11.0.0" });
+    runDetectAuthLibraries({ firebase: "11.0.0" });
     const output = captured.out;
     expect(output).toContain("Firebase");
   });
 
   test("detects Passport.js", () => {
-    detectAuthLibraries({ passport: "0.7.0" });
+    runDetectAuthLibraries({ passport: "0.7.0" });
     const output = captured.out;
     expect(output).toContain("Passport.js");
   });
 
   test("detects Better Auth", () => {
-    detectAuthLibraries({ "better-auth": "1.0.0" });
+    runDetectAuthLibraries({ "better-auth": "1.0.0" });
     const output = captured.out;
     expect(output).toContain("Better Auth");
   });
 
   test("detects Kinde", () => {
-    detectAuthLibraries({ "@kinde-oss/kinde-auth-nextjs": "2.0.0" });
+    runDetectAuthLibraries({ "@kinde-oss/kinde-auth-nextjs": "2.0.0" });
     const output = captured.out;
     expect(output).toContain("Kinde");
   });
 
   test("detects multiple auth libraries", () => {
-    detectAuthLibraries({ "next-auth": "5.0.0", firebase: "11.0.0" });
+    runDetectAuthLibraries({ "next-auth": "5.0.0", firebase: "11.0.0" });
     const output = captured.out;
     expect(output).toContain("NextAuth");
     expect(output).toContain("Firebase");
   });
 
   test("does not warn when no auth library found", () => {
-    detectAuthLibraries({ react: "19.0.0", next: "15.0.0" });
+    runDetectAuthLibraries({ react: "19.0.0", next: "15.0.0" });
     expect(captured.out).toBe("");
   });
 });

--- a/packages/cli-core/src/commands/init/scan.ts
+++ b/packages/cli-core/src/commands/init/scan.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { yellow, dim, cyan } from "../../lib/color.js";
+import { log } from "../../lib/log.js";
 
 type AuthLibraryScan = {
   packages: string[];
@@ -65,8 +66,8 @@ export function detectAuthLibraries(deps: Record<string, string>): void {
     const found = scan.packages.some((pkg) => pkg in deps);
     if (!found) continue;
 
-    console.log(yellow(`\n⚠ Detected ${scan.name} in your project.`));
-    console.log(dim(`  Migration guide: ${scan.docsUrl}`));
+    log.data(yellow(`\n⚠ Detected ${scan.name} in your project.`));
+    log.data(dim(`  Migration guide: ${scan.docsUrl}`));
   }
 }
 
@@ -170,10 +171,10 @@ export async function scanForIssues(cwd: string, frameworkDep: string): Promise<
 export function printFindings(findings: ScanFinding[]): void {
   if (findings.length === 0) return;
 
-  console.log(dim("\n  Recommendations:"));
+  log.data(dim("\n  Recommendations:"));
   for (const f of findings) {
     const location = `${cyan(f.file)}:${f.line}`;
-    console.log(`  ${yellow("⚠")} ${location} ${dim("—")} ${f.message}`);
-    if (f.docsUrl) console.log(`    ${dim(f.docsUrl)}`);
+    log.data(`  ${yellow("⚠")} ${location} ${dim("—")} ${f.message}`);
+    if (f.docsUrl) log.data(`    ${dim(f.docsUrl)}`);
   }
 }

--- a/packages/cli-core/src/commands/link/index.test.ts
+++ b/packages/cli-core/src/commands/link/index.test.ts
@@ -152,12 +152,16 @@ describe("link", () => {
     consoleSpy?.mockRestore();
   });
 
+  function runLink(options?: Parameters<typeof link>[0]) {
+    return captured.run(() => link(options));
+  }
+
   describe("agent mode", () => {
     test("outputs prompt and returns", async () => {
       mockIsAgent.mockReturnValue(true);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link();
+      await runLink();
 
       expect(captured.out).toContain("linking a Clerk application");
     });
@@ -166,7 +170,7 @@ describe("link", () => {
       mockIsAgent.mockReturnValue(true);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link();
+      await runLink();
 
       expect(mockSearch).not.toHaveBeenCalled();
       expect(mockGetToken).not.toHaveBeenCalled();
@@ -195,7 +199,7 @@ describe("link", () => {
       mockConfirm.mockResolvedValue(false);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link();
+      await runLink();
 
       const output = captured.out;
       expect(output).toContain("Already linked");
@@ -216,7 +220,7 @@ describe("link", () => {
       mockFetchApplication.mockResolvedValue(mockApp);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link({ app: "app_123" });
+      await runLink({ app: "app_123" });
 
       expect(mockConfirm).toHaveBeenCalled();
       expect(mockSetProfile).toHaveBeenCalled();
@@ -231,7 +235,7 @@ describe("link", () => {
       mockFetchApplication.mockResolvedValue(mockApp);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link({ app: "app_123" });
+      await runLink({ app: "app_123" });
 
       expect(mockLogin).toHaveBeenCalled();
     });
@@ -242,7 +246,7 @@ describe("link", () => {
       mockFetchApplication.mockResolvedValue(mockApp);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link({ app: "app_123" });
+      await runLink({ app: "app_123" });
 
       expect(mockLogin).not.toHaveBeenCalled();
     });
@@ -254,7 +258,7 @@ describe("link", () => {
       mockFetchApplication.mockResolvedValue(mockApp);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link({ app: "app_123" });
+      await runLink({ app: "app_123" });
 
       expect(mockLogin).toHaveBeenCalledWith({ showNextSteps: false });
     });
@@ -267,7 +271,7 @@ describe("link", () => {
       mockFetchApplication.mockResolvedValue(mockApp);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link({ app: "app_123" });
+      await runLink({ app: "app_123" });
 
       expect(mockListApplications).not.toHaveBeenCalled();
       expect(mockSearch).not.toHaveBeenCalled();
@@ -294,7 +298,7 @@ describe("link", () => {
       mockSearch.mockResolvedValue("app_a");
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link();
+      await runLink();
 
       expect(mockListApplications).toHaveBeenCalled();
       expect(mockSearch).toHaveBeenCalled();
@@ -329,7 +333,7 @@ describe("link", () => {
       );
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link();
+      await runLink();
     });
 
     test("source filters choices by name substring (case-insensitive), keeps create option", async () => {
@@ -369,7 +373,7 @@ describe("link", () => {
       );
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link();
+      await runLink();
     });
 
     test("source filters by app ID when name is absent", async () => {
@@ -403,7 +407,7 @@ describe("link", () => {
       );
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link();
+      await runLink();
     });
 
     test("shows picker with create option when no apps found", async () => {
@@ -435,7 +439,7 @@ describe("link", () => {
       });
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link();
+      await runLink();
 
       expect(mockCreateApplication).toHaveBeenCalledWith("New App");
       expect(mockFetchApplication).toHaveBeenCalledWith("app_created");
@@ -471,7 +475,7 @@ describe("link", () => {
       });
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link();
+      await runLink();
 
       expect(mockCreateApplication).toHaveBeenCalledWith("My App");
       expect(mockSetProfile).toHaveBeenCalled();
@@ -482,7 +486,7 @@ describe("link", () => {
       mockGetToken.mockResolvedValue("token");
       mockListApplications.mockRejectedValue(new PlapiError(401, "Unauthorized"));
 
-      await expect(link()).rejects.toBeInstanceOf(PlapiError);
+      await expect(runLink()).rejects.toBeInstanceOf(PlapiError);
     });
   });
 
@@ -495,7 +499,7 @@ describe("link", () => {
       mockGetGitRepoIdentifier.mockResolvedValue("/repo/.git");
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link({ app: "app_123" });
+      await runLink({ app: "app_123" });
 
       expect(mockSetProfile).toHaveBeenCalledWith("github.com/org/repo", {
         workspaceId: "",
@@ -515,7 +519,7 @@ describe("link", () => {
       mockGetGitRepoIdentifier.mockResolvedValue("/repo/.git");
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link({ app: "app_123" });
+      await runLink({ app: "app_123" });
 
       expect(mockSetProfile).toHaveBeenCalledWith("/repo/.git", {
         workspaceId: "",
@@ -536,7 +540,7 @@ describe("link", () => {
       mockGetGitRepoRoot.mockResolvedValue(undefined);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link({ app: "app_123" });
+      await runLink({ app: "app_123" });
 
       expect(mockSetProfile).toHaveBeenCalledWith(process.cwd(), {
         workspaceId: "",
@@ -564,7 +568,7 @@ describe("link", () => {
       });
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link({ app: "app_123" });
+      await runLink({ app: "app_123" });
 
       const storedProfile = mockSetProfile.mock.calls[0]![1];
       expect(storedProfile.instances.production).toBeUndefined();
@@ -585,7 +589,7 @@ describe("link", () => {
         ],
       });
 
-      await expect(link({ app: "app_123" })).rejects.toThrow(
+      await expect(runLink({ app: "app_123" })).rejects.toThrow(
         "Application has no development instance",
       );
     });
@@ -596,7 +600,7 @@ describe("link", () => {
       mockFetchApplication.mockResolvedValue(mockApp);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link({ app: "app_123" });
+      await runLink({ app: "app_123" });
 
       expect(captured.out).toContain("Linked to");
     });
@@ -614,7 +618,7 @@ describe("link", () => {
       mockConfirm.mockResolvedValue(false);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link();
+      await runLink();
 
       const output = captured.out;
       expect(output).toContain("Auto-linked via git remote");
@@ -631,7 +635,7 @@ describe("link", () => {
       });
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link({ skipIfLinked: true });
+      await runLink({ skipIfLinked: true });
 
       const output = captured.out;
       expect(output).toContain("Auto-linked via git remote");
@@ -649,7 +653,7 @@ describe("link", () => {
       mockConfirm.mockResolvedValue(false);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link();
+      await runLink();
 
       const output = captured.out;
       expect(output).not.toContain("Auto-linked via git remote");
@@ -672,7 +676,7 @@ describe("link", () => {
       mockConfirm.mockResolvedValueOnce(true); // accept upgrade
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link();
+      await runLink();
 
       const output = captured.out;
       expect(output).toContain("git repository with remote");
@@ -689,7 +693,7 @@ describe("link", () => {
         .mockResolvedValueOnce(false); // decline re-link
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link();
+      await runLink();
 
       expect(mockMoveProfile).not.toHaveBeenCalled();
       expect(mockGetToken).not.toHaveBeenCalled();
@@ -701,7 +705,7 @@ describe("link", () => {
       mockResolveProfile.mockResolvedValue(dirProfile);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link({ skipIfLinked: true });
+      await runLink({ skipIfLinked: true });
 
       expect(mockConfirm).not.toHaveBeenCalled();
       expect(mockMoveProfile).not.toHaveBeenCalled();
@@ -719,7 +723,7 @@ describe("link", () => {
       mockConfirm.mockResolvedValueOnce(true); // accept upgrade
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link();
+      await runLink();
 
       expect(mockMoveProfile).toHaveBeenCalledWith("/repo/.git", "github.com/org/repo");
     });
@@ -741,7 +745,7 @@ describe("link", () => {
       mockConfirm.mockResolvedValue(true);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link();
+      await runLink();
 
       expect(mockFindClerkKeys).toHaveBeenCalled();
       expect(mockMatchKeyToApp).toHaveBeenCalled();
@@ -784,7 +788,7 @@ describe("link", () => {
       mockSearch.mockResolvedValue("app_other");
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link();
+      await runLink();
 
       expect(mockSearch).toHaveBeenCalled();
       expect(mockSetProfile).toHaveBeenCalledWith(
@@ -799,7 +803,7 @@ describe("link", () => {
       mockFetchApplication.mockResolvedValue(mockApp);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link({ app: "app_123" });
+      await runLink({ app: "app_123" });
 
       expect(mockFindClerkKeys).not.toHaveBeenCalled();
       expect(mockMatchKeyToApp).not.toHaveBeenCalled();
@@ -814,7 +818,7 @@ describe("link", () => {
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
       spyOn(console, "error").mockImplementation(() => {});
 
-      await link({ skipIfLinked: true });
+      await runLink({ skipIfLinked: true });
 
       expect(mockAutolink).toHaveBeenCalled();
       expect(mockConfirm).not.toHaveBeenCalled();
@@ -829,7 +833,7 @@ describe("link", () => {
       mockSearch.mockResolvedValue("app_123");
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link();
+      await runLink();
 
       expect(mockFindClerkKeys).toHaveBeenCalled();
       expect(mockMatchKeyToApp).not.toHaveBeenCalled();
@@ -845,7 +849,7 @@ describe("link", () => {
       mockSearch.mockResolvedValue("app_123");
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link();
+      await runLink();
 
       expect(mockMatchKeyToApp).toHaveBeenCalled();
       expect(mockConfirm).not.toHaveBeenCalled();
@@ -866,7 +870,7 @@ describe("link", () => {
       mockSearch.mockResolvedValue("app_123");
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link();
+      await runLink();
 
       expect(mockFindClerkKeys).not.toHaveBeenCalled();
       expect(mockMatchKeyToApp).not.toHaveBeenCalled();
@@ -886,7 +890,7 @@ describe("link", () => {
       mockSearch.mockResolvedValue("app_123");
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link();
+      await runLink();
 
       const output = captured.out;
       expect(output).toContain("Auto-linked via git remote");
@@ -905,7 +909,7 @@ describe("link", () => {
       mockFetchApplication.mockResolvedValue(mockApp);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link({ app: "app_123" });
+      await runLink({ app: "app_123" });
 
       expect(mockFindClerkKeys).not.toHaveBeenCalled();
       expect(mockSearch).not.toHaveBeenCalled();
@@ -924,7 +928,7 @@ describe("link", () => {
       mockConfirm.mockResolvedValue(true);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link({ app: "app_123" });
+      await runLink({ app: "app_123" });
 
       const confirmCall = mockConfirm.mock.calls.find((c: unknown[]) =>
         (c[0] as { message: string }).message.includes("Re-link"),
@@ -945,7 +949,7 @@ describe("link", () => {
       mockSearch.mockResolvedValue("app_123");
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link();
+      await runLink();
 
       const confirmCall = mockConfirm.mock.calls.find((c: unknown[]) =>
         (c[0] as { message: string }).message.includes("Re-link"),
@@ -971,7 +975,7 @@ describe("link", () => {
       mockConfirm.mockResolvedValue(true);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link();
+      await runLink();
 
       expect(mockFindClerkKeys).toHaveBeenCalled();
       expect(mockMatchKeyToApp).toHaveBeenCalled();
@@ -995,7 +999,7 @@ describe("link", () => {
       mockSearch.mockResolvedValue("app_123");
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link();
+      await runLink();
 
       expect(mockFindClerkKeys).not.toHaveBeenCalled();
       expect(mockSearch).toHaveBeenCalled();

--- a/packages/cli-core/src/commands/link/index.test.ts
+++ b/packages/cli-core/src/commands/link/index.test.ts
@@ -201,7 +201,7 @@ describe("link", () => {
 
       await runLink();
 
-      const output = captured.out;
+      const output = captured.err;
       expect(output).toContain("Already linked");
       expect(output).toContain("app_existing");
       expect(mockConfirm).toHaveBeenCalled();
@@ -602,7 +602,7 @@ describe("link", () => {
 
       await runLink({ app: "app_123" });
 
-      expect(captured.out).toContain("Linked to");
+      expect(captured.err).toContain("Linked to");
     });
   });
 
@@ -620,7 +620,7 @@ describe("link", () => {
 
       await runLink();
 
-      const output = captured.out;
+      const output = captured.err;
       expect(output).toContain("Auto-linked via git remote");
       expect(output).toContain("github.com/org/repo");
     });
@@ -637,7 +637,7 @@ describe("link", () => {
 
       await runLink({ skipIfLinked: true });
 
-      const output = captured.out;
+      const output = captured.err;
       expect(output).toContain("Auto-linked via git remote");
       expect(mockConfirm).not.toHaveBeenCalled();
       expect(mockGetToken).not.toHaveBeenCalled();
@@ -655,7 +655,7 @@ describe("link", () => {
 
       await runLink();
 
-      const output = captured.out;
+      const output = captured.err;
       expect(output).not.toContain("Auto-linked via git remote");
       expect(output).toContain("Already linked");
     });
@@ -678,7 +678,7 @@ describe("link", () => {
 
       await runLink();
 
-      const output = captured.out;
+      const output = captured.err;
       expect(output).toContain("git repository with remote");
       expect(output).toContain("Link updated");
       expect(mockMoveProfile).toHaveBeenCalledWith("/projects/myapp", "github.com/org/repo");
@@ -892,7 +892,7 @@ describe("link", () => {
 
       await runLink();
 
-      const output = captured.out;
+      const output = captured.err;
       expect(output).toContain("Auto-linked via git remote");
       expect(mockFindClerkKeys).not.toHaveBeenCalled();
       expect(mockSearch).toHaveBeenCalled();
@@ -979,7 +979,7 @@ describe("link", () => {
 
       expect(mockFindClerkKeys).toHaveBeenCalled();
       expect(mockMatchKeyToApp).toHaveBeenCalled();
-      const output = captured.out;
+      const output = captured.err;
       expect(output).toContain("We found");
     });
 

--- a/packages/cli-core/src/commands/link/index.test.ts
+++ b/packages/cli-core/src/commands/link/index.test.ts
@@ -1,6 +1,6 @@
-import { test, expect, describe, afterEach, mock, spyOn } from "bun:test";
+import { test, expect, describe, beforeEach, afterEach, mock, spyOn } from "bun:test";
 import {
-  capturedOutput,
+  captureLog,
   configStubs,
   credentialStoreStubs,
   autolinkStubs,
@@ -115,8 +115,14 @@ const mockApp = {
 
 describe("link", () => {
   let consoleSpy: ReturnType<typeof spyOn>;
+  let captured: ReturnType<typeof captureLog>;
+
+  beforeEach(() => {
+    captured = captureLog();
+  });
 
   afterEach(() => {
+    captured.teardown();
     _modeOverride = undefined;
     mockIsAgent.mockReset();
     mockGetToken.mockReset();
@@ -153,9 +159,7 @@ describe("link", () => {
 
       await link();
 
-      expect(consoleSpy).toHaveBeenCalledTimes(1);
-      const output = consoleSpy.mock.calls[0][0] as string;
-      expect(output).toContain("linking a Clerk application");
+      expect(captured.out).toContain("linking a Clerk application");
     });
 
     test("does not trigger interactive prompts", async () => {
@@ -193,7 +197,7 @@ describe("link", () => {
 
       await link();
 
-      const output = capturedOutput(consoleSpy);
+      const output = captured.out;
       expect(output).toContain("Already linked");
       expect(output).toContain("app_existing");
       expect(mockConfirm).toHaveBeenCalled();
@@ -594,8 +598,7 @@ describe("link", () => {
 
       await link({ app: "app_123" });
 
-      const lastCall = consoleSpy.mock.calls[consoleSpy.mock.calls.length - 1][0] as string;
-      expect(lastCall).toContain("Linked to");
+      expect(captured.out).toContain("Linked to");
     });
   });
 
@@ -613,7 +616,7 @@ describe("link", () => {
 
       await link();
 
-      const output = capturedOutput(consoleSpy);
+      const output = captured.out;
       expect(output).toContain("Auto-linked via git remote");
       expect(output).toContain("github.com/org/repo");
     });
@@ -630,7 +633,7 @@ describe("link", () => {
 
       await link({ skipIfLinked: true });
 
-      const output = capturedOutput(consoleSpy);
+      const output = captured.out;
       expect(output).toContain("Auto-linked via git remote");
       expect(mockConfirm).not.toHaveBeenCalled();
       expect(mockGetToken).not.toHaveBeenCalled();
@@ -648,7 +651,7 @@ describe("link", () => {
 
       await link();
 
-      const output = capturedOutput(consoleSpy);
+      const output = captured.out;
       expect(output).not.toContain("Auto-linked via git remote");
       expect(output).toContain("Already linked");
     });
@@ -671,7 +674,7 @@ describe("link", () => {
 
       await link();
 
-      const output = capturedOutput(consoleSpy);
+      const output = captured.out;
       expect(output).toContain("git repository with remote");
       expect(output).toContain("Link updated");
       expect(mockMoveProfile).toHaveBeenCalledWith("/projects/myapp", "github.com/org/repo");
@@ -885,7 +888,7 @@ describe("link", () => {
 
       await link();
 
-      const output = capturedOutput(consoleSpy);
+      const output = captured.out;
       expect(output).toContain("Auto-linked via git remote");
       expect(mockFindClerkKeys).not.toHaveBeenCalled();
       expect(mockSearch).toHaveBeenCalled();
@@ -972,7 +975,7 @@ describe("link", () => {
 
       expect(mockFindClerkKeys).toHaveBeenCalled();
       expect(mockMatchKeyToApp).toHaveBeenCalled();
-      const output = capturedOutput(consoleSpy);
+      const output = captured.out;
       expect(output).toContain("We found");
     });
 

--- a/packages/cli-core/src/commands/link/index.test.ts
+++ b/packages/cli-core/src/commands/link/index.test.ts
@@ -181,11 +181,10 @@ describe("link", () => {
       mockIsAgent.mockReturnValue(true);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link();
+      await runLink();
 
-      const output = consoleSpy.mock.calls[0][0] as string;
-      expect(output).toContain("no applications exist");
-      expect(output).toContain("POST /v1/platform/applications");
+      expect(captured.out).toContain("no applications exist");
+      expect(captured.out).toContain("POST /v1/platform/applications");
     });
   });
 
@@ -1153,11 +1152,10 @@ describe("link", () => {
       });
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await link();
+      await runLink();
 
-      const output = capturedOutput(consoleSpy);
-      expect(output).toContain("Created");
-      expect(output).toContain("Created App");
+      expect(captured.err).toContain("Created");
+      expect(captured.err).toContain("Created App");
     });
   });
 });

--- a/packages/cli-core/src/commands/link/index.ts
+++ b/packages/cli-core/src/commands/link/index.ts
@@ -109,7 +109,7 @@ export async function link(options: LinkOptions = {}): Promise<void> {
   });
 
   const label = app.name || app.application_id;
-  log.data(`Linked to ${cyan(label)} in ${dim(displayPath)}`);
+  log.info(`Linked to ${cyan(label)} in ${dim(displayPath)}`);
 
   outro(NEXT_STEPS.LINK);
 }
@@ -121,7 +121,7 @@ async function ensureAuth() {
   if (process.env.CLERK_PLATFORM_API_KEY) return;
   const token = await getToken();
   if (!token) {
-    log.data("Not logged in. Authenticating first...");
+    log.info("Not logged in. Authenticating first...");
     await login({ showNextSteps: false });
   }
 }
@@ -136,9 +136,9 @@ function printExistingStatus(
   normalizedRemote: string | undefined,
 ) {
   if (existing.resolvedVia === "remote") {
-    log.data(`Auto-linked via git remote (${dim(normalizedRemote ?? existing.path)})`);
+    log.info(`Auto-linked via git remote (${dim(normalizedRemote ?? existing.path)})`);
   } else {
-    log.data(`Already linked to ${cyan(existing.profile.appId)} in ${dim(existing.path)}`);
+    log.info(`Already linked to ${cyan(existing.profile.appId)} in ${dim(existing.path)}`);
   }
 }
 
@@ -150,7 +150,7 @@ async function handleExistingProfile(
   printExistingStatus(existing, normalizedRemote);
 
   if (existing.availableRemote) {
-    log.data(
+    log.info(
       `We detected this is now a git repository with remote ${dim(existing.availableRemote)}.`,
     );
     const upgrade = await confirm({
@@ -159,7 +159,7 @@ async function handleExistingProfile(
     });
     if (upgrade) {
       await moveProfile(existing.path, existing.availableRemote);
-      log.data(`\nLink updated to use git remote (${cyan(existing.availableRemote)})`);
+      log.info(`\nLink updated to use git remote (${cyan(existing.availableRemote)})`);
       return false;
     }
   }

--- a/packages/cli-core/src/commands/link/index.ts
+++ b/packages/cli-core/src/commands/link/index.ts
@@ -109,7 +109,7 @@ export async function link(options: LinkOptions = {}): Promise<void> {
   });
 
   const label = app.name || app.application_id;
-  log.info(`Linked to ${cyan(label)} in ${dim(displayPath)}`);
+  log.success(`Linked to ${cyan(label)} in ${dim(displayPath)}`);
 
   outro(NEXT_STEPS.LINK);
 }

--- a/packages/cli-core/src/commands/link/index.ts
+++ b/packages/cli-core/src/commands/link/index.ts
@@ -16,6 +16,7 @@ import { dim, cyan } from "../../lib/color.ts";
 import { NEXT_STEPS } from "../../lib/next-steps.ts";
 import { CliError, PlapiError, ERROR_CODE, withApiContext } from "../../lib/errors.ts";
 import { intro, outro, withSpinner } from "../../lib/spinner.ts";
+import { log } from "../../lib/log.ts";
 
 const AGENT_PROMPT = `You are linking a Clerk application to the current project directory.
 
@@ -49,7 +50,7 @@ function appLabel(app: Application): string {
 
 export async function link(options: LinkOptions = {}): Promise<void> {
   if (isAgent()) {
-    console.log(AGENT_PROMPT);
+    log.data(AGENT_PROMPT);
     return;
   }
 
@@ -108,7 +109,7 @@ export async function link(options: LinkOptions = {}): Promise<void> {
   });
 
   const label = app.name || app.application_id;
-  console.log(`Linked to ${cyan(label)} in ${dim(displayPath)}`);
+  log.data(`Linked to ${cyan(label)} in ${dim(displayPath)}`);
 
   outro(NEXT_STEPS.LINK);
 }
@@ -120,7 +121,7 @@ async function ensureAuth() {
   if (process.env.CLERK_PLATFORM_API_KEY) return;
   const token = await getToken();
   if (!token) {
-    console.log("Not logged in. Authenticating first...");
+    log.data("Not logged in. Authenticating first...");
     await login({ showNextSteps: false });
   }
 }
@@ -135,9 +136,9 @@ function printExistingStatus(
   normalizedRemote: string | undefined,
 ) {
   if (existing.resolvedVia === "remote") {
-    console.log(`Auto-linked via git remote (${dim(normalizedRemote ?? existing.path)})`);
+    log.data(`Auto-linked via git remote (${dim(normalizedRemote ?? existing.path)})`);
   } else {
-    console.log(`Already linked to ${cyan(existing.profile.appId)} in ${dim(existing.path)}`);
+    log.data(`Already linked to ${cyan(existing.profile.appId)} in ${dim(existing.path)}`);
   }
 }
 
@@ -149,7 +150,7 @@ async function handleExistingProfile(
   printExistingStatus(existing, normalizedRemote);
 
   if (existing.availableRemote) {
-    console.log(
+    log.data(
       `We detected this is now a git repository with remote ${dim(existing.availableRemote)}.`,
     );
     const upgrade = await confirm({
@@ -158,7 +159,7 @@ async function handleExistingProfile(
     });
     if (upgrade) {
       await moveProfile(existing.path, existing.availableRemote);
-      console.log(`\nLink updated to use git remote (${cyan(existing.availableRemote)})`);
+      log.data(`\nLink updated to use git remote (${cyan(existing.availableRemote)})`);
       return false;
     }
   }
@@ -182,7 +183,7 @@ async function tryDetectApp(cwd: string, apps: Application[]): Promise<Applicati
   const match = matchKeyToApp(detectedKeys, apps);
   if (!match) return undefined;
 
-  console.log(`We found ${cyan(appLabel(match.app))} from ${dim(match.source)}.`);
+  log.info(`We found ${cyan(appLabel(match.app))} from ${dim(match.source)}.`);
   const useDetected = await confirm({ message: "Link to this application?", default: true });
   return useDetected ? match.app : undefined;
 }
@@ -199,7 +200,7 @@ async function resolveApp(
     );
   } catch (error) {
     if (error instanceof PlapiError && error.status >= 500) {
-      console.log("Could not fetch your applications — you can still create a new one");
+      log.info("Could not fetch your applications — you can still create a new one");
       apps = [];
     } else {
       throw error;

--- a/packages/cli-core/src/commands/switch-env/index.test.ts
+++ b/packages/cli-core/src/commands/switch-env/index.test.ts
@@ -1,5 +1,5 @@
-import { test, expect, describe, afterEach, mock, spyOn } from "bun:test";
-import { configStubs, credentialStoreStubs } from "../../test/lib/stubs.ts";
+import { test, expect, describe, beforeEach, afterEach, mock, spyOn } from "bun:test";
+import { captureLog, configStubs, credentialStoreStubs } from "../../test/lib/stubs.ts";
 
 const mockSetEnvironment = mock();
 const mockGetToken = mock();
@@ -30,8 +30,14 @@ const { switchEnv } = await import("./index.ts");
 
 describe("switch-env", () => {
   let logSpy: ReturnType<typeof spyOn>;
+  let captured: ReturnType<typeof captureLog>;
+
+  beforeEach(() => {
+    captured = captureLog();
+  });
 
   afterEach(() => {
+    captured.teardown();
     mockSetEnvironment.mockReset();
     mockGetToken.mockReset();
     mockCurrentEnv = "production";
@@ -42,8 +48,8 @@ describe("switch-env", () => {
     logSpy = spyOn(console, "log").mockImplementation(() => {});
     await switchEnv(undefined);
 
-    expect(logSpy).toHaveBeenCalledWith("Current environment: production");
-    expect(logSpy).toHaveBeenCalledWith("Available environments: production, staging");
+    expect(captured.out).toContain("Current environment: production");
+    expect(captured.out).toContain("Available environments: production, staging");
   });
 
   test("switches to a valid environment", async () => {
@@ -55,7 +61,7 @@ describe("switch-env", () => {
 
     expect(mockCurrentEnv).toBe("staging");
     expect(mockSetEnvironment).toHaveBeenCalledWith("staging");
-    expect(logSpy).toHaveBeenCalledWith("Switched from production to staging.");
+    expect(captured.out).toContain("Switched from production to staging.");
   });
 
   test("reports already on environment when switching to current", async () => {
@@ -65,7 +71,7 @@ describe("switch-env", () => {
     logSpy = spyOn(console, "log").mockImplementation(() => {});
     await switchEnv("production");
 
-    expect(logSpy).toHaveBeenCalledWith("Already on production environment.");
+    expect(captured.out).toContain("Already on production environment.");
   });
 
   test("throws on invalid environment", async () => {
@@ -81,7 +87,7 @@ describe("switch-env", () => {
     logSpy = spyOn(console, "log").mockImplementation(() => {});
     await switchEnv("staging");
 
-    expect(logSpy).toHaveBeenCalledWith(
+    expect(captured.out).toContain(
       "No credentials found for staging. Run `clerk auth login` to authenticate.",
     );
   });
@@ -93,6 +99,6 @@ describe("switch-env", () => {
     logSpy = spyOn(console, "log").mockImplementation(() => {});
     await switchEnv("staging");
 
-    expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining("No credentials found"));
+    expect(captured.out).not.toContain("No credentials found");
   });
 });

--- a/packages/cli-core/src/commands/switch-env/index.test.ts
+++ b/packages/cli-core/src/commands/switch-env/index.test.ts
@@ -44,9 +44,13 @@ describe("switch-env", () => {
     logSpy?.mockRestore();
   });
 
+  function runSwitchEnv(environment: string | undefined) {
+    return captured.run(() => switchEnv(environment));
+  }
+
   test("prints current environment when no argument given", async () => {
     logSpy = spyOn(console, "log").mockImplementation(() => {});
-    await switchEnv(undefined);
+    await runSwitchEnv(undefined);
 
     expect(captured.out).toContain("Current environment: production");
     expect(captured.out).toContain("Available environments: production, staging");
@@ -57,7 +61,7 @@ describe("switch-env", () => {
     mockGetToken.mockResolvedValue("some-token");
 
     logSpy = spyOn(console, "log").mockImplementation(() => {});
-    await switchEnv("staging");
+    await runSwitchEnv("staging");
 
     expect(mockCurrentEnv).toBe("staging");
     expect(mockSetEnvironment).toHaveBeenCalledWith("staging");
@@ -69,13 +73,13 @@ describe("switch-env", () => {
     mockGetToken.mockResolvedValue("some-token");
 
     logSpy = spyOn(console, "log").mockImplementation(() => {});
-    await switchEnv("production");
+    await runSwitchEnv("production");
 
     expect(captured.out).toContain("Already on production environment.");
   });
 
   test("throws on invalid environment", async () => {
-    await expect(switchEnv("nonexistent")).rejects.toThrow(
+    await expect(runSwitchEnv("nonexistent")).rejects.toThrow(
       'Unknown environment "nonexistent". Available environments: production, staging',
     );
   });
@@ -85,7 +89,7 @@ describe("switch-env", () => {
     mockGetToken.mockResolvedValue(null);
 
     logSpy = spyOn(console, "log").mockImplementation(() => {});
-    await switchEnv("staging");
+    await runSwitchEnv("staging");
 
     expect(captured.out).toContain(
       "No credentials found for staging. Run `clerk auth login` to authenticate.",
@@ -97,7 +101,7 @@ describe("switch-env", () => {
     mockGetToken.mockResolvedValue("valid-token");
 
     logSpy = spyOn(console, "log").mockImplementation(() => {});
-    await switchEnv("staging");
+    await runSwitchEnv("staging");
 
     expect(captured.out).not.toContain("No credentials found");
   });

--- a/packages/cli-core/src/commands/switch-env/index.test.ts
+++ b/packages/cli-core/src/commands/switch-env/index.test.ts
@@ -52,8 +52,8 @@ describe("switch-env", () => {
     logSpy = spyOn(console, "log").mockImplementation(() => {});
     await runSwitchEnv(undefined);
 
-    expect(captured.out).toContain("Current environment: production");
-    expect(captured.out).toContain("Available environments: production, staging");
+    expect(captured.err).toContain("Current environment: production");
+    expect(captured.err).toContain("Available environments: production, staging");
   });
 
   test("switches to a valid environment", async () => {

--- a/packages/cli-core/src/commands/switch-env/index.ts
+++ b/packages/cli-core/src/commands/switch-env/index.ts
@@ -16,6 +16,7 @@ import {
   setCurrentEnv,
 } from "../../lib/environment.ts";
 import { CliError } from "../../lib/errors.ts";
+import { log } from "../../lib/log.ts";
 
 export async function switchEnv(environment: string | undefined): Promise<void> {
   const available = getAvailableEnvs();
@@ -23,8 +24,8 @@ export async function switchEnv(environment: string | undefined): Promise<void> 
   // No argument: print current environment
   if (!environment) {
     const current = getCurrentEnvName();
-    console.log(`Current environment: ${current}`);
-    console.log(`Available environments: ${available.join(", ")}`);
+    log.data(`Current environment: ${current}`);
+    log.data(`Available environments: ${available.join(", ")}`);
     return;
   }
 
@@ -37,7 +38,7 @@ export async function switchEnv(environment: string | undefined): Promise<void> 
   const previousEnv = getCurrentEnvName();
 
   if (previousEnv === environment) {
-    console.log(`Already on ${environment} environment.`);
+    log.data(`Already on ${environment} environment.`);
     return;
   }
 
@@ -45,13 +46,11 @@ export async function switchEnv(environment: string | undefined): Promise<void> 
   setCurrentEnv(environment);
   await setEnvironment(environment);
 
-  console.log(`Switched from ${previousEnv} to ${environment}.`);
+  log.data(`Switched from ${previousEnv} to ${environment}.`);
 
   // Check if there's a stored token for the target environment
   const token = await getToken();
   if (!token) {
-    console.log(
-      `No credentials found for ${environment}. Run \`clerk auth login\` to authenticate.`,
-    );
+    log.data(`No credentials found for ${environment}. Run \`clerk auth login\` to authenticate.`);
   }
 }

--- a/packages/cli-core/src/commands/switch-env/index.ts
+++ b/packages/cli-core/src/commands/switch-env/index.ts
@@ -24,8 +24,8 @@ export async function switchEnv(environment: string | undefined): Promise<void> 
   // No argument: print current environment
   if (!environment) {
     const current = getCurrentEnvName();
-    log.data(`Current environment: ${current}`);
-    log.data(`Available environments: ${available.join(", ")}`);
+    log.info(`Current environment: ${current}`);
+    log.info(`Available environments: ${available.join(", ")}`);
     return;
   }
 

--- a/packages/cli-core/src/commands/unlink/index.test.ts
+++ b/packages/cli-core/src/commands/unlink/index.test.ts
@@ -1,5 +1,5 @@
-import { test, expect, describe, afterEach, mock, spyOn } from "bun:test";
-import { capturedOutput, configStubs, gitStubs, promptsStubs } from "../../test/lib/stubs.ts";
+import { test, expect, describe, beforeEach, afterEach, mock, spyOn } from "bun:test";
+import { captureLog, configStubs, gitStubs, promptsStubs } from "../../test/lib/stubs.ts";
 
 const mockIsAgent = mock();
 const mockIsHuman = mock();
@@ -46,8 +46,14 @@ describe("unlink", () => {
   let consoleSpy: ReturnType<typeof spyOn>;
   let errorSpy: ReturnType<typeof spyOn>;
   let exitSpy: ReturnType<typeof spyOn>;
+  let captured: ReturnType<typeof captureLog>;
+
+  beforeEach(() => {
+    captured = captureLog();
+  });
 
   afterEach(() => {
+    captured.teardown();
     _modeOverride = undefined;
     mockIsAgent.mockReset();
     mockIsHuman.mockReset();
@@ -68,9 +74,7 @@ describe("unlink", () => {
 
       await unlink();
 
-      expect(consoleSpy).toHaveBeenCalledTimes(1);
-      const output = consoleSpy.mock.calls[0][0] as string;
-      expect(output).toContain("unlinking a Clerk application");
+      expect(captured.out).toContain("unlinking a Clerk application");
     });
 
     test("does not trigger side effects", async () => {
@@ -150,8 +154,7 @@ describe("unlink", () => {
 
       await unlink({ yes: true });
 
-      const output = capturedOutput(consoleSpy);
-      expect(output).toContain("Unlinked");
+      expect(captured.out).toContain("Unlinked");
     });
   });
 });

--- a/packages/cli-core/src/commands/unlink/index.test.ts
+++ b/packages/cli-core/src/commands/unlink/index.test.ts
@@ -67,12 +67,16 @@ describe("unlink", () => {
     exitSpy?.mockRestore();
   });
 
+  function runUnlink(options?: Parameters<typeof unlink>[0]) {
+    return captured.run(() => unlink(options));
+  }
+
   describe("agent mode", () => {
     test("outputs prompt and returns", async () => {
       mockIsAgent.mockReturnValue(true);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await unlink();
+      await runUnlink();
 
       expect(captured.out).toContain("unlinking a Clerk application");
     });
@@ -81,7 +85,7 @@ describe("unlink", () => {
       mockIsAgent.mockReturnValue(true);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await unlink();
+      await runUnlink();
 
       expect(mockResolveProfile).not.toHaveBeenCalled();
       expect(mockRemoveProfile).not.toHaveBeenCalled();
@@ -98,7 +102,7 @@ describe("unlink", () => {
         throw new Error("exit");
       });
 
-      await expect(unlink()).rejects.toThrow("not linked");
+      await expect(runUnlink()).rejects.toThrow("not linked");
     });
   });
 
@@ -110,7 +114,7 @@ describe("unlink", () => {
       mockRemoveProfile.mockResolvedValue(undefined);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await unlink({ yes: true });
+      await runUnlink({ yes: true });
 
       expect(mockConfirm).not.toHaveBeenCalled();
       expect(mockRemoveProfile).toHaveBeenCalledWith(process.cwd());
@@ -124,7 +128,7 @@ describe("unlink", () => {
       mockRemoveProfile.mockResolvedValue(undefined);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await unlink();
+      await runUnlink();
 
       expect(mockConfirm).toHaveBeenCalledWith(
         expect.objectContaining({ message: expect.stringContaining("/repo") }),
@@ -139,7 +143,7 @@ describe("unlink", () => {
       mockConfirm.mockResolvedValue(false);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await expect(unlink()).rejects.toThrow("User aborted");
+      await expect(runUnlink()).rejects.toThrow("User aborted");
       expect(mockRemoveProfile).not.toHaveBeenCalled();
     });
   });
@@ -152,7 +156,7 @@ describe("unlink", () => {
       mockRemoveProfile.mockResolvedValue(undefined);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
-      await unlink({ yes: true });
+      await runUnlink({ yes: true });
 
       expect(captured.out).toContain("Unlinked");
     });

--- a/packages/cli-core/src/commands/unlink/index.ts
+++ b/packages/cli-core/src/commands/unlink/index.ts
@@ -4,6 +4,7 @@ import { resolveProfile, removeProfile } from "../../lib/config.ts";
 import { getGitRepoRoot } from "../../lib/git.ts";
 import { dim, cyan } from "../../lib/color.ts";
 import { CliError, ERROR_CODE, throwUserAbort } from "../../lib/errors.ts";
+import { log } from "../../lib/log.ts";
 
 const AGENT_PROMPT = `You are unlinking a Clerk application from the current project directory.
 
@@ -26,7 +27,7 @@ interface UnlinkOptions {
 
 export async function unlink(options: UnlinkOptions = {}): Promise<void> {
   if (isAgent()) {
-    console.log(AGENT_PROMPT);
+    log.data(AGENT_PROMPT);
     return;
   }
 
@@ -54,5 +55,5 @@ export async function unlink(options: UnlinkOptions = {}): Promise<void> {
   }
 
   await removeProfile(existing.path);
-  console.log(`\nUnlinked ${cyan(label)} from ${dim(displayPath)}`);
+  log.data(`\nUnlinked ${cyan(label)} from ${dim(displayPath)}`);
 }

--- a/packages/cli-core/src/commands/whoami/index.test.ts
+++ b/packages/cli-core/src/commands/whoami/index.test.ts
@@ -1,5 +1,6 @@
 import { test, expect, describe, beforeEach, afterEach, mock, spyOn } from "bun:test";
 import { captureLog, credentialStoreStubs, tokenExchangeStubs } from "../../test/lib/stubs.ts";
+import { CliError } from "../../lib/errors.ts";
 
 const mockGetToken = mock();
 const mockFetchUserInfo = mock();
@@ -48,23 +49,21 @@ describe("whoami", () => {
     expect(captured.out).toContain("alice@example.com");
   });
 
-  test("prompts to login when no token exists", async () => {
+  test("throws CliError when no token exists", async () => {
     mockGetToken.mockResolvedValue(null);
 
-    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
-    await runWhoami();
-
-    expect(captured.out).toContain("Not logged in");
+    await expect(runWhoami()).rejects.toThrow(CliError);
+    await expect(captured.run(() => whoami())).rejects.toThrow(/Not logged in/);
+    expect(captured.out).toBe("");
     expect(mockFetchUserInfo).not.toHaveBeenCalled();
   });
 
-  test("prints session expired when token is invalid", async () => {
+  test("throws CliError when token is invalid", async () => {
     mockGetToken.mockResolvedValue("expired-token");
     mockFetchUserInfo.mockRejectedValue(new Error("Unauthorized"));
 
-    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
-    await runWhoami();
-
-    expect(captured.out).toContain("Session expired");
+    await expect(runWhoami()).rejects.toThrow(CliError);
+    await expect(captured.run(() => whoami())).rejects.toThrow(/Session expired/);
+    expect(captured.out).toBe("");
   });
 });

--- a/packages/cli-core/src/commands/whoami/index.test.ts
+++ b/packages/cli-core/src/commands/whoami/index.test.ts
@@ -1,5 +1,5 @@
-import { test, expect, describe, afterEach, mock, spyOn } from "bun:test";
-import { credentialStoreStubs, tokenExchangeStubs } from "../../test/lib/stubs.ts";
+import { test, expect, describe, beforeEach, afterEach, mock, spyOn } from "bun:test";
+import { captureLog, credentialStoreStubs, tokenExchangeStubs } from "../../test/lib/stubs.ts";
 
 const mockGetToken = mock();
 const mockFetchUserInfo = mock();
@@ -18,8 +18,14 @@ const { whoami } = await import("./index.ts");
 
 describe("whoami", () => {
   let consoleSpy: ReturnType<typeof spyOn>;
+  let captured: ReturnType<typeof captureLog>;
+
+  beforeEach(() => {
+    captured = captureLog();
+  });
 
   afterEach(() => {
+    captured.teardown();
     mockGetToken.mockReset();
     mockFetchUserInfo.mockReset();
     consoleSpy?.mockRestore();
@@ -35,7 +41,7 @@ describe("whoami", () => {
     consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     await whoami();
 
-    expect(consoleSpy).toHaveBeenCalledWith("alice@example.com");
+    expect(captured.out).toContain("alice@example.com");
   });
 
   test("prompts to login when no token exists", async () => {
@@ -44,7 +50,7 @@ describe("whoami", () => {
     consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     await whoami();
 
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Not logged in"));
+    expect(captured.out).toContain("Not logged in");
     expect(mockFetchUserInfo).not.toHaveBeenCalled();
   });
 
@@ -55,6 +61,6 @@ describe("whoami", () => {
     consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     await whoami();
 
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Session expired"));
+    expect(captured.out).toContain("Session expired");
   });
 });

--- a/packages/cli-core/src/commands/whoami/index.test.ts
+++ b/packages/cli-core/src/commands/whoami/index.test.ts
@@ -31,6 +31,10 @@ describe("whoami", () => {
     consoleSpy?.mockRestore();
   });
 
+  function runWhoami() {
+    return captured.run(() => whoami());
+  }
+
   test("prints email when authenticated", async () => {
     mockGetToken.mockResolvedValue("valid-token");
     mockFetchUserInfo.mockResolvedValue({
@@ -39,7 +43,7 @@ describe("whoami", () => {
     });
 
     consoleSpy = spyOn(console, "log").mockImplementation(() => {});
-    await whoami();
+    await runWhoami();
 
     expect(captured.out).toContain("alice@example.com");
   });
@@ -48,7 +52,7 @@ describe("whoami", () => {
     mockGetToken.mockResolvedValue(null);
 
     consoleSpy = spyOn(console, "log").mockImplementation(() => {});
-    await whoami();
+    await runWhoami();
 
     expect(captured.out).toContain("Not logged in");
     expect(mockFetchUserInfo).not.toHaveBeenCalled();
@@ -59,7 +63,7 @@ describe("whoami", () => {
     mockFetchUserInfo.mockRejectedValue(new Error("Unauthorized"));
 
     consoleSpy = spyOn(console, "log").mockImplementation(() => {});
-    await whoami();
+    await runWhoami();
 
     expect(captured.out).toContain("Session expired");
   });

--- a/packages/cli-core/src/commands/whoami/index.ts
+++ b/packages/cli-core/src/commands/whoami/index.ts
@@ -1,19 +1,20 @@
 import { getToken } from "../../lib/credential-store.ts";
 import { fetchUserInfo } from "../../lib/token-exchange.ts";
 import { withSpinner } from "../../lib/spinner.ts";
+import { log } from "../../lib/log.ts";
 
 export async function whoami() {
   const token = await getToken();
   if (!token) {
-    console.log("Not logged in. Run `clerk auth login` to authenticate");
+    log.data("Not logged in. Run `clerk auth login` to authenticate");
     return;
   }
 
   try {
     const userInfo = await withSpinner("Fetching account info...", () => fetchUserInfo(token));
-    console.log(userInfo.email);
+    log.data(userInfo.email);
   } catch {
-    console.log("Session expired. Run `clerk auth login` to re-authenticate");
+    log.data("Session expired. Run `clerk auth login` to re-authenticate");
     return;
   }
 }

--- a/packages/cli-core/src/commands/whoami/index.ts
+++ b/packages/cli-core/src/commands/whoami/index.ts
@@ -2,19 +2,22 @@ import { getToken } from "../../lib/credential-store.ts";
 import { fetchUserInfo } from "../../lib/token-exchange.ts";
 import { withSpinner } from "../../lib/spinner.ts";
 import { log } from "../../lib/log.ts";
+import { CliError, ERROR_CODE } from "../../lib/errors.ts";
 
 export async function whoami() {
   const token = await getToken();
   if (!token) {
-    log.data("Not logged in. Run `clerk auth login` to authenticate");
-    return;
+    throw new CliError("Not logged in. Run `clerk auth login` to authenticate", {
+      code: ERROR_CODE.AUTH_REQUIRED,
+    });
   }
 
   try {
     const userInfo = await withSpinner("Fetching account info...", () => fetchUserInfo(token));
     log.data(userInfo.email);
   } catch {
-    log.data("Session expired. Run `clerk auth login` to re-authenticate");
-    return;
+    throw new CliError("Session expired. Run `clerk auth login` to re-authenticate", {
+      code: ERROR_CODE.AUTH_REQUIRED,
+    });
   }
 }

--- a/packages/cli-core/src/lib/autolink.test.ts
+++ b/packages/cli-core/src/lib/autolink.test.ts
@@ -2,7 +2,7 @@ import { test, expect, describe, beforeEach, afterEach, mock, spyOn } from "bun:
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { credentialStoreStubs, gitStubs, stubFetch } from "../test/lib/stubs.ts";
+import { credentialStoreStubs, gitStubs, stubFetch, captureLog } from "../test/lib/stubs.ts";
 
 mock.module("./credential-store.ts", () => credentialStoreStubs);
 
@@ -223,6 +223,7 @@ describe("autolink", () => {
   let tempDir: string;
   let errorSpy: ReturnType<typeof spyOn>;
   let debugSpy: ReturnType<typeof spyOn>;
+  let captured: ReturnType<typeof captureLog>;
 
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), "clerk-autolink-test-"));
@@ -237,11 +238,13 @@ describe("autolink", () => {
     mockGetGitNormalizedRemote.mockResolvedValue(undefined);
     errorSpy = spyOn(console, "error").mockImplementation(() => {});
     debugSpy = spyOn(console, "debug").mockImplementation(() => {});
+    captured = captureLog();
 
     stubFetch(async () => new Response(JSON.stringify(mockApps), { status: 200 }));
   });
 
   afterEach(async () => {
+    captured.teardown();
     _setConfigDir(undefined);
     process.env = { ...originalEnv };
     globalThis.fetch = originalFetch;
@@ -340,10 +343,9 @@ describe("autolink", () => {
 
     await autolink(tempDir);
 
-    const output = errorSpy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
-    expect(output).toContain("Auto-linked to");
-    expect(output).toContain("My App");
-    expect(output).toContain("CLERK_PUBLISHABLE_KEY env var");
+    expect(captured.err).toContain("Auto-linked to");
+    expect(captured.err).toContain("My App");
+    expect(captured.err).toContain("CLERK_PUBLISHABLE_KEY env var");
   });
 
   test("returns undefined when matched app has no development instance", async () => {

--- a/packages/cli-core/src/lib/autolink.test.ts
+++ b/packages/cli-core/src/lib/autolink.test.ts
@@ -253,8 +253,12 @@ describe("autolink", () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
+  function runAutolink(cwd: string) {
+    return captured.run(() => autolink(cwd));
+  }
+
   test("returns undefined when no keys detected", async () => {
-    const result = await autolink(tempDir);
+    const result = await runAutolink(tempDir);
     expect(result).toBeUndefined();
   });
 
@@ -262,7 +266,7 @@ describe("autolink", () => {
     process.env.CLERK_PUBLISHABLE_KEY = "pk_test_abc";
     delete process.env.CLERK_PLATFORM_API_KEY;
 
-    const result = await autolink(tempDir);
+    const result = await runAutolink(tempDir);
     expect(result).toBeUndefined();
   });
 
@@ -270,21 +274,21 @@ describe("autolink", () => {
     process.env.CLERK_PUBLISHABLE_KEY = "pk_test_abc";
     stubFetch(async () => new Response("Unauthorized", { status: 401 }));
 
-    const result = await autolink(tempDir);
+    const result = await runAutolink(tempDir);
     expect(result).toBeUndefined();
   });
 
   test("returns undefined when key doesn't match any app", async () => {
     process.env.CLERK_PUBLISHABLE_KEY = "pk_test_unknown";
 
-    const result = await autolink(tempDir);
+    const result = await runAutolink(tempDir);
     expect(result).toBeUndefined();
   });
 
   test("auto-links when publishable key matches via env var", async () => {
     process.env.CLERK_PUBLISHABLE_KEY = "pk_test_abc";
 
-    const result = await autolink(tempDir);
+    const result = await runAutolink(tempDir);
 
     expect(result).toBeDefined();
     expect(result!.profile.appId).toBe("app_123");
@@ -300,7 +304,7 @@ describe("autolink", () => {
   test("auto-links when publishable key matches via .env file", async () => {
     await Bun.write(join(tempDir, ".env.local"), "CLERK_PUBLISHABLE_KEY=pk_test_def\n");
 
-    const result = await autolink(tempDir);
+    const result = await runAutolink(tempDir);
 
     expect(result).toBeDefined();
     expect(result!.profile.appId).toBe("app_456");
@@ -311,7 +315,7 @@ describe("autolink", () => {
     process.env.CLERK_PUBLISHABLE_KEY = "pk_test_abc";
     mockGetGitNormalizedRemote.mockResolvedValue("github.com/org/repo");
 
-    const result = await autolink(tempDir);
+    const result = await runAutolink(tempDir);
 
     expect(result!.path).toBe("github.com/org/repo");
     const config = await readConfig();
@@ -323,7 +327,7 @@ describe("autolink", () => {
     mockGetGitNormalizedRemote.mockResolvedValue(undefined);
     mockGetGitRepoIdentifier.mockResolvedValue("/repo/.git");
 
-    const result = await autolink(tempDir);
+    const result = await runAutolink(tempDir);
 
     expect(result!.path).toBe("/repo/.git");
     const config = await readConfig();
@@ -333,7 +337,7 @@ describe("autolink", () => {
   test("falls back to cwd when not in a git repo", async () => {
     process.env.CLERK_PUBLISHABLE_KEY = "pk_test_abc";
 
-    const result = await autolink(tempDir);
+    const result = await runAutolink(tempDir);
 
     expect(result!.path).toBe(tempDir);
   });
@@ -341,7 +345,7 @@ describe("autolink", () => {
   test("prints auto-link message to stderr", async () => {
     process.env.CLERK_PUBLISHABLE_KEY = "pk_test_abc";
 
-    await autolink(tempDir);
+    await runAutolink(tempDir);
 
     expect(captured.err).toContain("Auto-linked to");
     expect(captured.err).toContain("My App");
@@ -369,7 +373,7 @@ describe("autolink", () => {
         ),
     );
 
-    const result = await autolink(tempDir);
+    const result = await runAutolink(tempDir);
     expect(result).toBeUndefined();
   });
 
@@ -377,14 +381,14 @@ describe("autolink", () => {
     process.env.CLERK_PUBLISHABLE_KEY = "pk_test_abc";
     stubFetch(async () => new Response(JSON.stringify({ error: "not an array" }), { status: 200 }));
 
-    const result = await autolink(tempDir);
+    const result = await runAutolink(tempDir);
     expect(result).toBeUndefined();
   });
 
   test("omits production instance when not present", async () => {
     process.env.CLERK_PUBLISHABLE_KEY = "pk_test_def";
 
-    const result = await autolink(tempDir);
+    const result = await runAutolink(tempDir);
 
     expect(result!.profile.instances.production).toBeUndefined();
   });

--- a/packages/cli-core/src/lib/autolink.ts
+++ b/packages/cli-core/src/lib/autolink.ts
@@ -5,6 +5,7 @@ import { getGitRepoIdentifier, getGitNormalizedRemote } from "./git.ts";
 import { parseEnvFile } from "./dotenv.ts";
 import { detectPublishableKeyName } from "./framework.ts";
 import { dim, cyan } from "./color.ts";
+import { log } from "./log.ts";
 
 const ENV_FILES = [".env", ".env.local"];
 
@@ -85,7 +86,7 @@ export async function autolink(
   try {
     apps = await listApplications();
   } catch (err) {
-    console.error(`Failed to list applications: ${err}`);
+    log.error(`Failed to list applications: ${err}`);
     return undefined;
   }
 
@@ -120,7 +121,7 @@ export async function autolink(
   await setProfile(profileKey, profile);
 
   const label = match.app.name || match.app.application_id;
-  console.error(`Auto-linked to ${cyan(label)} ${dim(`(detected key in ${match.source})`)}`);
+  log.info(`Auto-linked to ${cyan(label)} ${dim(`(detected key in ${match.source})`)}`);
 
   return { path: profileKey, profile };
 }

--- a/packages/cli-core/src/lib/log.test.ts
+++ b/packages/cli-core/src/lib/log.test.ts
@@ -1,10 +1,12 @@
-import { test, expect, beforeEach, afterEach } from "bun:test";
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
 import {
   log,
   type CapturedLogs,
   withCapturedLogs,
   setLogLevel,
   getLogLevel,
+  pushPrefix,
+  popPrefix,
   type LogLevel,
 } from "./log.ts";
 
@@ -20,56 +22,6 @@ function deferred() {
   return { promise, resolve };
 }
 
-// ── Async isolation ──────────────────────────────────────────────────────
-
-test("withCapturedLogs isolates interleaved async logging", async () => {
-  const first = createCapture();
-  const second = createCapture();
-  const firstMayFinish = deferred();
-  const secondHasStarted = deferred();
-
-  const firstTask = withCapturedLogs(first, async () => {
-    log.info("first:start");
-    secondHasStarted.resolve();
-    await firstMayFinish.promise;
-    log.data("first:end");
-  });
-
-  const secondTask = withCapturedLogs(second, async () => {
-    log.info("second:start");
-    await secondHasStarted.promise;
-    log.data("second:end");
-    firstMayFinish.resolve();
-  });
-
-  await Promise.all([firstTask, secondTask]);
-
-  expect(first.stderr).toEqual(["first:start"]);
-  expect(first.stdout).toEqual(["first:end"]);
-  expect(second.stderr).toEqual(["second:start"]);
-  expect(second.stdout).toEqual(["second:end"]);
-});
-
-test("withCapturedLogs restores the parent capture after nested scopes", async () => {
-  const outer = createCapture();
-  const inner = createCapture();
-
-  await withCapturedLogs(outer, async () => {
-    log.info("outer:before");
-    await withCapturedLogs(inner, async () => {
-      log.data("inner:data");
-    });
-    log.info("outer:after");
-  });
-
-  expect(outer.stderr).toEqual(["outer:before", "outer:after"]);
-  expect(outer.stdout).toEqual([]);
-  expect(inner.stderr).toEqual([]);
-  expect(inner.stdout).toEqual(["inner:data"]);
-});
-
-// ── Log levels ───────────────────────────────────────────────────────────
-
 let savedLevel: LogLevel;
 
 beforeEach(() => {
@@ -80,132 +32,245 @@ afterEach(() => {
   setLogLevel(savedLevel);
 });
 
-test("debug messages are hidden at default info level", () => {
-  const cap = createCapture();
-  setLogLevel("info");
+describe("withCapturedLogs", () => {
+  test("isolates interleaved async logging", async () => {
+    const first = createCapture();
+    const second = createCapture();
+    const firstMayFinish = deferred();
+    const secondHasStarted = deferred();
 
-  withCapturedLogs(cap, () => {
-    log.debug("should be hidden");
-    log.info("should be visible");
+    const firstTask = withCapturedLogs(first, async () => {
+      log.info("first:start");
+      secondHasStarted.resolve();
+      await firstMayFinish.promise;
+      log.data("first:end");
+    });
+
+    const secondTask = withCapturedLogs(second, async () => {
+      log.info("second:start");
+      await secondHasStarted.promise;
+      log.data("second:end");
+      firstMayFinish.resolve();
+    });
+
+    await Promise.all([firstTask, secondTask]);
+
+    expect(first.stderr).toEqual(["first:start"]);
+    expect(first.stdout).toEqual(["first:end"]);
+    expect(second.stderr).toEqual(["second:start"]);
+    expect(second.stdout).toEqual(["second:end"]);
   });
 
-  expect(cap.stderr).toEqual(["should be visible"]);
+  test("restores the parent capture after nested scopes", async () => {
+    const outer = createCapture();
+    const inner = createCapture();
+
+    await withCapturedLogs(outer, async () => {
+      log.info("outer:before");
+      await withCapturedLogs(inner, async () => {
+        log.data("inner:data");
+      });
+      log.info("outer:after");
+    });
+
+    expect(outer.stderr).toEqual(["outer:before", "outer:after"]);
+    expect(outer.stdout).toEqual([]);
+    expect(inner.stderr).toEqual([]);
+    expect(inner.stdout).toEqual(["inner:data"]);
+  });
 });
 
-test("debug messages are shown at debug level", () => {
-  const cap = createCapture();
-  setLogLevel("debug");
+describe("log levels", () => {
+  test("debug messages are hidden at default info level", () => {
+    const cap = createCapture();
+    setLogLevel("info");
 
-  withCapturedLogs(cap, () => {
-    log.debug("visible debug");
+    withCapturedLogs(cap, () => {
+      log.debug("should be hidden");
+      log.info("should be visible");
+    });
+
+    expect(cap.stderr).toEqual(["should be visible"]);
   });
 
-  expect(cap.stderr.length).toBe(1);
-  expect(cap.stderr[0]).toContain("visible debug");
+  test("debug messages are shown at debug level", () => {
+    const cap = createCapture();
+    setLogLevel("debug");
+
+    withCapturedLogs(cap, () => {
+      log.debug("visible debug");
+    });
+
+    expect(cap.stderr.length).toBe(1);
+    expect(cap.stderr[0]).toContain("visible debug");
+  });
+
+  test("warn level hides info and debug", () => {
+    const cap = createCapture();
+    setLogLevel("warn");
+
+    withCapturedLogs(cap, () => {
+      log.debug("hidden");
+      log.info("hidden");
+      log.warn("visible");
+      log.error("visible");
+    });
+
+    expect(cap.stderr.length).toBe(2);
+  });
+
+  test("silent level hides everything", () => {
+    const cap = createCapture();
+    setLogLevel("silent");
+
+    withCapturedLogs(cap, () => {
+      log.error("hidden");
+      log.warn("hidden");
+      log.info("hidden");
+      log.debug("hidden");
+    });
+
+    expect(cap.stderr).toEqual([]);
+  });
+
+  test("data output is never filtered by log level", () => {
+    const cap = createCapture();
+    setLogLevel("silent");
+
+    withCapturedLogs(cap, () => {
+      log.data("always visible");
+    });
+
+    expect(cap.stdout).toEqual(["always visible"]);
+  });
 });
 
-test("warn level hides info and debug", () => {
-  const cap = createCapture();
-  setLogLevel("warn");
+describe("withTag", () => {
+  test("prefixes messages with dim tag", () => {
+    const cap = createCapture();
+    const tagged = log.withTag("api");
 
-  withCapturedLogs(cap, () => {
-    log.debug("hidden");
-    log.info("hidden");
-    log.warn("visible");
-    log.error("visible");
+    withCapturedLogs(cap, () => {
+      tagged.info("request sent");
+    });
+
+    expect(cap.stderr.length).toBe(1);
+    expect(cap.stderr[0]).toContain("[api]");
+    expect(cap.stderr[0]).toContain("request sent");
   });
 
-  expect(cap.stderr.length).toBe(2);
+  test("nested tags combine with colon", () => {
+    const cap = createCapture();
+    const tagged = log.withTag("http").withTag("request");
+
+    withCapturedLogs(cap, () => {
+      tagged.info("GET /");
+    });
+
+    expect(cap.stderr[0]).toContain("[http:request]");
+    expect(cap.stderr[0]).toContain("GET /");
+  });
+
+  test("respects log level", () => {
+    const cap = createCapture();
+    setLogLevel("warn");
+    const tagged = log.withTag("api");
+
+    withCapturedLogs(cap, () => {
+      tagged.info("hidden");
+      tagged.warn("visible");
+    });
+
+    expect(cap.stderr.length).toBe(1);
+    expect(cap.stderr[0]).toContain("visible");
+  });
+
+  test("data goes to stdout without tag prefix", () => {
+    const cap = createCapture();
+    const tagged = log.withTag("api");
+
+    withCapturedLogs(cap, () => {
+      tagged.data("raw output");
+    });
+
+    expect(cap.stdout).toEqual(["raw output"]);
+  });
+
+  test("preserves outer color after dim tag", () => {
+    const cap = createCapture();
+    const tagged = log.withTag("api");
+
+    withCapturedLogs(cap, () => {
+      tagged.error("broken");
+    });
+
+    expect(cap.stderr).toHaveLength(1);
+    const [output] = cap.stderr;
+    const tagEnd = output.indexOf("]");
+    const afterTagBeforeMessage = output.slice(tagEnd + 1, output.indexOf("broken"));
+    expect(afterTagBeforeMessage).not.toContain("\x1b[0m");
+    expect(output).toContain("\x1b[22m");
+  });
 });
 
-test("silent level hides everything", () => {
-  const cap = createCapture();
-  setLogLevel("silent");
+describe("inline highlighting", () => {
+  test("backtick spans are highlighted in cyan", () => {
+    const cap = createCapture();
 
-  withCapturedLogs(cap, () => {
-    log.error("hidden");
-    log.warn("hidden");
-    log.info("hidden");
-    log.debug("hidden");
+    withCapturedLogs(cap, () => {
+      log.info("Run `clerk link` to continue");
+    });
+
+    expect(cap.stderr.length).toBe(1);
+    expect(cap.stderr[0]).toContain("\x1b[36m");
+    expect(cap.stderr[0]).toContain("clerk link");
   });
 
-  expect(cap.stderr).toEqual([]);
+  test("does not use full ANSI reset that breaks outer styles", () => {
+    const cap = createCapture();
+
+    withCapturedLogs(cap, () => {
+      log.info("Run `clerk link` then check");
+    });
+
+    expect(cap.stderr).toHaveLength(1);
+    const [output] = cap.stderr;
+    const beforeBacktick = output.indexOf("\x1b[36m");
+    const afterBacktick = output.indexOf("clerk link") + "clerk link".length;
+    const highlightRegion = output.slice(beforeBacktick, afterBacktick + 10);
+    expect(highlightRegion).not.toContain("\x1b[0m");
+  });
 });
 
-test("data output is never filtered by log level", () => {
-  const cap = createCapture();
-  setLogLevel("silent");
+describe("blank", () => {
+  test("includes pipe prefix when inside intro/outro flow", () => {
+    const cap = createCapture();
 
-  withCapturedLogs(cap, () => {
-    log.data("always visible");
+    withCapturedLogs(cap, () => {
+      pushPrefix();
+      log.blank();
+      popPrefix();
+    });
+
+    expect(cap.stderr.length).toBe(1);
+    expect(cap.stderr[0]).toContain("│");
   });
-
-  expect(cap.stdout).toEqual(["always visible"]);
 });
 
-// ── Tagged loggers ───────────────────────────────────────────────────────
+describe("raw", () => {
+  test("is never throttled for duplicate messages", () => {
+    const cap = createCapture();
+    const payload = JSON.stringify({
+      error: { code: "auth_required", message: "Not authenticated" },
+    });
 
-test("withTag prefixes messages with dim tag", () => {
-  const cap = createCapture();
-  const tagged = log.withTag("api");
+    withCapturedLogs(cap, () => {
+      log.raw(payload);
+      log.raw(payload);
+      log.raw(payload);
+    });
 
-  withCapturedLogs(cap, () => {
-    tagged.info("request sent");
+    expect(cap.stderr.length).toBe(3);
+    expect(cap.stderr.every((line) => line === payload)).toBe(true);
   });
-
-  expect(cap.stderr.length).toBe(1);
-  expect(cap.stderr[0]).toContain("[api]");
-  expect(cap.stderr[0]).toContain("request sent");
-});
-
-test("nested withTag combines tags with colon", () => {
-  const cap = createCapture();
-  const tagged = log.withTag("http").withTag("request");
-
-  withCapturedLogs(cap, () => {
-    tagged.info("GET /");
-  });
-
-  expect(cap.stderr[0]).toContain("[http:request]");
-  expect(cap.stderr[0]).toContain("GET /");
-});
-
-test("tagged logger respects log level", () => {
-  const cap = createCapture();
-  setLogLevel("warn");
-  const tagged = log.withTag("api");
-
-  withCapturedLogs(cap, () => {
-    tagged.info("hidden");
-    tagged.warn("visible");
-  });
-
-  expect(cap.stderr.length).toBe(1);
-  expect(cap.stderr[0]).toContain("visible");
-});
-
-test("tagged data goes to stdout without tag prefix", () => {
-  const cap = createCapture();
-  const tagged = log.withTag("api");
-
-  withCapturedLogs(cap, () => {
-    tagged.data("raw output");
-  });
-
-  expect(cap.stdout).toEqual(["raw output"]);
-});
-
-// ── Inline highlighting ──────────────────────────────────────────────────
-
-test("backtick spans are highlighted in info messages", () => {
-  const cap = createCapture();
-
-  withCapturedLogs(cap, () => {
-    log.info("Run `clerk link` to continue");
-  });
-
-  expect(cap.stderr.length).toBe(1);
-  // Should contain ANSI cyan codes around the backtick content
-  expect(cap.stderr[0]).toContain("\x1b[36m");
-  expect(cap.stderr[0]).toContain("clerk link");
 });

--- a/packages/cli-core/src/lib/log.test.ts
+++ b/packages/cli-core/src/lib/log.test.ts
@@ -1,5 +1,12 @@
-import { test, expect } from "bun:test";
-import { log, type CapturedLogs, withCapturedLogs } from "./log.ts";
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  log,
+  type CapturedLogs,
+  withCapturedLogs,
+  setLogLevel,
+  getLogLevel,
+  type LogLevel,
+} from "./log.ts";
 
 function createCapture(): CapturedLogs {
   return { stdout: [], stderr: [] };
@@ -12,6 +19,8 @@ function deferred() {
   });
   return { promise, resolve };
 }
+
+// ── Async isolation ──────────────────────────────────────────────────────
 
 test("withCapturedLogs isolates interleaved async logging", async () => {
   const first = createCapture();
@@ -57,4 +66,146 @@ test("withCapturedLogs restores the parent capture after nested scopes", async (
   expect(outer.stdout).toEqual([]);
   expect(inner.stderr).toEqual([]);
   expect(inner.stdout).toEqual(["inner:data"]);
+});
+
+// ── Log levels ───────────────────────────────────────────────────────────
+
+let savedLevel: LogLevel;
+
+beforeEach(() => {
+  savedLevel = getLogLevel();
+});
+
+afterEach(() => {
+  setLogLevel(savedLevel);
+});
+
+test("debug messages are hidden at default info level", () => {
+  const cap = createCapture();
+  setLogLevel("info");
+
+  withCapturedLogs(cap, () => {
+    log.debug("should be hidden");
+    log.info("should be visible");
+  });
+
+  expect(cap.stderr).toEqual(["should be visible"]);
+});
+
+test("debug messages are shown at debug level", () => {
+  const cap = createCapture();
+  setLogLevel("debug");
+
+  withCapturedLogs(cap, () => {
+    log.debug("visible debug");
+  });
+
+  expect(cap.stderr.length).toBe(1);
+  expect(cap.stderr[0]).toContain("visible debug");
+});
+
+test("warn level hides info and debug", () => {
+  const cap = createCapture();
+  setLogLevel("warn");
+
+  withCapturedLogs(cap, () => {
+    log.debug("hidden");
+    log.info("hidden");
+    log.warn("visible");
+    log.error("visible");
+  });
+
+  expect(cap.stderr.length).toBe(2);
+});
+
+test("silent level hides everything", () => {
+  const cap = createCapture();
+  setLogLevel("silent");
+
+  withCapturedLogs(cap, () => {
+    log.error("hidden");
+    log.warn("hidden");
+    log.info("hidden");
+    log.debug("hidden");
+  });
+
+  expect(cap.stderr).toEqual([]);
+});
+
+test("data output is never filtered by log level", () => {
+  const cap = createCapture();
+  setLogLevel("silent");
+
+  withCapturedLogs(cap, () => {
+    log.data("always visible");
+  });
+
+  expect(cap.stdout).toEqual(["always visible"]);
+});
+
+// ── Tagged loggers ───────────────────────────────────────────────────────
+
+test("withTag prefixes messages with dim tag", () => {
+  const cap = createCapture();
+  const tagged = log.withTag("api");
+
+  withCapturedLogs(cap, () => {
+    tagged.info("request sent");
+  });
+
+  expect(cap.stderr.length).toBe(1);
+  expect(cap.stderr[0]).toContain("[api]");
+  expect(cap.stderr[0]).toContain("request sent");
+});
+
+test("nested withTag combines tags with colon", () => {
+  const cap = createCapture();
+  const tagged = log.withTag("http").withTag("request");
+
+  withCapturedLogs(cap, () => {
+    tagged.info("GET /");
+  });
+
+  expect(cap.stderr[0]).toContain("[http:request]");
+  expect(cap.stderr[0]).toContain("GET /");
+});
+
+test("tagged logger respects log level", () => {
+  const cap = createCapture();
+  setLogLevel("warn");
+  const tagged = log.withTag("api");
+
+  withCapturedLogs(cap, () => {
+    tagged.info("hidden");
+    tagged.warn("visible");
+  });
+
+  expect(cap.stderr.length).toBe(1);
+  expect(cap.stderr[0]).toContain("visible");
+});
+
+test("tagged data goes to stdout without tag prefix", () => {
+  const cap = createCapture();
+  const tagged = log.withTag("api");
+
+  withCapturedLogs(cap, () => {
+    tagged.data("raw output");
+  });
+
+  expect(cap.stdout).toEqual(["raw output"]);
+});
+
+// ── Inline highlighting ──────────────────────────────────────────────────
+
+test("backtick spans are highlighted in info messages", () => {
+  const cap = createCapture();
+
+  withCapturedLogs(cap, () => {
+    log.info("Run `clerk link` to continue");
+  });
+
+  expect(cap.stderr.length).toBe(1);
+  // Should contain ANSI cyan codes around the backtick content
+  expect(cap.stderr[0]).toContain("\x1b[36m");
+  expect(cap.stderr[0]).toContain("clerk link");
 });

--- a/packages/cli-core/src/lib/log.test.ts
+++ b/packages/cli-core/src/lib/log.test.ts
@@ -1,0 +1,60 @@
+import { test, expect } from "bun:test";
+import { log, type CapturedLogs, withCapturedLogs } from "./log.ts";
+
+function createCapture(): CapturedLogs {
+  return { stdout: [], stderr: [] };
+}
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+test("withCapturedLogs isolates interleaved async logging", async () => {
+  const first = createCapture();
+  const second = createCapture();
+  const firstMayFinish = deferred();
+  const secondHasStarted = deferred();
+
+  const firstTask = withCapturedLogs(first, async () => {
+    log.info("first:start");
+    secondHasStarted.resolve();
+    await firstMayFinish.promise;
+    log.data("first:end");
+  });
+
+  const secondTask = withCapturedLogs(second, async () => {
+    log.info("second:start");
+    await secondHasStarted.promise;
+    log.data("second:end");
+    firstMayFinish.resolve();
+  });
+
+  await Promise.all([firstTask, secondTask]);
+
+  expect(first.stderr).toEqual(["first:start"]);
+  expect(first.stdout).toEqual(["first:end"]);
+  expect(second.stderr).toEqual(["second:start"]);
+  expect(second.stdout).toEqual(["second:end"]);
+});
+
+test("withCapturedLogs restores the parent capture after nested scopes", async () => {
+  const outer = createCapture();
+  const inner = createCapture();
+
+  await withCapturedLogs(outer, async () => {
+    log.info("outer:before");
+    await withCapturedLogs(inner, async () => {
+      log.data("inner:data");
+    });
+    log.info("outer:after");
+  });
+
+  expect(outer.stderr).toEqual(["outer:before", "outer:after"]);
+  expect(outer.stdout).toEqual([]);
+  expect(inner.stderr).toEqual([]);
+  expect(inner.stdout).toEqual(["inner:data"]);
+});

--- a/packages/cli-core/src/lib/log.ts
+++ b/packages/cli-core/src/lib/log.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
-import { cyan, dim, green, red, yellow } from "./color.ts";
+import { dim, green, red, yellow } from "./color.ts";
 
 // ── Log level ────────────────────────────────────────────────────────────
 
@@ -61,17 +61,18 @@ let lastLogTime = 0;
 let throttleTimer: ReturnType<typeof setTimeout> | undefined;
 
 function flushThrottle() {
-  if (lastLogCount > THROTTLE_MIN) {
-    const repeated = lastLogCount - THROTTLE_MIN;
+  const repeated = lastLogCount - THROTTLE_MIN;
+  // Reset state before writing to avoid re-entering shouldWrite → flushThrottle
+  lastLogKey = "";
+  lastLogCount = 0;
+  throttleTimer = undefined;
+  if (repeated > 0) {
     writeln(
       process.stderr,
       "stderr",
       applyPrefix(dim(`  (repeated ${repeated} more time${repeated === 1 ? "" : "s"})`)),
     );
   }
-  lastLogKey = "";
-  lastLogCount = 0;
-  throttleTimer = undefined;
 }
 
 /**
@@ -115,7 +116,9 @@ function shouldWrite(channel: "stdout" | "stderr", msg: string): boolean {
  * Highlights `backtick` spans in cyan within a message.
  */
 function highlight(msg: string): string {
-  return msg.replace(/`([^`]+)`/g, (_, content) => cyan(`\`${content}\``));
+  // Use targeted foreground color set/reset (\x1b[39m = default fg) instead of
+  // cyan() which uses \x1b[0m (full reset) and kills surrounding styles.
+  return msg.replace(/`([^`]+)`/g, (_, content) => `\x1b[36m\`${content}\`\x1b[39m`);
 }
 
 // ── Capture context (for testing) ─────────────────────────────────────────
@@ -150,7 +153,9 @@ export type Logger = typeof log & {
 function createLogger(tag?: string): Logger {
   function formatTag(msg: string): string {
     if (!tag) return msg;
-    return `${dim(`[${tag}]`)} ${msg}`;
+    // Use targeted dim on/off (\x1b[22m = normal intensity) instead of dim()
+    // which uses \x1b[0m (full reset) and kills surrounding color styles.
+    return `\x1b[2m[${tag}]\x1b[22m ${msg}`;
   }
 
   const logger = {
@@ -179,18 +184,24 @@ function createLogger(tag?: string): Logger {
       if (!isLevelEnabled("debug")) return;
       writeln(process.stderr, "stderr", applyPrefix(dim(formatTag(msg))));
     },
-    /** Blank line to stderr. */
+    /** Blank line to stderr. Preserves pipe prefix inside intro/outro flow. */
     blank() {
+      const prefix = applyPrefix("");
       const captured = captureStorage.getStore();
       if (captured) {
-        captured.stderr.push("");
+        captured.stderr.push(prefix);
       } else {
-        process.stderr.write("\n");
+        process.stderr.write(prefix + "\n");
       }
     },
-    /** Raw stderr — no color, no prefix. For machine-readable output (agent JSON). */
+    /** Raw stderr — no color, no prefix, no throttle. For machine-readable output (agent JSON). */
     raw(msg: string) {
-      writeln(process.stderr, "stderr", msg);
+      const captured = captureStorage.getStore();
+      if (captured) {
+        captured.stderr.push(msg);
+      } else {
+        process.stderr.write(msg + "\n");
+      }
     },
     /** Primary data output to stdout (pipeable, never prefixed). */
     data(msg: string) {

--- a/packages/cli-core/src/lib/log.ts
+++ b/packages/cli-core/src/lib/log.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { dim, red, yellow, green } from "./color.ts";
 
 // ── Pipe prefix state (for intro/outro flow) ──────────────────────────────
@@ -23,18 +24,23 @@ function applyPrefix(msg: string): string {
     .join("\n");
 }
 
-// ── Capture hook (for testing) ────────────────────────────────────────────
+// ── Capture context (for testing) ─────────────────────────────────────────
 
-type CaptureHook = (stream: "stdout" | "stderr", msg: string) => void;
-let captureHook: CaptureHook | null = null;
+export type CapturedLogs = {
+  stdout: string[];
+  stderr: string[];
+};
 
-export function setCaptureHook(hook: CaptureHook | null) {
-  captureHook = hook;
+const captureStorage = new AsyncLocalStorage<CapturedLogs>();
+
+export function withCapturedLogs<T>(captured: CapturedLogs, fn: () => T): T {
+  return captureStorage.run(captured, fn);
 }
 
 function writeln(stream: NodeJS.WriteStream, channel: "stdout" | "stderr", msg: string) {
-  if (captureHook) {
-    captureHook(channel, msg);
+  const captured = captureStorage.getStore();
+  if (captured) {
+    captured[channel].push(msg);
   } else {
     stream.write(msg + "\n");
   }
@@ -61,8 +67,9 @@ export const log = {
   },
   /** Blank line to stderr. */
   blank() {
-    if (captureHook) {
-      captureHook("stderr", "");
+    const captured = captureStorage.getStore();
+    if (captured) {
+      captured.stderr.push("");
     } else {
       process.stderr.write("\n");
     }

--- a/packages/cli-core/src/lib/log.ts
+++ b/packages/cli-core/src/lib/log.ts
@@ -1,0 +1,78 @@
+import { dim, red, yellow, green } from "./color.ts";
+
+// ── Pipe prefix state (for intro/outro flow) ──────────────────────────────
+
+const S_BAR = "│";
+let prefixDepth = 0;
+
+export function pushPrefix() {
+  prefixDepth++;
+}
+
+export function popPrefix() {
+  prefixDepth = Math.max(0, prefixDepth - 1);
+}
+
+function applyPrefix(msg: string): string {
+  if (prefixDepth === 0) return msg;
+  const bar = dim(S_BAR);
+  if (!msg) return bar;
+  return msg
+    .split("\n")
+    .map((line) => `${bar}  ${line}`)
+    .join("\n");
+}
+
+// ── Capture hook (for testing) ────────────────────────────────────────────
+
+type CaptureHook = (stream: "stdout" | "stderr", msg: string) => void;
+let captureHook: CaptureHook | null = null;
+
+export function setCaptureHook(hook: CaptureHook | null) {
+  captureHook = hook;
+}
+
+function writeln(stream: NodeJS.WriteStream, channel: "stdout" | "stderr", msg: string) {
+  if (captureHook) {
+    captureHook(channel, msg);
+  } else {
+    stream.write(msg + "\n");
+  }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────
+
+export const log = {
+  /** Informational message to stderr (neutral, no error styling). */
+  info(msg: string) {
+    writeln(process.stderr, "stderr", applyPrefix(msg));
+  },
+  /** Success message to stderr (green). */
+  success(msg: string) {
+    writeln(process.stderr, "stderr", applyPrefix(green(msg)));
+  },
+  /** Warning to stderr (yellow). */
+  warn(msg: string) {
+    writeln(process.stderr, "stderr", applyPrefix(yellow(msg)));
+  },
+  /** Error to stderr (red, prefixed with "error: "). */
+  error(msg: string) {
+    writeln(process.stderr, "stderr", applyPrefix(red(`error: ${msg}`)));
+  },
+  /** Blank line to stderr. */
+  blank() {
+    if (captureHook) {
+      captureHook("stderr", "");
+    } else {
+      process.stderr.write("\n");
+    }
+  },
+  /** Raw stderr — no color, no prefix. For machine-readable output (agent JSON). */
+  raw(msg: string) {
+    writeln(process.stderr, "stderr", msg);
+  },
+  /** Primary data output to stdout (pipeable, never prefixed). */
+  data(msg: string) {
+    writeln(process.stdout, "stdout", msg);
+  },
+};

--- a/packages/cli-core/src/lib/log.ts
+++ b/packages/cli-core/src/lib/log.ts
@@ -1,5 +1,31 @@
 import { AsyncLocalStorage } from "node:async_hooks";
-import { dim, red, yellow, green } from "./color.ts";
+import { cyan, dim, green, red, yellow } from "./color.ts";
+
+// ── Log level ────────────────────────────────────────────────────────────
+
+export type LogLevel = "silent" | "error" | "warn" | "info" | "debug";
+
+const LEVEL_VALUE: Record<LogLevel, number> = {
+  silent: 0,
+  error: 1,
+  warn: 2,
+  info: 3,
+  debug: 4,
+};
+
+let currentLevel: LogLevel = "info";
+
+export function setLogLevel(level: LogLevel) {
+  currentLevel = level;
+}
+
+export function getLogLevel(): LogLevel {
+  return currentLevel;
+}
+
+function isLevelEnabled(level: LogLevel): boolean {
+  return LEVEL_VALUE[level] <= LEVEL_VALUE[currentLevel];
+}
 
 // ── Pipe prefix state (for intro/outro flow) ──────────────────────────────
 
@@ -24,6 +50,74 @@ function applyPrefix(msg: string): string {
     .join("\n");
 }
 
+// ── Spam throttle ────────────────────────────────────────────────────────
+
+const THROTTLE_WINDOW_MS = 1000;
+const THROTTLE_MIN = 5;
+
+let lastLogKey = "";
+let lastLogCount = 0;
+let lastLogTime = 0;
+let throttleTimer: ReturnType<typeof setTimeout> | undefined;
+
+function flushThrottle() {
+  if (lastLogCount > THROTTLE_MIN) {
+    const repeated = lastLogCount - THROTTLE_MIN;
+    writeln(
+      process.stderr,
+      "stderr",
+      applyPrefix(dim(`  (repeated ${repeated} more time${repeated === 1 ? "" : "s"})`)),
+    );
+  }
+  lastLogKey = "";
+  lastLogCount = 0;
+  throttleTimer = undefined;
+}
+
+/**
+ * Returns true if the message should be written, false if throttled.
+ */
+function shouldWrite(channel: "stdout" | "stderr", msg: string): boolean {
+  // Only throttle stderr (UI messages), never stdout (data)
+  if (channel === "stdout") return true;
+  // Don't throttle in test capture mode
+  if (captureStorage.getStore()) return true;
+
+  const key = msg;
+  const now = Date.now();
+
+  if (key === lastLogKey && now - lastLogTime < THROTTLE_WINDOW_MS) {
+    lastLogCount++;
+    lastLogTime = now;
+
+    // Restart the flush timer
+    if (throttleTimer) clearTimeout(throttleTimer);
+    throttleTimer = setTimeout(flushThrottle, THROTTLE_WINDOW_MS);
+
+    return lastLogCount <= THROTTLE_MIN;
+  }
+
+  // New message — flush any pending throttle summary first
+  if (throttleTimer) {
+    clearTimeout(throttleTimer);
+    flushThrottle();
+  }
+
+  lastLogKey = key;
+  lastLogCount = 1;
+  lastLogTime = now;
+  return true;
+}
+
+// ── Inline highlighting ──────────────────────────────────────────────────
+
+/**
+ * Highlights `backtick` spans in cyan within a message.
+ */
+function highlight(msg: string): string {
+  return msg.replace(/`([^`]+)`/g, (_, content) => cyan(`\`${content}\``));
+}
+
 // ── Capture context (for testing) ─────────────────────────────────────────
 
 export type CapturedLogs = {
@@ -42,44 +136,76 @@ function writeln(stream: NodeJS.WriteStream, channel: "stdout" | "stderr", msg: 
   if (captured) {
     captured[channel].push(msg);
   } else {
+    if (!shouldWrite(channel, msg)) return;
     stream.write(msg + "\n");
   }
 }
 
+// ── Tagged child logger ──────────────────────────────────────────────────
+
+export type Logger = typeof log & {
+  withTag(tag: string): Logger;
+};
+
+function createLogger(tag?: string): Logger {
+  function formatTag(msg: string): string {
+    if (!tag) return msg;
+    return `${dim(`[${tag}]`)} ${msg}`;
+  }
+
+  const logger = {
+    /** Informational message to stderr (neutral, no error styling). */
+    info(msg: string) {
+      if (!isLevelEnabled("info")) return;
+      writeln(process.stderr, "stderr", applyPrefix(highlight(formatTag(msg))));
+    },
+    /** Success message to stderr (green). */
+    success(msg: string) {
+      if (!isLevelEnabled("info")) return;
+      writeln(process.stderr, "stderr", applyPrefix(green(formatTag(msg))));
+    },
+    /** Warning to stderr (yellow). */
+    warn(msg: string) {
+      if (!isLevelEnabled("warn")) return;
+      writeln(process.stderr, "stderr", applyPrefix(yellow(formatTag(msg))));
+    },
+    /** Error to stderr (red, prefixed with "error: "). */
+    error(msg: string) {
+      if (!isLevelEnabled("error")) return;
+      writeln(process.stderr, "stderr", applyPrefix(red(`error: ${formatTag(msg)}`)));
+    },
+    /** Debug message to stderr (dim). Only shown when log level is "debug". */
+    debug(msg: string) {
+      if (!isLevelEnabled("debug")) return;
+      writeln(process.stderr, "stderr", applyPrefix(dim(formatTag(msg))));
+    },
+    /** Blank line to stderr. */
+    blank() {
+      const captured = captureStorage.getStore();
+      if (captured) {
+        captured.stderr.push("");
+      } else {
+        process.stderr.write("\n");
+      }
+    },
+    /** Raw stderr — no color, no prefix. For machine-readable output (agent JSON). */
+    raw(msg: string) {
+      writeln(process.stderr, "stderr", msg);
+    },
+    /** Primary data output to stdout (pipeable, never prefixed). */
+    data(msg: string) {
+      writeln(process.stdout, "stdout", msg);
+    },
+    /** Create a child logger with a tag prefix. */
+    withTag(childTag: string): Logger {
+      const combined = tag ? `${tag}:${childTag}` : childTag;
+      return createLogger(combined);
+    },
+  } as Logger;
+
+  return logger;
+}
+
 // ── Public API ────────────────────────────────────────────────────────────
 
-export const log = {
-  /** Informational message to stderr (neutral, no error styling). */
-  info(msg: string) {
-    writeln(process.stderr, "stderr", applyPrefix(msg));
-  },
-  /** Success message to stderr (green). */
-  success(msg: string) {
-    writeln(process.stderr, "stderr", applyPrefix(green(msg)));
-  },
-  /** Warning to stderr (yellow). */
-  warn(msg: string) {
-    writeln(process.stderr, "stderr", applyPrefix(yellow(msg)));
-  },
-  /** Error to stderr (red, prefixed with "error: "). */
-  error(msg: string) {
-    writeln(process.stderr, "stderr", applyPrefix(red(`error: ${msg}`)));
-  },
-  /** Blank line to stderr. */
-  blank() {
-    const captured = captureStorage.getStore();
-    if (captured) {
-      captured.stderr.push("");
-    } else {
-      process.stderr.write("\n");
-    }
-  },
-  /** Raw stderr — no color, no prefix. For machine-readable output (agent JSON). */
-  raw(msg: string) {
-    writeln(process.stderr, "stderr", msg);
-  },
-  /** Primary data output to stdout (pipeable, never prefixed). */
-  data(msg: string) {
-    writeln(process.stdout, "stdout", msg);
-  },
-};
+export const log: Logger = createLogger();

--- a/packages/cli-core/src/lib/next-steps.ts
+++ b/packages/cli-core/src/lib/next-steps.ts
@@ -1,5 +1,6 @@
-import { cyan, dimNeutral } from "./color.ts";
+import { cyan } from "./color.ts";
 import { isHuman } from "../mode.ts";
+import { log } from "./log.ts";
 
 export const NEXT_STEPS = {
   LOGIN: [
@@ -27,7 +28,7 @@ export const NEXT_STEPS = {
 export function printNextSteps(steps: readonly string[]): void {
   if (!isHuman() || steps.length === 0) return;
   for (const step of steps) {
-    console.error(`   ${cyan("\u2192")} ${step}`);
+    log.info(`   ${cyan("\u2192")} ${step}`);
   }
-  console.error();
+  log.blank();
 }

--- a/packages/cli-core/src/lib/spinner.ts
+++ b/packages/cli-core/src/lib/spinner.ts
@@ -1,5 +1,6 @@
 import { isHuman } from "../mode.ts";
 import { dim, cyan, green, red } from "./color.ts";
+import { pushPrefix, popPrefix } from "./log.ts";
 
 const FRAMES = ["◒", "◐", "◓", "◑"];
 const INTERVAL = 80;
@@ -13,56 +14,21 @@ const S_STEP_ERROR = "■";
 const stream = process.stderr;
 const isInteractive = () => stream.isTTY && !process.env.CI;
 
-// --- Console pipe (auto-prefix console.log/error with │ inside intro/outro flow) ---
-
-const _log = console.log;
-const _error = console.error;
-let flowDepth = 0;
-
-function pipedFn(original: typeof console.log): typeof console.log {
-  return (...args: unknown[]) => {
-    const msg = args.map((a) => (typeof a === "string" ? a : String(a))).join(" ");
-    if (!msg) {
-      stream.write(`${dim(S_BAR)}\n`);
-      return;
-    }
-    for (const line of msg.split("\n")) {
-      stream.write(`${dim(S_BAR)}  ${line}\n`);
-    }
-  };
-}
-
-function patchConsole() {
-  if (flowDepth === 0) {
-    console.log = pipedFn(_log);
-    console.error = pipedFn(_error);
-  }
-  flowDepth++;
-}
-
-function unpatchConsole() {
-  flowDepth = Math.max(0, flowDepth - 1);
-  if (flowDepth === 0) {
-    console.log = _log;
-    console.error = _error;
-  }
-}
-
 // --- Public API ---
 
-/** Print intro bracket: ┌  title — pipes all console output until outro(). */
+/** Print intro bracket: ┌  title — prefixes log output with │ until outro(). */
 export function intro(title?: string) {
   if (!isHuman()) return;
   const line = title ? `${dim(S_BAR_START)}  ${title}` : dim(S_BAR_START);
   stream.write(`${line}\n`);
-  patchConsole();
+  pushPrefix();
 }
 
-/** Print outro bracket: └  message — restores normal console output.
+/** Print outro bracket: └  message — restores normal log output.
  *  Pass a string[] to render as next steps after the bracket. */
 export function outro(messageOrSteps?: string | readonly string[]) {
   if (!isHuman()) return;
-  unpatchConsole();
+  popPrefix();
   stream.write(`${dim(S_BAR)}\n`);
 
   if (Array.isArray(messageOrSteps)) {

--- a/packages/cli-core/src/test/integration/auth-lifecycle.test.ts
+++ b/packages/cli-core/src/test/integration/auth-lifecycle.test.ts
@@ -11,10 +11,11 @@ useIntegrationTestHarness();
 test.each([{ mode: "human" }, { mode: "agent" }])(
   "whoami -> logout -> whoami cycle ($mode mode)",
   async ({ mode }) => {
-    // Not logged in
+    // Not logged in — exits non-zero, error on stderr
     mockState.storedToken = null;
-    const { stdout: notLoggedIn } = await clerk("--mode", mode, "whoami");
-    expect(notLoggedIn).toContain("Not logged in");
+    const notLoggedIn = await clerk.raw("--mode", mode, "whoami");
+    expect(notLoggedIn.exitCode).not.toBe(0);
+    expect(notLoggedIn.stderr).toContain("Not logged in");
 
     // Set token and verify whoami shows email
     mockState.storedToken = "valid_token";
@@ -27,7 +28,8 @@ test.each([{ mode: "human" }, { mode: "agent" }])(
     expect(mockState.storedToken).toBeNull();
 
     // Whoami again -> not logged in
-    const { stdout: afterLogout } = await clerk("--mode", mode, "whoami");
-    expect(afterLogout).toContain("Not logged in");
+    const afterLogout = await clerk.raw("--mode", mode, "whoami");
+    expect(afterLogout.exitCode).not.toBe(0);
+    expect(afterLogout.stderr).toContain("Not logged in");
   },
 );

--- a/packages/cli-core/src/test/integration/auth-lifecycle.test.ts
+++ b/packages/cli-core/src/test/integration/auth-lifecycle.test.ts
@@ -23,8 +23,8 @@ test.each([{ mode: "human" }, { mode: "agent" }])(
     expect(loggedIn).toContain("test@example.com");
 
     // Logout
-    const { stdout: logoutOutput } = await clerk("--mode", mode, "auth", "logout");
-    expect(logoutOutput).toContain("Logged out successfully");
+    const logoutResult = await clerk.raw("--mode", mode, "auth", "logout");
+    expect(logoutResult.stderr).toContain("Logged out successfully");
     expect(mockState.storedToken).toBeNull();
 
     // Whoami again -> not logged in

--- a/packages/cli-core/src/test/integration/lib/harness.ts
+++ b/packages/cli-core/src/test/integration/lib/harness.ts
@@ -17,6 +17,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { capturedOutput } from "../../lib/stubs.ts";
+import { setCaptureHook } from "../../../lib/log.ts";
 import { http } from "../../lib/http.ts";
 import type { Application, ApplicationInstance } from "../../../lib/plapi.ts";
 
@@ -384,6 +385,8 @@ async function execCLI(...args: string[]): Promise<CLIResult> {
   currentHarness.logSpy.mockClear();
   currentHarness.errorSpy.mockClear();
   currentHarness.exitSpy.mockClear();
+  currentHarness.captured.stdout.length = 0;
+  currentHarness.captured.stderr.length = 0;
 
   let exitCode = 0;
 
@@ -400,9 +403,15 @@ async function execCLI(...args: string[]): Promise<CLIResult> {
     }
   }
 
+  // Merge output from both console spies (non-migrated code) and capture hook (migrated code)
+  const consoleStdout = capturedOutput(currentHarness.logSpy);
+  const consoleStderr = capturedOutput(currentHarness.errorSpy);
+  const hookStdout = currentHarness.captured.stdout.join("\n");
+  const hookStderr = currentHarness.captured.stderr.join("\n");
+
   return {
-    stdout: capturedOutput(currentHarness.logSpy),
-    stderr: capturedOutput(currentHarness.errorSpy),
+    stdout: [consoleStdout, hookStdout].filter(Boolean).join("\n"),
+    stderr: [consoleStderr, hookStderr].filter(Boolean).join("\n"),
     exitCode,
   };
 }
@@ -436,6 +445,8 @@ export interface TestHarness {
   logSpy: ReturnType<typeof spyOn>;
   errorSpy: ReturnType<typeof spyOn>;
   exitSpy: ReturnType<typeof spyOn>;
+  /** Output captured from log.* calls via the capture hook. */
+  captured: { stdout: string[]; stderr: string[] };
 }
 
 const originalCwd = process.cwd;
@@ -478,7 +489,12 @@ export async function setupTest(): Promise<TestHarness> {
     throw new Error("process.exit");
   });
 
-  const harness = { tempDir, logSpy, errorSpy, exitSpy };
+  const captured = { stdout: [] as string[], stderr: [] as string[] };
+  setCaptureHook((stream, msg) => {
+    captured[stream].push(msg);
+  });
+
+  const harness = { tempDir, logSpy, errorSpy, exitSpy, captured };
   currentHarness = harness;
   return harness;
 }
@@ -491,6 +507,7 @@ export async function setupTest(): Promise<TestHarness> {
  */
 export async function teardownTest(harness: TestHarness): Promise<void> {
   currentHarness = null;
+  setCaptureHook(null);
   assertPromptQueuesEmpty();
   http.assertRoutesConsumed();
   _setConfigDir(undefined);

--- a/packages/cli-core/src/test/integration/lib/harness.ts
+++ b/packages/cli-core/src/test/integration/lib/harness.ts
@@ -17,7 +17,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { capturedOutput } from "../../lib/stubs.ts";
-import { setCaptureHook } from "../../../lib/log.ts";
+import { withCapturedLogs } from "../../../lib/log.ts";
 import { http } from "../../lib/http.ts";
 import type { Application, ApplicationInstance } from "../../../lib/plapi.ts";
 
@@ -391,7 +391,9 @@ async function execCLI(...args: string[]): Promise<CLIResult> {
   let exitCode = 0;
 
   try {
-    await runProgram(program, args, { from: "user" });
+    await withCapturedLogs(currentHarness.captured, () =>
+      runProgram(program, args, { from: "user" }),
+    );
   } catch (error: unknown) {
     if ((error as any)?.code?.startsWith?.("commander.")) {
       exitCode = (error as any).exitCode ?? 1;
@@ -403,7 +405,7 @@ async function execCLI(...args: string[]): Promise<CLIResult> {
     }
   }
 
-  // Merge output from both console spies (non-migrated code) and capture hook (migrated code)
+  // Merge output from both console spies (non-migrated code) and scoped log capture.
   const consoleStdout = capturedOutput(currentHarness.logSpy);
   const consoleStderr = capturedOutput(currentHarness.errorSpy);
   const hookStdout = currentHarness.captured.stdout.join("\n");
@@ -445,7 +447,7 @@ export interface TestHarness {
   logSpy: ReturnType<typeof spyOn>;
   errorSpy: ReturnType<typeof spyOn>;
   exitSpy: ReturnType<typeof spyOn>;
-  /** Output captured from log.* calls via the capture hook. */
+  /** Output captured from log.* calls via the scoped capture context. */
   captured: { stdout: string[]; stderr: string[] };
 }
 
@@ -490,10 +492,6 @@ export async function setupTest(): Promise<TestHarness> {
   });
 
   const captured = { stdout: [] as string[], stderr: [] as string[] };
-  setCaptureHook((stream, msg) => {
-    captured[stream].push(msg);
-  });
-
   const harness = { tempDir, logSpy, errorSpy, exitSpy, captured };
   currentHarness = harness;
   return harness;
@@ -507,7 +505,6 @@ export async function setupTest(): Promise<TestHarness> {
  */
 export async function teardownTest(harness: TestHarness): Promise<void> {
   currentHarness = null;
-  setCaptureHook(null);
   assertPromptQueuesEmpty();
   http.assertRoutesConsumed();
   _setConfigDir(undefined);

--- a/packages/cli-core/src/test/lib/stubs.ts
+++ b/packages/cli-core/src/test/lib/stubs.ts
@@ -1,5 +1,5 @@
 import type { spyOn } from "bun:test";
-import { withCapturedLogs } from "../lib/log.ts";
+import { withCapturedLogs } from "../../lib/log.ts";
 
 export function capturedOutput(spy: ReturnType<typeof spyOn>): string {
   return spy.mock.calls.map((c: unknown[]) => c[0]).join("\n");

--- a/packages/cli-core/src/test/lib/stubs.ts
+++ b/packages/cli-core/src/test/lib/stubs.ts
@@ -1,22 +1,18 @@
 import type { spyOn } from "bun:test";
-import { setCaptureHook } from "../lib/log.ts";
+import { withCapturedLogs } from "../lib/log.ts";
 
 export function capturedOutput(spy: ReturnType<typeof spyOn>): string {
   return spy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
 }
 
 /**
- * Install a capture hook for `log.*` calls. Returns an object with `stdout`/`stderr`
- * arrays and a `teardown` function to remove the hook.
+ * Create a scoped capture buffer for `log.*` calls.
  *
- * Use this in unit tests that exercise migrated commands (which use `log.*`
- * instead of `console.log`/`console.error`).
+ * Use `run()` to execute code inside the capture context in unit tests that
+ * exercise migrated commands (which use `log.*` instead of `console.log`/`console.error`).
  */
 export function captureLog() {
   const captured = { stdout: [] as string[], stderr: [] as string[] };
-  setCaptureHook((stream, msg) => {
-    captured[stream].push(msg);
-  });
   return {
     ...captured,
     /** Joined stdout output. */
@@ -27,8 +23,11 @@ export function captureLog() {
     get err() {
       return captured.stderr.join("\n");
     },
+    run<T>(fn: () => T): T {
+      return withCapturedLogs(captured, fn);
+    },
     teardown() {
-      setCaptureHook(null);
+      // No-op: capture scope is tied to run(), not process-global state.
     },
   };
 }

--- a/packages/cli-core/src/test/lib/stubs.ts
+++ b/packages/cli-core/src/test/lib/stubs.ts
@@ -1,7 +1,36 @@
 import type { spyOn } from "bun:test";
+import { setCaptureHook } from "../lib/log.ts";
 
 export function capturedOutput(spy: ReturnType<typeof spyOn>): string {
   return spy.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+}
+
+/**
+ * Install a capture hook for `log.*` calls. Returns an object with `stdout`/`stderr`
+ * arrays and a `teardown` function to remove the hook.
+ *
+ * Use this in unit tests that exercise migrated commands (which use `log.*`
+ * instead of `console.log`/`console.error`).
+ */
+export function captureLog() {
+  const captured = { stdout: [] as string[], stderr: [] as string[] };
+  setCaptureHook((stream, msg) => {
+    captured[stream].push(msg);
+  });
+  return {
+    ...captured,
+    /** Joined stdout output. */
+    get out() {
+      return captured.stdout.join("\n");
+    },
+    /** Joined stderr output. */
+    get err() {
+      return captured.stderr.join("\n");
+    },
+    teardown() {
+      setCaptureHook(null);
+    },
+  };
 }
 
 const noop = async () => {};


### PR DESCRIPTION
## Summary

- Introduces `packages/cli-core/src/lib/log.ts` — a structured logging utility that enforces
  stdout/stderr channel discipline across all CLI commands
- Migrates all 48 command and library files from raw `console.log`/`console.error` to the
  new `log.*` API
- Replaces the monkey-patching of `console.log`/`console.error` in `spinner.ts` with a
  clean `pushPrefix()`/`popPrefix()` mechanism backed by the same module
- Adds `withCapturedLogs()` (AsyncLocalStorage-based) for test output capture, replacing
  brittle `spyOn(console, "log")` patterns across all test files
- **Log levels** (`silent`/`error`/`warn`/`info`/`debug`) with global `--verbose` flag support
- **`log.debug()`** method gated by level — replaces ad-hoc debug closures in commands
- **Tagged child loggers** via `log.withTag("name")` — scoped, nestable, async-safe
- **Spam throttle** — deduplicates repeated stderr messages within a 1s window
- **Inline highlighting** — backtick-wrapped spans auto-highlighted in cyan

## Motivation

The CLI had no consistent output-channel contract. Every command used `console.log()` for
everything — JSON data, human status messages, error context — all landing on stdout. This
made it impossible to:

1. **Pipe machine-readable output** (`clerk api /users | jq .`) without human chrome polluting
   the stream
2. **Test output reliably** — `console.log` spies are global singletons, so concurrent async
   tests could bleed into each other
3. **Reason about what goes where** — no compile-time or review-time signal about whether a
   given print statement is data or decoration

The `spinner.ts` intro/outro flow also relied on replacing `console.log` and `console.error`
at runtime with prefixed wrappers, which broke any code that captured a reference to the
original functions.

Commands also had no consistent way to emit debug output — the `deploy` command created its
own ad-hoc `debug()` closure, and other commands had no debug logging at all. The new log
level system provides a unified `log.debug()` method gated by a global `--verbose` flag.

## Design

### `log.*` API

| Method         | Stream   | Color/prefix     | Level gate | Use for                                          |
|----------------|----------|------------------|------------|--------------------------------------------------|
| `log.data()`   | **stdout** | none           | —          | Machine-readable output: JSON, agent prompts, piped values |
| `log.info()`   | stderr   | none (dim `│` when inside intro/outro) | `info` | Human-facing status, confirmations |
| `log.success()`| stderr   | green            | `info`     | Completion messages                              |
| `log.warn()`   | stderr   | yellow           | `warn`     | Warnings                                         |
| `log.error()`  | stderr   | red, `error: ` prefix | `error` | Error messages                              |
| `log.debug()`  | stderr   | dim              | `debug`    | Verbose/diagnostic output (hidden by default)    |
| `log.blank()`  | stderr   | —                | —          | Visual spacing                                   |
| `log.raw()`    | stderr   | none, no prefix  | —          | Machine-readable stderr (agent JSON on stderr)   |

**Rule of thumb:** if a message contains color codes (`cyan()`, `dim()`) or is meant for
human eyes, it belongs on stderr via `log.info()`. If it's the command's primary data output
(JSON, an email address for scripting, an agent prompt), it belongs on stdout via `log.data()`.

### Log levels

Five levels with numeric ordering: `silent` (0) → `error` (1) → `warn` (2) → `info` (3, default) → `debug` (4).

Each `log.*` method checks `isLevelEnabled()` before writing. `log.data()`, `log.blank()`, and
`log.raw()` are never gated — stdout/raw output is always emitted regardless of level.

The global `--verbose` flag calls `setLogLevel("debug")` in the commander `preAction` hook,
enabling `log.debug()` across all commands. Commands can also call `setLogLevel()` directly
for per-command flags (e.g., `deploy --debug`).

### Tagged child loggers

`log.withTag("api")` returns a new logger that prefixes messages with a dim `[api]` tag.
Tags are nestable: `log.withTag("http").withTag("req")` → `[http:req]`.

Tagged loggers share the same level, capture, and prefix state as the root logger. Unlike
`pushPrefix()`/`popPrefix()`, they're scoped and don't require cleanup — safe for async code:

```ts
const apiLog = log.withTag("api");
apiLog.info("fetching users...");   // → [api] fetching users...
apiLog.debug("response: 200 OK");  // → [api] response: 200 OK (only if --verbose)
```

### Spam throttle

Identical stderr messages within a 1-second window are suppressed after 5 occurrences. When the
window expires, a summary is printed: `(repeated N more times)`. This prevents terminal flooding
from polling loops or retry sequences without losing information.

Throttling only applies to stderr (never stdout/data) and is disabled in test capture mode.

### Inline highlighting

Messages passed to `log.info()` (and tagged variants) auto-highlight backtick-wrapped spans
in cyan. e.g., `` log.info("Run `clerk link` to continue") `` renders `clerk link` in cyan
without manual `cyan()` wrapping at each call site.

### Intro/outro prefix

The old `patchConsole()`/`unpatchConsole()` that swapped `console.log` globally is replaced by
`pushPrefix()`/`popPrefix()` in `log.ts`. When `prefixDepth > 0`, `log.info/success/warn/error`
automatically prepend `│  ` to each line. `log.data()` is never prefixed — stdout stays clean.

### Test capture

`withCapturedLogs()` uses `AsyncLocalStorage` to intercept `log.*` calls within a scope.
Concurrent async tests get isolated capture buffers with no global state mutation:

```ts
import { captureLog } from "../../test/stubs.ts";

const captured = captureLog();

test("outputs the email to stdout", async () => {
  await captured.run(() => whoami());
  expect(captured.out).toContain("user@example.com");
});

test("status messages go to stderr", async () => {
  await captured.run(() => login());
  expect(captured.err).toContain("Logged in as");
});
```

The `captureLog()` helper (in `test/stubs.ts`) wraps this with convenience getters:
- `captured.out` — joined stdout lines
- `captured.err` — joined stderr lines
- `captured.run(fn)` — execute `fn` inside the capture scope

## Files changed

- **New:** `packages/cli-core/src/lib/log.ts` — the logging utility (log levels, tagged loggers, throttle, highlighting)
- **New:** `packages/cli-core/src/lib/log.test.ts` — async isolation, nesting, log level, tag, and highlighting tests
- **Modified:** `packages/cli-core/src/lib/spinner.ts` — removed 35-line console monkey-patch,
  replaced with `pushPrefix()`/`popPrefix()` imports
- **Modified:** `packages/cli-core/src/cli-program.ts` — wired `--verbose` flag to `setLogLevel("debug")`
- **Modified:** `packages/cli-core/src/commands/deploy/index.ts` — replaced ad-hoc `debug()` with `log.debug()`
- **Modified:** `packages/cli-core/src/test/stubs.ts` — added `captureLog()` helper
- **Modified:** 44 command/test files — migrated from `console.log`/`console.error` + spy-based
  assertions to `log.*` + `captureLog()`

## Follow-up ideas

- Add a lint rule to flag `console.log`/`console.error` in command files, suggesting `log.*`

## Test plan

- [x] `bun test packages/cli-core/src/lib/log.test.ts` — capture isolation, nesting, log levels, tags, highlighting (12 tests)
- [x] `bun test packages/cli-core/src/commands/deploy/index.test.ts` — deploy with log.debug (7 tests)
- [x] `bun test packages/cli-core/src/commands/auth/login.test.ts` — login output on stderr
- [x] `bun test packages/cli-core/src/commands/link/index.test.ts` — link output on stderr, agent prompt on stdout
- [x] `bun test` — 745 pass, 2 pre-existing failures (unrelated api test flake)
- [x] `bun run format` — clean
- [x] `bun run lint` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified CLI output through a centralized logging system for improved consistency and debugging across all commands.

* **Documentation**
  * Added logging guidelines for developers to standardize output handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->