### PR TITLE
docs(rules): add shell completion authoring guide

### DIFF
--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -18,6 +18,10 @@ When adding a new command, create its directory and README. When modifying a com
 
 When creating or modifying a command, evaluate whether it needs an agent mode. Commands with interactive prompts (menus, wizards, multi-step flows) should check `isAgent()` from `src/mode.ts` and, when in agent mode, output a structured prompt that an AI agent can follow instead of running the interactive flow. Commands that are already non-interactive (e.g., single API calls, browser-based OAuth) typically don't need agent mode.
 
+## Shell completion
+
+When adding or modifying a command, ensure tab-completion stays correct. See `.claude/rules/completion.md` for the full guide. Short version: use `.choices()` on arguments and options so completions are automatic; only touch `__complete.ts` when `.choices()` is not suitable.
+
 ## Root README
 
 `README.md` at the project root contains the CLI help output. When commands are added, removed, or their options change, update the help output in `README.md` to stay in sync. You can regenerate it by running `bun run src/cli.ts --help`.

--- a/.claude/rules/completion.md
+++ b/.claude/rules/completion.md
@@ -1,0 +1,37 @@
+---
+description: Shell completion — how new commands and options get tab-completed
+paths:
+  - "packages/cli-core/src/commands/**"
+  - "packages/cli-core/src/cli-program.ts"
+  - "packages/cli-core/src/commands/completion/__complete.ts"
+alwaysApply: false
+---
+
+`__complete.ts` walks the Commander.js command tree dynamically. Command names, aliases, flags, and any values declared with `.choices()` are completed automatically.
+
+## When you add or change a command
+
+**1. Fixed values that should also reject invalid input — use `.choices()`** (completions are automatic, no extra work):
+
+```ts
+.addArgument(createArgument("<path>", "Dashboard path").choices(["users", "api-keys"]))
+.addOption(createOption("--format <fmt>", "Output format").choices(["json", "yaml"]))
+```
+
+**2. Common hint values, but the option also accepts other input — add to `KNOWN_OPTION_VALUES`** in `packages/cli-core/src/commands/completion/__complete.ts`:
+
+```ts
+"--my-flag": [
+  { name: "value-a", description: "Description" },
+],
+```
+
+Use this when `.choices()` would be too restrictive — e.g. `--instance` shows `dev`/`prod` but also accepts raw instance IDs.
+
+**3. Fully dynamic or user-specific values** (app IDs, file paths, live API data) — do nothing. The shell falls back to file completion or freeform input.
+
+## Checklist
+
+- [ ] Fixed known values → used `.choices()` → completions are automatic
+- [ ] Hint-only values → added to `KNOWN_OPTION_VALUES` and added a test in `packages/cli-core/src/test/integration/completion.test.ts`
+- [ ] Dynamic/user-specific values → no completion entry needed


### PR DESCRIPTION
## Summary

- Adds `.claude/rules/completion.md` — a concise rule explaining the three cases for keeping tab-completion correct when adding or changing CLI commands
- Updates `.claude/rules/commands.md` with a cross-reference to the new rule

## What the rule covers

1. **Use `.choices()`** for fixed values known at build time — completions are automatic and input is validated at parse time
2. **Add to `KNOWN_OPTION_VALUES`** in `__complete.ts` for hint-only completions where the option also accepts values outside the fixed set (e.g. `--instance` shows `dev`/`prod` but also accepts raw instance IDs)
3. **Do nothing** for fully dynamic/user-specific values (app IDs, file paths, live API data)

The rule also calls out that `KNOWN_OPTION_VALUES` additions should be paired with an integration test in `packages/cli-core/src/test/integration/completion.test.ts`.

## Test plan

- [ ] Rule is surfaced when working on files under `packages/cli-core/src/commands/**` or `cli-program.ts`