### PR TITLE
feat(init): non-interactive bootstrap, auth headers, and keyless support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,20 +51,21 @@ Commands:
   deploy      [options]                      Deploy your Clerk application (hidden)
 
 clerk init
-  --framework <name>   Framework to set up (skips auto-detection)
-  --app <id>           Link to a specific Clerk application by ID
-  --starter            Bootstrap a new project from a starter template
-  --prompt             Output a prompt for an AI agent to integrate Clerk
-  --yes                Skip confirmation prompts
-  --no-skills          Skip the optional agent skills install prompt
+  --framework <name>     Framework to set up (skips auto-detection)
+  --pm <manager>         Package manager to use (skips prompt/auto-detection)
+  --name <project-name>  Project name for --starter (skips prompt)
+  --starter              Bootstrap a new project from a starter template
+  --prompt               Output a prompt for an AI agent to integrate Clerk
+  --yes                  Skip confirmation prompts
+  --no-skills            Skip the optional agent skills install prompt
   Examples:
-    $ clerk init                       Auto-detect framework and set up Clerk
-    $ clerk init --framework next      Set up for Next.js (skips detection)
-    $ clerk init --app app_123         Link to a specific Clerk application
-    $ clerk init --starter             Create a new project with Clerk
-    $ clerk init --prompt              Output a setup prompt for an AI agent
-    $ clerk init -y                    Skip all confirmation prompts
-    $ clerk init --no-skills           Skip the agent skills install prompt
+    $ clerk init                                      Auto-detect framework and set up Clerk
+    $ clerk init --framework next                     Set up for Next.js (skips detection)
+    $ clerk init --starter                            Create a new project with Clerk
+    $ clerk init --starter --framework next --pm bun  Bootstrap with Bun
+    $ clerk init --prompt                             Output a setup prompt for an AI agent
+    $ clerk init -y                                   Skip all confirmation prompts
+    $ clerk init --no-skills                          Skip the agent skills install prompt
 
 clerk auth login         Log in via browser (OAuth)
 clerk auth logout        Remove stored credentials

--- a/packages/cli-core/src/cli-program.ts
+++ b/packages/cli-core/src/cli-program.ts
@@ -89,7 +89,13 @@ export function createProgram() {
         FRAMEWORK_NAMES,
       ),
     )
-    .option("--app <id>", "Link to a specific Clerk application by ID")
+    .addOption(
+      createOption(
+        "--pm <manager>",
+        "Package manager to use (skips prompt/auto-detection)",
+      ).choices(["bun", "pnpm", "yarn", "npm"]),
+    )
+    .option("--name <project-name>", "Project name for --starter (skips prompt)")
     .option("--prompt", "Output a prompt for an AI agent to integrate Clerk")
     .option("--starter", "Create a new project from a starter template")
     .option("-y, --yes", "Skip confirmation prompts")
@@ -105,6 +111,10 @@ export function createProgram() {
         description: "Link to a specific Clerk application",
       },
       { command: "clerk init --starter", description: "Create a new project with Clerk" },
+      {
+        command: "clerk init --starter --framework next --pm bun",
+        description: "Bootstrap with Bun",
+      },
       { command: "clerk init --prompt", description: "Output a setup prompt for an AI agent" },
       { command: "clerk init -y", description: "Skip all confirmation prompts" },
       { command: "clerk init --no-skills", description: "Skip the agent skills install prompt" },

--- a/packages/cli-core/src/commands/init/README.md
+++ b/packages/cli-core/src/commands/init/README.md
@@ -48,7 +48,7 @@ Use `--prompt` to output a setup prompt for an AI agent without running init.
    - If already authenticated and linked: uses authenticated mode automatically
    - If authenticated but not linked: uses authenticated mode (runs `clerk link`)
    - If not authenticated: asks user — "Continue with temporary keys (connect your account later)" or "Log in to an existing Clerk account"
-   - With `--yes` and not authenticated: skips authentication (connect your account later)
+   - With `--yes` and not authenticated: skips authentication (connect your account later), including for non-keyless frameworks during bootstrap
 4. **Authenticated mode only**: authenticates via `clerk auth login` (skipped if already authenticated) and links the project via `clerk link` (skipped if already linked)
 5. Displays detected framework and variant
 6. Detects existing auth libraries (NextAuth, Auth0, Supabase, Firebase, Passport, Better Auth, Kinde) and shows migration guidance

--- a/packages/cli-core/src/commands/init/README.md
+++ b/packages/cli-core/src/commands/init/README.md
@@ -72,12 +72,12 @@ Detects the project's framework from `package.json` dependencies (checked top-to
 | ----------------------- | -------------- | ----------------------------- | ----------------------------------- | ------- |
 | `next`                  | Next.js        | `@clerk/nextjs`               | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Yes     |
 | `astro`                 | Astro          | `@clerk/astro`                | `PUBLIC_CLERK_PUBLISHABLE_KEY`      | Yes     |
-| `nuxt`                  | Nuxt           | `@clerk/nuxt`                 | `NUXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | No      |
+| `nuxt`                  | Nuxt           | `@clerk/nuxt`                 | `NUXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Yes     |
 | `@tanstack/react-start` | TanStack Start | `@clerk/tanstack-react-start` | `VITE_CLERK_PUBLISHABLE_KEY`        | Yes     |
 | `react-router`          | React Router   | `@clerk/react-router`         | `VITE_CLERK_PUBLISHABLE_KEY`        | Yes     |
 | `vue`                   | Vue            | `@clerk/vue`                  | `VITE_CLERK_PUBLISHABLE_KEY`        | No      |
 | `expo`                  | Expo           | `@clerk/expo`                 | `EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY` | No      |
-| `react`                 | React          | `@clerk/react`                | `VITE_CLERK_PUBLISHABLE_KEY`        | Yes     |
+| `react`                 | React          | `@clerk/react`                | `VITE_CLERK_PUBLISHABLE_KEY`        | No      |
 | `vite`                  | JavaScript     | `@clerk/clerk-js`             | `VITE_CLERK_PUBLISHABLE_KEY`        | No      |
 | `express`               | Express        | `@clerk/express`              | `CLERK_PUBLISHABLE_KEY`             | No      |
 | `fastify`               | Fastify        | `@clerk/fastify`              | `CLERK_PUBLISHABLE_KEY`             | No      |

--- a/packages/cli-core/src/commands/init/README.md
+++ b/packages/cli-core/src/commands/init/README.md
@@ -9,7 +9,8 @@ clerk init
 clerk init --app app_123
 clerk init --framework next
 clerk init --starter
-clerk init --starter --framework next
+clerk init --starter --framework next --pm bun
+clerk init --starter --framework next --pm bun --name my-app
 clerk init --prompt
 clerk init -y
 clerk init --yes
@@ -18,23 +19,31 @@ clerk init --no-skills
 
 ## Options
 
-| Option               | Description                                                                                                                                                                           |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--framework <name>` | Framework to set up (skips auto-detection). Valid values: `next`, `astro`, `nuxt`, `tanstack-start`, `react-router`, `vue`, `expo`, `react`, `javascript`, `js`, `express`, `fastify` |
-| `--app <id>`         | Link to a specific Clerk application by ID (skips the interactive app picker). If the repo is already linked to a different application, prompts to re-link.                          |
-| `--starter`          | Bootstrap a new project from a starter template (runs the framework generator, installs deps, and scaffolds Clerk)                                                                    |
-| `--prompt`           | Output a prompt for an AI agent to integrate Clerk, then exit                                                                                                                         |
-| `-y, --yes`          | Skip confirmation prompts (also skips authentication after bootstrap, letting you connect your account later)                                                                         |
-| `--no-skills`        | Skip the optional agent skills install prompt at the end of init                                                                                                                      |
+| Option                  | Description                                                                                                                                                                           |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--framework <name>`    | Framework to set up (skips auto-detection). Valid values: `next`, `astro`, `nuxt`, `tanstack-start`, `react-router`, `vue`, `expo`, `react`, `javascript`, `js`, `express`, `fastify` |
+| `--pm <manager>`        | Package manager to use. Valid values: `bun`, `pnpm`, `yarn`, `npm`. Skips the PM prompt (bootstrap) or overrides lockfile detection (existing project)                                |
+| `--name <project-name>` | Project name for `--starter` (skips prompt). Must be lowercase, no spaces, no path separators                                                                                         |
+| `--starter`             | Bootstrap a new project from a starter template (runs the framework generator, installs deps, and scaffolds Clerk)                                                                    |
+| `--prompt`              | Output a prompt for an AI agent to integrate Clerk, then exit                                                                                                                         |
+| `-y, --yes`             | Skip confirmation prompts (also skips authentication after bootstrap, letting you connect your account later)                                                                         |
+| `--no-skills`           | Skip the optional agent skills install prompt at the end of init                                                                                                                      |
 
 ## Agent Mode
 
-When running in agent mode (`--mode agent` or non-TTY), outputs a framework-specific prompt with exact file paths and code snippets, then exits without modifying the project.
+When running in agent mode (`--mode agent` or non-TTY), the command runs the full init flow non-interactively:
+
+- All confirmation prompts are auto-skipped (as if `--yes` was passed)
+- For **existing projects**: framework and package manager are auto-detected, no flags required
+- For **new projects** (`--starter` or blank directory): `--framework` is required (no way to auto-detect in an empty dir). Package manager is auto-selected by availability (bun → pnpm → yarn → npm) unless `--pm` is provided
+- Project name defaults to the framework's default (e.g. `my-clerk-next-app`) unless `--name` is provided
+
+Use `--prompt` to output a setup prompt for an AI agent without running init.
 
 ## Flow
 
-1. Gathers project context (framework, router variant, TypeScript, `src/` directory, package manager)
-2. **Agent mode**: outputs a framework-specific prompt, then exits
+1. **`--prompt`**: outputs a framework-specific prompt, then exits
+2. Gathers project context (framework, router variant, TypeScript, `src/` directory, package manager)
 3. **Human mode**: determines auth mode:
    - If already authenticated and linked: uses authenticated mode automatically
    - If authenticated but not linked: uses authenticated mode (runs `clerk link`)
@@ -59,19 +68,21 @@ When running in agent mode (`--mode agent` or non-TTY), outputs a framework-spec
 
 Detects the project's framework from `package.json` dependencies (checked top-to-bottom, first match wins):
 
-| Dependency              | Framework      | Clerk SDK                     | Publishable Key Env Var             |
-| ----------------------- | -------------- | ----------------------------- | ----------------------------------- |
-| `next`                  | Next.js        | `@clerk/nextjs`               | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` |
-| `astro`                 | Astro          | `@clerk/astro`                | `PUBLIC_CLERK_PUBLISHABLE_KEY`      |
-| `nuxt`                  | Nuxt           | `@clerk/nuxt`                 | `NUXT_PUBLIC_CLERK_PUBLISHABLE_KEY` |
-| `@tanstack/react-start` | TanStack Start | `@clerk/tanstack-react-start` | `VITE_CLERK_PUBLISHABLE_KEY`        |
-| `react-router`          | React Router   | `@clerk/react-router`         | `VITE_CLERK_PUBLISHABLE_KEY`        |
-| `vue`                   | Vue            | `@clerk/vue`                  | `VITE_CLERK_PUBLISHABLE_KEY`        |
-| `expo`                  | Expo           | `@clerk/expo`                 | `EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY` |
-| `react`                 | React          | `@clerk/react`                | `VITE_CLERK_PUBLISHABLE_KEY`        |
-| `vite`                  | JavaScript     | `@clerk/clerk-js`             | `VITE_CLERK_PUBLISHABLE_KEY`        |
-| `express`               | Express        | `@clerk/express`              | `CLERK_PUBLISHABLE_KEY`             |
-| `fastify`               | Fastify        | `@clerk/fastify`              | `CLERK_PUBLISHABLE_KEY`             |
+| Dependency              | Framework      | Clerk SDK                     | Publishable Key Env Var             | Keyless |
+| ----------------------- | -------------- | ----------------------------- | ----------------------------------- | ------- |
+| `next`                  | Next.js        | `@clerk/nextjs`               | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Yes     |
+| `astro`                 | Astro          | `@clerk/astro`                | `PUBLIC_CLERK_PUBLISHABLE_KEY`      | Yes     |
+| `nuxt`                  | Nuxt           | `@clerk/nuxt`                 | `NUXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | No      |
+| `@tanstack/react-start` | TanStack Start | `@clerk/tanstack-react-start` | `VITE_CLERK_PUBLISHABLE_KEY`        | Yes     |
+| `react-router`          | React Router   | `@clerk/react-router`         | `VITE_CLERK_PUBLISHABLE_KEY`        | Yes     |
+| `vue`                   | Vue            | `@clerk/vue`                  | `VITE_CLERK_PUBLISHABLE_KEY`        | No      |
+| `expo`                  | Expo           | `@clerk/expo`                 | `EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY` | No      |
+| `react`                 | React          | `@clerk/react`                | `VITE_CLERK_PUBLISHABLE_KEY`        | Yes     |
+| `vite`                  | JavaScript     | `@clerk/clerk-js`             | `VITE_CLERK_PUBLISHABLE_KEY`        | No      |
+| `express`               | Express        | `@clerk/express`              | `CLERK_PUBLISHABLE_KEY`             | No      |
+| `fastify`               | Fastify        | `@clerk/fastify`              | `CLERK_PUBLISHABLE_KEY`             | No      |
+
+The **Keyless** column indicates whether the framework's Clerk SDK supports keyless mode (auto-generated temporary dev keys). Frameworks without keyless support require API keys and always force authentication during `clerk init`, even with `--yes`.
 
 Package manager is detected from lock files: `bun.lockb`/`bun.lock` → bun, `yarn.lock` → yarn, `pnpm-lock.yaml` → pnpm, else npm.
 
@@ -157,6 +168,8 @@ Nuxt's module system auto-configures middleware and auto-imports components.
 | MODIFY        | `src/router/index.ts`   | Add sign-in and sign-up routes (if router exists)  |
 | MODIFY        | `.env`                  | Add sign-in/sign-up route env vars (VITE\_ prefix) |
 
+**Bootstrap (new project)**: When scaffolding a new Vue project via `--starter` or blank directory, `vue-router` is installed and a router config is created with sign-in/sign-up routes. `App.vue` is updated to use `<RouterView />`.
+
 ### JavaScript (Vite)
 
 | Action | File             | Description                                     |
