### PR TITLE
ci(e2e): run E2E job in Playwright container image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,10 +69,11 @@ jobs:
       github.actor != 'dependabot[bot]'
     runs-on: blacksmith-8vcpu-ubuntu-2404
     container:
-      image: mcr.microsoft.com/playwright:v1.52.0-noble
-      options: --user 1001
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
     timeout-minutes: 30
     steps:
+      - name: Install unzip (required by setup-bun)
+        run: apt-get update && apt-get install -y unzip
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.actor != 'dependabot[bot]'
     runs-on: blacksmith-8vcpu-ubuntu-2404
+    container:
+      image: mcr.microsoft.com/playwright:v1.52.0-noble
+      options: --user 1001
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -81,8 +84,6 @@ jobs:
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
           restore-keys: bun-${{ runner.os }}-
       - run: bun install --frozen-lockfile
-      - run: bunx playwright install chromium --with-deps
-
       - name: Run E2E tests
         run: bun run test:e2e
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,15 @@ jobs:
     steps:
       - name: Install unzip (required by setup-bun)
         run: apt-get update && apt-get install -y unzip
+      - name: Pin localhost to IPv4 in /etc/hosts
+        # The playwright image resolves `localhost` to `::1` first, which
+        # breaks Next.js dev: Next's internal proxy connects to `localhost`
+        # regardless of the -H flag, so if localhost is IPv6-only the
+        # proxy gets ECONNRESET. Drop the `::1 localhost` entry so every
+        # consumer (Next dev proxy, Bun fetch, Chromium) reaches 127.0.0.1.
+        run: |
+          grep -v '::1.*localhost' /etc/hosts > /tmp/hosts.new
+          cat /tmp/hosts.new > /etc/hosts
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
+      - name: Mark workspace as safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - uses: oven-sh/setup-bun@v2
       - uses: actions/cache/restore@v5
         with:

--- a/test/e2e/lib/dev-server.ts
+++ b/test/e2e/lib/dev-server.ts
@@ -1,4 +1,4 @@
-import { createServer } from "node:net";
+import { createServer, Socket } from "node:net";
 import type { Subprocess } from "bun";
 import { log } from "./logger.ts";
 
@@ -45,6 +45,32 @@ export function buildDevCommand(devCmd: string[], port: number): string[] {
   const portFlag = isNextjs ? "-p" : "--port";
   const hostFlag = isNextjs ? "-H" : "--host";
   return [...devCmd, hostFlag, DEV_SERVER_HOST, portFlag, String(port)];
+}
+
+/**
+ * TCP connect probe: resolves true if the given host:port accepts a TCP
+ * connection within `timeoutMs`. We use this instead of an HTTP fetch because
+ * dev servers (notably Next.js with Clerk middleware) can take longer than a
+ * short HTTP timeout to produce the first response while compiling on demand,
+ * even though they're already accepting connections. Playwright's page.goto
+ * with waitUntil:"load" handles the slow first response.
+ */
+async function canConnect(host: string, port: number, timeoutMs: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = new Socket();
+    let done = false;
+    const finish = (ok: boolean) => {
+      if (done) return;
+      done = true;
+      socket.destroy();
+      resolve(ok);
+    };
+    socket.setTimeout(timeoutMs);
+    socket.once("connect", () => finish(true));
+    socket.once("timeout", () => finish(false));
+    socket.once("error", () => finish(false));
+    socket.connect(port, host);
+  });
 }
 
 interface ReadyServer {
@@ -142,17 +168,9 @@ async function tryStart(opts: {
       );
     }
 
-    try {
-      const res = await fetch(`http://${DEV_SERVER_HOST}:${port}`, {
-        signal: AbortSignal.timeout(1000),
-        redirect: "manual",
-      });
-      if (res.status < 500) {
-        log(fixtureName, `dev server ready (status ${res.status})`);
-        return { kind: "ready", value: { proc, port, stdout: stdoutLines, stderr: stderrLines } };
-      }
-    } catch {
-      // Connection refused / timeout while polling — keep waiting.
+    if (await canConnect(DEV_SERVER_HOST, port, 1000)) {
+      log(fixtureName, `dev server ready (accepting TCP on ${DEV_SERVER_HOST}:${port})`);
+      return { kind: "ready", value: { proc, port, stdout: stdoutLines, stderr: stderrLines } };
     }
     await Bun.sleep(500);
   }

--- a/test/e2e/lib/dev-server.ts
+++ b/test/e2e/lib/dev-server.ts
@@ -31,11 +31,20 @@ async function getAvailablePort(): Promise<number> {
   });
 }
 
