### PR TITLE
fix(init): pre-check package manager binary in installSdk

### DIFF
--- a/packages/cli-core/src/commands/init/heuristics.ts
+++ b/packages/cli-core/src/commands/init/heuristics.ts
@@ -12,14 +12,41 @@ import type { ScanFinding } from "./scan.js";
 
 export async function installSdk(ctx: ProjectContext): Promise<void> {
   const addCmd = pmInstallCommand(ctx.packageManager);
+
+  // The package manager is detected from lockfiles, which can exist without
+  // the actual binary being installed (e.g. teammate committed bun.lock, you
+  // only have npm). Fail fast with a useful message rather than a raw ENOENT.
+  const pmBinary = addCmd.split(" ")[0];
+  if (Bun.which(pmBinary) === null) {
+    console.log(
+      yellow(
+        `${pmBinary} is not installed but the project's lockfile suggests it. ` +
+          `Install ${pmBinary} or run \`${addCmd} ${ctx.framework.sdk}\` manually with another package manager.`,
+      ),
+    );
+    return;
+  }
+
   console.log(`Installing ${cyan(ctx.framework.sdk)} for ${ctx.framework.name}...`);
 
-  const proc = Bun.spawn(addCmd.split(" ").concat(ctx.framework.sdk), {
-    cwd: ctx.cwd,
-    stdout: "inherit",
-    stderr: "inherit",
-  });
-  const exitCode = await proc.exited;
+  // try/catch covers the TOCTOU window between Bun.which and spawn.
+  let exitCode: number;
+  try {
+    const proc = Bun.spawn(addCmd.split(" ").concat(ctx.framework.sdk), {
+      cwd: ctx.cwd,
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+    exitCode = await proc.exited;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.log(
+      yellow(
+        `Failed to spawn ${addCmd}: ${message}. You can install manually: ${addCmd} ${ctx.framework.sdk}`,
+      ),
+    );
+    return;
+  }
 
   if (exitCode !== 0) {
     console.log(


### PR DESCRIPTION
## Summary

Hardens `installSdk` in `init/heuristics.ts` against the case where a project's lockfile points to a package manager that isn't actually installed locally (e.g. teammate committed `bun.lock`, you only have `npm`). Previously this surfaced as a raw `ENOENT` from `Bun.spawn` and crashed `clerk init`.

Two defensive layers:

1. **Pre-check:** `Bun.which(pmBinary)` runs before spawning. On miss, prints a yellow warning naming the missing binary and suggesting an alternate install command, then bails non-fatally so init keeps scaffolding.
2. **try/catch around `Bun.spawn`:** covers the TOCTOU window between the pre-check and the spawn call (or any other spawn-time failure). Prints a yellow warning that includes the underlying error message so a real failure is diagnosable, and again bails non-fatally.

SDK install is recoverable, so failing here should never block init. The user can run the install command manually after the rest of init completes.

## Test plan

- [ ] Unit tests pass (`bun run test`)
- [ ] E2E tests pass (`bun run test:e2e:op`)
- [ ] Manual: in a project with a `bun.lock` but no `bun` binary on PATH, run `clerk init` and confirm the warning fires and init completes