### PR TITLE
fix(init): handle skill installer failures and stub in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,13 @@ clerk init
   --framework <name>   Framework to set up (skips auto-detection)
   --prompt             Output a prompt for an AI agent to integrate Clerk
   --yes                Skip confirmation prompts
+  --no-skills          Skip the optional agent skills install prompt
   Examples:
     $ clerk init                       Auto-detect framework and set up Clerk
     $ clerk init --framework next      Set up for Next.js (skips detection)
     $ clerk init --prompt              Output a setup prompt for an AI agent
     $ clerk init -y                    Skip all confirmation prompts
+    $ clerk init --no-skills           Skip the agent skills install prompt
 
 clerk auth login         Log in via browser (OAuth)
 clerk auth logout        Remove stored credentials

--- a/packages/cli-core/src/commands/init/README.md
+++ b/packages/cli-core/src/commands/init/README.md
@@ -10,6 +10,7 @@ clerk init --framework next
 clerk init --prompt
 clerk init -y
 clerk init --yes
+clerk init --no-skills
 ```
 
 ## Options
@@ -19,6 +20,7 @@ clerk init --yes
 | `--framework <name>` | Framework to set up (skips auto-detection). Valid values: `next`, `astro`, `nuxt`, `tanstack-start`, `react-router`, `vue`, `expo`, `react`, `express`, `fastify` |
 | `--prompt`           | Output a prompt for an AI agent to integrate Clerk, then exit                                                                                                     |
 | `-y, --yes`          | Skip confirmation prompts                                                                                                                                         |
+| `--no-skills`        | Skip the optional agent skills install prompt at the end of init                                                                                                  |
 
 ## Agent Mode
 
@@ -46,6 +48,7 @@ When running in agent mode (`--mode agent` or non-TTY), outputs a framework-spec
 14. Prints a summary of created, modified, and skipped files with recommendations
 15. **Authenticated mode**: pulls development instance API keys via `clerk env pull`
 16. **Keyless mode**: prints instructions for keyless development and how to connect a Clerk account later
+17. Optionally installs framework-specific Clerk agent skills via `npx skills add` (see [Agent skills install](#agent-skills-install))
 
 ## Framework Detection
 
@@ -147,6 +150,30 @@ Nuxt's module system auto-configures middleware and auto-imports components.
 | CREATE        | `src/views/sign-up.vue` | Sign-up page with `<SignUp />` component           |
 | MODIFY        | `src/router/index.ts`   | Add sign-in and sign-up routes (if router exists)  |
 | MODIFY        | `.env`                  | Add sign-in/sign-up route env vars (VITE\_ prefix) |
+
+## Agent skills install
+
+After scaffolding (and after env keys are pulled or keyless instructions are printed), `clerk init` offers to install Clerk's framework-specific agent skills from [`clerk/skills`](https://github.com/clerk/skills) via `npx skills add`. This step is optional and non-fatal: if `npx` is missing or the install command exits non-zero, init prints a yellow warning with the manual install command and still exits successfully.
+
+- **Human mode**: prompts `Install agent skills? (...)` defaulting to yes. Pass `--no-skills` to suppress the prompt entirely, or `-y/--yes` to accept it without confirmation.
+- **Agent mode / `--prompt`**: `clerk init` exits early before the skills step runs (see the `if (options.prompt || isAgent()) { ... return }` branch in [`index.ts`](./index.ts)), so nothing is installed. Agent users should run `npx skills add clerk/skills` manually, or have their agent do it.
+
+The base skills `clerk` and `clerk-setup` are always included. The detected framework dependency adds a matching skill:
+
+| Framework dep           | Added skill                   |
+| ----------------------- | ----------------------------- |
+| `next`                  | `clerk-nextjs-patterns`       |
+| `react`                 | `clerk-react-patterns`        |
+| `react-router`          | `clerk-react-router-patterns` |
+| `vue`                   | `clerk-vue-patterns`          |
+| `nuxt`                  | `clerk-nuxt-patterns`         |
+| `astro`                 | `clerk-astro-patterns`        |
+| `@tanstack/react-start` | `clerk-tanstack-patterns`     |
+| `expo`                  | `clerk-expo-patterns`         |
+| `express`               | `clerk-backend-api`           |
+| `fastify`               | `clerk-backend-api`           |
+
+Implementation lives in [`skills.ts`](./skills.ts). Note that the E2E fixture setup runs `clerk init --yes --no-skills` because the skill templates reference framework-generated types (e.g. React Router's `./+types/root`) that don't exist outside a real app directory and would break the fixture's `tsc` step.
 
 ## API Endpoints
 

--- a/packages/cli-core/src/commands/init/index.test.ts
+++ b/packages/cli-core/src/commands/init/index.test.ts
@@ -14,6 +14,9 @@ import * as previewMod from "./preview.ts";
 import * as formatMod from "./format.ts";
 import * as scanMod from "./scan.ts";
 import * as heuristics from "./heuristics.ts";
+// installSkills must be stubbed — without this spy, init() would shell out
+// to a real `npx skills add` and write real files into the test cwd.
+import * as skillsMod from "./skills.ts";
 import { init } from "./index.ts";
 
 describe("init command", () => {
@@ -45,6 +48,7 @@ describe("init command", () => {
       spyOn(heuristics, "writePlan").mockResolvedValue([]),
       spyOn(heuristics, "checkGitDirty").mockResolvedValue(false),
       spyOn(heuristics, "printOutro").mockReturnValue(undefined),
+      spyOn(skillsMod, "installSkills").mockResolvedValue(undefined),
       spyOn(linkMod, "link").mockResolvedValue(undefined),
       spyOn(pullMod, "pull").mockResolvedValue(undefined),
     ];

--- a/packages/cli-core/src/commands/init/index.test.ts
+++ b/packages/cli-core/src/commands/init/index.test.ts
@@ -14,8 +14,6 @@ import * as previewMod from "./preview.ts";
 import * as formatMod from "./format.ts";
 import * as scanMod from "./scan.ts";
 import * as heuristics from "./heuristics.ts";
-// installSkills must be stubbed — without this spy, init() would shell out
-// to a real `npx skills add` and write real files into the test cwd.
 import * as skillsMod from "./skills.ts";
 import { init } from "./index.ts";
 

--- a/packages/cli-core/src/commands/init/skills.ts
+++ b/packages/cli-core/src/commands/init/skills.ts
@@ -72,13 +72,27 @@ export async function installSkills(
   const interactive = isHuman() && !skipPrompt;
   const args = buildSkillsArgs(skills, interactive);
 
-  const proc = Bun.spawn(args, {
-    cwd,
-    stdin: "inherit",
-    stdout: "inherit",
-    stderr: "inherit",
-  });
-  const exitCode = await proc.exited;
+  // Skills are optional — soft-fail with a warning rather than tearing down
+  // a successful scaffold. Bun.spawn can throw synchronously when the binary
+  // is missing (e.g. `npx` not on PATH on a minimal CI image), so the
+  // try/catch is needed in addition to the exit code check below.
+  let exitCode: number;
+  try {
+    const proc = Bun.spawn(args, {
+      cwd,
+      stdin: "inherit",
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+    exitCode = await proc.exited;
+  } catch {
+    console.log(
+      yellow(
+        `\nCould not run \`npx skills add\`. You can install manually later: npx skills add ${SKILLS_SOURCE}`,
+      ),
+    );
+    return;
+  }
 
   if (exitCode !== 0) {
     console.log(


### PR DESCRIPTION
## Summary

- Wrap the `Bun.spawn(["npx", "skills", "add", ...])` call inside `installSkills` in try/catch so a missing `npx` binary on a stripped-down CI image can't crash init *after* the scaffold has already succeeded.
- Add an `installSkills` spy to `init/index.test.ts`. Without it, running the unit test would shell out to the real `npx skills add` and pollute the working tree with `.augment/`, `.claude/`, `skills/clerk-*`, etc. on every test run.
- Document the existing `--no-skills` flag in both the root README and `init/README.md`.

## Test plan

- [ ] `bun run test` passes (57 passed)
- [ ] `bun run format` and `bun run lint` (cli-core) clean
- [ ] Manual: run `bun test packages/cli-core/src/commands/init/index.test.ts` and confirm no stray `skills/clerk-*` directories are written