### PR TITLE
feat(apps): add `clerk apps create` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Commands:
   whoami                                     Show the current logged-in user
   apps                                       Manage your Clerk applications
     list      [options]                      List your Clerk applications
+    create    [options] <name>               Create a new Clerk application
   config                                     Manage instance configuration
     pull      [options]                      Pull instance configuration from Clerk
     schema    [options]                      Pull instance config schema from Clerk
@@ -155,6 +156,12 @@ clerk api                Interactive request builder (TTY only)
 
 clerk apps list
   --json               Output as JSON
+
+clerk apps create <name>
+  --json               Output as JSON
+  Examples:
+    $ clerk apps create "My App"           Create a new application
+    $ clerk apps create "My App" --json    Output as JSON
 
 clerk doctor
   --verbose            Show detailed output for each check

--- a/packages/cli-core/src/cli-program.ts
+++ b/packages/cli-core/src/cli-program.ts
@@ -12,7 +12,7 @@ import { configSchema } from "./commands/config/schema.ts";
 import { api } from "./commands/api/index.ts";
 import { link } from "./commands/link/index.ts";
 import { unlink } from "./commands/unlink/index.ts";
-import { list as appsList } from "./commands/apps/list.ts";
+import { apps as appsHandlers } from "./commands/apps/index.ts";
 import { doctor } from "./commands/doctor/index.ts";
 import { switchEnv } from "./commands/switch-env/index.ts";
 import { getEnvironment } from "./lib/config.ts";
@@ -170,7 +170,18 @@ export function createProgram() {
       { command: "clerk apps list", description: "List all applications" },
       { command: "clerk apps list --json", description: "Output as JSON" },
     ])
-    .action(appsList);
+    .action(appsHandlers.list);
+
+  apps
+    .command("create")
+    .description("Create a new Clerk application")
+    .argument("<name>", "Application name")
+    .option("--json", "Output as JSON")
+    .setExamples([
+      { command: 'clerk apps create "My App"', description: "Create a new application" },
+      { command: 'clerk apps create "My App" --json', description: "Output as JSON" },
+    ])
+    .action(appsHandlers.create);
 
   const env = program
     .command("env")