-/** Build the full dev server command with the port flag appended. */
+/**
+ * Host the dev server should bind to. We pin to IPv4 loopback instead of
+ * `localhost` because some environments (e.g. the Playwright Docker image)
+ * resolve `localhost` to `::1` first, which leaves the dev server listening
+ * only on IPv6 while Bun's `fetch` and some tooling try IPv4 first.
+ */
+export const DEV_SERVER_HOST = "127.0.0.1";
+
+/** Build the full dev server command with host and port flags appended. */
 export function buildDevCommand(devCmd: string[], port: number): string[] {
   const isNextjs = devCmd[0] === "next";
   const portFlag = isNextjs ? "-p" : "--port";
-  return [...devCmd, portFlag, String(port)];
+  const hostFlag = isNextjs ? "-H" : "--host";
+  return [...devCmd, hostFlag, DEV_SERVER_HOST, portFlag, String(port)];
 }
 
 interface ReadyServer {
@@ -134,7 +143,7 @@ async function tryStart(opts: {
     }
 
     try {
-      const res = await fetch(`http://localhost:${port}`, {
+      const res = await fetch(`http://${DEV_SERVER_HOST}:${port}`, {
         signal: AbortSignal.timeout(1000),
         redirect: "manual",
       });

--- a/test/e2e/lib/dev-server.ts
+++ b/test/e2e/lib/dev-server.ts
@@ -31,20 +31,11 @@ async function getAvailablePort(): Promise<number> {
   });
 }
 
-/**
- * Host the dev server should bind to. We pin to IPv4 loopback instead of
- * `localhost` because some environments (e.g. the Playwright Docker image)
- * resolve `localhost` to `::1` first, which leaves the dev server listening
- * only on IPv6 while Bun's `fetch` and some tooling try IPv4 first.
- */
-export const DEV_SERVER_HOST = "127.0.0.1";
-
-/** Build the full dev server command with host and port flags appended. */
+/** Build the full dev server command with the port flag appended. */
 export function buildDevCommand(devCmd: string[], port: number): string[] {
   const isNextjs = devCmd[0] === "next";
   const portFlag = isNextjs ? "-p" : "--port";
-  const hostFlag = isNextjs ? "-H" : "--host";
-  return [...devCmd, hostFlag, DEV_SERVER_HOST, portFlag, String(port)];
+  return [...devCmd, portFlag, String(port)];
 }
 
 /**
@@ -168,8 +159,8 @@ async function tryStart(opts: {
       );
     }
 
-    if (await canConnect(DEV_SERVER_HOST, port, 1000)) {
-      log(fixtureName, `dev server ready (accepting TCP on ${DEV_SERVER_HOST}:${port})`);
+    if (await canConnect("127.0.0.1", port, 1000)) {
+      log(fixtureName, `dev server ready (accepting TCP on 127.0.0.1:${port})`);
       return { kind: "ready", value: { proc, port, stdout: stdoutLines, stderr: stderrLines } };
     }
     await Bun.sleep(500);

--- a/test/e2e/lib/fixture-test.ts
+++ b/test/e2e/lib/fixture-test.ts
@@ -4,7 +4,7 @@ import { setupFixture } from "./fixture-setup.ts";
 import type { FixtureConfig } from "./types.ts";
 import { chromium } from "playwright";
 import { clerkSetup, setupClerkTestingToken, clerk } from "@clerk/testing/playwright";
-import { startDevServer, killDevServer, DEV_SERVER_HOST } from "./dev-server.ts";
+import { startDevServer, killDevServer } from "./dev-server.ts";
 import { createTestUser, deleteTestUser } from "./test-user.ts";
 import { log } from "./logger.ts";
 
@@ -225,9 +225,8 @@ export function runBrowserTest(getFixture: () => FixtureState, config: FixtureCo
           context,
           options: frontendApiUrl ? { frontendApiUrl } : undefined,
         });
-        const baseUrl = `http://${DEV_SERVER_HOST}:${port}`;
-        log(fixtureName, `navigating to ${baseUrl}`);
-        await page.goto(baseUrl, { waitUntil: "load" });
+        log(fixtureName, `navigating to http://localhost:${port}`);
+        await page.goto(`http://localhost:${port}`, { waitUntil: "load" });
 
         // 5. Sign in
         log(fixtureName, "signing in");

--- a/test/e2e/lib/fixture-test.ts
+++ b/test/e2e/lib/fixture-test.ts
@@ -4,7 +4,7 @@ import { setupFixture } from "./fixture-setup.ts";
 import type { FixtureConfig } from "./types.ts";
 import { chromium } from "playwright";
 import { clerkSetup, setupClerkTestingToken, clerk } from "@clerk/testing/playwright";
-import { startDevServer, killDevServer } from "./dev-server.ts";
+import { startDevServer, killDevServer, DEV_SERVER_HOST } from "./dev-server.ts";
 import { createTestUser, deleteTestUser } from "./test-user.ts";
 import { log } from "./logger.ts";
 
@@ -225,8 +225,9 @@ export function runBrowserTest(getFixture: () => FixtureState, config: FixtureCo
           context,
           options: frontendApiUrl ? { frontendApiUrl } : undefined,
         });
-        log(fixtureName, `navigating to http://localhost:${port}`);
-        await page.goto(`http://localhost:${port}`, { waitUntil: "load" });
+        const baseUrl = `http://${DEV_SERVER_HOST}:${port}`;
+        log(fixtureName, `navigating to ${baseUrl}`);
+        await page.goto(baseUrl, { waitUntil: "load" });
 
         // 5. Sign in
         log(fixtureName, "signing in");


### PR DESCRIPTION
## Summary
- Run the E2E job inside `mcr.microsoft.com/playwright:v1.52.0-noble` so browsers and system dependencies ship with the image.
- Drop the `bunx playwright install chromium --with-deps` step now that the container provides them.

## Test plan
- [ ] CI E2E job runs to completion on this PR