### PR TITLE
fix(init): delegate skills scope + agent picker to skills CLI

### DIFF
--- a/packages/cli-core/src/commands/init/skills.test.ts
+++ b/packages/cli-core/src/commands/init/skills.test.ts
@@ -1,0 +1,37 @@
+import { test, expect, describe } from "bun:test";
+import { buildSkillsArgs } from "./skills.ts";
+
+describe("buildSkillsArgs", () => {
+  const skills = ["clerk", "clerk-setup", "clerk-nextjs-patterns"];
+
+  test("interactive mode: no -y or -g, lets skills CLI take over", () => {
+    const args = buildSkillsArgs(skills, true);
+    expect(args).toEqual([
+      "npx",
+      "skills",
+      "add",
+      "clerk/skills",
+      "--skill",
+      "clerk",
+      "--skill",
+      "clerk-setup",
+      "--skill",
+      "clerk-nextjs-patterns",
+    ]);
+    expect(args).not.toContain("-y");
+    expect(args).not.toContain("-g");
+    expect(args).not.toContain("--agent");
+  });
+
+  test("non-interactive mode: includes -y and -g for global auto-detect", () => {
+    const args = buildSkillsArgs(skills, false);
+    expect(args).toContain("-y");
+    expect(args).toContain("-g");
+    expect(args).not.toContain("--agent");
+  });
+
+  test("never passes --agent (lets skills CLI auto-detect)", () => {
+    expect(buildSkillsArgs(skills, true)).not.toContain("--agent");
+    expect(buildSkillsArgs(skills, false)).not.toContain("--agent");
+  });
+});

--- a/packages/cli-core/src/commands/init/skills.ts
+++ b/packages/cli-core/src/commands/init/skills.ts
@@ -36,6 +36,21 @@ function resolveSkills(frameworkDep: string | undefined): string[] {
   return skills;
 }
 
+/**
+ * Build the argv for `npx skills add`.
+ *
+ * Interactive mode: hand off to the skills CLI's native UX (auto-detect
+ * installed agents, scope picker). Non-interactive: pass `-y -g` so it
+ * runs unattended with global scope and auto-detected agents.
+ *
+ * Exported for tests.
+ */
+export function buildSkillsArgs(skills: string[], interactive: boolean): string[] {
+  const skillFlags = skills.flatMap((s) => ["--skill", s]);
+  const extraFlags = interactive ? [] : ["-y", "-g"];
+  return ["npx", "skills", "add", SKILLS_SOURCE, ...skillFlags, ...extraFlags];
+}
+
 export async function installSkills(
   cwd: string,
   frameworkDep: string | undefined,
@@ -54,15 +69,15 @@ export async function installSkills(
 
   console.log(`\nInstalling skills: ${cyan(skillList)}`);
 
-  const skillFlags = skills.flatMap((s) => ["--skill", s]);
-  const proc = Bun.spawn(
-    ["npx", "skills", "add", SKILLS_SOURCE, ...skillFlags, "--agent", "*", "-y"],
-    {
-      cwd,
-      stdout: "inherit",
-      stderr: "inherit",
-    },
-  );
+  const interactive = isHuman() && !skipPrompt;
+  const args = buildSkillsArgs(skills, interactive);
+
+  const proc = Bun.spawn(args, {
+    cwd,
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
   const exitCode = await proc.exited;
 
   if (exitCode !== 0) {


### PR DESCRIPTION
## Problem

`clerk init` was forcing skills install to all 45 supported agents non-interactively by passing `--agent '*' -y`. Result: 30+ agent folders (`.claude/`, `.cursor/`, `.cline/`, ...) in the project root + ~25 lines added to `.gitignore`, even when the user only uses 1-2 agents.

Reported by @rafael-thayto in Slack.

## Root cause

The skills CLI ([vercel-labs/skills](https://github.com/vercel-labs/skills)) already has the UX we want:

- Auto-detects installed agents on the system if `--agent` is not passed
- Shows a scope picker (project vs global) when run interactively
- Has a multi-select for fine-tuning agents

We were stomping on all of that.

## Fix

Drop `--agent '*' -y` in interactive human mode and inherit stdin so the skills CLI's pickers actually work. Non-interactive mode (agent or `-y`) falls back to `-y -g` so CI keeps working.

| Mode | Flags | Result |
|------|-------|--------|
| Human (interactive) | (none) | Skills CLI auto-detects + shows scope picker |
| `clerk init -y` | `-y -g` | Non-interactive, global, auto-detected agents |
| Agent mode | `-y -g` | Same as `-y` |

`clerk init` keeps its single opt-in prompt upfront ("Install agent skills?"). Everything past that — scope, agents — is the user's call via the skills CLI's native interface.

## Tests

- Extracted `buildSkillsArgs(skills, interactive)` as a pure function
- 3 unit tests covering: interactive mode passes no `-y`/`-g`/`--agent`, non-interactive includes `-y -g`, neither mode passes `--agent` (let auto-detect work)
- Full init test suite still green (156 tests)

Closes AIE-791
Follow-up to #86