--- a/packages/cli-core/src/commands/apps/README.md
+++ b/packages/cli-core/src/commands/apps/README.md
@@ -27,11 +27,36 @@ clerk apps list                    # List all applications
 clerk apps list --json             # Output as JSON
 ```
 
+### `clerk apps create`
+
+Create a new Clerk application.
+
+#### Usage
+
+```
+clerk apps create <name> [options]
+```
+
+#### Options
+
+| Option   | Description    |
+| -------- | -------------- |
+| `--json` | Output as JSON |
+
+#### Examples
+
+```sh
+clerk apps create "My App"             # Create a new application
+clerk apps create "My App" --json      # Output as JSON
+```
+
 ## API Endpoints
 
-| Method | Endpoint                    | Description           |
-| ------ | --------------------------- | --------------------- |
-| GET    | `/v1/platform/applications` | List all applications |
+| Method | Endpoint                             | Description              |
+| ------ | ------------------------------------ | ------------------------ |
+| GET    | `/v1/platform/applications`          | List all applications    |
+| POST   | `/v1/platform/applications`          | Create a new application |
+| GET    | `/v1/platform/applications/{app_id}` | Fetch application detail |
 
 ## Notes
 

--- a/packages/cli-core/src/commands/apps/create.test.ts
+++ b/packages/cli-core/src/commands/apps/create.test.ts
@@ -100,6 +100,14 @@ describe("apps create", () => {
       expect(output).not.toContain("sk_test_xxx");
       expect(output).not.toContain("sk_live_xxx");
     });
+
+    test("shows next steps on stderr", async () => {
+      await create("My SaaS App");
+
+      const output = capturedOutput(errorSpy);
+      expect(output).toContain("clerk link");
+      expect(output).toContain("clerk env pull");
+    });
   });
 
   describe("JSON output", () => {
@@ -121,6 +129,16 @@ describe("apps create", () => {
       const output = capturedOutput(logSpy);
       const parsed = JSON.parse(output);
       expect(parsed.application_id).toBe("app_abc123");
+    });
+
+    test("does not show next steps", async () => {
+      mockIsAgent.mockReturnValue(true);
+
+      await create("My SaaS App");
+
+      const output = capturedOutput(errorSpy);
+      expect(output).not.toContain("clerk link");
+      expect(output).not.toContain("clerk env pull");
     });
 
     test("strips secret_key from JSON", async () => {

--- a/packages/cli-core/src/commands/apps/create.test.ts
+++ b/packages/cli-core/src/commands/apps/create.test.ts
@@ -1,0 +1,152 @@
+import { test, expect, describe, beforeEach, afterEach, mock, spyOn } from "bun:test";
+import { capturedOutput } from "../../test/lib/stubs.ts";
+
+const mockCreateApplication = mock();
+const mockFetchApplication = mock();
+mock.module("../../lib/plapi.ts", () => ({
+  createApplication: (...args: unknown[]) => mockCreateApplication(...args),
+  fetchApplication: (...args: unknown[]) => mockFetchApplication(...args),
+  PlapiError: class PlapiError extends Error {},
+}));
+
+const mockIsAgent = mock();
+mock.module("../../mode.ts", () => ({
+  isAgent: (...args: unknown[]) => mockIsAgent(...args),
+  isHuman: (...args: unknown[]) => !mockIsAgent(...args),
+  setMode: () => {},
+  getMode: () => "human",
+}));
+
+const { create } = await import("./create.ts");
+
+const mockApp = {
+  application_id: "app_abc123",
+  name: "My SaaS App",
+  instances: [
+    {
+      instance_id: "ins_dev1",
+      environment_type: "development",
+      publishable_key: "pk_test_xxx",
+      secret_key: "sk_test_xxx",
+    },
+    {
+      instance_id: "ins_prod1",
+      environment_type: "production",
+      publishable_key: "pk_live_xxx",
+      secret_key: "sk_live_xxx",
+    },
+  ],
+};
+
+describe("apps create", () => {
+  let logSpy: ReturnType<typeof spyOn>;
+  let errorSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    mockIsAgent.mockReturnValue(false);
+    mockCreateApplication.mockResolvedValue({
+      application_id: "app_abc123",
+      name: "My SaaS App",
+    });
+    mockFetchApplication.mockResolvedValue(mockApp);
+    logSpy = spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    mockCreateApplication.mockReset();
+    mockFetchApplication.mockReset();
+    mockIsAgent.mockReset();
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  test("calls createApplication then fetchApplication", async () => {
+    await create("My SaaS App");
+
+    expect(mockCreateApplication).toHaveBeenCalledWith("My SaaS App");
+    expect(mockFetchApplication).toHaveBeenCalledWith("app_abc123");
+  });
+
+  describe("human output", () => {
+    test("shows created app name and id", async () => {
+      await create("My SaaS App");
+
+      const output = capturedOutput(logSpy);
+      expect(output).toContain("Created");
+      expect(output).toContain("My SaaS App");
+      expect(output).toContain("app_abc123");
+    });
+
+    test("falls back to app id when name is absent", async () => {
+      mockCreateApplication.mockResolvedValue({ application_id: "app_noname" });
+      mockFetchApplication.mockResolvedValue({
+        application_id: "app_noname",
+        instances: [
+          { instance_id: "ins_1", environment_type: "development", publishable_key: "pk_test" },
+        ],
+      });
+
+      await create("Some Name");
+
+      const output = capturedOutput(logSpy);
+      expect(output).toContain("app_noname");
+    });
+
+    test("does not show secret keys", async () => {
+      await create("My SaaS App");
+
+      const output = capturedOutput(logSpy);
+      expect(output).not.toContain("sk_test_xxx");
+      expect(output).not.toContain("sk_live_xxx");
+    });
+  });
+
+  describe("JSON output", () => {
+    test("outputs JSON when --json flag is set", async () => {
+      await create("My SaaS App", { json: true });
+
+      const output = capturedOutput(logSpy);
+      const parsed = JSON.parse(output);
+      expect(parsed.application_id).toBe("app_abc123");
+      expect(parsed.name).toBe("My SaaS App");
+      expect(parsed.instances).toHaveLength(2);
+    });
+
+    test("outputs JSON in agent mode", async () => {
+      mockIsAgent.mockReturnValue(true);
+
+      await create("My SaaS App");
+
+      const output = capturedOutput(logSpy);
+      const parsed = JSON.parse(output);
+      expect(parsed.application_id).toBe("app_abc123");
+    });
+
+    test("strips secret_key from JSON", async () => {
+      await create("My SaaS App", { json: true });
+
+      const output = capturedOutput(logSpy);
+      const parsed = JSON.parse(output);
+      for (const instance of parsed.instances) {
+        expect(instance).not.toHaveProperty("secret_key");
+        expect(instance).toHaveProperty("publishable_key");
+      }
+    });
+  });
+
+  describe("error handling", () => {
+    test("propagates createApplication failure without fetching", async () => {
+      mockCreateApplication.mockRejectedValue(new Error("Unprocessable Entity"));
+
+      await expect(create("Bad App")).rejects.toThrow("Unprocessable Entity");
+      expect(mockFetchApplication).not.toHaveBeenCalled();
+    });
+
+    test("propagates fetchApplication failure after create", async () => {
+      mockFetchApplication.mockRejectedValue(new Error("Service Unavailable"));
+
+      await expect(create("My SaaS App")).rejects.toThrow("Service Unavailable");
+    });
+  });
+});

--- a/packages/cli-core/src/commands/apps/create.ts
+++ b/packages/cli-core/src/commands/apps/create.ts
@@ -2,6 +2,7 @@ import { createApplication, fetchApplication } from "../../lib/plapi.ts";
 import { withApiContext } from "../../lib/errors.ts";
 import { dim, cyan } from "../../lib/color.ts";
 import { withSpinner } from "../../lib/spinner.ts";
+import { printNextSteps, NEXT_STEPS } from "../../lib/next-steps.ts";
 import { stripSecrets, displayName, printJson, type AppsOptions } from "./shared.ts";
 
 export async function create(name: string, options: AppsOptions = {}): Promise<void> {
@@ -13,4 +14,5 @@ export async function create(name: string, options: AppsOptions = {}): Promise<v
   if (printJson(stripSecrets(app), options)) return;
 
   console.log(`Created ${cyan(displayName(app))} ${dim(app.application_id)}`);
+  printNextSteps(NEXT_STEPS.CREATE);
 }

--- a/packages/cli-core/src/commands/apps/create.ts
+++ b/packages/cli-core/src/commands/apps/create.ts
@@ -1,0 +1,31 @@
+import { createApplication, fetchApplication, type Application } from "../../lib/plapi.ts";
+import { withApiContext } from "../../lib/errors.ts";
+import { isAgent } from "../../mode.ts";
+import { dim, cyan } from "../../lib/color.ts";
+import { withSpinner } from "../../lib/spinner.ts";
+
+interface AppsCreateOptions {
+  json?: boolean;
+}
+
+function stripSecrets(app: Application) {
+  return {
+    ...app,
+    instances: app.instances.map(({ secret_key: _, ...rest }) => rest),
+  };
+}
+
+export async function create(name: string, options: AppsCreateOptions = {}): Promise<void> {
+  const app = await withSpinner("Creating application...", async () => {
+    const created = await withApiContext(createApplication(name), "Failed to create application");
+    return withApiContext(fetchApplication(created.application_id), "Failed to fetch application");
+  });
+
+  if (options.json || isAgent()) {
+    console.log(JSON.stringify(stripSecrets(app), null, 2));
+    return;
+  }
+
+  const label = app.name ?? app.application_id;
+  console.log(`Created ${cyan(label)} ${dim(app.application_id)}`);
+}

--- a/packages/cli-core/src/commands/apps/create.ts
+++ b/packages/cli-core/src/commands/apps/create.ts
@@ -1,31 +1,16 @@
-import { createApplication, fetchApplication, type Application } from "../../lib/plapi.ts";
+import { createApplication, fetchApplication } from "../../lib/plapi.ts";
 import { withApiContext } from "../../lib/errors.ts";
-import { isAgent } from "../../mode.ts";
 import { dim, cyan } from "../../lib/color.ts";
 import { withSpinner } from "../../lib/spinner.ts";
+import { stripSecrets, displayName, printJson, type AppsOptions } from "./shared.ts";
 
-interface AppsCreateOptions {
-  json?: boolean;
-}
-
-function stripSecrets(app: Application) {
-  return {
-    ...app,
-    instances: app.instances.map(({ secret_key: _, ...rest }) => rest),
-  };
-}
-
-export async function create(name: string, options: AppsCreateOptions = {}): Promise<void> {
+export async function create(name: string, options: AppsOptions = {}): Promise<void> {
   const app = await withSpinner("Creating application...", async () => {
     const created = await withApiContext(createApplication(name), "Failed to create application");
     return withApiContext(fetchApplication(created.application_id), "Failed to fetch application");
   });
 
-  if (options.json || isAgent()) {
-    console.log(JSON.stringify(stripSecrets(app), null, 2));
-    return;
-  }
+  if (printJson(stripSecrets(app), options)) return;
 
-  const label = app.name ?? app.application_id;
-  console.log(`Created ${cyan(label)} ${dim(app.application_id)}`);
+  console.log(`Created ${cyan(displayName(app))} ${dim(app.application_id)}`);
 }

--- a/packages/cli-core/src/commands/apps/index.ts
+++ b/packages/cli-core/src/commands/apps/index.ts
@@ -1,0 +1,4 @@
+import { list } from "./list.ts";
+import { create } from "./create.ts";
+
+export const apps = { list, create };

--- a/packages/cli-core/src/commands/apps/list.ts
+++ b/packages/cli-core/src/commands/apps/list.ts
@@ -1,23 +1,10 @@
 import { listApplications, type Application } from "../../lib/plapi.ts";
 import { withApiContext } from "../../lib/errors.ts";
-import { isAgent } from "../../mode.ts";
 import { dim, cyan } from "../../lib/color.ts";
 import { withSpinner } from "../../lib/spinner.ts";
-
-interface AppsListOptions {
-  json?: boolean;
-}
+import { stripSecrets, displayName, printJson, type AppsOptions } from "./shared.ts";
 
 const COLUMN_PADDING = 2;
-
-const displayName = (app: Application) => app.name ?? app.application_id;
-
-function stripSecrets(apps: Application[]) {
-  return apps.map(({ instances, ...app }) => ({
-    ...app,
-    instances: instances.map(({ secret_key: _, ...rest }) => rest),
-  }));
-}
 
 function formatAppsTable(apps: Application[]): void {
   const nameWidth =
@@ -36,15 +23,12 @@ function formatAppsTable(apps: Application[]): void {
   }
 }
 
-export async function list(options: AppsListOptions = {}): Promise<void> {
+export async function list(options: AppsOptions = {}): Promise<void> {
   const result = await withSpinner("Fetching applications...", () =>
     withApiContext(listApplications(), "Failed to list applications"),
   );
 
-  if (options.json || isAgent()) {
-    console.log(JSON.stringify(stripSecrets(result), null, 2));
-    return;
-  }
+  if (printJson(result.map(stripSecrets), options)) return;
 
   if (result.length === 0) {
     console.log("No applications found. Create one at https://dashboard.clerk.com");

--- a/packages/cli-core/src/commands/apps/shared.ts
+++ b/packages/cli-core/src/commands/apps/shared.ts
@@ -1,0 +1,21 @@
+import type { Application } from "../../lib/plapi.ts";
+import { isAgent } from "../../mode.ts";
+
+export type AppsOptions = {
+  json?: boolean;
+};
+
+export function stripSecrets(app: Application) {
+  return {
+    ...app,
+    instances: app.instances.map(({ secret_key: _, ...rest }) => rest),
+  };
+}
+
+export const displayName = (app: Application) => app.name ?? app.application_id;
+
+export function printJson(data: unknown, options: AppsOptions = {}): boolean {
+  if (!options.json && !isAgent()) return false;
+  console.log(JSON.stringify(data, null, 2));
+  return true;
+}

--- a/packages/cli-core/src/lib/next-steps.ts
+++ b/packages/cli-core/src/lib/next-steps.ts
@@ -10,6 +10,10 @@ export const NEXT_STEPS = {
     "Run `clerk env pull` to fetch your environment variables",
     "Run `clerk doctor` to verify your setup",
   ],
+  CREATE: [
+    "Run `clerk link` to connect this app to your project",
+    "Run `clerk env pull` to fetch your environment variables",
+  ],
   DEPLOY: [
     "Run `clerk env pull --instance prod` to fetch production keys",
     "Run `clerk doctor` to verify your setup",


### PR DESCRIPTION
## Summary

- Add non-interactive `clerk apps create <name>` command that creates a Clerk application via the Platform API
- Add `apps/index.ts` barrel export so `cli-program.ts` imports `{ apps as appsHandlers }` — matching the `auth`, `env`, `config` naming convention
- Support `--json` flag and auto-detect agent mode for JSON output; secret keys are always stripped

## Test plan

- [x] `bun run format` — passes
- [x] `bun run lint` — no new warnings
- [x] `bun run test` — 61/61 pass, including new `apps/create.test.ts` covering:
  - Two-phase API call (createApplication → fetchApplication)
  - Human output with app name and ID
  - Name fallback when `app.name` is absent
  - JSON output via `--json` flag and agent mode
  - Secret key stripping (structural check on parsed JSON)
  - Atomicity: `fetchApplication` not called when `createApplication` fails
- [ ] Manual smoke test: `bun run dev -- apps create "Test App"` (requires auth)