### PR TITLE
fix(lint): pass oxlint config explicitly for scripts/

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:e2e": "bun run scripts/run-tests.ts --pattern 'test/e2e/*.test.ts' --retries 1",
     "test:e2e:op": "bun run scripts/run-e2e-op.ts",
     "e2e:refresh-fixtures": "bun run scripts/refresh-e2e-fixtures.ts",
-    "lint": "bun run --filter @clerk/cli-core lint && oxlint scripts/",
+    "lint": "bun run --filter @clerk/cli-core lint && oxlint -c .oxlintrc.json scripts/",
     "format": "bun run --filter @clerk/cli-core format && oxfmt --write scripts/",
     "format:check": "bun run --filter @clerk/cli-core format:check && oxfmt --check scripts/",
     "build:compile": "bun run --filter @clerk/cli-core build:compile",


### PR DESCRIPTION
## Summary

- `bun run lint` currently passes 6 `unicorn/no-process-exit` errors in `scripts/run-tests.ts` and `scripts/run-e2e-op.ts` even though the root `.oxlintrc.json` has an override disabling that rule for `scripts/*`.
- The override is being silently dropped because oxlint 1.58.0 does not auto-discover the root config when invoked with a directory argument from the repo root. Passing `-c .oxlintrc.json` explicitly makes the override apply as intended.
- One-line change to the `lint` script in `package.json`. No behavior change to any source file.

## Test plan

- [x] `bun run lint` passes cleanly on this branch (previously 6 errors)
- [x] `bun run format:check` still passes
- [x] `bun run test` still passes
- [x] `bun run test:e2e:op` still passes (9/9 fixtures)