### PR TITLE
fix(ci): add NODE_AUTH_TOKEN to npm publish steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,8 @@ jobs:
       - name: Publish packages
         run: bun run release
         env:
+          # TODO: remove once we've completed our first publish
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           ARTIFACTS_DIR: ${{ github.workspace }}/dist/artifacts
           GH_TOKEN: ${{ github.token }}
 
@@ -250,5 +252,7 @@ jobs:
       - name: Publish canary packages
         run: bun run release:canary --version "$CANARY_VERSION"
         env:
+          # TODO: remove once we've completed our first publish
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           CANARY_VERSION: ${{ needs.canary-version.outputs.version }}
           ARTIFACTS_DIR: ${{ github.workspace }}/dist/artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,3 +256,4 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           CANARY_VERSION: ${{ needs.canary-version.outputs.version }}
           ARTIFACTS_DIR: ${{ github.workspace }}/dist/artifacts
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -138,6 +138,8 @@ jobs:
       - name: Publish snapshot packages
         run: bun run release:snapshot --version "$SNAPSHOT_VERSION"
         env:
+          # TODO: remove once we've completed our first publish
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           SNAPSHOT_VERSION: ${{ needs.snapshot.outputs.version }}
           ARTIFACTS_DIR: ${{ github.workspace }}/dist/artifacts
 


### PR DESCRIPTION
Add \`NODE_AUTH_TOKEN\` to all three npm publish jobs so \`actions/setup-node\`'s generated \`.npmrc\` can authenticate against the registry. The previous state had no token at all in those steps.

Also adds \`GH_TOKEN\` to the \`canary-publish-npm\` step for consistency with the stable publish job.

> **TODO:** Remove \`NODE_AUTH_TOKEN\` once OIDC trusted publishing is configured for this package on npmjs.com.