### PR TITLE
refactor(init): use runner detection in format.ts

### DIFF
--- a/packages/cli-core/src/commands/init/format.test.ts
+++ b/packages/cli-core/src/commands/init/format.test.ts
@@ -1,0 +1,256 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { join } from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { runFormatters } from "./format.ts";
+import type { ProjectContext } from "./frameworks/types.js";
+
+type SpawnArgs = readonly string[];
+
+const origSpawn = Bun.spawn;
+const origWhich = Bun.which;
+const origSpawnSync = Bun.spawnSync;
+
+type SpawnImpl = (
+  cmd: SpawnArgs,
+  opts?: { cwd?: string; stdout?: unknown; stderr?: unknown },
+) => { exited: Promise<number> };
+
+function setSpawn(impl: SpawnImpl) {
+  try {
+    (Bun as unknown as { spawn: SpawnImpl }).spawn = impl;
+  } catch {
+    // Bun.spawn may not be writable on some runtimes
+  }
+}
+function restoreSpawn() {
+  try {
+    (Bun as unknown as { spawn: typeof Bun.spawn }).spawn = origSpawn;
+  } catch {
+    // ignore
+  }
+}
+
+function mockWhich(present: ReadonlySet<string>) {
+  try {
+    (Bun as unknown as { which: (bin: string) => string | null }).which = (bin) =>
+      present.has(bin) ? `/usr/local/bin/${bin}` : null;
+  } catch {
+    // ignore
+  }
+}
+function restoreWhich() {
+  try {
+    (Bun as unknown as { which: typeof Bun.which }).which = origWhich;
+  } catch {
+    // ignore
+  }
+}
+
+function mockSpawnSync(yarnDlxExitCode: number) {
+  try {
+    (Bun as unknown as { spawnSync: (cmd: string[]) => { exitCode: number } }).spawnSync = (
+      cmd,
+    ) => {
+      if (cmd[0] === "yarn" && cmd[1] === "dlx") return { exitCode: yarnDlxExitCode };
+      return { exitCode: 0 };
+    };
+  } catch {
+    // ignore
+  }
+}
+function restoreSpawnSync() {
+  try {
+    (Bun as unknown as { spawnSync: typeof Bun.spawnSync }).spawnSync = origSpawnSync;
+  } catch {
+    // ignore
+  }
+}
+
+/** Minimal ProjectContext suitable for driving runFormatters. */
+function makeCtx(overrides: Partial<ProjectContext> & { cwd: string }): ProjectContext {
+  return {
+    framework: {
+      name: "next",
+      sdk: "@clerk/nextjs",
+      dep: "next",
+      envFile: ".env.local",
+    } as ProjectContext["framework"],
+    typescript: true,
+    srcDir: false,
+    packageManager: "bun",
+    existingClerk: false,
+    deps: {},
+    envFile: ".env.local",
+    ...overrides,
+  };
+}
+
+describe("runFormatters", () => {
+  let tempDir: string;
+  let spawnCalls: SpawnArgs[];
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "clerk-format-"));
+    spawnCalls = [];
+    setSpawn((cmd) => {
+      spawnCalls.push(cmd);
+      return { exited: Promise.resolve(0) };
+    });
+    mockWhich(new Set(["bunx", "npx", "pnpm", "yarn"]));
+    mockSpawnSync(0);
+  });
+
+  afterEach(async () => {
+    restoreSpawn();
+    restoreWhich();
+    restoreSpawnSync();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("no-op when files is empty", async () => {
+    const ctx = makeCtx({ cwd: tempDir, deps: { prettier: "3.0.0" } });
+    await runFormatters(ctx, []);
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  test("no-op when no supported formatter is in deps", async () => {
+    const ctx = makeCtx({ cwd: tempDir, deps: { next: "15.0.0" } });
+    await runFormatters(ctx, ["a.ts"]);
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  test("runs prettier via the package-manager's preferred runner (bun → bunx)", async () => {
+    const ctx = makeCtx({
+      cwd: tempDir,
+      packageManager: "bun",
+      deps: { prettier: "3.0.0" },
+    });
+    await runFormatters(ctx, ["src/a.ts", "src/b.ts"]);
+    expect(spawnCalls).toEqual([
+      ["bunx", "prettier", "--ignore-unknown", "--write", "src/a.ts", "src/b.ts"],
+    ]);
+  });
+
+  test("runs biome via pnpm dlx when packageManager is pnpm", async () => {
+    const ctx = makeCtx({
+      cwd: tempDir,
+      packageManager: "pnpm",
+      deps: { "@biomejs/biome": "1.9.0" },
+    });
+    await runFormatters(ctx, ["src/a.ts"]);
+    expect(spawnCalls).toEqual([
+      ["pnpm", "dlx", "@biomejs/biome", "format", "--write", "src/a.ts"],
+    ]);
+  });
+
+  test("runs both prettier and biome when both are in deps, in FORMATTERS order", async () => {
+    const ctx = makeCtx({
+      cwd: tempDir,
+      packageManager: "npm",
+      deps: { prettier: "3.0.0", "@biomejs/biome": "1.9.0" },
+    });
+    await runFormatters(ctx, ["x.ts"]);
+    expect(spawnCalls).toEqual([
+      ["npx", "prettier", "--ignore-unknown", "--write", "x.ts"],
+      ["npx", "@biomejs/biome", "format", "--write", "x.ts"],
+    ]);
+  });
+
+  test("falls back to the first available runner when the pm's runner is missing", async () => {
+    // Project says bun, but only npx/pnpm are on PATH.
+    mockWhich(new Set(["npx", "pnpm"]));
+    const ctx = makeCtx({
+      cwd: tempDir,
+      packageManager: "bun",
+      deps: { prettier: "3.0.0" },
+    });
+    await runFormatters(ctx, ["x.ts"]);
+    expect(spawnCalls).toEqual([["npx", "prettier", "--ignore-unknown", "--write", "x.ts"]]);
+  });
+
+  test("skips silently when no runners are on PATH", async () => {
+    mockWhich(new Set());
+    const ctx = makeCtx({
+      cwd: tempDir,
+      packageManager: "bun",
+      deps: { prettier: "3.0.0" },
+    });
+    await runFormatters(ctx, ["x.ts"]);
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  test("excludes yarn when yarn dlx probe fails (Yarn Classic)", async () => {
+    mockWhich(new Set(["yarn"]));
+    mockSpawnSync(1); // yarn dlx --help exits non-zero
+    const ctx = makeCtx({
+      cwd: tempDir,
+      packageManager: "yarn",
+      deps: { prettier: "3.0.0" },
+    });
+    await runFormatters(ctx, ["x.ts"]);
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  test("swallows spawn errors (best-effort) and continues to later formatters", async () => {
+    const attempted: SpawnArgs[] = [];
+    setSpawn((cmd) => {
+      attempted.push(cmd);
+      if (cmd[1] === "prettier") {
+        throw new Error("spawn failed");
+      }
+      return { exited: Promise.resolve(0) };
+    });
+    const ctx = makeCtx({
+      cwd: tempDir,
+      packageManager: "npm",
+      deps: { prettier: "3.0.0", "@biomejs/biome": "1.9.0" },
+    });
+    // Should not throw even though prettier spawn blows up.
+    await runFormatters(ctx, ["x.ts"]);
+    expect(attempted).toEqual([
+      ["npx", "prettier", "--ignore-unknown", "--write", "x.ts"],
+      ["npx", "@biomejs/biome", "format", "--write", "x.ts"],
+    ]);
+  });
+
+  test("reads deps from disk when ctx.deps is empty", async () => {
+    await Bun.write(
+      join(tempDir, "package.json"),
+      JSON.stringify({ dependencies: { prettier: "3.0.0" } }),
+    );
+    const ctx = makeCtx({
+      cwd: tempDir,
+      packageManager: "bun",
+      deps: {}, // empty → triggers disk fallback
+    });
+    await runFormatters(ctx, ["x.ts"]);
+    expect(spawnCalls).toEqual([["bunx", "prettier", "--ignore-unknown", "--write", "x.ts"]]);
+  });
+
+  test("no-op when ctx.deps is empty and package.json is missing", async () => {
+    const ctx = makeCtx({
+      cwd: tempDir,
+      packageManager: "bun",
+      deps: {},
+    });
+    await runFormatters(ctx, ["x.ts"]);
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  test("spawns in the project cwd", async () => {
+    let seenCwd: string | undefined;
+    setSpawn((cmd, opts?: { cwd?: string }) => {
+      seenCwd = opts?.cwd;
+      spawnCalls.push(cmd);
+      return { exited: Promise.resolve(0) };
+    });
+    const ctx = makeCtx({
+      cwd: tempDir,
+      packageManager: "bun",
+      deps: { prettier: "3.0.0" },
+    });
+    await runFormatters(ctx, ["x.ts"]);
+    expect(seenCwd).toBe(tempDir);
+  });
+});

--- a/packages/cli-core/src/commands/init/format.ts
+++ b/packages/cli-core/src/commands/init/format.ts
@@ -1,35 +1,58 @@
 import { readDeps } from "./context.js";
+// Pulls in the same runner detection skills.ts uses, so a bun project with
+// no `npx` on PATH (entirely possible if the user installed Bun via Homebrew
+// but never installed Node) will fall back to bunx instead of silently failing.
+import { detectAvailableRunners, preferredRunner, runnerCommand } from "../../lib/runners.js";
+import type { ProjectContext } from "./frameworks/types.js";
 
 type FormatterConfig = {
   pkg: string;
-  args: (files: string[]) => string[];
+  /** Args after the runner: binary + flags + files. The runner is prepended at spawn time. */
+  binArgs: (files: string[]) => string[];
 };
 
 const FORMATTERS: FormatterConfig[] = [
   {
     pkg: "prettier",
-    args: (files) => ["npx", "prettier", "--ignore-unknown", "--write", ...files],
+    binArgs: (files) => ["prettier", "--ignore-unknown", "--write", ...files],
   },
   {
     pkg: "@biomejs/biome",
-    args: (files) => ["npx", "@biomejs/biome", "format", "--write", ...files],
+    binArgs: (files) => ["@biomejs/biome", "format", "--write", ...files],
   },
 ];
 
-export async function runFormatters(cwd: string, files: string[]): Promise<void> {
+/**
+ * Format scaffolded files with prettier or biome (whichever the project uses).
+ *
+ * Best-effort: failures are silent (stdio ignored, spawn errors swallowed)
+ * because formatting is purely cosmetic and shouldn't break init.
+ */
+export async function runFormatters(ctx: ProjectContext, files: string[]): Promise<void> {
   if (files.length === 0) return;
 
-  const deps = await readDeps(cwd);
+  const deps = ctx.deps && Object.keys(ctx.deps).length > 0 ? ctx.deps : await readDeps(ctx.cwd);
   if (!deps) return;
 
-  for (const formatter of FORMATTERS) {
-    if (!(formatter.pkg in deps)) continue;
+  const matchingFormatters = FORMATTERS.filter((f) => f.pkg in deps);
+  if (matchingFormatters.length === 0) return;
 
-    const proc = Bun.spawn(formatter.args(files), {
-      cwd,
-      stdout: "ignore",
-      stderr: "ignore",
-    });
-    await proc.exited;
+  const available = detectAvailableRunners();
+  if (available.length === 0) return;
+  const runner = preferredRunner(ctx.packageManager, available);
+  if (!runner) return;
+
+  for (const formatter of matchingFormatters) {
+    const command = runnerCommand(runner, formatter.binArgs(files));
+    try {
+      const proc = Bun.spawn(command, {
+        cwd: ctx.cwd,
+        stdout: "ignore",
+        stderr: "ignore",
+      });
+      await proc.exited;
+    } catch {
+      // Best-effort, see function doc comment.
+    }
   }
 }

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -321,7 +321,7 @@ async function scaffoldAndWrite(
   }
 
   const writtenFiles = await writePlan(cwd, plan);
-  await runFormatters(cwd, writtenFiles);
+  await runFormatters(ctx, writtenFiles);
 
   const findings = await withSpinner("Scanning for issues...", () =>
     scanForIssues(cwd, ctx.framework.dep),


### PR DESCRIPTION
## Summary

- Replaces hardcoded `["npx", "prettier", ...]` arrays in `init/format.ts` with the runner detection from `lib/runners.ts`. A bun project with no `npx` installed (e.g. Bun via Homebrew but no Node) now falls back to `bunx` instead of silently failing to format.
- Wraps the `Bun.spawn` call in try/catch, formatting is best-effort and shouldn't break init even if the runner subprocess crashes.
- Signature change: `runFormatters` now takes the full `ProjectContext` instead of just `cwd`, so it can read `packageManager`. Updates the lone caller in `init/index.ts`.

Stacked on #118.

## Test plan

- [ ] `bun run test` passes (59 passed)
- [ ] Manual: on a bun-only machine without `npx`, run `clerk init` in a Prettier-using project and confirm formatting still runs (via `bunx`)