### PR TITLE
fix(init): install skills in project directory during bootstrap

### DIFF
--- a/packages/cli-core/src/commands/init/index.test.ts
+++ b/packages/cli-core/src/commands/init/index.test.ts
@@ -218,6 +218,27 @@ describe("init", () => {
     expect(bootstrapMod.confirmOverwrite).toHaveBeenCalledWith(expect.any(String));
   });
 
+  test("bootstrap passes project dir to installSkills, not original cwd", async () => {
+    setup();
+
+    const bootstrapCtx = {
+      ...FAKE_CTX,
+      cwd: FAKE_BOOTSTRAP.projectDir,
+      existingClerk: false,
+    };
+
+    spyOn(context, "gatherContext").mockResolvedValueOnce(null).mockResolvedValueOnce(bootstrapCtx);
+
+    spyOn(scaffoldMod, "scaffold").mockResolvedValue({
+      actions: [{ type: "write", path: "app/layout.tsx", content: "" }],
+      postInstructions: [],
+    });
+
+    await init({ yes: true });
+
+    expect(skillsMod.installSkills).toHaveBeenCalledWith(FAKE_BOOTSTRAP.projectDir, "react", true);
+  });
+
   test("--starter in agent mode prints guidance without bootstrap", async () => {
     const { captured } = setup({ isAgent: true });
 

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -100,7 +100,7 @@ export async function init(options: InitOptions = {}) {
 
   if (options.skills !== false) {
     bar();
-    await installSkills(cwd, ctx?.framework.dep, options.yes ?? false);
+    await installSkills(ctx.cwd, ctx?.framework.dep, options.yes ?? false);
   }
 
   outro("Done");


### PR DESCRIPTION
## Summary

- Fixed `installSkills` receiving `process.cwd()` instead of `ctx.cwd` during bootstrap, causing skills to be installed in the parent directory instead of the newly created project
- Added regression test asserting `installSkills` receives the bootstrap project directory with exact argument matching

## Test plan

- [x] `bun run test` — all 63 tests pass
- [x] `bun run lint` — no warnings or errors
- [x] `bun run format` — clean
- [x] Manual: run `clerk init` in a blank directory, verify `skills/` and `skills-lock.json` appear inside the created project, not the parent