### PR TITLE
fix(login): Display currently linked application

### DIFF
--- a/packages/cli-core/src/commands/auth/login.test.ts
+++ b/packages/cli-core/src/commands/auth/login.test.ts
@@ -5,6 +5,7 @@ const mockGetToken = mock();
 const mockStoreToken = mock();
 const mockGetAuth = mock();
 const mockSetAuth = mock();
+const mockResolveProfile = mock();
 const mockExchangeCodeForToken = mock();
 const mockFetchUserInfo = mock();
 const mockStartAuthServer = mock();
@@ -21,6 +22,7 @@ mock.module("../../lib/config.ts", () => ({
   ...configStubs,
   getAuth: (...args: unknown[]) => mockGetAuth(...args),
   setAuth: (...args: unknown[]) => mockSetAuth(...args),
+  resolveProfile: (...args: unknown[]) => mockResolveProfile(...args),
 }));
 
 mock.module("../../lib/token-exchange.ts", () => ({
@@ -82,6 +84,7 @@ describe("login", () => {
     mockStoreToken.mockReset();
     mockGetAuth.mockReset();
     mockSetAuth.mockReset();
+    mockResolveProfile.mockReset();
     mockExchangeCodeForToken.mockReset();
     mockFetchUserInfo.mockReset();
     mockStartAuthServer.mockReset();
@@ -313,6 +316,113 @@ describe("login", () => {
     await expect(runLogin()).rejects.toThrow("User aborted");
     expect(mockConfirm).toHaveBeenCalled();
     expect(mockStartAuthServer).not.toHaveBeenCalled();
+  });
+
+  test("shows linked app with name and id in next steps when linked", async () => {
+    mockGetToken.mockResolvedValue(null);
+    mockBunSpawn();
+
+    const mockServer = {
+      port: 54321,
+      waitForCallback: mock().mockResolvedValue({ code: "fresh-auth-code" }),
+      stop: mock(),
+    };
+    mockStartAuthServer.mockReturnValue(mockServer);
+
+    mockExchangeCodeForToken.mockResolvedValue({
+      access_token: "new-access-token",
+      token_type: "Bearer",
+      expires_in: 3600,
+    });
+    mockStoreToken.mockResolvedValue(undefined);
+    mockFetchUserInfo.mockResolvedValue({
+      userId: "user_new",
+      email: "new@example.com",
+    });
+    mockSetAuth.mockResolvedValue(undefined);
+    mockResolveProfile.mockResolvedValue({
+      path: "/some/path",
+      profile: {
+        workspaceId: "ws_123",
+        appId: "app_abc123",
+        appName: "My App",
+        instances: { development: "ins_dev" },
+      },
+      resolvedVia: "remote",
+    });
+
+    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+    await runLogin();
+
+    expect(captured.err).toContain("Linked to `My App` (app_abc123)");
+  });
+
+  test("shows linked app with only id when appName is missing", async () => {
+    mockGetToken.mockResolvedValue(null);
+    mockBunSpawn();
+
+    const mockServer = {
+      port: 54321,
+      waitForCallback: mock().mockResolvedValue({ code: "fresh-auth-code" }),
+      stop: mock(),
+    };
+    mockStartAuthServer.mockReturnValue(mockServer);
+
+    mockExchangeCodeForToken.mockResolvedValue({
+      access_token: "new-access-token",
+      token_type: "Bearer",
+      expires_in: 3600,
+    });
+    mockStoreToken.mockResolvedValue(undefined);
+    mockFetchUserInfo.mockResolvedValue({
+      userId: "user_new",
+      email: "new@example.com",
+    });
+    mockSetAuth.mockResolvedValue(undefined);
+    mockResolveProfile.mockResolvedValue({
+      path: "/some/path",
+      profile: {
+        workspaceId: "ws_123",
+        appId: "app_abc123",
+        instances: { development: "ins_dev" },
+      },
+      resolvedVia: "remote",
+    });
+
+    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+    await runLogin();
+
+    expect(captured.err).toContain("Linked to `app_abc123`");
+  });
+
+  test("shows default next steps when not linked", async () => {
+    mockGetToken.mockResolvedValue(null);
+    mockBunSpawn();
+
+    const mockServer = {
+      port: 54321,
+      waitForCallback: mock().mockResolvedValue({ code: "fresh-auth-code" }),
+      stop: mock(),
+    };
+    mockStartAuthServer.mockReturnValue(mockServer);
+
+    mockExchangeCodeForToken.mockResolvedValue({
+      access_token: "new-access-token",
+      token_type: "Bearer",
+      expires_in: 3600,
+    });
+    mockStoreToken.mockResolvedValue(undefined);
+    mockFetchUserInfo.mockResolvedValue({
+      userId: "user_new",
+      email: "new@example.com",
+    });
+    mockSetAuth.mockResolvedValue(undefined);
+    mockResolveProfile.mockResolvedValue(undefined);
+
+    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+    await runLogin();
+
+    expect(captured.err).not.toContain("Linked to");
   });
 
   test("suppresses auth next-steps when requested", async () => {

--- a/packages/cli-core/src/commands/auth/login.ts
+++ b/packages/cli-core/src/commands/auth/login.ts
@@ -3,7 +3,7 @@ import { startAuthServer } from "../../lib/auth-server.ts";
 import { exchangeCodeForToken, fetchUserInfo, type UserInfo } from "../../lib/token-exchange.ts";
 import { getOAuthConfig } from "../../lib/environment.ts";
 import { storeToken, getToken } from "../../lib/credential-store.ts";
-import { getAuth, setAuth } from "../../lib/config.ts";
+import { getAuth, setAuth, resolveProfile } from "../../lib/config.ts";
 import { AUTH_TIMEOUT_MS, CALLBACK_PATH } from "../../lib/constants.ts";
 import { confirm } from "../../lib/prompts.ts";
 import { isHuman } from "../../mode.ts";
@@ -113,6 +113,19 @@ export async function login(options: LoginOptions = {}): Promise<UserInfo> {
   bar();
   log.success(`Logged in as ${userInfo.email}`);
 
-  outro(showNextSteps ? NEXT_STEPS.LOGIN : "Done");
+  if (showNextSteps) {
+    const linked = await resolveProfile(process.cwd());
+    if (linked) {
+      const appLabel = linked.profile.appName
+        ? `\`${linked.profile.appName}\` (${linked.profile.appId})`
+        : `\`${linked.profile.appId}\``;
+      log.success(`Linked to ${appLabel}`);
+      outro(NEXT_STEPS.LOGIN_LINKED);
+    } else {
+      outro(NEXT_STEPS.LOGIN);
+    }
+  } else {
+    outro("Done");
+  }
   return userInfo;
 }

--- a/packages/cli-core/src/commands/link/index.ts
+++ b/packages/cli-core/src/commands/link/index.ts
@@ -138,7 +138,10 @@ function printExistingStatus(
   if (existing.resolvedVia === "remote") {
     log.info(`Auto-linked via git remote (${dim(normalizedRemote ?? existing.path)})`);
   } else {
-    log.info(`Already linked to ${cyan(existing.profile.appId)} in ${dim(existing.path)}`);
+    const label = existing.profile.appName
+      ? `${existing.profile.appName} (${existing.profile.appId})`
+      : existing.profile.appId;
+    log.info(`Already linked to ${cyan(label)} in ${dim(existing.path)}`);
   }
 }
 

--- a/packages/cli-core/src/lib/next-steps.ts
+++ b/packages/cli-core/src/lib/next-steps.ts
@@ -7,6 +7,7 @@ export const NEXT_STEPS = {
     "Run `clerk init` to set up Clerk in your project",
     "Run `clerk link` to connect an existing Clerk application",
   ],
+  LOGIN_LINKED: ["Run `clerk link` to connect a different Clerk application"],
   LINK: [
     "Run `clerk env pull` to fetch your environment variables",
     "Run `clerk doctor` to verify your setup",


### PR DESCRIPTION
When going through reverification for the Clerk CLI on an existing project, display the linked application if one is already linked and adjust the after steps.

```
> clerk auth login
┌  clerk login
◇  Checking session
│  Waiting for authentication (timeout in 2m)...
◇  Waiting for authentication
◇  Completing authentication
│
│  Logged in as daniel@clerk.dev
│  Linked to `FakeSilverSingles` (app_3BPJjaC3XU26UcZC7fchSD59KD5)
│
└  Next steps
   → Run `clerk link` to connect a different Clerk application
```

While we are in here, also normalize the display of the already linked app in `clerk link` to include the app name if available.