### PR TITLE
fix(init): write env vars to existing .env instead of creating .env.local

### DIFF
--- a/packages/cli-core/src/commands/env/pull.test.ts
+++ b/packages/cli-core/src/commands/env/pull.test.ts
@@ -320,6 +320,38 @@ describe("env pull", () => {
     expect(content).toContain("CLERK_SECRET_KEY=sk_test_xyz789");
   });
 
+  test("writes to .env.development.local when it exists (highest priority)", async () => {
+    await setProfile(tempDir, {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+    await Bun.write(join(tempDir, ".env.local"), "OTHER=1\n");
+    await Bun.write(join(tempDir, ".env.development.local"), "DEV_LOCAL=1\n");
+
+    await runEnvPull();
+
+    const content = await Bun.file(join(tempDir, ".env.development.local")).text();
+    expect(content).toContain("CLERK_SECRET_KEY=sk_test_xyz789");
+    // .env.local should be untouched
+    expect(await Bun.file(join(tempDir, ".env.local")).text()).toBe("OTHER=1\n");
+  });
+
+  test("writes to .env.development.local even when preferred file does not exist", async () => {
+    await setProfile(tempDir, {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+    await Bun.write(join(tempDir, ".env.development.local"), "DEV_LOCAL=1\n");
+
+    await runEnvPull();
+
+    const content = await Bun.file(join(tempDir, ".env.development.local")).text();
+    expect(content).toContain("CLERK_SECRET_KEY=sk_test_xyz789");
+    expect(await Bun.file(join(tempDir, ".env.local")).exists()).toBe(false);
+  });
+
   test("uses --file flag to target specific file", async () => {
     await setProfile(tempDir, {
       workspaceId: "org_1",

--- a/packages/cli-core/src/commands/env/pull.ts
+++ b/packages/cli-core/src/commands/env/pull.ts
@@ -1,12 +1,7 @@
 import { join } from "node:path";
 import { resolveAppContext } from "../../lib/config.ts";
 import { fetchApplication } from "../../lib/plapi.ts";
-import {
-  parseEnvFile,
-  mergeEnvVars,
-  serializeEnvFile,
-  ENV_FILE_CANDIDATES,
-} from "../../lib/dotenv.ts";
+import { parseEnvFile, mergeEnvVars, serializeEnvFile } from "../../lib/dotenv.ts";
 import {
   detectPublishableKeyName,
   detectSecretKeyName,
@@ -15,6 +10,8 @@ import {
 import { CliError, ERROR_CODE, withApiContext } from "../../lib/errors.ts";
 import { withSpinner } from "../../lib/spinner.ts";
 import { dim } from "../../lib/color.ts";
+
+const DEV_LOCAL_ENV_FILE = ".env.development.local";
 
 interface EnvPullOptions {
   app?: string;
@@ -33,25 +30,22 @@ async function hasClerkKeys(path: string): Promise<boolean> {
 async function resolveTargetFile(
   cwd: string,
   flag?: string,
-  preferredFile: string = ".env.local",
+  fallbackFile: string = ".env.local",
 ): Promise<string> {
   if (flag) return join(cwd, flag);
 
-  // .env.development.local is the highest-priority file in the Next.js/Vite dev load order
-  // and is always gitignored, so it's safe for secrets.
-  const devLocal = join(cwd, ENV_FILE_CANDIDATES[0]);
+  const devLocal = join(cwd, DEV_LOCAL_ENV_FILE);
   if (await Bun.file(devLocal).exists()) return devLocal;
 
-  const preferred = join(cwd, preferredFile);
-  if (await Bun.file(preferred).exists()) return preferred;
+  const fallback = join(cwd, fallbackFile);
+  if (await Bun.file(fallback).exists()) return fallback;
 
-  // Backwards compat: if the non-preferred file already has Clerk keys,
+  // Backwards compat: if the non-fallback file already has Clerk keys,
   // keep writing there so we don't leave stale keys behind.
-  const other = preferredFile === ".env" ? ".env.local" : ".env";
-  const otherPath = join(cwd, other);
-  if (await hasClerkKeys(otherPath)) return otherPath;
+  const other = fallbackFile === ".env" ? ".env.local" : ".env";
+  if (await hasClerkKeys(join(cwd, other))) return join(cwd, other);
 
-  return preferred;
+  return fallback;
 }
 
 export async function pull(options: EnvPullOptions): Promise<void> {

--- a/packages/cli-core/src/commands/env/pull.ts
+++ b/packages/cli-core/src/commands/env/pull.ts
@@ -1,7 +1,12 @@
 import { join } from "node:path";
 import { resolveAppContext } from "../../lib/config.ts";
 import { fetchApplication } from "../../lib/plapi.ts";
-import { parseEnvFile, mergeEnvVars, serializeEnvFile } from "../../lib/dotenv.ts";
+import {
+  parseEnvFile,
+  mergeEnvVars,
+  serializeEnvFile,
+  ENV_FILE_CANDIDATES,
+} from "../../lib/dotenv.ts";
 import {
   detectPublishableKeyName,
   detectSecretKeyName,
@@ -31,6 +36,11 @@ async function resolveTargetFile(
   preferredFile: string = ".env.local",
 ): Promise<string> {
   if (flag) return join(cwd, flag);
+
+  // .env.development.local is the highest-priority file in the Next.js/Vite dev load order
+  // and is always gitignored, so it's safe for secrets.
+  const devLocal = join(cwd, ENV_FILE_CANDIDATES[0]);
+  if (await Bun.file(devLocal).exists()) return devLocal;
 
   const preferred = join(cwd, preferredFile);
   if (await Bun.file(preferred).exists()) return preferred;

--- a/packages/cli-core/src/commands/init/context.test.ts
+++ b/packages/cli-core/src/commands/init/context.test.ts
@@ -192,6 +192,91 @@ test("defaults to npm when no lockfile found", async () => {
   expect(ctx!.packageManager).toBe("npm");
 });
 
+// ─── envFile detection ────────────────────────────────────────────────────────
+
+test("Next.js: uses .env when only .env exists", async () => {
+  await Bun.write(
+    join(tempDir, "package.json"),
+    JSON.stringify({ dependencies: { next: "15.0.0" } }),
+  );
+  await Bun.write(join(tempDir, ".env"), "EXISTING=1");
+
+  const ctx = await gatherContext(tempDir);
+
+  expect(ctx!.envFile).toBe(".env");
+});
+
+test("Next.js: uses .env when neither .env nor .env.local exists", async () => {
+  await Bun.write(
+    join(tempDir, "package.json"),
+    JSON.stringify({ dependencies: { next: "15.0.0" } }),
+  );
+
+  const ctx = await gatherContext(tempDir);
+
+  expect(ctx!.envFile).toBe(".env");
+});
+
+test("Next.js: uses .env.local when both .env and .env.local exist (keep existing setup)", async () => {
+  await Bun.write(
+    join(tempDir, "package.json"),
+    JSON.stringify({ dependencies: { next: "15.0.0" } }),
+  );
+  await Bun.write(join(tempDir, ".env"), "EXISTING=1");
+  await Bun.write(join(tempDir, ".env.local"), "LOCAL=1");
+
+  const ctx = await gatherContext(tempDir);
+
+  expect(ctx!.envFile).toBe(".env.local");
+});
+
+test("Next.js: falls back to .env.local when only .env.local exists", async () => {
+  await Bun.write(
+    join(tempDir, "package.json"),
+    JSON.stringify({ dependencies: { next: "15.0.0" } }),
+  );
+  await Bun.write(join(tempDir, ".env.local"), "LOCAL=1");
+
+  const ctx = await gatherContext(tempDir);
+
+  expect(ctx!.envFile).toBe(".env.local");
+});
+
+test("React (Vite): uses .env.local when only .env.local exists", async () => {
+  await Bun.write(
+    join(tempDir, "package.json"),
+    JSON.stringify({ dependencies: { react: "19.0.0", vite: "6.0.0" } }),
+  );
+  await Bun.write(join(tempDir, ".env.local"), "LOCAL=1");
+
+  const ctx = await gatherContext(tempDir);
+
+  expect(ctx!.envFile).toBe(".env.local");
+});
+
+test("React (Vite): uses .env.local when neither .env nor .env.local exists", async () => {
+  await Bun.write(
+    join(tempDir, "package.json"),
+    JSON.stringify({ dependencies: { react: "19.0.0", vite: "6.0.0" } }),
+  );
+
+  const ctx = await gatherContext(tempDir);
+
+  expect(ctx!.envFile).toBe(".env.local");
+});
+
+test("React (Vite): falls back to existing .env when only .env exists", async () => {
+  await Bun.write(
+    join(tempDir, "package.json"),
+    JSON.stringify({ dependencies: { react: "19.0.0", vite: "6.0.0" } }),
+  );
+  await Bun.write(join(tempDir, ".env"), "EXISTING=1");
+
+  const ctx = await gatherContext(tempDir);
+
+  expect(ctx!.envFile).toBe(".env");
+});
+
 test("defaults to app-router when neither app/ nor pages/ exists", async () => {
   await Bun.write(
     join(tempDir, "package.json"),

--- a/packages/cli-core/src/commands/init/context.test.ts
+++ b/packages/cli-core/src/commands/init/context.test.ts
@@ -277,6 +277,44 @@ test("React (Vite): falls back to existing .env when only .env exists", async ()
   expect(ctx!.envFile).toBe(".env");
 });
 
+test("uses .env.development.local when it exists (highest priority)", async () => {
+  await Bun.write(
+    join(tempDir, "package.json"),
+    JSON.stringify({ dependencies: { next: "15.0.0" } }),
+  );
+  await Bun.write(join(tempDir, ".env"), "EXISTING=1");
+  await Bun.write(join(tempDir, ".env.development.local"), "DEV_LOCAL=1");
+
+  const ctx = await gatherContext(tempDir);
+
+  expect(ctx!.envFile).toBe(".env.development.local");
+});
+
+test(".env.development.local beats .env.local", async () => {
+  await Bun.write(
+    join(tempDir, "package.json"),
+    JSON.stringify({ dependencies: { next: "15.0.0" } }),
+  );
+  await Bun.write(join(tempDir, ".env.local"), "LOCAL=1");
+  await Bun.write(join(tempDir, ".env.development.local"), "DEV_LOCAL=1");
+
+  const ctx = await gatherContext(tempDir);
+
+  expect(ctx!.envFile).toBe(".env.development.local");
+});
+
+test("uses .env.development when it exists and no higher-priority file present", async () => {
+  await Bun.write(
+    join(tempDir, "package.json"),
+    JSON.stringify({ dependencies: { next: "15.0.0" } }),
+  );
+  await Bun.write(join(tempDir, ".env.development"), "DEV=1");
+
+  const ctx = await gatherContext(tempDir);
+
+  expect(ctx!.envFile).toBe(".env.development");
+});
+
 test("defaults to app-router when neither app/ nor pages/ exists", async () => {
   await Bun.write(
     join(tempDir, "package.json"),

--- a/packages/cli-core/src/commands/init/context.ts
+++ b/packages/cli-core/src/commands/init/context.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { stat } from "node:fs/promises";
 import { detectFramework, readDeps } from "../../lib/framework.js";
 import type { FrameworkInfo } from "../../lib/framework.js";
+import { findExistingEnvFile } from "../../lib/dotenv.js";
 import type { ProjectContext } from "./frameworks/types.js";
 
 export async function fileExists(path: string): Promise<boolean> {
@@ -65,17 +66,7 @@ export async function gatherContext(
   const deps = await readDeps(cwd);
   const existingClerk = deps ? framework.sdk in deps : false;
 
-  const [envLocalExists, envExists] = await Promise.all([
-    fileExists(join(cwd, ".env.local")),
-    fileExists(join(cwd, ".env")),
-  ]);
-
-  function resolveEnvFile(): string {
-    if (envLocalExists) return ".env.local";
-    if (envExists) return ".env";
-    return framework.envFile;
-  }
-  const envFile = resolveEnvFile();
+  const envFile = await findExistingEnvFile(cwd, framework.envFile);
 
   return {
     cwd,

--- a/packages/cli-core/src/commands/init/context.ts
+++ b/packages/cli-core/src/commands/init/context.ts
@@ -65,7 +65,16 @@ export async function gatherContext(
   const deps = await readDeps(cwd);
   const existingClerk = deps ? framework.sdk in deps : false;
 
-  const envFile = (await fileExists(join(cwd, ".env.local"))) ? ".env.local" : ".env";
+  // Pick the env file to write to:
+  //   1. If .env.local already exists, use it (respect the user's existing setup).
+  //   2. If only .env exists, use it (don't create a new .env.local alongside it).
+  //   3. If neither exists, fall back to the framework's preferred file
+  //      (".env" for Next.js/Astro/Nuxt, ".env.local" for Vite-based frameworks).
+  const [envLocalExists, envExists] = await Promise.all([
+    fileExists(join(cwd, ".env.local")),
+    fileExists(join(cwd, ".env")),
+  ]);
+  const envFile = envLocalExists ? ".env.local" : envExists ? ".env" : framework.envFile;
 
   return {
     cwd,

--- a/packages/cli-core/src/commands/init/context.ts
+++ b/packages/cli-core/src/commands/init/context.ts
@@ -65,16 +65,17 @@ export async function gatherContext(
   const deps = await readDeps(cwd);
   const existingClerk = deps ? framework.sdk in deps : false;
 
-  // Pick the env file to write to:
-  //   1. If .env.local already exists, use it (respect the user's existing setup).
-  //   2. If only .env exists, use it (don't create a new .env.local alongside it).
-  //   3. If neither exists, fall back to the framework's preferred file
-  //      (".env" for Next.js/Astro/Nuxt, ".env.local" for Vite-based frameworks).
   const [envLocalExists, envExists] = await Promise.all([
     fileExists(join(cwd, ".env.local")),
     fileExists(join(cwd, ".env")),
   ]);
-  const envFile = envLocalExists ? ".env.local" : envExists ? ".env" : framework.envFile;
+
+  function resolveEnvFile(): string {
+    if (envLocalExists) return ".env.local";
+    if (envExists) return ".env";
+    return framework.envFile;
+  }
+  const envFile = resolveEnvFile();
 
   return {
     cwd,

--- a/packages/cli-core/src/commands/init/index.test.ts
+++ b/packages/cli-core/src/commands/init/index.test.ts
@@ -245,4 +245,35 @@ describe("init", () => {
     expect(heuristics.printKeylessInfo).not.toHaveBeenCalled();
     expect(skillsMod.installSkills).not.toHaveBeenCalled();
   });
+
+  test("pulls env to ctx.envFile when authenticated and framework detected", async () => {
+    const { gatherContextSpy } = setup({ email: "test@test.com" });
+
+    const mockCtx = {
+      cwd: process.cwd(),
+      framework: {
+        dep: "next",
+        name: "Next.js",
+        sdk: "@clerk/nextjs",
+        envVar: "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+        envFile: ".env" as const,
+      },
+      typescript: true,
+      srcDir: false,
+      packageManager: "npm" as const,
+      existingClerk: false,
+      deps: { next: "15.0.0" },
+      envFile: ".env",
+    };
+
+    gatherContextSpy.mockResolvedValue(mockCtx);
+    spyOn(scaffoldMod, "scaffold").mockResolvedValue({
+      actions: [{ type: "write", path: "app/layout.tsx", content: "" }],
+      postInstructions: [],
+    });
+
+    await init({ yes: true });
+
+    expect(pullMod.pull).toHaveBeenCalledWith({ file: ".env" });
+  });
 });

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -88,7 +88,7 @@ export async function init(options: InitOptions = {}) {
 
   bar();
   if (!keyless) {
-    await pull({});
+    await pull({ file: ctx.envFile });
   } else {
     printKeylessInfo();
   }

--- a/packages/cli-core/src/lib/dotenv.ts
+++ b/packages/cli-core/src/lib/dotenv.ts
@@ -3,6 +3,31 @@
  * Preserves comments, blank lines, and key ordering when merging new values.
  */
 
+import { join } from "node:path";
+
+/**
+ * Env file candidates in Next.js/Vite development load order (highest priority first).
+ * Production/test variants (.env.production.local, .env.test.local) are excluded —
+ * the CLI always runs in a development-setup context.
+ */
+export const ENV_FILE_CANDIDATES = [
+  ".env.development.local",
+  ".env.local",
+  ".env.development",
+  ".env",
+] as const;
+
+/**
+ * Returns the first candidate from ENV_FILE_CANDIDATES that exists on disk,
+ * or `fallback` if none do.
+ */
+export async function findExistingEnvFile(cwd: string, fallback: string): Promise<string> {
+  for (const candidate of ENV_FILE_CANDIDATES) {
+    if (await Bun.file(join(cwd, candidate)).exists()) return candidate;
+  }
+  return fallback;
+}
+
 export type EnvLine =
   | { type: "comment"; raw: string }
   | { type: "blank" }


### PR DESCRIPTION
## Summary

- Fixes `clerk init` creating a new `.env.local` when the project already has a `.env` file
- Expands env file detection to cover the full Next.js/Vite dev load order: `.env.development.local` → `.env.local` → `.env.development` → `.env`
- Passes `ctx.envFile` to the internal `env pull` call so both the scaffolding write and the API key write target the same file

## Env file selection priority (new behavior)

Matches the official Next.js/Vite load order for `NODE_ENV=development`:

| Priority | File | Notes |
|---|---|---|
| 1 (highest) | `.env.development.local` | Always gitignored; local dev overrides |
| 2 | `.env.local` | Always gitignored; local overrides |
| 3 | `.env.development` | Dev-specific shared config |
| 4 | `.env` | Base defaults |
| fallback | `framework.envFile` | Created when none of the above exist |

## Changes

- **`lib/dotenv.ts`** — adds `ENV_FILE_CANDIDATES` constant and `findExistingEnvFile(cwd, fallback)` shared utility
- **`init/context.ts`** — uses `findExistingEnvFile` for scaffolding (all 4 candidates)
- **`env/pull.ts`** — adds `.env.development.local` as highest-priority check for secrets; intentionally skips `.env`/`.env.development` to avoid writing secrets to potentially git-tracked files

## Test plan

- [ ] `bun test packages/cli-core/src/commands/init/` — all pass
- [ ] `bun test packages/cli-core/src/commands/env/pull.test.ts` — all pass
- [ ] Next.js project with only `.env`: env vars written to `.env`, no `.env.local` created
- [ ] Next.js project with `.env.development.local`: env vars written to `.env.development.local`
- [ ] `.env.development.local` takes priority over `.env.local` when both exist
- [ ] Vite project with no env files: `.env.local` created (framework preference)