@@ -170,7 +183,8 @@ If no entry file is found, a post-instruction is printed pointing to the Clerk J
 After scaffolding (and after env keys are pulled or keyless instructions are printed), `clerk init` offers to install Clerk's framework-specific agent skills from [`clerk/skills`](https://github.com/clerk/skills) via the [`skills`](https://www.npmjs.com/package/skills) CLI. The runner is detected from the project's package manager (`bunx`, `npx`, `pnpm dlx`, or `yarn dlx`), so a Bun project installs via `bunx skills add clerk/skills`, a pnpm project via `pnpm dlx skills add clerk/skills`, and so on. This step is optional and non-fatal: if no package runner is available on PATH or the install command exits non-zero, init prints a yellow warning with a runner-appropriate manual command and still exits successfully.
 
 - **Human mode**: prompts `Install agent skills? (...)` defaulting to yes. Pass `--no-skills` to suppress the prompt entirely, or `-y/--yes` to accept it without confirmation. When more than one runner is available, a second prompt picks which one to use (the project's package manager wins by default).
-- **Agent mode / `--prompt`**: `clerk init` exits early before the skills step runs (see the `if (options.prompt || isAgent()) { ... return }` branch in [`index.ts`](./index.ts)), so nothing is installed. Agent users should run `skills add clerk/skills` via their preferred runner manually, or have their agent do it.
+- **Agent mode**: skills are installed non-interactively with `-y -g` flags (no prompt shown). Pass `--no-skills` to skip entirely.
+- **`--prompt`**: exits before the skills step runs. Agent users should run `skills add clerk/skills` via their preferred runner manually.
 
 The base skills `clerk` and `clerk-setup` are always included. The detected framework dependency adds a matching skill:
 

--- a/packages/cli-core/src/commands/init/bootstrap-registry.ts
+++ b/packages/cli-core/src/commands/init/bootstrap-registry.ts
@@ -29,7 +29,8 @@ function runner(pm: PackageManager): string[] {
 // create-astro) infer the PM from npm_config_user_agent, which is set automatically when run
 // via bunx/pnpm dlx/yarn dlx/npx. This works in practice since we run them via the selected
 // PM's runner, and our own installDependencies() step uses the correct PM regardless.
-export const BOOTSTRAP_REGISTRY: BootstrapEntry[] = [
+/** Frameworks that support keyless mode — used for bootstrap (new project from empty dir / --starter). */
+export const BOOTSTRAP_KEYLESS_REGISTRY: BootstrapEntry[] = [
   {
     label: "Next.js",
     dep: "next",
@@ -42,24 +43,6 @@ export const BOOTSTRAP_REGISTRY: BootstrapEntry[] = [
       "--skip-install",
       "--disable-git",
     ],
-  },
-  {
-    label: "React",
-    dep: "react",
-    defaultProjectName: "my-clerk-react-app",
-    buildCommand: (pm, name) => [
-      ...runner(pm),
-      "create-vite@latest",
-      name,
-      "--template",
-      "react-ts",
-    ],
-  },
-  {
-    label: "Vue",
-    dep: "vue",
-    defaultProjectName: "my-clerk-vue-app",
-    buildCommand: (pm, name) => [...runner(pm), "create-vite@latest", name, "--template", "vue-ts"],
   },
   {
     label: "React Router",
@@ -124,6 +107,28 @@ export const BOOTSTRAP_REGISTRY: BootstrapEntry[] = [
       pm,
     ],
   },
+];
+
+/** Frameworks that require API keys — keyless mode is not yet supported. */
+export const BOOTSTRAP_AUTHENTICATED_REGISTRY: BootstrapEntry[] = [
+  {
+    label: "React",
+    dep: "react",
+    defaultProjectName: "my-clerk-react-app",
+    buildCommand: (pm, name) => [
+      ...runner(pm),
+      "create-vite@latest",
+      name,
+      "--template",
+      "react-ts",
+    ],
+  },
+  {
+    label: "Vue",
+    dep: "vue",
+    defaultProjectName: "my-clerk-vue-app",
+    buildCommand: (pm, name) => [...runner(pm), "create-vite@latest", name, "--template", "vue-ts"],
+  },
   {
     label: "JavaScript",
     dep: "vite",
@@ -136,6 +141,12 @@ export const BOOTSTRAP_REGISTRY: BootstrapEntry[] = [
       "vanilla",
     ],
   },
+];
+
+/** All bootstrap-capable frameworks (keyless + authenticated). */
+export const BOOTSTRAP_REGISTRY: BootstrapEntry[] = [
+  ...BOOTSTRAP_KEYLESS_REGISTRY,
+  ...BOOTSTRAP_AUTHENTICATED_REGISTRY,
 ];
 
 export const PM_INSTALL_COMMANDS: Record<PackageManager, string[]> = {

--- a/packages/cli-core/src/commands/init/bootstrap.test.ts
+++ b/packages/cli-core/src/commands/init/bootstrap.test.ts
@@ -1,5 +1,6 @@
-import { test, expect, describe } from "bun:test";
+import { test, expect, describe, spyOn, afterEach } from "bun:test";
 import { BOOTSTRAP_REGISTRY } from "./bootstrap-registry.ts";
+import { resolvePackageManager } from "./bootstrap.ts";
 
 function entryFor(dep: string) {
   const entry = BOOTSTRAP_REGISTRY.find((e) => e.dep === dep);
@@ -122,5 +123,46 @@ describe("BOOTSTRAP_REGISTRY", () => {
     const cmd = entryFor("react").buildCommand("pnpm", "app");
     expect(cmd[0]).toBe("pnpm");
     expect(cmd[1]).toBe("dlx");
+  });
+});
+
+describe("resolvePackageManager", () => {
+  let whichSpy: ReturnType<typeof spyOn>;
+
+  afterEach(() => {
+    whichSpy?.mockRestore();
+  });
+
+  test("returns first available PM in priority order", () => {
+    whichSpy = spyOn(Bun, "which").mockImplementation((bin) => {
+      if (bin === "bun") return "/usr/local/bin/bun";
+      return null;
+    });
+
+    expect(resolvePackageManager()).toBe("bun");
+  });
+
+  test("falls back to pnpm when bun is unavailable", () => {
+    whichSpy = spyOn(Bun, "which").mockImplementation((bin) => {
+      if (bin === "pnpm") return "/usr/local/bin/pnpm";
+      return null;
+    });
+
+    expect(resolvePackageManager()).toBe("pnpm");
+  });
+
+  test("falls back to yarn when bun and pnpm are unavailable", () => {
+    whichSpy = spyOn(Bun, "which").mockImplementation((bin) => {
+      if (bin === "yarn") return "/usr/local/bin/yarn";
+      return null;
+    });
+
+    expect(resolvePackageManager()).toBe("yarn");
+  });
+
+  test("falls back to npm as last resort", () => {
+    whichSpy = spyOn(Bun, "which").mockReturnValue(null);
+
+    expect(resolvePackageManager()).toBe("npm");
   });
 });

--- a/packages/cli-core/src/commands/init/bootstrap.test.ts
+++ b/packages/cli-core/src/commands/init/bootstrap.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe, spyOn, afterEach } from "bun:test";
+import { test, expect, describe, spyOn, afterAll } from "bun:test";
 import { BOOTSTRAP_REGISTRY } from "./bootstrap-registry.ts";
 import { resolvePackageManager } from "./bootstrap.ts";
 
@@ -127,14 +127,14 @@ describe("BOOTSTRAP_REGISTRY", () => {
 });
 
 describe("resolvePackageManager", () => {
-  let whichSpy: ReturnType<typeof spyOn>;
+  const whichSpy = spyOn(Bun, "which");
 
-  afterEach(() => {
-    whichSpy?.mockRestore();
+  afterAll(() => {
+    whichSpy.mockRestore();
   });
 
   test("returns first available PM in priority order", () => {
-    whichSpy = spyOn(Bun, "which").mockImplementation((bin) => {
+    whichSpy.mockImplementation((bin) => {
       if (bin === "bun") return "/usr/local/bin/bun";
       return null;
     });
@@ -143,7 +143,7 @@ describe("resolvePackageManager", () => {
   });
 
   test("falls back to pnpm when bun is unavailable", () => {
-    whichSpy = spyOn(Bun, "which").mockImplementation((bin) => {
+    whichSpy.mockImplementation((bin) => {
       if (bin === "pnpm") return "/usr/local/bin/pnpm";
       return null;
     });
@@ -152,7 +152,7 @@ describe("resolvePackageManager", () => {
   });
 
   test("falls back to yarn when bun and pnpm are unavailable", () => {
-    whichSpy = spyOn(Bun, "which").mockImplementation((bin) => {
+    whichSpy.mockImplementation((bin) => {
       if (bin === "yarn") return "/usr/local/bin/yarn";
       return null;
     });
@@ -161,7 +161,7 @@ describe("resolvePackageManager", () => {
   });
 
   test("falls back to npm as last resort", () => {
-    whichSpy = spyOn(Bun, "which").mockReturnValue(null);
+    whichSpy.mockReturnValue(null);
 
     expect(resolvePackageManager()).toBe("npm");
   });

--- a/packages/cli-core/src/commands/init/bootstrap.ts
+++ b/packages/cli-core/src/commands/init/bootstrap.ts
@@ -1,10 +1,9 @@
 import { join } from "node:path";
-import { access } from "node:fs/promises";
 import { search, confirm, input } from "@inquirer/prompts";
 import { throwUserAbort, throwUsageError, CliError } from "../../lib/errors.js";
 import { log } from "../../lib/log.js";
 import type { FrameworkInfo } from "../../lib/framework.js";
-import { hasPackageJson } from "./context.js";
+import { dirExists, hasPackageJson } from "./context.js";
 import {
   BOOTSTRAP_REGISTRY,
   PM_INSTALL_COMMANDS,
@@ -188,12 +187,7 @@ export async function promptAndBootstrap(
     nameOverride ?? (skipConfirm ? entry.defaultProjectName : await askProjectName(entry));
   const projectDir = join(cwd, projectName);
 
-  if (
-    await access(projectDir).then(
-      () => true,
-      () => false,
-    )
-  ) {
+  if (await dirExists(projectDir)) {
     throw new CliError(
       `Directory '${projectName}' already exists. Pick a different name or remove it first.`,
     );

--- a/packages/cli-core/src/commands/init/bootstrap.ts
+++ b/packages/cli-core/src/commands/init/bootstrap.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 import { search, confirm, input } from "@inquirer/prompts";
-import { throwUserAbort, CliError } from "../../lib/errors.js";
+import { throwUserAbort, throwUsageError, CliError } from "../../lib/errors.js";
 import { log } from "../../lib/log.js";
 import type { FrameworkInfo } from "../../lib/framework.js";
 import { hasPackageJson } from "./context.js";
@@ -63,24 +63,51 @@ async function pickPackageManager(): Promise<PackageManager> {
   });
 }
 
-function defaultProjectName(entry: BootstrapEntry): string {
-  return entry.defaultProjectName;
+const PM_PRIORITY: PackageManager[] = ["bun", "pnpm", "yarn", "npm"];
+
+/**
+ * Auto-select the first available package manager by priority: bun → pnpm → yarn → npm.
+ * Used when running non-interactively (-y / agent mode) and no explicit --pm was given.
+ */
+export function resolvePackageManager(): PackageManager {
+  for (const pm of PM_PRIORITY) {
+    if (Bun.which(pm) !== null) return pm;
+  }
+  return "npm";
+}
+
+function validateProjectName(value: string): string | true {
+  if (!value.trim()) return "Project name is required";
+  if (/[A-Z]/.test(value)) return "Project name must be lowercase";
+  if (/\s/.test(value)) return "Project name cannot contain spaces";
+  if (value.includes("/") || value.includes(".."))
+    return "Project name cannot contain path separators";
+  return true;
 }
 
 async function askProjectName(entry: BootstrapEntry): Promise<string> {
   const name = await input({
     message: "Project name:",
-    default: defaultProjectName(entry),
-    validate: (value) => {
-      if (!value.trim()) return "Project name is required";
-      if (/[A-Z]/.test(value)) return "Project name must be lowercase";
-      if (/\s/.test(value)) return "Project name cannot contain spaces";
-      if (value.includes("/") || value.includes(".."))
-        return "Project name cannot contain path separators";
-      return true;
-    },
+    default: entry.defaultProjectName,
+    validate: validateProjectName,
   });
   return name.trim();
+}
+
+function resolvePm(override?: PackageManager, skipConfirm = false): PackageManager | null {
+  if (override) return override;
+  if (skipConfirm) return resolvePackageManager();
+  return null;
+}
+
+function resolveName(
+  override?: string,
+  skipConfirm = false,
+  entry?: BootstrapEntry,
+): string | null {
+  if (override) return override;
+  if (skipConfirm && entry) return entry.defaultProjectName;
+  return null;
 }
 
 async function generateProject(label: string, command: string[], cwd: string): Promise<void> {
@@ -129,6 +156,12 @@ export async function askSkipAuth(): Promise<boolean> {
   });
 }
 
+export type BootstrapOverrides = {
+  skipConfirm: boolean;
+  pmOverride?: PackageManager;
+  nameOverride?: string;
+};
+
 export type BootstrapResult = {
   projectDir: string;
   projectName: string;
@@ -137,13 +170,13 @@ export type BootstrapResult = {
 
 /**
  * Interactive bootstrap flow.
- * When skipConfirm is true (e.g. --starter flag), skips the "create a new one?" prompt.
- * Returns bootstrap result on success, or null on failure.
+ * When skipConfirm is true (e.g. --starter flag, -y, or agent mode), skips the
+ * "create a new one?" prompt and auto-resolves PM/project name when not overridden.
  */
 export async function promptAndBootstrap(
   cwd: string,
-  frameworkOverride?: FrameworkInfo,
-  { skipConfirm = false } = {},
+  frameworkOverride: FrameworkInfo | undefined,
+  { skipConfirm = false, pmOverride, nameOverride }: BootstrapOverrides = { skipConfirm: false },
 ): Promise<BootstrapResult> {
   if (!skipConfirm) {
     const wantBootstrap = await confirm({
@@ -153,9 +186,21 @@ export async function promptAndBootstrap(
     if (!wantBootstrap) throwUserAbort();
   }
 
+  if (skipConfirm && !frameworkOverride) {
+    throwUsageError(
+      "Non-interactive mode requires --framework for new projects. Example: clerk init --starter --framework next",
+    );
+  }
+
+  if (nameOverride) {
+    const valid = validateProjectName(nameOverride);
+    if (valid !== true) throwUsageError(valid);
+  }
+
   const entry = await pickFramework(frameworkOverride);
-  const pm = await pickPackageManager();
-  const projectName = await askProjectName(entry);
+  const pm = resolvePm(pmOverride, skipConfirm) ?? (await pickPackageManager());
+  const projectName =
+    resolveName(nameOverride, skipConfirm, entry) ?? (await askProjectName(entry));
   const projectDir = join(cwd, projectName);
 
   await generateProject(entry.label, entry.buildCommand(pm, projectName), cwd);

--- a/packages/cli-core/src/commands/init/bootstrap.ts
+++ b/packages/cli-core/src/commands/init/bootstrap.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import { access } from "node:fs/promises";
 import { search, confirm, input } from "@inquirer/prompts";
 import { throwUserAbort, throwUsageError, CliError } from "../../lib/errors.js";
 import { log } from "../../lib/log.js";
@@ -178,7 +179,7 @@ export async function promptAndBootstrap(
 
   if (nameOverride) {
     const valid = validateProjectName(nameOverride);
-    if (valid !== true) throwUsageError(valid);
+    if (valid !== true) throwUsageError(`Invalid --name "${nameOverride}": ${valid}`);
   }
 
   const entry = await pickFramework(frameworkOverride);
@@ -186,6 +187,17 @@ export async function promptAndBootstrap(
   const projectName =
     nameOverride ?? (skipConfirm ? entry.defaultProjectName : await askProjectName(entry));
   const projectDir = join(cwd, projectName);
+
+  if (
+    await access(projectDir).then(
+      () => true,
+      () => false,
+    )
+  ) {
+    throw new CliError(
+      `Directory '${projectName}' already exists. Pick a different name or remove it first.`,
+    );
+  }
 
   await generateProject(entry.label, entry.buildCommand(pm, projectName), cwd);
 

--- a/packages/cli-core/src/commands/init/bootstrap.ts
+++ b/packages/cli-core/src/commands/init/bootstrap.ts
@@ -94,22 +94,6 @@ async function askProjectName(entry: BootstrapEntry): Promise<string> {
   return name.trim();
 }
 
-function resolvePm(override?: PackageManager, skipConfirm = false): PackageManager | null {
-  if (override) return override;
-  if (skipConfirm) return resolvePackageManager();
-  return null;
-}
-
-function resolveName(
-  override?: string,
-  skipConfirm = false,
-  entry?: BootstrapEntry,
-): string | null {
-  if (override) return override;
-  if (skipConfirm && entry) return entry.defaultProjectName;
-  return null;
-}
-
 async function generateProject(label: string, command: string[], cwd: string): Promise<void> {
   log.blank();
   log.info(`Creating \`${label}\` project...`);
@@ -198,9 +182,9 @@ export async function promptAndBootstrap(
   }
 
   const entry = await pickFramework(frameworkOverride);
-  const pm = resolvePm(pmOverride, skipConfirm) ?? (await pickPackageManager());
+  const pm = pmOverride ?? (skipConfirm ? resolvePackageManager() : await pickPackageManager());
   const projectName =
-    resolveName(nameOverride, skipConfirm, entry) ?? (await askProjectName(entry));
+    nameOverride ?? (skipConfirm ? entry.defaultProjectName : await askProjectName(entry));
   const projectDir = join(cwd, projectName);
 
   await generateProject(entry.label, entry.buildCommand(pm, projectName), cwd);

--- a/packages/cli-core/src/commands/init/context.ts
+++ b/packages/cli-core/src/commands/init/context.ts
@@ -4,6 +4,7 @@ import { detectFramework, readDeps } from "../../lib/framework.js";
 import type { FrameworkInfo } from "../../lib/framework.js";
 import { findExistingEnvFile } from "../../lib/dotenv.js";
 import type { ProjectContext } from "./frameworks/types.js";
+import type { PackageManager } from "./bootstrap-registry.js";
 
 export async function fileExists(path: string): Promise<boolean> {
   return Bun.file(path).exists();
@@ -43,6 +44,7 @@ export async function hasPackageJson(cwd: string): Promise<boolean> {
 export async function gatherContext(
   cwd: string,
   frameworkOverride?: FrameworkInfo,
+  pmOverride?: PackageManager,
 ): Promise<ProjectContext | null> {
   const framework = frameworkOverride ?? (await detectFramework(cwd));
   if (!framework) return null;
@@ -61,7 +63,7 @@ export async function gatherContext(
   const hasRootStructure = rootAppDir || rootPagesDir;
   const srcDir = srcDirExists && !hasRootStructure;
 
-  const packageManager = await detectPackageManager(cwd);
+  const packageManager = pmOverride ?? (await detectPackageManager(cwd));
 
   const deps = await readDeps(cwd);
   const existingClerk = deps ? framework.sdk in deps : false;

--- a/packages/cli-core/src/commands/init/frameworks/astro.test.ts
+++ b/packages/cli-core/src/commands/init/frameworks/astro.test.ts
@@ -15,7 +15,7 @@ function makeCtx(overrides?: Partial<ProjectContext>): ProjectContext {
       name: "Astro",
       sdk: "@clerk/astro",
       envVar: "PUBLIC_CLERK_PUBLISHABLE_KEY",
-      envFile: ".env",
+      envFile: ".env" as const,
     },
     typescript: true,
     srcDir: false,
@@ -245,6 +245,100 @@ export default defineConfig({
 
   // The only post-instruction should be about SSR, not i18n
   expect(plan.postInstructions.some((i) => i.includes("locale"))).toBe(false);
+});
+
+test("adds auth header in layout during bootstrap", async () => {
+  await Bun.write(
+    join(tempDir, "astro.config.mjs"),
+    `import { defineConfig } from "astro/config";
+export default defineConfig({ integrations: [] });
+`,
+  );
+  await mkdir(join(tempDir, "src/layouts"), { recursive: true });
+  await Bun.write(
+    join(tempDir, "src/layouts/Layout.astro"),
+    `---
+---
+
+<html lang="en">
+\t<body>
+\t\t<slot />
+\t</body>
+</html>
+`,
+  );
+
+  const plan = await astro.scaffold(makeCtx({ isBootstrap: true, deps: { tailwindcss: "4.0.0" } }));
+  const layout = findAction(plan.actions, "src/layouts/Layout.astro");
+
+  expect(layout.type).toBe("modify");
+  if (layout.type !== "modify") throw new Error("Expected modify action");
+
+  expect(layout.content).toContain('<Show when="signed-out">');
+  expect(layout.content).toContain("<SignInButton />");
+  expect(layout.content).toContain("<SignUpButton />");
+  expect(layout.content).toContain('<Show when="signed-in">');
+  expect(layout.content).toContain("<UserButton />");
+  expect(layout.content).toContain(
+    'class="flex h-16 items-center justify-end gap-4 border-b px-4"',
+  );
+  expect(layout.content).toContain("@clerk/astro/components");
+  expect(layout.description).toContain("auth header");
+});
+
+test("does not add auth header for non-bootstrap init", async () => {
+  await Bun.write(
+    join(tempDir, "astro.config.mjs"),
+    `import { defineConfig } from "astro/config";
+export default defineConfig({ integrations: [] });
+`,
+  );
+  await mkdir(join(tempDir, "src/layouts"), { recursive: true });
+  await Bun.write(
+    join(tempDir, "src/layouts/Layout.astro"),
+    `<html lang="en">
+\t<body>
+\t\t<slot />
+\t</body>
+</html>
+`,
+  );
+
+  const plan = await astro.scaffold(makeCtx());
+
+  const layoutAction = plan.actions.find((a) => a.path === "src/layouts/Layout.astro");
+  expect(layoutAction).toBeUndefined();
+});
+
+test("uses plain styles for auth header in Astro when no Tailwind", async () => {
+  await Bun.write(
+    join(tempDir, "astro.config.mjs"),
+    `import { defineConfig } from "astro/config";
+export default defineConfig({ integrations: [] });
+`,
+  );
+  await mkdir(join(tempDir, "src/layouts"), { recursive: true });
+  await Bun.write(
+    join(tempDir, "src/layouts/Layout.astro"),
+    `---
+---
+
+<html lang="en">
+\t<body>
+\t\t<slot />
+\t</body>
+</html>
+`,
+  );
+
+  const plan = await astro.scaffold(makeCtx({ isBootstrap: true, deps: {} }));
+  const layout = findAction(plan.actions, "src/layouts/Layout.astro");
+
+  expect(layout.type).toBe("modify");
+  if (layout.type !== "modify") throw new Error("Expected modify action");
+
+  expect(layout.content).toContain('style="display: flex;');
+  expect(layout.content).not.toContain('class="flex');
 });
 
 test("uses .js extension when typescript is false", async () => {

--- a/packages/cli-core/src/commands/init/frameworks/astro.ts
+++ b/packages/cli-core/src/commands/init/frameworks/astro.ts
@@ -73,16 +73,25 @@ function addClerkToIntegrations(content: string): string {
   return content;
 }
 
-function addClerkIntegration(content: string): string {
-  return addClerkToIntegrations(addClerkImport(content));
+function enableServerOutput(content: string): string {
+  if (content.includes("output:")) return content;
+  return content.replace(/(defineConfig\s*\(\s*\{)/, '$1\n  output: "server",');
+}
+
+function addClerkIntegration(content: string, enableSsr = false): string {
+  let result = addClerkToIntegrations(addClerkImport(content));
+  if (enableSsr) result = enableServerOutput(result);
+  return result;
 }
 
 function scaffoldConfig(ctx: ProjectContext): Promise<FileAction> {
   return scaffoldConfigFile(ctx.cwd, {
     candidates: ["astro.config.mjs", "astro.config.ts", "astro.config.js"],
     existsCheck: "@clerk/astro",
-    modify: addClerkIntegration,
-    description: "Add clerk() to integrations and import",
+    modify: (content) => addClerkIntegration(content, Boolean(ctx.isBootstrap)),
+    description: ctx.isBootstrap
+      ? "Add clerk() to integrations, import, and enable SSR output"
+      : "Add clerk() to integrations and import",
     existingSkipReason: "Already has @clerk/astro integration",
     missingAction: {
       type: "skip",

--- a/packages/cli-core/src/commands/init/frameworks/astro.ts
+++ b/packages/cli-core/src/commands/init/frameworks/astro.ts
@@ -6,6 +6,7 @@ import {
   findFirstFile,
   hasClerkImport,
   hasTailwindStyles,
+  headerHtmlBlock,
   htmlAuthComponentMarkup,
   scaffoldAuthFiles,
   scaffoldConfigFile,
@@ -119,6 +120,47 @@ async function scaffoldMiddleware(ctx: ProjectContext): Promise<FileAction> {
   };
 }
 
+const ASTRO_HEADER_IMPORT = `import { Show, SignInButton, SignUpButton, UserButton } from "@clerk/astro/components";`;
+
+/** Inject a frontmatter import line into an Astro file. */
+function addAstroFrontmatterImport(content: string, importLine: string): string {
+  const fencePattern = /^---\n([\s\S]*?)^---/m;
+  const match = fencePattern.exec(content);
+  if (match) {
+    const [fullMatch, frontmatter = ""] = match;
+    if (frontmatter.includes(importLine)) return content;
+    return content.replace(fullMatch!, `---\n${frontmatter}${importLine}\n---`);
+  }
+  return `---\n${importLine}\n---\n\n${content}`;
+}
+
+/**
+ * Inject an auth header into the Astro layout file during bootstrap.
+ * Adds the necessary component import and inserts the header before `<slot />`.
+ */
+async function scaffoldLayout(ctx: ProjectContext, tailwind: boolean): Promise<FileAction | null> {
+  if (!ctx.isBootstrap) return null;
+
+  const layoutPath = await findFirstFile(ctx.cwd, ["src/layouts/Layout.astro"]);
+  if (!layoutPath) return null;
+
+  let content = await Bun.file(join(ctx.cwd, layoutPath)).text();
+
+  if (!content.includes("<slot")) return null;
+
+  content = addAstroFrontmatterImport(content, ASTRO_HEADER_IMPORT);
+
+  const header = headerHtmlBlock("\t\t", tailwind);
+  content = content.replace(/(\s*)(<slot\s*\/?>)/, `\n${header}\n$1$2`);
+
+  return {
+    path: layoutPath,
+    type: "modify",
+    content,
+    description: "Add auth header with Clerk components to layout",
+  };
+}
+
 /** Check if the Astro config contains an i18n configuration. */
 async function hasAstroI18n(cwd: string): Promise<boolean> {
   const configPath = await findFirstFile(cwd, [
@@ -143,20 +185,30 @@ export const astro: FrameworkScaffold = {
 
   async scaffold(ctx: ProjectContext): Promise<ScaffoldPlan> {
     const tailwind = hasTailwindStyles(ctx);
-    const [configAction, middlewareAction, authActions, envAction, i18n] = await Promise.all([
-      scaffoldConfig(ctx),
-      scaffoldMiddleware(ctx),
-      scaffoldAuthFiles(
-        ctx.cwd,
-        authFileSpecs({
-          path: (kind) => `src/pages/${kind}.astro`,
-          content: (kind) => authPageContent(kind, tailwind),
-          surface: "page",
-        }),
-      ),
-      scaffoldEnvVars(ctx, SIGN_ROUTE_ENV_VARS.astro),
-      hasAstroI18n(ctx.cwd),
-    ]);
+    const [configAction, middlewareAction, layoutAction, authActions, envAction, i18n] =
+      await Promise.all([
+        scaffoldConfig(ctx),
+        scaffoldMiddleware(ctx),
+        scaffoldLayout(ctx, tailwind),
+        scaffoldAuthFiles(
+          ctx.cwd,
+          authFileSpecs({
+            path: (kind) => `src/pages/${kind}.astro`,
+            content: (kind) => authPageContent(kind, tailwind),
+            surface: "page",
+          }),
+        ),
+        scaffoldEnvVars(ctx, SIGN_ROUTE_ENV_VARS.astro),
+        hasAstroI18n(ctx.cwd),
+      ]);
+
+    const actions = [
+      configAction,
+      middlewareAction,
+      layoutAction,
+      ...authActions,
+      envAction,
+    ].filter((action): action is FileAction => action !== null);
 
     const postInstructions = [
       "Ensure your Astro config has `output: 'server'` and an SSR adapter (e.g., @astrojs/node)",
@@ -169,7 +221,7 @@ export const astro: FrameworkScaffold = {
     }
 
     return {
-      actions: [configAction, middlewareAction, ...authActions, envAction],
+      actions,
       postInstructions,
     };
   },

--- a/packages/cli-core/src/commands/init/frameworks/helpers.ts
+++ b/packages/cli-core/src/commands/init/frameworks/helpers.ts
@@ -17,6 +17,8 @@ export {
   insertAfterLastImport,
   wrapBodyWithProvider,
   injectHeaderInProvider,
+  addBootstrapHeader,
+  headerHtmlBlock,
 } from "./transformations.js";
 
 export type AuthKind = "sign-in" | "sign-up";

--- a/packages/cli-core/src/commands/init/frameworks/helpers.ts
+++ b/packages/cli-core/src/commands/init/frameworks/helpers.ts
@@ -283,6 +283,8 @@ export function authComponentName(kind: AuthKind): "SignIn" | "SignUp" {
   return kind === "sign-in" ? "SignIn" : "SignUp";
 }
 
+export const MISSING_PUBLISHABLE_KEY_ERROR = `Missing VITE_CLERK_PUBLISHABLE_KEY. Add your key to .env.local.\\nRun: 1) clerk auth login  2) clerk link  3) clerk env pull — then restart the dev server.`;
+
 /** Generate a JSX auth page component for a Clerk framework SDK that exports SignIn/SignUp. */
 export function jsxAuthPageContent(
   kind: AuthKind,

--- a/packages/cli-core/src/commands/init/frameworks/javascript.ts
+++ b/packages/cli-core/src/commands/init/frameworks/javascript.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import { findFirstFile, scriptExt, srcPrefix } from "./helpers.js";
+import { findFirstFile, MISSING_PUBLISHABLE_KEY_ERROR, scriptExt, srcPrefix } from "./helpers.js";
 import type { FileAction, FrameworkScaffold, ProjectContext, ScaffoldPlan } from "./types.js";
 
 async function findEntryFile(ctx: ProjectContext): Promise<string | null> {
@@ -24,7 +24,7 @@ function clerkInitContent(typescript: boolean): string {
 const publishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
 
 if (!publishableKey) {
-  throw new Error("Missing VITE_CLERK_PUBLISHABLE_KEY. Add your key to .env.local.\\nRun: 1) clerk auth login  2) clerk link  3) clerk env pull — then restart the dev server.");
+  throw new Error("${MISSING_PUBLISHABLE_KEY_ERROR}");
 }
 
 const clerk = new Clerk(publishableKey);

--- a/packages/cli-core/src/commands/init/frameworks/javascript.ts
+++ b/packages/cli-core/src/commands/init/frameworks/javascript.ts
@@ -23,9 +23,14 @@ function clerkInitContent(typescript: boolean): string {
 
 const publishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
 
+if (!publishableKey) {
+  throw new Error("Missing VITE_CLERK_PUBLISHABLE_KEY. Add your key to .env.local.\\nRun: 1) clerk auth login  2) clerk link  3) clerk env pull — then restart the dev server.");
+}
+
 const clerk = new Clerk(publishableKey);
 await clerk.load();
 
+// Static string literals with no user input — safe to use as markup
 if (clerk.user) {
   const div = document.getElementById("app")${castDiv};
   div.innerHTML = '<div id="user-button"></div>';

--- a/packages/cli-core/src/commands/init/frameworks/nextjs-app.test.ts
+++ b/packages/cli-core/src/commands/init/frameworks/nextjs-app.test.ts
@@ -15,7 +15,7 @@ function makeCtx(overrides?: Partial<ProjectContext>): ProjectContext {
       name: "Next.js",
       sdk: "@clerk/nextjs",
       envVar: "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
-      envFile: ".env",
+      envFile: ".env" as const,
     },
     variant: "app-router",
     typescript: true,

--- a/packages/cli-core/src/commands/init/frameworks/nextjs-pages.test.ts
+++ b/packages/cli-core/src/commands/init/frameworks/nextjs-pages.test.ts
@@ -15,7 +15,7 @@ function makeCtx(overrides?: Partial<ProjectContext>): ProjectContext {
       name: "Next.js",
       sdk: "@clerk/nextjs",
       envVar: "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
-      envFile: ".env",
+      envFile: ".env" as const,
     },
     variant: "pages-router",
     typescript: true,

--- a/packages/cli-core/src/commands/init/frameworks/nuxt.test.ts
+++ b/packages/cli-core/src/commands/init/frameworks/nuxt.test.ts
@@ -324,6 +324,51 @@ test("omits Show post-instruction when bootstrap includes header", async () => {
   expect(plan.postInstructions.some((i) => i.includes("<Show"))).toBe(false);
 });
 
+test("creates index page during bootstrap (Nuxt 4 app/ layout)", async () => {
+  await mkdir(join(tempDir, "app"), { recursive: true });
+  await Bun.write(
+    join(tempDir, "nuxt.config.ts"),
+    `export default defineNuxtConfig({ modules: [] });\n`,
+  );
+  await Bun.write(join(tempDir, "app/app.vue"), `<template>\n  <NuxtWelcome />\n</template>\n`);
+
+  const plan = await nuxt.scaffold(makeCtx({ isBootstrap: true }));
+
+  const indexPage = findAction(plan.actions, "app/pages/index.vue");
+  expect(indexPage.type).toBe("create");
+  if (indexPage.type === "create") {
+    expect(indexPage.content).toContain("It works!");
+    expect(indexPage.content).toContain("app/pages/index.vue");
+  }
+});
+
+test("skips index page during bootstrap when it already exists", async () => {
+  await mkdir(join(tempDir, "app/pages"), { recursive: true });
+  await Bun.write(
+    join(tempDir, "nuxt.config.ts"),
+    `export default defineNuxtConfig({ modules: [] });\n`,
+  );
+  await Bun.write(join(tempDir, "app/app.vue"), `<template>\n  <NuxtWelcome />\n</template>\n`);
+  await Bun.write(join(tempDir, "app/pages/index.vue"), `<template><div>existing</div></template>`);
+
+  const plan = await nuxt.scaffold(makeCtx({ isBootstrap: true }));
+
+  const indexPage = findAction(plan.actions, "app/pages/index.vue");
+  expect(indexPage.type).toBe("skip");
+});
+
+test("does not create index page for non-bootstrap init", async () => {
+  await Bun.write(
+    join(tempDir, "nuxt.config.ts"),
+    `export default defineNuxtConfig({ modules: [] });\n`,
+  );
+
+  const plan = await nuxt.scaffold(makeCtx());
+
+  const indexPage = plan.actions.find((a) => a.path.endsWith("index.vue"));
+  expect(indexPage).toBeUndefined();
+});
+
 test("handles nuxt.config.js variant", async () => {
   await Bun.write(
     join(tempDir, "nuxt.config.js"),

--- a/packages/cli-core/src/commands/init/frameworks/nuxt.test.ts
+++ b/packages/cli-core/src/commands/init/frameworks/nuxt.test.ts
@@ -15,7 +15,7 @@ function makeCtx(overrides?: Partial<ProjectContext>): ProjectContext {
       name: "Nuxt",
       sdk: "@clerk/nuxt",
       envVar: "NUXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
-      envFile: ".env",
+      envFile: ".env" as const,
     },
     typescript: true,
     srcDir: false,
@@ -230,6 +230,98 @@ test("no i18n instruction without @nuxtjs/i18n", async () => {
   const plan = await nuxt.scaffold(makeCtx({ deps: {} }));
 
   expect(plan.postInstructions.some((i) => i.includes("@nuxtjs/i18n"))).toBe(false);
+});
+
+test("adds auth header in app.vue during bootstrap", async () => {
+  await mkdir(join(tempDir, "app"), { recursive: true });
+  await Bun.write(
+    join(tempDir, "nuxt.config.ts"),
+    `export default defineNuxtConfig({
+  modules: [],
+});
+`,
+  );
+  await Bun.write(
+    join(tempDir, "app/app.vue"),
+    `<template>
+  <div>
+    <NuxtRouteAnnouncer />
+    <NuxtWelcome />
+  </div>
+</template>
+`,
+  );
+
+  const plan = await nuxt.scaffold(makeCtx({ isBootstrap: true, deps: { tailwindcss: "4.0.0" } }));
+  const appVue = findAction(plan.actions, "app/app.vue");
+
+  expect(appVue.type).toBe("modify");
+  if (appVue.type !== "modify") throw new Error("Expected modify action");
+
+  expect(appVue.content).toContain('<Show when="signed-out">');
+  expect(appVue.content).toContain("<SignInButton />");
+  expect(appVue.content).toContain("<SignUpButton />");
+  expect(appVue.content).toContain('<Show when="signed-in">');
+  expect(appVue.content).toContain("<UserButton />");
+  expect(appVue.content).toContain("<NuxtPage />");
+  expect(appVue.content).toContain(
+    'class="flex h-16 items-center justify-end gap-4 border-b px-4"',
+  );
+  // Nuxt auto-imports — no script setup needed
+  expect(appVue.content).not.toContain("<script");
+  expect(appVue.description).toContain("auth header");
+});
+
+test("does not add auth header for non-bootstrap init", async () => {
+  await mkdir(join(tempDir, "app"), { recursive: true });
+  await Bun.write(
+    join(tempDir, "nuxt.config.ts"),
+    `export default defineNuxtConfig({
+  modules: [],
+});
+`,
+  );
+  await Bun.write(
+    join(tempDir, "app/app.vue"),
+    `<template>
+  <div>
+    <NuxtWelcome />
+  </div>
+</template>
+`,
+  );
+
+  const plan = await nuxt.scaffold(makeCtx());
+  const appVue = findAction(plan.actions, "app/app.vue");
+
+  expect(appVue.type).toBe("modify");
+  if (appVue.type !== "modify") throw new Error("Expected modify action");
+
+  expect(appVue.content).toContain("<NuxtPage />");
+  expect(appVue.content).not.toContain("<Show");
+  expect(appVue.content).not.toContain("<SignInButton");
+});
+
+test("omits Show post-instruction when bootstrap includes header", async () => {
+  await mkdir(join(tempDir, "app"), { recursive: true });
+  await Bun.write(
+    join(tempDir, "nuxt.config.ts"),
+    `export default defineNuxtConfig({ modules: [] });
+`,
+  );
+  await Bun.write(
+    join(tempDir, "app/app.vue"),
+    `<template>
+  <div>
+    <NuxtWelcome />
+  </div>
+</template>
+`,
+  );
+
+  const plan = await nuxt.scaffold(makeCtx({ isBootstrap: true }));
+
+  expect(plan.postInstructions.some((i) => i.includes("<Show"))).toBe(false);
 });
 
 test("handles nuxt.config.js variant", async () => {

--- a/packages/cli-core/src/commands/init/frameworks/nuxt.ts
+++ b/packages/cli-core/src/commands/init/frameworks/nuxt.ts
@@ -6,6 +6,7 @@ import {
   authFileSpecs,
   findFirstFile,
   hasTailwindStyles,
+  headerHtmlBlock,
   htmlAuthComponentMarkup,
   indentBlock,
   scaffoldAuthFiles,
@@ -74,7 +75,7 @@ function scaffoldConfig(ctx: ProjectContext): Promise<FileAction> {
  * The minimal Nuxt template uses `<NuxtWelcome />` without a router
  * outlet, which means pages/ routes never render.
  */
-async function scaffoldAppVue(ctx: ProjectContext): Promise<FileAction | null> {
+async function scaffoldAppVue(ctx: ProjectContext, tailwind: boolean): Promise<FileAction | null> {
   const appPath = await findFirstFile(ctx.cwd, ["app/app.vue", "app.vue"]);
   if (!appPath) return null;
 
@@ -85,6 +86,20 @@ async function scaffoldAppVue(ctx: ProjectContext): Promise<FileAction | null> {
   }
 
   if (!content.includes("<NuxtWelcome")) return null;
+
+  if (ctx.isBootstrap) {
+    const header = headerHtmlBlock("    ", tailwind);
+    return {
+      path: appPath,
+      type: "modify",
+      content: `<template>
+${header}
+    <NuxtPage />
+</template>
+`,
+      description: "Replace <NuxtWelcome /> with <NuxtPage /> and add auth header",
+    };
+  }
 
   const updated = content.replace(/<NuxtWelcome\s*\/?>/, "<NuxtPage />");
   return {
@@ -107,7 +122,7 @@ export const nuxt: FrameworkScaffold = {
     const pagesRoot = await pagesDir(ctx.cwd);
     const [configAction, appVueAction, authActions, envAction] = await Promise.all([
       scaffoldConfig(ctx),
-      scaffoldAppVue(ctx),
+      scaffoldAppVue(ctx, tailwind),
       scaffoldAuthFiles(
         ctx.cwd,
         authFileSpecs({
@@ -133,9 +148,11 @@ export const nuxt: FrameworkScaffold = {
       );
     }
 
-    postInstructions.push(
-      'Use <Show when="signed-in"> and <Show when="signed-out"> components in your app.vue for conditional rendering (auto-imported)',
-    );
+    if (!ctx.isBootstrap) {
+      postInstructions.push(
+        'Use <Show when="signed-in"> and <Show when="signed-out"> components in your app.vue for conditional rendering (auto-imported)',
+      );
+    }
 
     if (ctx.deps["@nuxtjs/i18n"]) {
       postInstructions.push(

--- a/packages/cli-core/src/commands/init/frameworks/nuxt.ts
+++ b/packages/cli-core/src/commands/init/frameworks/nuxt.ts
@@ -110,6 +110,25 @@ ${header}
   };
 }
 
+async function scaffoldIndexPage(cwd: string, pagesRoot: string): Promise<FileAction> {
+  const indexPath = `${pagesRoot}/index.vue`;
+  if (await Bun.file(join(cwd, indexPath)).exists()) {
+    return { type: "skip", path: indexPath, skipReason: "Index page already exists" };
+  }
+  return {
+    type: "create",
+    path: indexPath,
+    content: `<template>
+  <div style="display: flex; flex-direction: column; align-items: center; justify-content: center; min-height: calc(100vh - 65px); font-family: system-ui, sans-serif;">
+    <h1>It works!</h1>
+    <p>Edit <code>${indexPath}</code> to get started.</p>
+  </div>
+</template>
+`,
+    description: "Create index page so the root route renders",
+  };
+}
+
 export const nuxt: FrameworkScaffold = {
   name: "Nuxt",
   dep: "nuxt",
@@ -120,7 +139,7 @@ export const nuxt: FrameworkScaffold = {
   async scaffold(ctx: ProjectContext): Promise<ScaffoldPlan> {
     const tailwind = hasTailwindStyles(ctx);
     const pagesRoot = await pagesDir(ctx.cwd);
-    const [configAction, appVueAction, authActions, envAction] = await Promise.all([
+    const [configAction, appVueAction, authActions, envAction, indexAction] = await Promise.all([
       scaffoldConfig(ctx),
       scaffoldAppVue(ctx, tailwind),
       scaffoldAuthFiles(
@@ -134,9 +153,10 @@ export const nuxt: FrameworkScaffold = {
         }),
       ),
       scaffoldEnvVars(ctx, SIGN_ROUTE_ENV_VARS.nuxt),
+      ctx.isBootstrap ? scaffoldIndexPage(ctx.cwd, pagesRoot) : Promise.resolve(null),
     ]);
 
-    const actions = [configAction, appVueAction, ...authActions, envAction].filter(
+    const actions = [configAction, appVueAction, indexAction, ...authActions, envAction].filter(
       (action): action is FileAction => action !== null,
     );
 

--- a/packages/cli-core/src/commands/init/frameworks/react-router.test.ts
+++ b/packages/cli-core/src/commands/init/frameworks/react-router.test.ts
@@ -15,7 +15,7 @@ function makeCtx(overrides?: Partial<ProjectContext>): ProjectContext {
       name: "React Router",
       sdk: "@clerk/react-router",
       envVar: "VITE_CLERK_PUBLISHABLE_KEY",
-      envFile: ".env.local",
+      envFile: ".env.local" as const,
     },
     typescript: true,
     srcDir: false,
@@ -306,6 +306,60 @@ export default [
   const occurrences = (routesAction.content.match(/sign-in/g) ?? []).length;
   expect(occurrences).toBe(2);
   expect(routesAction.content).toContain('route("sign-up/*", "routes/sign-up.tsx")');
+});
+
+test("adds auth header in root during bootstrap with Tailwind", async () => {
+  await mkdir(join(tempDir, "app"), { recursive: true });
+  await Bun.write(
+    join(tempDir, "app/root.tsx"),
+    `import { Outlet } from "react-router";
+
+export default function Root() {
+  return <Outlet />;
+}
+`,
+  );
+
+  const plan = await reactRouter.scaffold(
+    makeCtx({ isBootstrap: true, deps: { "react-router": "7.0.0", tailwindcss: "4.0.0" } }),
+  );
+  const rootAction = plan.actions.find((action) => action.path === "app/root.tsx");
+
+  expect(rootAction?.type).toBe("modify");
+  if (rootAction?.type !== "modify") throw new Error("Expected modify action");
+
+  expect(rootAction.content).toContain('<Show when="signed-out">');
+  expect(rootAction.content).toContain("<SignInButton />");
+  expect(rootAction.content).toContain("<SignUpButton />");
+  expect(rootAction.content).toContain('<Show when="signed-in">');
+  expect(rootAction.content).toContain("<UserButton />");
+  expect(rootAction.content).toContain(
+    'className="flex h-16 items-center justify-end gap-4 border-b px-4"',
+  );
+  expect(rootAction.description).toContain("auth header");
+});
+
+test("does not add auth header for non-bootstrap init", async () => {
+  await mkdir(join(tempDir, "app"), { recursive: true });
+  await Bun.write(
+    join(tempDir, "app/root.tsx"),
+    `import { Outlet } from "react-router";
+
+export default function Root() {
+  return <Outlet />;
+}
+`,
+  );
+
+  const plan = await reactRouter.scaffold(makeCtx());
+  const rootAction = plan.actions.find((action) => action.path === "app/root.tsx");
+
+  expect(rootAction?.type).toBe("modify");
+  if (rootAction?.type !== "modify") throw new Error("Expected modify action");
+
+  expect(rootAction.content).toContain("ClerkProvider");
+  expect(rootAction.content).not.toContain("<Show");
+  expect(rootAction.content).not.toContain("<SignInButton");
 });
 
 test("wires locale-prefixed routes into app/routes.ts", async () => {

--- a/packages/cli-core/src/commands/init/frameworks/react-router.ts
+++ b/packages/cli-core/src/commands/init/frameworks/react-router.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import { parseModule } from "magicast";
 import {
+  addBootstrapHeader,
   authFileSpecs,
   findFirstDirMatch,
   findFirstFile,
@@ -92,16 +93,19 @@ function addLoaderDataBinding(source: string): { content: string; hasLoaderData:
 function describeRootAction(options: {
   hasLoaderData: boolean;
   needsManualLoaderMerge: boolean;
+  isBootstrap: boolean;
 }): string {
+  const suffix = options.isBootstrap ? ", and auth header" : "";
+
   if (options.needsManualLoaderMerge) {
-    return "Add ClerkProvider and clerkMiddleware (manual rootAuthLoader merge still required)";
+    return `Add ClerkProvider and clerkMiddleware (manual rootAuthLoader merge still required)${suffix}`;
   }
 
   if (options.hasLoaderData) {
-    return "Add ClerkProvider, clerkMiddleware, rootAuthLoader, and loaderData wiring";
+    return `Add ClerkProvider, clerkMiddleware, rootAuthLoader, and loaderData wiring${suffix}`;
   }
 
-  return "Add ClerkProvider, clerkMiddleware, and rootAuthLoader (manual loaderData wiring may be needed)";
+  return `Add ClerkProvider, clerkMiddleware, and rootAuthLoader (manual loaderData wiring may be needed)${suffix}`;
 }
 
 function wrapOutletWithProvider(source: string, hasLoaderData: boolean): string {
@@ -178,6 +182,10 @@ async function scaffoldRoot(ctx: ProjectContext): Promise<RootScaffoldResult> {
     : addLoaderDataBinding(result);
   result = wrapOutletWithProvider(loaderDataResult.content, loaderDataResult.hasLoaderData);
 
+  if (ctx.isBootstrap) {
+    result = addBootstrapHeader(result, "@clerk/react-router", hasTailwindStyles(ctx));
+  }
+
   return {
     action: {
       path: rootPath,
@@ -186,6 +194,7 @@ async function scaffoldRoot(ctx: ProjectContext): Promise<RootScaffoldResult> {
       description: describeRootAction({
         hasLoaderData: loaderDataResult.hasLoaderData,
         needsManualLoaderMerge,
+        isBootstrap: Boolean(ctx.isBootstrap),
       }),
     },
     needsManualLoaderMerge,
@@ -226,7 +235,7 @@ function ensureRouteImported(source: string): string {
   const importMatch = source.match(
     /import\s*\{([^}]*)\}\s*from\s*["']@react-router\/dev\/routes["']/,
   );
-  if (!importMatch || !importMatch[1] || /\broute\b/.test(importMatch[1])) return source;
+  if (!importMatch || /\broute\b/.test(importMatch[1]!)) return source;
 
   return source.replace(
     /(\bimport\s*\{[^}]*)(\}\s*from\s*["']@react-router\/dev\/routes["'])/,
@@ -301,8 +310,8 @@ function injectRouteEntries(
   // Strategy 1: canonical create-react-router pattern.
   const canonicalPattern = /export default \[([^\]]*)\]\s*satisfies\s*RouteConfig\s*;/s;
   const canonical = source.match(canonicalPattern);
-  if (canonical && canonical[1] !== undefined) {
-    const innerContent = canonical[1].trimEnd();
+  if (canonical) {
+    const innerContent = canonical[1]!.trimEnd();
     const separator = innerContent.length > 0 && !innerContent.endsWith(",") ? "," : "";
     const newInner = `${innerContent}${separator}\n  ${newEntries},\n`;
     return source.replace(canonicalPattern, `export default [${newInner}] satisfies RouteConfig;`);
@@ -311,8 +320,8 @@ function injectRouteEntries(
   // Strategy 2: any `export default [...]` array (no satisfies).
   const simplePattern = /(export\s+default\s+\[)([\s\S]*?)(\]\s*;)/;
   const simple = source.match(simplePattern);
-  if (simple && simple[2] !== undefined) {
-    const innerContent = simple[2].trimEnd();
+  if (simple) {
+    const innerContent = simple[2]!.trimEnd();
     const separator = innerContent.length > 0 && !innerContent.endsWith(",") ? "," : "";
     const newInner = `${innerContent}${separator}\n  ${newEntries},\n`;
     return source.replace(simplePattern, `$1${newInner}$3`);

--- a/packages/cli-core/src/commands/init/frameworks/react.test.ts
+++ b/packages/cli-core/src/commands/init/frameworks/react.test.ts
@@ -15,7 +15,7 @@ function makeCtx(overrides?: Partial<ProjectContext>): ProjectContext {
       name: "React",
       sdk: "@clerk/react",
       envVar: "VITE_CLERK_PUBLISHABLE_KEY",
-      envFile: ".env.local",
+      envFile: ".env.local" as const,
     },
     typescript: true,
     srcDir: true,
@@ -159,6 +159,96 @@ ReactDOM.createRoot(document.getElementById("root")!).render(<App />);
 
   const entry = findAction(plan.actions, "main.tsx");
   expect(entry.type).toBe("modify");
+});
+
+test("adds auth header in entry during bootstrap with Tailwind", async () => {
+  await mkdir(join(tempDir, "src"), { recursive: true });
+  await Bun.write(
+    join(tempDir, "src/main.tsx"),
+    `import { StrictMode } from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);
+`,
+  );
+
+  const plan = await reactVite.scaffold(
+    makeCtx({ isBootstrap: true, deps: { tailwindcss: "4.0.0" } }),
+  );
+  const entry = findAction(plan.actions, "src/main.tsx");
+
+  expect(entry.type).toBe("modify");
+  if (entry.type !== "modify") throw new Error("Expected modify action");
+
+  expect(entry.content).toContain('<Show when="signed-out">');
+  expect(entry.content).toContain("<SignInButton />");
+  expect(entry.content).toContain("<SignUpButton />");
+  expect(entry.content).toContain('<Show when="signed-in">');
+  expect(entry.content).toContain("<UserButton />");
+  expect(entry.content).toContain(
+    'className="flex h-16 items-center justify-end gap-4 border-b px-4"',
+  );
+  expect(entry.description).toContain("auth header");
+});
+
+test("does not add auth header for non-bootstrap init", async () => {
+  await mkdir(join(tempDir, "src"), { recursive: true });
+  await Bun.write(
+    join(tempDir, "src/main.tsx"),
+    `import { StrictMode } from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);
+`,
+  );
+
+  const plan = await reactVite.scaffold(makeCtx());
+  const entry = findAction(plan.actions, "src/main.tsx");
+
+  expect(entry.type).toBe("modify");
+  if (entry.type !== "modify") throw new Error("Expected modify action");
+
+  expect(entry.content).toContain("ClerkProvider");
+  expect(entry.content).not.toContain("<Show");
+  expect(entry.content).not.toContain("<SignInButton");
+  expect(entry.content).not.toContain("<UserButton");
+});
+
+test("uses plain styles for auth header when no Tailwind", async () => {
+  await mkdir(join(tempDir, "src"), { recursive: true });
+  await Bun.write(
+    join(tempDir, "src/main.tsx"),
+    `import { StrictMode } from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);
+`,
+  );
+
+  const plan = await reactVite.scaffold(makeCtx({ isBootstrap: true, deps: {} }));
+  const entry = findAction(plan.actions, "src/main.tsx");
+
+  expect(entry.type).toBe("modify");
+  if (entry.type !== "modify") throw new Error("Expected modify action");
+
+  expect(entry.content).toContain("style={{");
+  expect(entry.content).toContain("justifyContent");
+  expect(entry.content).not.toContain('className="flex');
 });
 
 test("includes env var post-instruction", async () => {

--- a/packages/cli-core/src/commands/init/frameworks/react.ts
+++ b/packages/cli-core/src/commands/init/frameworks/react.ts
@@ -1,5 +1,13 @@
 import { join } from "node:path";
-import { findFirstFile, jsxExt, safeAddImport, scriptExt, srcPrefix } from "./helpers.js";
+import {
+  addBootstrapHeader,
+  findFirstFile,
+  hasTailwindStyles,
+  jsxExt,
+  safeAddImport,
+  scriptExt,
+  srcPrefix,
+} from "./helpers.js";
 import type { FileAction, FrameworkScaffold, ProjectContext, ScaffoldPlan } from "./types.js";
 
 async function findEntryFile(ctx: ProjectContext): Promise<string | null> {
@@ -39,13 +47,19 @@ async function scaffoldEntry(ctx: ProjectContext): Promise<FileAction | null> {
   }
 
   const imported = safeAddImport(content, "@clerk/react", "ClerkProvider");
-  const newContent = wrapWithClerkProvider(imported);
+  let newContent = wrapWithClerkProvider(imported);
+
+  if (ctx.isBootstrap) {
+    newContent = addBootstrapHeader(newContent, "@clerk/react", hasTailwindStyles(ctx));
+  }
 
   return {
     path: entryPath,
     type: "modify",
     content: newContent,
-    description: "Add ClerkProvider import and wrap app root",
+    description: ctx.isBootstrap
+      ? "Add ClerkProvider, wrap app root, and add auth header"
+      : "Add ClerkProvider import and wrap app root",
   };
 }
 

--- a/packages/cli-core/src/commands/init/frameworks/react.ts
+++ b/packages/cli-core/src/commands/init/frameworks/react.ts
@@ -53,14 +53,11 @@ async function scaffoldEntry(ctx: ProjectContext): Promise<FileAction | null> {
     newContent = addBootstrapHeader(newContent, "@clerk/react", hasTailwindStyles(ctx));
   }
 
-  return {
-    path: entryPath,
-    type: "modify",
-    content: newContent,
-    description: ctx.isBootstrap
-      ? "Add ClerkProvider, wrap app root, and add auth header"
-      : "Add ClerkProvider import and wrap app root",
-  };
+  const description = ctx.isBootstrap
+    ? "Add ClerkProvider, wrap app root, and add auth header"
+    : "Add ClerkProvider import and wrap app root";
+
+  return { path: entryPath, type: "modify", content: newContent, description };
 }
 
 export const reactVite: FrameworkScaffold = {

--- a/packages/cli-core/src/commands/init/frameworks/tanstack-start.test.ts
+++ b/packages/cli-core/src/commands/init/frameworks/tanstack-start.test.ts
@@ -15,7 +15,7 @@ function makeCtx(overrides?: Partial<ProjectContext>): ProjectContext {
       name: "TanStack Start",
       sdk: "@clerk/tanstack-react-start",
       envVar: "VITE_CLERK_PUBLISHABLE_KEY",
-      envFile: ".env.local",
+      envFile: ".env.local" as const,
     },
     typescript: true,
     srcDir: true,
@@ -126,6 +126,81 @@ export const start = createStart(() => { return {}; });
   expect(appStart).toBeDefined();
   expect(appStart?.type).toBe("create");
   expect(srcStart).toBeUndefined();
+});
+
+test("adds auth header in root during bootstrap", async () => {
+  await mkdir(join(tempDir, "src/routes"), { recursive: true });
+  await Bun.write(
+    join(tempDir, "src/routes/__root.tsx"),
+    `import { createRootRoute } from "@tanstack/react-router";
+
+export const Route = createRootRoute({
+  shellComponent: RootDocument,
+});
+
+function RootDocument({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        {children}
+      </body>
+    </html>
+  );
+}
+`,
+  );
+
+  const plan = await tanstackStart.scaffold(
+    makeCtx({
+      isBootstrap: true,
+      deps: { "@tanstack/react-start": "1.0.0", tailwindcss: "4.0.0" },
+    }),
+  );
+  const rootAction = plan.actions.find((a) => a.path === "src/routes/__root.tsx");
+
+  expect(rootAction?.type).toBe("modify");
+  if (rootAction?.type !== "modify") throw new Error("Expected modify action");
+
+  expect(rootAction.content).toContain('<Show when="signed-out">');
+  expect(rootAction.content).toContain("<SignInButton />");
+  expect(rootAction.content).toContain("<UserButton />");
+  expect(rootAction.content).toContain(
+    'className="flex h-16 items-center justify-end gap-4 border-b px-4"',
+  );
+  expect(rootAction.description).toContain("auth header");
+});
+
+test("does not add auth header for non-bootstrap init", async () => {
+  await mkdir(join(tempDir, "src/routes"), { recursive: true });
+  await Bun.write(
+    join(tempDir, "src/routes/__root.tsx"),
+    `import { createRootRoute } from "@tanstack/react-router";
+
+export const Route = createRootRoute({
+  shellComponent: RootDocument,
+});
+
+function RootDocument({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        {children}
+      </body>
+    </html>
+  );
+}
+`,
+  );
+
+  const plan = await tanstackStart.scaffold(makeCtx());
+  const rootAction = plan.actions.find((a) => a.path === "src/routes/__root.tsx");
+
+  expect(rootAction?.type).toBe("modify");
+  if (rootAction?.type !== "modify") throw new Error("Expected modify action");
+
+  expect(rootAction.content).toContain("ClerkProvider");
+  expect(rootAction.content).not.toContain("<Show");
+  expect(rootAction.content).not.toContain("<SignInButton");
 });
 
 test("does not use locale dir when none detected", async () => {

--- a/packages/cli-core/src/commands/init/frameworks/tanstack-start.ts
+++ b/packages/cli-core/src/commands/init/frameworks/tanstack-start.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import {
+  addBootstrapHeader,
   authComponentName,
   authFileSpecs,
   findFirstFile,
@@ -187,11 +188,21 @@ async function scaffoldRoot(ctx: ProjectContext): Promise<FileAction | null> {
     newContent = wrapBodyWithProvider(newContent, "ClerkProvider");
   }
 
+  if (ctx.isBootstrap) {
+    newContent = addBootstrapHeader(
+      newContent,
+      "@clerk/tanstack-react-start",
+      hasTailwindStyles(ctx),
+    );
+  }
+
   return {
     path: rootPath,
     type: "modify",
     content: newContent,
-    description: "Add ClerkProvider import and wrap body contents",
+    description: ctx.isBootstrap
+      ? "Add ClerkProvider, wrap body contents, and add auth header"
+      : "Add ClerkProvider import and wrap body contents",
   };
 }
 

--- a/packages/cli-core/src/commands/init/frameworks/tanstack-start.ts
+++ b/packages/cli-core/src/commands/init/frameworks/tanstack-start.ts
@@ -196,14 +196,11 @@ async function scaffoldRoot(ctx: ProjectContext): Promise<FileAction | null> {
     );
   }
 
-  return {
-    path: rootPath,
-    type: "modify",
-    content: newContent,
-    description: ctx.isBootstrap
-      ? "Add ClerkProvider, wrap body contents, and add auth header"
-      : "Add ClerkProvider import and wrap body contents",
-  };
+  const description = ctx.isBootstrap
+    ? "Add ClerkProvider, wrap body contents, and add auth header"
+    : "Add ClerkProvider import and wrap body contents";
+
+  return { path: rootPath, type: "modify", content: newContent, description };
 }
 
 export const tanstackStart: FrameworkScaffold = {

--- a/packages/cli-core/src/commands/init/frameworks/transformations.ts
+++ b/packages/cli-core/src/commands/init/frameworks/transformations.ts
@@ -40,11 +40,36 @@ export function insertAfterLastImport(source: string, snippet: string): string {
 }
 
 /**
+ * Build the auth header block using HTML attributes (`class` / `style="..."`).
+ * Used by Vue, Nuxt, and Astro scaffolders.
+ */
+export function headerHtmlBlock(indent: string, tailwind: boolean): string {
+  const innerIndent = indent + "  ";
+  const headerAttr = tailwind
+    ? `class="flex h-16 items-center justify-end gap-4 border-b px-4"`
+    : `style="display: flex; height: 64px; align-items: center; justify-content: flex-end; gap: 16px; border-bottom: 1px solid #e5e7eb; padding: 0 16px;"`;
+
+  return [
+    `${indent}<header ${headerAttr}>`,
+    `${innerIndent}<Show when="signed-out">`,
+    `${innerIndent}  <SignInButton />`,
+    `${innerIndent}  <SignUpButton />`,
+    `${innerIndent}</Show>`,
+    `${innerIndent}<Show when="signed-in">`,
+    `${innerIndent}  <UserButton />`,
+    `${innerIndent}</Show>`,
+    `${indent}</header>`,
+  ].join("\n");
+}
+
+/**
  * Inject a navigation header with auth buttons inside `<ClerkProvider>`.
  * Must be called AFTER `wrapBodyWithProvider` has already wrapped body contents.
  */
 export function injectHeaderInProvider(content: string, tailwind: boolean): string {
-  const providerPattern = /^( *)<ClerkProvider>/m;
+  // Match a line containing <ClerkProvider>, capturing leading whitespace for indentation.
+  // The provider tag may appear after `return` or other tokens (e.g. React Router).
+  const providerPattern = /^( *).*<ClerkProvider[^>]*>/m;
   const match = providerPattern.exec(content);
   if (!match) return content;
 
@@ -68,7 +93,23 @@ export function injectHeaderInProvider(content: string, tailwind: boolean): stri
     `${innerIndent}</header>`,
   ].join("\n");
 
-  return content.replace(providerPattern, `${indent}<ClerkProvider>\n${headerBlock}`);
+  return content.replace(providerPattern, (fullMatch) => `${fullMatch}\n${headerBlock}`);
+}
+
+/**
+ * Add Show, SignInButton, SignUpButton, UserButton imports from a Clerk package
+ * and inject a header inside <ClerkProvider>. Used by JSX frameworks during bootstrap.
+ */
+export function addBootstrapHeader(
+  content: string,
+  clerkPackage: string,
+  tailwind: boolean,
+): string {
+  let result = safeAddImport(content, clerkPackage, "Show");
+  result = safeAddImport(result, clerkPackage, "SignInButton");
+  result = safeAddImport(result, clerkPackage, "SignUpButton");
+  result = safeAddImport(result, clerkPackage, "UserButton");
+  return injectHeaderInProvider(result, tailwind);
 }
 
 /** Wrap the contents of a `<body>` tag with a provider component (e.g. `<ClerkProvider>`). */

--- a/packages/cli-core/src/commands/init/frameworks/transformations.ts
+++ b/packages/cli-core/src/commands/init/frameworks/transformations.ts
@@ -39,18 +39,28 @@ export function insertAfterLastImport(source: string, snippet: string): string {
   return source.slice(0, lineEnd + 1) + snippet + source.slice(lineEnd + 1);
 }
 
-/**
- * Build the auth header block using HTML attributes (`class` / `style="..."`).
- * Used by Vue, Nuxt, and Astro scaffolders.
- */
-export function headerHtmlBlock(indent: string, tailwind: boolean): string {
+type HeaderSyntax = "html" | "jsx";
+
+const HEADER_ATTRS: Record<HeaderSyntax, { tailwind: string; inline: string }> = {
+  html: {
+    tailwind: `class="flex h-16 items-center justify-end gap-4 border-b px-4"`,
+    inline: `style="display: flex; height: 64px; align-items: center; justify-content: flex-end; gap: 16px; border-bottom: 1px solid #e5e7eb; padding: 0 16px;"`,
+  },
+  jsx: {
+    tailwind: `className="flex h-16 items-center justify-end gap-4 border-b px-4"`,
+    inline: `style={{ display: "flex", height: "64px", alignItems: "center", justifyContent: "flex-end", gap: "16px", borderBottom: "1px solid #e5e7eb", padding: "0 16px" }}`,
+  },
+};
+
+const AUTH_HEADER_COMPONENTS = ["Show", "SignInButton", "SignUpButton", "UserButton"] as const;
+
+function buildHeaderBlock(indent: string, tailwind: boolean, syntax: HeaderSyntax): string {
   const innerIndent = indent + "  ";
-  const headerAttr = tailwind
-    ? `class="flex h-16 items-center justify-end gap-4 border-b px-4"`
-    : `style="display: flex; height: 64px; align-items: center; justify-content: flex-end; gap: 16px; border-bottom: 1px solid #e5e7eb; padding: 0 16px;"`;
+  const attrs = HEADER_ATTRS[syntax];
+  const attr = tailwind ? attrs.tailwind : attrs.inline;
 
   return [
-    `${indent}<header ${headerAttr}>`,
+    `${indent}<header ${attr}>`,
     `${innerIndent}<Show when="signed-out">`,
     `${innerIndent}  <SignInButton />`,
     `${innerIndent}  <SignUpButton />`,
@@ -63,35 +73,24 @@ export function headerHtmlBlock(indent: string, tailwind: boolean): string {
 }
 
 /**
+ * Build the auth header block using HTML attributes (`class` / `style="..."`).
+ * Used by Vue, Nuxt, and Astro scaffolders.
+ */
+export function headerHtmlBlock(indent: string, tailwind: boolean): string {
+  return buildHeaderBlock(indent, tailwind, "html");
+}
+
+/**
  * Inject a navigation header with auth buttons inside `<ClerkProvider>`.
  * Must be called AFTER `wrapBodyWithProvider` has already wrapped body contents.
  */
 export function injectHeaderInProvider(content: string, tailwind: boolean): string {
-  // Match a line containing <ClerkProvider>, capturing leading whitespace for indentation.
-  // The provider tag may appear after `return` or other tokens (e.g. React Router).
   const providerPattern = /^( *).*<ClerkProvider[^>]*>/m;
   const match = providerPattern.exec(content);
   if (!match) return content;
 
-  const [, indent] = match;
-  const innerIndent = indent + "  ";
-  const deepIndent = innerIndent + "  ";
-
-  const headerAttr = tailwind
-    ? `className="flex h-16 items-center justify-end gap-4 border-b px-4"`
-    : `style={{ display: "flex", height: "64px", alignItems: "center", justifyContent: "flex-end", gap: "16px", borderBottom: "1px solid #e5e7eb", padding: "0 16px" }}`;
-
-  const headerBlock = [
-    `${innerIndent}<header ${headerAttr}>`,
-    `${deepIndent}<Show when="signed-out">`,
-    `${deepIndent}  <SignInButton />`,
-    `${deepIndent}  <SignUpButton />`,
-    `${deepIndent}</Show>`,
-    `${deepIndent}<Show when="signed-in">`,
-    `${deepIndent}  <UserButton />`,
-    `${deepIndent}</Show>`,
-    `${innerIndent}</header>`,
-  ].join("\n");
+  const innerIndent = match[1] + "  ";
+  const headerBlock = buildHeaderBlock(innerIndent, tailwind, "jsx");
 
   return content.replace(providerPattern, (fullMatch) => `${fullMatch}\n${headerBlock}`);
 }
@@ -105,11 +104,11 @@ export function addBootstrapHeader(
   clerkPackage: string,
   tailwind: boolean,
 ): string {
-  let result = safeAddImport(content, clerkPackage, "Show");
-  result = safeAddImport(result, clerkPackage, "SignInButton");
-  result = safeAddImport(result, clerkPackage, "SignUpButton");
-  result = safeAddImport(result, clerkPackage, "UserButton");
-  return injectHeaderInProvider(result, tailwind);
+  const withImports = AUTH_HEADER_COMPONENTS.reduce(
+    (result, name) => safeAddImport(result, clerkPackage, name),
+    content,
+  );
+  return injectHeaderInProvider(withImports, tailwind);
 }
 
 /** Wrap the contents of a `<body>` tag with a provider component (e.g. `<ClerkProvider>`). */

--- a/packages/cli-core/src/commands/init/frameworks/types.ts
+++ b/packages/cli-core/src/commands/init/frameworks/types.ts
@@ -31,6 +31,8 @@ export type FileAction =
 export interface ScaffoldPlan {
   actions: FileAction[];
   postInstructions: string[];
+  /** Additional packages to install before writing files (e.g., vue-router for Vue bootstrap). */
+  additionalDeps?: string[];
 }
 
 export interface FrameworkScaffold {

--- a/packages/cli-core/src/commands/init/frameworks/vue.test.ts
+++ b/packages/cli-core/src/commands/init/frameworks/vue.test.ts
@@ -15,7 +15,7 @@ function makeCtx(overrides?: Partial<ProjectContext>): ProjectContext {
       name: "Vue",
       sdk: "@clerk/vue",
       envVar: "VITE_CLERK_PUBLISHABLE_KEY",
-      envFile: ".env.local",
+      envFile: ".env.local" as const,
     },
     typescript: true,
     srcDir: true,
@@ -358,4 +358,69 @@ export default router;
     type: "skip",
     skipReason: "Already has sign-in/sign-up routes",
   });
+});
+
+test("adds auth header in App.vue during bootstrap with Tailwind", async () => {
+  await mkdir(join(tempDir, "src"), { recursive: true });
+  await Bun.write(
+    join(tempDir, "src/main.ts"),
+    `import { createApp } from "vue";
+import App from "./App.vue";
+
+createApp(App).mount("#app");
+`,
+  );
+  await Bun.write(
+    join(tempDir, "src/App.vue"),
+    `<template>
+  <HelloWorld />
+</template>
+`,
+  );
+
+  const plan = await vue.scaffold(makeCtx({ isBootstrap: true, deps: { tailwindcss: "4.0.0" } }));
+  const appVue = findAction(plan.actions, "src/App.vue");
+
+  expect(appVue.type).toBe("modify");
+  if (appVue.type !== "modify") throw new Error("Expected modify action");
+
+  expect(appVue.content).toContain('<Show when="signed-out">');
+  expect(appVue.content).toContain("<SignInButton />");
+  expect(appVue.content).toContain("<SignUpButton />");
+  expect(appVue.content).toContain('<Show when="signed-in">');
+  expect(appVue.content).toContain("<UserButton />");
+  expect(appVue.content).toContain(
+    'class="flex h-16 items-center justify-end gap-4 border-b px-4"',
+  );
+  expect(appVue.content).toContain("@clerk/vue");
+  expect(appVue.content).toContain("<RouterView />");
+  expect(appVue.description).toContain("auth header");
+});
+
+test("uses plain styles for auth header in Vue when no Tailwind", async () => {
+  await mkdir(join(tempDir, "src"), { recursive: true });
+  await Bun.write(
+    join(tempDir, "src/main.ts"),
+    `import { createApp } from "vue";
+import App from "./App.vue";
+
+createApp(App).mount("#app");
+`,
+  );
+  await Bun.write(
+    join(tempDir, "src/App.vue"),
+    `<template>
+  <HelloWorld />
+</template>
+`,
+  );
+
+  const plan = await vue.scaffold(makeCtx({ isBootstrap: true, deps: {} }));
+  const appVue = findAction(plan.actions, "src/App.vue");
+
+  expect(appVue.type).toBe("modify");
+  if (appVue.type !== "modify") throw new Error("Expected modify action");
+
+  expect(appVue.content).toContain('style="display: flex;');
+  expect(appVue.content).not.toContain('class="flex');
 });

--- a/packages/cli-core/src/commands/init/frameworks/vue.ts
+++ b/packages/cli-core/src/commands/init/frameworks/vue.ts
@@ -4,6 +4,7 @@ import {
   authFileSpecs,
   findFirstFile,
   hasTailwindStyles,
+  headerHtmlBlock,
   htmlAuthComponentMarkup,
   indentBlock,
   insertAfterLastImport,
@@ -44,11 +45,13 @@ function addClerkPluginSetup(source: string): string {
   return insertAfterLastImport(result, keyBlock);
 }
 
-function newEntryContent(): string {
+function newEntryContent(withRouter = false): string {
+  const routerImport = withRouter ? `import router from "./router";\n` : "";
+  const routerUse = withRouter ? `app.use(router);\n` : "";
   return `import { createApp } from "vue";
 import { clerkPlugin } from "@clerk/vue";
 import App from "./App.vue";
-
+${routerImport}
 const PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
 
 if (!PUBLISHABLE_KEY) {
@@ -57,11 +60,11 @@ if (!PUBLISHABLE_KEY) {
 
 const app = createApp(App);
 app.use(clerkPlugin, { publishableKey: PUBLISHABLE_KEY });
-app.mount("#app");
+${routerUse}app.mount("#app");
 `;
 }
 
-async function scaffoldEntry(ctx: ProjectContext): Promise<FileAction> {
+async function scaffoldEntry(ctx: ProjectContext, withRouter = false): Promise<FileAction> {
   const entryPath = await findEntryFile(ctx);
 
   if (!entryPath) {
@@ -70,7 +73,7 @@ async function scaffoldEntry(ctx: ProjectContext): Promise<FileAction> {
     return {
       type: "create",
       path: `${base}main.${ext}`,
-      content: newEntryContent(),
+      content: newEntryContent(withRouter),
       description: "Create entry file with clerkPlugin setup",
     };
   }
@@ -83,16 +86,25 @@ async function scaffoldEntry(ctx: ProjectContext): Promise<FileAction> {
 
   let newContent = safeAddImport(content, "@clerk/vue", "clerkPlugin");
 
+  if (withRouter) {
+    newContent = insertAfterLastImport(newContent, `\nimport router from "./router";\n`);
+  }
+
   // Add the publishable key constant and app.use() call before app.mount()
   if (newContent.includes(".mount(")) {
     newContent = addClerkPluginSetup(newContent);
+    if (withRouter) {
+      newContent = newContent.replace(/(.+\.mount\s*\()/, `app.use(router);\n$1`);
+    }
   }
 
   return {
     path: entryPath,
     type: "modify",
     content: newContent,
-    description: "Add clerkPlugin with publishableKey to Vue app",
+    description: withRouter
+      ? "Add clerkPlugin with publishableKey and vue-router to Vue app"
+      : "Add clerkPlugin with publishableKey to Vue app",
   };
 }
 
@@ -127,6 +139,69 @@ function addSignRoutes(source: string, viewPrefix: string): string {
   );
 }
 
+function newRouterContent(viewPrefix: string): string {
+  return `import { createRouter, createWebHistory } from "vue-router";
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    {
+      path: "/sign-in",
+      component: () => import("${viewPrefix}views/sign-in.vue"),
+    },
+    {
+      path: "/sign-up",
+      component: () => import("${viewPrefix}views/sign-up.vue"),
+    },
+  ],
+});
+
+export default router;
+`;
+}
+
+function scaffoldNewRouter(ctx: ProjectContext): FileAction {
+  const base = srcPrefix(ctx);
+  const ext = scriptExt(ctx);
+  return {
+    type: "create",
+    path: `${base}router/index.${ext}`,
+    content: newRouterContent("../"),
+    description: "Create vue-router config with sign-in and sign-up routes",
+  };
+}
+
+async function scaffoldAppVue(ctx: ProjectContext, tailwind: boolean): Promise<FileAction | null> {
+  const base = srcPrefix(ctx);
+  const appPath = await findFirstFile(ctx.cwd, [`${base}App.vue`]);
+  if (!appPath) return null;
+
+  const header = headerHtmlBlock("    ", tailwind);
+  const content = ctx.isBootstrap
+    ? `<script setup>
+import { Show, SignInButton, SignUpButton, UserButton } from "@clerk/vue";
+</script>
+
+<template>
+${header}
+    <RouterView />
+</template>
+`
+    : `<template>
+  <RouterView />
+</template>
+`;
+
+  return {
+    path: appPath,
+    type: "modify",
+    content,
+    description: ctx.isBootstrap
+      ? "Replace template with <RouterView /> and add auth header"
+      : "Replace template with <RouterView /> for vue-router",
+  };
+}
+
 async function scaffoldRouter(ctx: ProjectContext): Promise<FileAction | null> {
   const routerPath = await findRouterFile(ctx);
   if (!routerPath) return null;
@@ -158,9 +233,10 @@ export const vue: FrameworkScaffold = {
   async scaffold(ctx: ProjectContext): Promise<ScaffoldPlan> {
     const tailwind = hasTailwindStyles(ctx);
     const base = srcPrefix(ctx);
+    const needsRouterBootstrap = ctx.isBootstrap && !ctx.deps["vue-router"];
 
     const [entryAction, authActions, envAction, routerAction] = await Promise.all([
-      scaffoldEntry(ctx),
+      scaffoldEntry(ctx, needsRouterBootstrap),
       scaffoldAuthFiles(
         ctx.cwd,
         authFileSpecs({
@@ -170,13 +246,19 @@ export const vue: FrameworkScaffold = {
         }),
       ),
       scaffoldEnvVars(ctx, SIGN_ROUTE_ENV_VARS.vite),
-      scaffoldRouter(ctx),
+      needsRouterBootstrap ? null : scaffoldRouter(ctx),
     ]);
 
     const actions: FileAction[] = [entryAction, ...authActions, envAction];
     const postInstructions: string[] = [];
+    const additionalDeps: string[] = [];
 
-    if (routerAction) {
+    if (needsRouterBootstrap) {
+      actions.push(scaffoldNewRouter(ctx));
+      const appVueAction = await scaffoldAppVue(ctx, tailwind);
+      if (appVueAction) actions.push(appVueAction);
+      additionalDeps.push("vue-router");
+    } else if (routerAction) {
       actions.push(routerAction);
     } else if (ctx.deps["vue-router"]) {
       postInstructions.push(
@@ -184,6 +266,6 @@ export const vue: FrameworkScaffold = {
       );
     }
 
-    return { actions, postInstructions };
+    return { actions, postInstructions, additionalDeps };
   },
 };

--- a/packages/cli-core/src/commands/init/frameworks/vue.ts
+++ b/packages/cli-core/src/commands/init/frameworks/vue.ts
@@ -8,6 +8,7 @@ import {
   htmlAuthComponentMarkup,
   indentBlock,
   insertAfterLastImport,
+  MISSING_PUBLISHABLE_KEY_ERROR,
   safeAddImport,
   scaffoldAuthFiles,
   scaffoldEnvVars,
@@ -23,22 +24,16 @@ async function findEntryFile(ctx: ProjectContext): Promise<string | null> {
 }
 
 function addClerkPluginSetup(source: string): string {
-  const keyBlock = `\nconst PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;\nif (!PUBLISHABLE_KEY) {\n  throw new Error("Missing VITE_CLERK_PUBLISHABLE_KEY. Add your key to .env.local.\\nRun: 1) clerk auth login  2) clerk link  3) clerk env pull — then restart the dev server.");\n}\n`;
-
-  let result = source;
-
+  const keyBlock = `\nconst PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;\nif (!PUBLISHABLE_KEY) {\n  throw new Error("${MISSING_PUBLISHABLE_KEY_ERROR}");\n}\n`;
   const useClerk = `app.use(clerkPlugin, { publishableKey: PUBLISHABLE_KEY });`;
 
   // Handle chained pattern: createApp(App).mount(...) -> split into separate statements
   const chainedPattern = /(createApp\([^)]*\))\.mount\s*\(([^)]*)\)/;
-  if (chainedPattern.test(result)) {
-    result = result.replace(chainedPattern, `const app = $1;\n${useClerk}\napp.mount($2)`);
-  } else {
-    // Handle variable pattern: app.mount(...) -> insert app.use() before it
-    result = result.replace(/((\w+)\.mount\s*\()/, `${useClerk}\n$1`);
-  }
+  const withPlugin = chainedPattern.test(source)
+    ? source.replace(chainedPattern, `const app = $1;\n${useClerk}\napp.mount($2)`)
+    : source.replace(/((\w+)\.mount\s*\()/, `${useClerk}\n$1`);
 
-  return insertAfterLastImport(result, keyBlock);
+  return insertAfterLastImport(withPlugin, keyBlock);
 }
 
 function newEntryContent(withRouter = false): string {
@@ -50,7 +45,7 @@ import App from "./App.vue";
 ${routerImport}
 const PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
 if (!PUBLISHABLE_KEY) {
-  throw new Error("Missing VITE_CLERK_PUBLISHABLE_KEY. Add your key to .env.local.\\nRun: 1) clerk auth login  2) clerk link  3) clerk env pull — then restart the dev server.");
+  throw new Error("${MISSING_PUBLISHABLE_KEY_ERROR}");
 }
 
 const app = createApp(App);
@@ -117,8 +112,12 @@ async function findRouterFile(ctx: ProjectContext): Promise<string | null> {
   return findFirstFile(ctx.cwd, [`${base}router/index.${ext}`, `${base}router.${ext}`]);
 }
 
+function hasSignRoutes(source: string): boolean {
+  return source.includes("/sign-in") || source.includes("/sign-up");
+}
+
 function addSignRoutes(source: string, viewPrefix: string): string {
-  if (source.includes("/sign-in") || source.includes("/sign-up")) {
+  if (hasSignRoutes(source)) {
     return source;
   }
 
@@ -190,7 +189,7 @@ async function scaffoldRouter(ctx: ProjectContext): Promise<FileAction | null> {
 
   const content = await Bun.file(join(ctx.cwd, routerPath)).text();
 
-  if (content.includes("/sign-in") || content.includes("/sign-up")) {
+  if (hasSignRoutes(content)) {
     return { type: "skip", path: routerPath, skipReason: "Already has sign-in/sign-up routes" };
   }
 

--- a/packages/cli-core/src/commands/init/frameworks/vue.ts
+++ b/packages/cli-core/src/commands/init/frameworks/vue.ts
@@ -23,23 +23,19 @@ async function findEntryFile(ctx: ProjectContext): Promise<string | null> {
 }
 
 function addClerkPluginSetup(source: string): string {
-  const keyBlock = `\nconst PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;\n\nif (!PUBLISHABLE_KEY) {\n  throw new Error("Add your Clerk Publishable Key to the .env file");\n}\n`;
+  const keyBlock = `\nconst PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;\nif (!PUBLISHABLE_KEY) {\n  throw new Error("Missing VITE_CLERK_PUBLISHABLE_KEY. Add your key to .env.local.\\nRun: 1) clerk auth login  2) clerk link  3) clerk env pull — then restart the dev server.");\n}\n`;
 
   let result = source;
+
+  const useClerk = `app.use(clerkPlugin, { publishableKey: PUBLISHABLE_KEY });`;
 
   // Handle chained pattern: createApp(App).mount(...) -> split into separate statements
   const chainedPattern = /(createApp\([^)]*\))\.mount\s*\(([^)]*)\)/;
   if (chainedPattern.test(result)) {
-    result = result.replace(
-      chainedPattern,
-      `const app = $1;\napp.use(clerkPlugin, { publishableKey: PUBLISHABLE_KEY });\napp.mount($2)`,
-    );
+    result = result.replace(chainedPattern, `const app = $1;\n${useClerk}\napp.mount($2)`);
   } else {
     // Handle variable pattern: app.mount(...) -> insert app.use() before it
-    result = result.replace(
-      /((\w+)\.mount\s*\()/,
-      `$2.use(clerkPlugin, { publishableKey: PUBLISHABLE_KEY });\n$1`,
-    );
+    result = result.replace(/((\w+)\.mount\s*\()/, `${useClerk}\n$1`);
   }
 
   return insertAfterLastImport(result, keyBlock);
@@ -53,9 +49,8 @@ import { clerkPlugin } from "@clerk/vue";
 import App from "./App.vue";
 ${routerImport}
 const PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
-
 if (!PUBLISHABLE_KEY) {
-  throw new Error("Add your Clerk Publishable Key to the .env file");
+  throw new Error("Missing VITE_CLERK_PUBLISHABLE_KEY. Add your key to .env.local.\\nRun: 1) clerk auth login  2) clerk link  3) clerk env pull — then restart the dev server.");
 }
 
 const app = createApp(App);
@@ -91,21 +86,16 @@ async function scaffoldEntry(ctx: ProjectContext, withRouter = false): Promise<F
   }
 
   // Add the publishable key constant and app.use() call before app.mount()
-  if (newContent.includes(".mount(")) {
-    newContent = addClerkPluginSetup(newContent);
-    if (withRouter) {
-      newContent = newContent.replace(/(.+\.mount\s*\()/, `app.use(router);\n$1`);
-    }
-  }
+  const hasMount = newContent.includes(".mount(");
+  if (hasMount) newContent = addClerkPluginSetup(newContent);
+  if (hasMount && withRouter)
+    newContent = newContent.replace(/(.+\.mount\s*\()/, `app.use(router);\n$1`);
 
-  return {
-    path: entryPath,
-    type: "modify",
-    content: newContent,
-    description: withRouter
-      ? "Add clerkPlugin with publishableKey and vue-router to Vue app"
-      : "Add clerkPlugin with publishableKey to Vue app",
-  };
+  const description = withRouter
+    ? "Add clerkPlugin with publishableKey and vue-router to Vue app"
+    : "Add clerkPlugin with publishableKey to Vue app";
+
+  return { path: entryPath, type: "modify", content: newContent, description };
 }
 
 function authPageContent(kind: "sign-in" | "sign-up", tailwind: boolean): string {
@@ -176,29 +166,21 @@ async function scaffoldAppVue(ctx: ProjectContext, tailwind: boolean): Promise<F
   const appPath = await findFirstFile(ctx.cwd, [`${base}App.vue`]);
   if (!appPath) return null;
 
+  if (!ctx.isBootstrap) {
+    return {
+      path: appPath,
+      type: "modify",
+      content: `<template>\n  <RouterView />\n</template>\n`,
+      description: "Replace template with <RouterView /> for vue-router",
+    };
+  }
+
   const header = headerHtmlBlock("    ", tailwind);
-  const content = ctx.isBootstrap
-    ? `<script setup>
-import { Show, SignInButton, SignUpButton, UserButton } from "@clerk/vue";
-</script>
-
-<template>
-${header}
-    <RouterView />
-</template>
-`
-    : `<template>
-  <RouterView />
-</template>
-`;
-
   return {
     path: appPath,
     type: "modify",
-    content,
-    description: ctx.isBootstrap
-      ? "Replace template with <RouterView /> and add auth header"
-      : "Replace template with <RouterView /> for vue-router",
+    content: `<script setup>\nimport { Show, SignInButton, SignUpButton, UserButton } from "@clerk/vue";\n</script>\n\n<template>\n${header}\n    <RouterView />\n</template>\n`,
+    description: "Replace template with <RouterView /> and add auth header",
   };
 }
 

--- a/packages/cli-core/src/commands/init/heuristics.ts
+++ b/packages/cli-core/src/commands/init/heuristics.ts
@@ -16,12 +16,16 @@ async function runPmInstall(
   addCmd: string,
   packages: string[],
   label: string,
+  { fromLockfile = false }: { fromLockfile?: boolean } = {},
 ): Promise<void> {
   const pmBinary = addCmd.split(" ")[0]!;
   const manualCmd = `${addCmd} ${packages.join(" ")}`;
 
   if (Bun.which(pmBinary) === null) {
-    log.warn(`${pmBinary} is not installed. Install manually: ${manualCmd}`);
+    const hint = fromLockfile
+      ? ` (detected from lockfile — install ${pmBinary} or switch package managers)`
+      : "";
+    log.warn(`${pmBinary} is not installed${hint}. Install manually: ${manualCmd}`);
     return;
   }
 
@@ -59,6 +63,7 @@ export async function installSdk(ctx: ProjectContext): Promise<void> {
     addCmd,
     [installPkg],
     `${cyan(ctx.framework.sdk)} for ${ctx.framework.name}`,
+    { fromLockfile: true },
   );
 }
 

--- a/packages/cli-core/src/commands/init/heuristics.ts
+++ b/packages/cli-core/src/commands/init/heuristics.ts
@@ -53,10 +53,11 @@ export async function installDeps(ctx: ProjectContext, packages: string[]): Prom
 
 export async function installSdk(ctx: ProjectContext): Promise<void> {
   const addCmd = pmInstallCommand(ctx.packageManager);
+  const installPkg = ctx.framework.sdkInstall ?? ctx.framework.sdk;
   await runPmInstall(
     ctx.cwd,
     addCmd,
-    [ctx.framework.sdk],
+    [installPkg],
     `${cyan(ctx.framework.sdk)} for ${ctx.framework.name}`,
   );
 }

--- a/packages/cli-core/src/commands/init/heuristics.ts
+++ b/packages/cli-core/src/commands/init/heuristics.ts
@@ -11,45 +11,54 @@ import { withSpinner } from "../../lib/spinner.js";
 import type { FileAction, ProjectContext, ScaffoldPlan } from "./frameworks/types.js";
 import type { ScanFinding } from "./scan.js";
 
-export async function installSdk(ctx: ProjectContext): Promise<void> {
-  const addCmd = pmInstallCommand(ctx.packageManager);
+async function runPmInstall(
+  cwd: string,
+  addCmd: string,
+  packages: string[],
+  label: string,
+): Promise<void> {
+  const pmBinary = addCmd.split(" ")[0]!;
+  const manualCmd = `${addCmd} ${packages.join(" ")}`;
 
-  // The package manager is detected from lockfiles, which can exist without
-  // the actual binary being installed (e.g. teammate committed bun.lock, you
-  // only have npm). Fail fast with a useful message rather than a raw ENOENT.
-  const pmBinary = addCmd.split(" ")[0] ?? addCmd;
   if (Bun.which(pmBinary) === null) {
-    log.warn(
-      `${pmBinary} is not installed but the project's lockfile suggests it. ` +
-        `Install ${pmBinary} or run \`${addCmd} ${ctx.framework.sdk}\` manually with another package manager.`,
-    );
+    log.warn(`${pmBinary} is not installed. Install manually: ${manualCmd}`);
     return;
   }
 
-  log.info(`Installing ${cyan(ctx.framework.sdk)} for ${ctx.framework.name}...`);
+  log.info(`Installing ${label}...`);
 
-  // try/catch covers the TOCTOU window between Bun.which and spawn.
   let exitCode: number;
   try {
-    const proc = Bun.spawn(addCmd.split(" ").concat(ctx.framework.sdk), {
-      cwd: ctx.cwd,
+    const proc = Bun.spawn(addCmd.split(" ").concat(packages), {
+      cwd,
       stdout: "inherit",
       stderr: "inherit",
     });
     exitCode = await proc.exited;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    log.warn(
-      `Failed to spawn ${addCmd}: ${message}. You can install manually: ${addCmd} ${ctx.framework.sdk}`,
-    );
+    log.warn(`Failed to spawn ${addCmd}: ${message}. Install manually: ${manualCmd}`);
     return;
   }
 
   if (exitCode !== 0) {
-    log.warn(
-      `Failed to install ${ctx.framework.sdk}. You can install it manually: ${addCmd} ${ctx.framework.sdk}`,
-    );
+    log.warn(`Failed to install ${packages.join(", ")}. Install manually: ${manualCmd}`);
   }
+}
+
+export async function installDeps(ctx: ProjectContext, packages: string[]): Promise<void> {
+  const addCmd = pmInstallCommand(ctx.packageManager);
+  await runPmInstall(ctx.cwd, addCmd, packages, packages.map(cyan).join(", "));
+}
+
+export async function installSdk(ctx: ProjectContext): Promise<void> {
+  const addCmd = pmInstallCommand(ctx.packageManager);
+  await runPmInstall(
+    ctx.cwd,
+    addCmd,
+    [ctx.framework.sdk],
+    `${cyan(ctx.framework.sdk)} for ${ctx.framework.name}`,
+  );
 }
 
 export async function writePlan(cwd: string, plan: ScaffoldPlan): Promise<string[]> {

--- a/packages/cli-core/src/commands/init/index.test.ts
+++ b/packages/cli-core/src/commands/init/index.test.ts
@@ -27,7 +27,8 @@ const FAKE_CTX = {
     name: "React",
     sdk: "@clerk/react",
     envVar: "VITE_CLERK_PUBLISHABLE_KEY",
-    envFile: ".env.local" as const,
+    envFile: ".env" as const,
+    supportsKeyless: true,
   },
   typescript: true,
   srcDir: false,
@@ -78,6 +79,7 @@ describe("init", () => {
       spyOn(heuristics, "getAuthenticatedEmail").mockResolvedValue(email),
       spyOn(heuristics, "printKeylessInfo").mockReturnValue(undefined),
       spyOn(heuristics, "installSdk").mockResolvedValue(undefined),
+      spyOn(heuristics, "installDeps").mockResolvedValue(undefined),
       spyOn(heuristics, "writePlan").mockResolvedValue([]),
       spyOn(heuristics, "checkGitDirty").mockResolvedValue(false),
       spyOn(heuristics, "printOutro").mockReturnValue(undefined),
@@ -136,10 +138,21 @@ describe("init", () => {
     expect(linkMod.link).toHaveBeenCalledWith({ skipIfLinked: true, app: "app_abc" });
   });
 
-  test("agent mode prints guidance without auth/bootstrap", async () => {
-    const { captured } = setup({ isAgent: true });
+  test("agent mode runs existing-project flow without prompts", async () => {
+    setup({ isAgent: true });
+    spyOn(context, "gatherContext").mockResolvedValue(FAKE_CTX);
 
-    await captured.run(() => init({}));
+    await init({});
+
+    expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
+    expect(previewMod.previewAndConfirm).not.toHaveBeenCalled();
+    expect(bootstrapMod.promptAndBootstrap).not.toHaveBeenCalled();
+  });
+
+  test("--prompt flag prints guidance and exits", async () => {
+    const { captured } = setup({ isAgent: false });
+
+    await captured.run(() => init({ prompt: true }));
 
     expect(captured.out).toContain("clerk init -y");
     expect(loginMod.login).not.toHaveBeenCalled();
@@ -165,6 +178,33 @@ describe("init", () => {
     expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalled();
     expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
     expect(heuristics.getAuthenticatedEmail).not.toHaveBeenCalled();
+  });
+
+  test("-y flag forces auth for frameworks without keyless support", async () => {
+    setup();
+
+    const noKeylessCtx = {
+      ...FAKE_CTX,
+      framework: {
+        dep: "vue",
+        name: "Vue",
+        sdk: "@clerk/vue",
+        envVar: "VITE_CLERK_PUBLISHABLE_KEY",
+        envFile: ".env.local" as const,
+      },
+      existingClerk: false,
+    };
+
+    spyOn(context, "gatherContext").mockResolvedValueOnce(null).mockResolvedValueOnce(noKeylessCtx);
+
+    await init({ yes: true });
+
+    expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalled();
+    // Should not ask about skipping auth — keyless not supported
+    expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
+    // Should force authentication since framework lacks keyless support
+    expect(heuristics.getAuthenticatedEmail).toHaveBeenCalled();
+    expect(heuristics.printKeylessInfo).not.toHaveBeenCalled();
   });
 
   test("blank dir bootstrap declined throws UserAbortError", async () => {
@@ -204,7 +244,7 @@ describe("init", () => {
       name: "Next.js",
       sdk: "@clerk/nextjs",
       envVar: "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
-      envFile: ".env" as const,
+      envFile: ".env.local" as const,
     };
     setup({ email: "test@test.com" });
     spyOn(frameworkMod, "lookupFramework").mockReturnValue(fwOverride);
@@ -215,6 +255,8 @@ describe("init", () => {
 
     expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalledWith(expect.any(String), fwOverride, {
       skipConfirm: true,
+      pmOverride: undefined,
+      nameOverride: undefined,
     });
   });
 
@@ -227,6 +269,8 @@ describe("init", () => {
 
     expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalledWith(expect.any(String), undefined, {
       skipConfirm: true,
+      pmOverride: undefined,
+      nameOverride: undefined,
     });
     // --yes skips confirmOverwrite
     expect(bootstrapMod.confirmOverwrite).not.toHaveBeenCalled();
@@ -268,13 +312,18 @@ describe("init", () => {
     );
   });
 
-  test("--starter in agent mode prints guidance without bootstrap", async () => {
-    const { captured } = setup({ isAgent: true });
+  test("--starter in agent mode runs bootstrap with skipConfirm", async () => {
+    setup({ isAgent: true });
+    spyOn(context, "gatherContext").mockResolvedValue(FAKE_CTX);
 
-    await captured.run(() => init({ starter: true }));
+    await init({ starter: true, framework: "react" });
 
-    expect(captured.out).toContain("clerk init -y");
-    expect(bootstrapMod.promptAndBootstrap).not.toHaveBeenCalled();
+    expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalledWith(
+      expect.any(String),
+      undefined,
+      expect.objectContaining({ skipConfirm: true }),
+    );
+    expect(bootstrapMod.confirmOverwrite).not.toHaveBeenCalled();
   });
 
   test("short-circuits env pull and skills install when already set up", async () => {
@@ -296,6 +345,40 @@ describe("init", () => {
     expect(pullMod.pull).not.toHaveBeenCalled();
     expect(heuristics.printKeylessInfo).not.toHaveBeenCalled();
     expect(skillsMod.installSkills).not.toHaveBeenCalled();
+  });
+
+  test("--pm overrides detected package manager in existing-project flow", async () => {
+    setup({ email: "test@test.com" });
+    spyOn(context, "gatherContext").mockResolvedValue(FAKE_CTX);
+    spyOn(config, "resolveProfile").mockResolvedValue({ profile: { appId: "app_123" } } as never);
+
+    await init({ pm: "pnpm", yes: true });
+
+    expect(context.gatherContext).toHaveBeenCalledWith(expect.any(String), undefined, "pnpm");
+  });
+
+  test("--pm and --name are threaded to bootstrap", async () => {
+    setup({ email: "test@test.com" });
+    spyOn(context, "gatherContext").mockResolvedValue(FAKE_CTX);
+    spyOn(config, "resolveProfile").mockResolvedValue({ profile: { appId: "app_123" } } as never);
+
+    await init({ starter: true, yes: true, pm: "bun", name: "my-project" });
+
+    expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalledWith(expect.any(String), undefined, {
+      skipConfirm: true,
+      pmOverride: "bun",
+      nameOverride: "my-project",
+    });
+  });
+
+  test("agent mode skips all confirmations implicitly", async () => {
+    setup({ isAgent: true });
+    spyOn(context, "gatherContext").mockResolvedValue(FAKE_CTX);
+
+    await init({});
+
+    // installSkills receives skipConfirm=true from agent mode
+    expect(skillsMod.installSkills).not.toHaveBeenCalled(); // alreadySetUp short-circuits
   });
 
   test("pulls env to ctx.envFile when authenticated and framework detected", async () => {

--- a/packages/cli-core/src/commands/init/index.test.ts
+++ b/packages/cli-core/src/commands/init/index.test.ts
@@ -28,7 +28,6 @@ const FAKE_CTX = {
     sdk: "@clerk/react",
     envVar: "VITE_CLERK_PUBLISHABLE_KEY",
     envFile: ".env" as const,
-    supportsKeyless: true,
   },
   typescript: true,
   srcDir: false,
@@ -62,7 +61,6 @@ describe("init", () => {
     const gatherContextSpy = spyOn(context, "gatherContext").mockResolvedValue(null);
 
     spies = [
-      spyOn(console, "log").mockImplementation(() => {}),
       spyOn(mode, "isAgent").mockReturnValue(agent),
       spyOn(mode, "isHuman").mockReturnValue(!agent),
       spyOn(config, "resolveProfile").mockResolvedValue(undefined),
@@ -162,6 +160,25 @@ describe("init", () => {
   test("blank dir in human mode triggers bootstrap flow", async () => {
     setup();
     setupBootstrapSuccess();
+
+    await init({});
+
+    expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalled();
+    // React doesn't support keyless, so askSkipAuth is never called
+    expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
+  });
+
+  test("blank dir with keyless framework prompts askSkipAuth", async () => {
+    setup();
+
+    const keylessCtx = {
+      ...FAKE_CTX,
+      framework: {
+        ...FAKE_CTX.framework,
+        supportsKeyless: true,
+      },
+    };
+    spyOn(context, "gatherContext").mockResolvedValueOnce(null).mockResolvedValueOnce(keylessCtx);
 
     await init({});
 

--- a/packages/cli-core/src/commands/init/index.test.ts
+++ b/packages/cli-core/src/commands/init/index.test.ts
@@ -180,7 +180,7 @@ describe("init", () => {
     expect(heuristics.getAuthenticatedEmail).not.toHaveBeenCalled();
   });
 
-  test("-y flag forces auth for frameworks without keyless support", async () => {
+  test("-y flag skips auth for frameworks without keyless support in bootstrap", async () => {
     setup();
 
     const noKeylessCtx = {
@@ -202,8 +202,9 @@ describe("init", () => {
     expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalled();
     // Should not ask about skipping auth — keyless not supported
     expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
-    // Should force authentication since framework lacks keyless support
-    expect(heuristics.getAuthenticatedEmail).toHaveBeenCalled();
+    // Should skip auth in non-interactive bootstrap — user connects later
+    expect(heuristics.getAuthenticatedEmail).not.toHaveBeenCalled();
+    expect(loginMod.login).not.toHaveBeenCalled();
     expect(heuristics.printKeylessInfo).not.toHaveBeenCalled();
   });
 

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -206,7 +206,7 @@ function printManualSetupInfo(frameworkName: string): void {
     "    clerk link",
     "    clerk env pull",
   ];
-  console.log(lines.map(dim).join("\n"));
+  log.info(lines.map(dim).join("\n"));
 }
 
 // --- Keyless ---
@@ -219,10 +219,10 @@ async function resolveKeylessMode(
   if (!bootstrap) return false;
 
   if (ctx.framework.supportsKeyless) {
-    return skipConfirm || askSkipAuth();
+    return skipConfirm || (await askSkipAuth());
   }
 
-  console.log(
+  log.info(
     dim(
       `\n  ${ctx.framework.name} requires API keys — keyless mode is not yet supported for this framework.`,
     ),

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -90,7 +90,9 @@ export async function init(options: InitOptions = {}) {
   const keyless = await resolveKeylessMode(bootstrap, ctx, overrides.skipConfirm);
   ctx.keyless = keyless;
 
-  if (!keyless) {
+  const skipAuth = !keyless && bootstrap != null && overrides.skipConfirm;
+
+  if (!keyless && !skipAuth) {
     bar();
     await authenticateAndLink(ctx.cwd, options.app);
   }
@@ -106,7 +108,9 @@ export async function init(options: InitOptions = {}) {
   }
 
   bar();
-  if (!keyless) {
+  if (skipAuth) {
+    printManualSetupInfo(ctx.framework.name);
+  } else if (!keyless) {
     await pull({ file: ctx.envFile });
   } else {
     printKeylessInfo();
@@ -193,6 +197,16 @@ function printBootstrapNextSteps(
     steps.push("clerk auth login  (when you're ready to connect your Clerk account)");
   }
   printNextSteps(steps);
+}
+
+function printManualSetupInfo(frameworkName: string): void {
+  const lines = [
+    `\n  ${frameworkName} requires API keys — set them up manually:`,
+    "    clerk auth login",
+    "    clerk link",
+    "    clerk env pull",
+  ];
+  console.log(lines.map(dim).join("\n"));
 }
 
 // --- Keyless ---

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -109,7 +109,7 @@ export async function init(options: InitOptions = {}) {
 
   bar();
   if (skipAuth) {
-    printManualSetupInfo(ctx.framework.name);
+    printBootstrapManualSetupInfo(ctx.framework.name);
   } else if (!keyless) {
     await pull({ file: ctx.envFile });
   } else {
@@ -122,7 +122,7 @@ export async function init(options: InitOptions = {}) {
 
   if (options.skills !== false) {
     bar();
-    await installSkills(ctx.cwd, ctx?.framework.dep, ctx?.packageManager, overrides.skipConfirm);
+    await installSkills(ctx.cwd, ctx.framework.dep, ctx.packageManager, overrides.skipConfirm);
   }
 
   outro("Done");
@@ -199,7 +199,7 @@ function printBootstrapNextSteps(
   printNextSteps(steps);
 }
 
-function printManualSetupInfo(frameworkName: string): void {
+function printBootstrapManualSetupInfo(frameworkName: string): void {
   const lines = [
     `\n  ${frameworkName} requires API keys — set them up manually:`,
     "    clerk auth login",

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -15,6 +15,7 @@ import { runFormatters } from "./format.js";
 import { detectAuthLibraries, scanForIssues } from "./scan.js";
 import {
   installSdk,
+  installDeps,
   writePlan,
   checkGitDirty,
   printOutro,
@@ -27,14 +28,17 @@ import {
   promptAndBootstrap,
   confirmOverwrite,
   askSkipAuth,
+  type BootstrapOverrides,
   type BootstrapResult,
 } from "./bootstrap.js";
 import type { ProjectContext } from "./frameworks/types.js";
+import type { PackageManager } from "./bootstrap-registry.js";
 
 type InitOptions = {
   /** Framework to set up (skips auto-detection). */
   framework?: string;
-  /** Skip confirmation prompts (in bootstrap mode, also skips authentication so you can connect your account later). */
+  pm?: PackageManager;
+  name?: string;
   yes?: boolean;
   /** Output a prompt for an AI agent to integrate Clerk, then exit. */
   prompt?: boolean;
@@ -53,18 +57,25 @@ export async function init(options: InitOptions = {}) {
     ? (lookupFramework(options.framework) ?? undefined)
     : undefined;
 
-  if (options.prompt || isAgent()) {
+  if (options.prompt) {
     log.data(
       "Run `clerk init -y` to automatically detect the framework, install the Clerk SDK, and scaffold authentication files without interactive prompts.",
     );
     return;
   }
 
+  // In agent mode, implicitly enable --yes to skip all confirmation prompts.
+  const overrides: BootstrapOverrides = {
+    skipConfirm: options.yes || isAgent(),
+    pmOverride: options.pm,
+    nameOverride: options.name,
+  };
+
   intro("clerk init");
 
   const resolved = options.starter
-    ? await handleStarter(cwd, frameworkOverride, options.yes)
-    : await resolveProjectContext(cwd, frameworkOverride, options.yes);
+    ? await handleStarter(cwd, frameworkOverride, overrides)
+    : await resolveProjectContext(cwd, frameworkOverride, overrides);
 
   if (!resolved) return;
 
@@ -76,7 +87,7 @@ export async function init(options: InitOptions = {}) {
 
   await enrichProjectContext(ctx);
 
-  const keyless = bootstrap ? options.yes || (await askSkipAuth()) : false;
+  const keyless = await resolveKeylessMode(bootstrap, ctx, overrides.skipConfirm);
   ctx.keyless = keyless;
 
   if (!keyless) {
@@ -86,7 +97,7 @@ export async function init(options: InitOptions = {}) {
 
   // Short-circuit on a fully-clean re-run so env pull / skills prompt don't
   // execute when there's nothing to do.
-  const { alreadySetUp } = await detectAndInstall(ctx.cwd, ctx, options);
+  const { alreadySetUp } = await detectAndInstall(ctx.cwd, ctx, overrides.skipConfirm);
 
   if (alreadySetUp) {
     log.success("\nClerk is already set up in this project.");
@@ -107,7 +118,7 @@ export async function init(options: InitOptions = {}) {
 
   if (options.skills !== false) {
     bar();
-    await installSkills(ctx.cwd, ctx?.framework.dep, ctx?.packageManager, options.yes ?? false);
+    await installSkills(ctx.cwd, ctx?.framework.dep, ctx?.packageManager, overrides.skipConfirm);
   }
 
   outro("Done");
@@ -122,10 +133,10 @@ type ResolvedContext = {
 
 async function bootstrapAndDetect(
   cwd: string,
-  frameworkOverride?: FrameworkInfo,
-  skipConfirm = false,
+  frameworkOverride: FrameworkInfo | undefined,
+  overrides: BootstrapOverrides,
 ): Promise<ResolvedContext> {
-  const bootstrap = await promptAndBootstrap(cwd, frameworkOverride, { skipConfirm });
+  const bootstrap = await promptAndBootstrap(cwd, frameworkOverride, overrides);
 
   const ctx = await gatherContext(bootstrap.projectDir);
   if (!ctx) {
@@ -136,23 +147,23 @@ async function bootstrapAndDetect(
 
 async function handleStarter(
   cwd: string,
-  frameworkOverride?: FrameworkInfo,
-  skipConfirm = false,
+  frameworkOverride: FrameworkInfo | undefined,
+  overrides: BootstrapOverrides,
 ): Promise<ResolvedContext> {
-  if (!skipConfirm) {
+  if (!overrides.skipConfirm) {
     await confirmOverwrite(cwd);
   }
 
-  return bootstrapAndDetect(cwd, frameworkOverride, true);
+  return bootstrapAndDetect(cwd, frameworkOverride, { ...overrides, skipConfirm: true });
 }
 
 async function resolveProjectContext(
   cwd: string,
-  frameworkOverride?: FrameworkInfo,
-  skipConfirm = false,
+  frameworkOverride: FrameworkInfo | undefined,
+  overrides: BootstrapOverrides,
 ): Promise<ResolvedContext> {
   const ctx = await withSpinner("Detecting framework...", () =>
-    gatherContext(cwd, frameworkOverride),
+    gatherContext(cwd, frameworkOverride, overrides.pmOverride),
   );
   if (ctx) return { ctx, bootstrap: null };
 
@@ -164,7 +175,7 @@ async function resolveProjectContext(
     );
   }
 
-  return bootstrapAndDetect(cwd, frameworkOverride, skipConfirm);
+  return bootstrapAndDetect(cwd, frameworkOverride, overrides);
 }
 
 // --- Next steps ---
@@ -182,6 +193,27 @@ function printBootstrapNextSteps(
     steps.push("clerk auth login  (when you're ready to connect your Clerk account)");
   }
   printNextSteps(steps);
+}
+
+// --- Keyless ---
+
+async function resolveKeylessMode(
+  bootstrap: BootstrapResult | null,
+  ctx: ProjectContext,
+  skipConfirm: boolean,
+): Promise<boolean> {
+  if (!bootstrap) return false;
+
+  if (ctx.framework.supportsKeyless) {
+    return skipConfirm || askSkipAuth();
+  }
+
+  console.log(
+    dim(
+      `\n  ${ctx.framework.name} requires API keys — keyless mode is not yet supported for this framework.`,
+    ),
+  );
+  return false;
 }
 
 // --- Auth ---
@@ -220,7 +252,7 @@ async function authenticateAndLink(cwd: string, app: string | undefined): Promis
 async function detectAndInstall(
   cwd: string,
   ctx: ProjectContext,
-  options: InitOptions,
+  skipConfirm: boolean,
 ): Promise<{ alreadySetUp: boolean }> {
   const variantLabel = ctx.variant ? ` (${ctx.variant})` : "";
   log.info(`\nDetected ${bold(ctx.framework.name)}${variantLabel}`);
@@ -234,13 +266,13 @@ async function detectAndInstall(
     await installSdk(ctx);
   }
 
-  return await scaffoldAndWrite(cwd, ctx, options);
+  return await scaffoldAndWrite(cwd, ctx, skipConfirm);
 }
 
 async function scaffoldAndWrite(
   cwd: string,
   ctx: ProjectContext,
-  options: InitOptions,
+  skipConfirm: boolean,
 ): Promise<{ alreadySetUp: boolean }> {
   const plan = await scaffold(ctx);
   const hasChanges = plan.actions.some((a) => a.type !== "skip");
@@ -263,11 +295,15 @@ async function scaffoldAndWrite(
     log.info(dim("Consider committing first so you can review what clerk init creates.\n"));
   }
 
-  if (options.yes) {
+  if (skipConfirm) {
     previewPlan(plan);
   } else {
     const proceed = await previewAndConfirm(plan);
     if (!proceed) throwUserAbort();
+  }
+
+  if (plan.additionalDeps?.length) {
+    await installDeps(ctx, plan.additionalDeps);
   }
 
   const writtenFiles = await writePlan(cwd, plan);

--- a/packages/cli-core/src/lib/framework.ts
+++ b/packages/cli-core/src/lib/framework.ts
@@ -83,7 +83,6 @@ export const FRAMEWORK_MAP: FrameworkInfo[] = [
     sdk: "@clerk/react",
     envVar: "VITE_CLERK_PUBLISHABLE_KEY",
     envFile: ".env.local",
-    supportsKeyless: true,
   },
   {
     dep: "vite",

--- a/packages/cli-core/src/lib/framework.ts
+++ b/packages/cli-core/src/lib/framework.ts
@@ -9,6 +9,8 @@ export interface FrameworkInfo {
   dep: string;
   name: string;
   sdk: string;
+  /** Override the install specifier when it differs from the package name (e.g. pinned version). */
+  sdkInstall?: string;
   envVar: string;
   /** Override for secret key env var name. Defaults to CLERK_SECRET_KEY when omitted. */
   secretKeyEnvVar?: string;
@@ -43,9 +45,12 @@ export const FRAMEWORK_MAP: FrameworkInfo[] = [
     dep: "nuxt",
     name: "Nuxt",
     sdk: "@clerk/nuxt",
+    // TODO: Remove sdkInstall once @clerk/nuxt stable (>=2.2.0) ships with keyless support
+    sdkInstall: "@clerk/nuxt@2.2.0-snapshot.v20260413174426",
     envVar: "NUXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
     secretKeyEnvVar: "NUXT_CLERK_SECRET_KEY",
     envFile: ".env",
+    supportsKeyless: true,
   },
   {
     dep: "@tanstack/react-start",

--- a/packages/cli-core/src/lib/framework.ts
+++ b/packages/cli-core/src/lib/framework.ts
@@ -15,6 +15,10 @@ export interface FrameworkInfo {
   /** Preferred env file for secrets. Frameworks that gitignore `.env` use it
    *  directly; Vite-based frameworks use `.env.local` since `.env` is tracked. */
   envFile: ".env" | ".env.local";
+  /** When true, the framework's Clerk SDK supports keyless mode (auto-generated
+   *  temporary dev keys). Frameworks without keyless support require API keys
+   *  and must authenticate during `clerk init`. */
+  supportsKeyless?: boolean;
 }
 
 // Order matters: more specific frameworks first (e.g. next before react, nuxt before vue)
@@ -25,6 +29,7 @@ export const FRAMEWORK_MAP: FrameworkInfo[] = [
     sdk: "@clerk/nextjs",
     envVar: "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
     envFile: ".env",
+    supportsKeyless: true,
   },
   {
     dep: "astro",
@@ -32,6 +37,7 @@ export const FRAMEWORK_MAP: FrameworkInfo[] = [
     sdk: "@clerk/astro",
     envVar: "PUBLIC_CLERK_PUBLISHABLE_KEY",
     envFile: ".env",
+    supportsKeyless: true,
   },
   {
     dep: "nuxt",
@@ -47,6 +53,7 @@ export const FRAMEWORK_MAP: FrameworkInfo[] = [
     sdk: "@clerk/tanstack-react-start",
     envVar: "VITE_CLERK_PUBLISHABLE_KEY",
     envFile: ".env.local",
+    supportsKeyless: true,
   },
   {
     dep: "react-router",
@@ -54,6 +61,7 @@ export const FRAMEWORK_MAP: FrameworkInfo[] = [
     sdk: "@clerk/react-router",
     envVar: "VITE_CLERK_PUBLISHABLE_KEY",
     envFile: ".env.local",
+    supportsKeyless: true,
   },
   {
     dep: "vue",
@@ -75,6 +83,7 @@ export const FRAMEWORK_MAP: FrameworkInfo[] = [
     sdk: "@clerk/react",
     envVar: "VITE_CLERK_PUBLISHABLE_KEY",
     envFile: ".env.local",
+    supportsKeyless: true,
   },
   {
     dep: "vite",

--- a/packages/cli-core/src/test/integration/agent-mode.test.ts
+++ b/packages/cli-core/src/test/integration/agent-mode.test.ts
@@ -8,8 +8,8 @@ import { useIntegrationTestHarness, http, clerk } from "./lib/harness.ts";
 
 useIntegrationTestHarness();
 
-test("init outputs structured agent prompt without API calls", async () => {
-  const { stdout } = await clerk("--mode", "agent", "init");
+test("init --prompt outputs structured agent prompt without API calls", async () => {
+  const { stdout } = await clerk("init", "--prompt");
   expect(stdout).toContain("clerk init -y");
   expect(http.requests.length).toBe(0);
 });


### PR DESCRIPTION
## Summary

- **Non-interactive bootstrap**: `clerk init` now runs the full flow in agent mode (implies `--yes`). `--prompt` is separated to just print guidance.
- **New CLI options**: `--pm <manager>` overrides package manager detection, `--name <project-name>` sets the project name for `--starter` (both skip prompts).
- **Auth header injection**: During `--starter` bootstrap, all framework scaffolders inject a ready-to-use auth header with `<Show>`, `<SignInButton>`, `<SignUpButton>`, and `<UserButton>` components.
- **Keyless support flag**: `FrameworkInfo.supportsKeyless` marks which SDKs support keyless mode. Frameworks without it force authentication during init.
- **Nuxt keyless mode**: Enabled keyless for Nuxt via a snapshot SDK (`@clerk/nuxt@2.2.0-snapshot.v20260413174426`). Added `sdkInstall` field to `FrameworkInfo` for pinning install specifiers that differ from the package name.
- **Bootstrap registry split**: `BOOTSTRAP_REGISTRY` is now split into `BOOTSTRAP_KEYLESS_REGISTRY` and `BOOTSTRAP_AUTHENTICATED_REGISTRY` so the init flow can distinguish frameworks that support keyless from those requiring API keys.
- **Vue router bootstrap**: New Vue projects without `vue-router` get it installed automatically with a router config and `App.vue` updated to use `<RouterView />`.
- **Nuxt index page**: Bootstrap creates an `app/pages/index.vue` so the root route renders content instead of a blank page.
- **Astro SSR output**: Bootstrap enables `output: "server"` in the Astro config so auth middleware works out of the box.
- **JavaScript publishable key validation**: The vanilla JS scaffold now throws a clear error with actionable instructions when `VITE_CLERK_PUBLISHABLE_KEY` is missing.
- **DRY refactoring**: Unified header block generation (HTML vs JSX) via shared `buildHeaderBlock` helper. Extracted `runPmInstall`, `addBootstrapHeader`, and `resolveKeylessMode` helpers. Simplified `bootstrap.ts` by inlining `resolvePm`/`resolveName`.
- **TypeScript fixes**: Added missing `envFile` to test stubs, fixed strict null errors in regex captures, removed unused imports.

## Keyless support matrix

| Framework      | SDK                           | Keyless? |
|----------------|-------------------------------|----------|
| Next.js        | `@clerk/nextjs`               | Yes      |
| Astro          | `@clerk/astro`                | Yes      |
| Nuxt           | `@clerk/nuxt` (snapshot)      | Yes      |
| TanStack Start | `@clerk/tanstack-react-start` | Yes      |
| React Router   | `@clerk/react-router`         | Yes      |
| React          | `@clerk/react`                | No       |
| Vue            | `@clerk/vue`                  | No       |
| JavaScript     | `@clerk/clerk-js`             | No       |

## Test plan

- [x] All 65 unit/integration tests pass (`bun run test`)
- [x] Zero lint errors (`bun run lint`)
- [x] Format check passes (`bun run format`)
- [x] Manual: scaffolded all 32 framework × PM combinations (`--starter` with bun/pnpm/npm/yarn for all 8 frameworks) — all scaffold successfully
- [x] Manual: all 32 dev servers start and return HTTP 200
- [x] Manual: keyless frameworks (next, react-router, astro, nuxt, tanstack-start) auto-generate temporary dev keys
- [x] Manual: non-keyless frameworks (react, vue, javascript) show clear "requires API keys" message with instructions
- [x] Manual: sign-in/sign-up pages exist and render Clerk components for all frameworks with routing
- [x] Manual: `clerk init --starter --framework next --pm bun --name my-app` creates project non-interactively
- [x] Manual: `clerk init --prompt` prints guidance without running init