### PR TITLE
fix: use canonical `clerk auth login` in suggestions

### DIFF
--- a/packages/cli-core/src/commands/auth/login.ts
+++ b/packages/cli-core/src/commands/auth/login.ts
@@ -89,7 +89,7 @@ async function performOAuthFlow(): Promise<UserInfo> {
 
 export async function login(options: LoginOptions = {}): Promise<UserInfo> {
   const { showNextSteps = true } = options;
-  intro("clerk login");
+  intro("clerk auth login");
   const existingSession = await withSpinner("Checking session...", () => getExistingSession());
 
   if (existingSession && !isHuman()) {

--- a/packages/cli-core/src/commands/init/bootstrap.ts
+++ b/packages/cli-core/src/commands/init/bootstrap.ts
@@ -121,7 +121,7 @@ export async function confirmOverwrite(cwd: string): Promise<void> {
 export async function askSkipAuth(): Promise<boolean> {
   return confirm({
     message:
-      "Skip authentication for now? (you can connect your Clerk account later with `clerk login`)",
+      "Skip authentication for now? (you can connect your Clerk account later with `clerk auth login`)",
     default: true,
   });
 }

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -172,7 +172,7 @@ function printBootstrapNextSteps(
 ): void {
   const steps = [`cd ${projectName}`, devCommand(packageManager)];
   if (keyless) {
-    steps.push("clerk login  (when you're ready to connect your Clerk account)");
+    steps.push("clerk auth login  (when you're ready to connect your Clerk account)");
   }
   printNextSteps(steps);
 }


### PR DESCRIPTION
## Summary
- Updated 3 places where user-facing suggestions referenced the hidden `clerk login` alias instead of the canonical `clerk auth login`
- `commands/auth/login.ts`: intro banner now says `clerk auth login`
- `commands/init/bootstrap.ts`: skip-auth prompt now suggests `clerk auth login`
- `commands/init/index.ts`: bootstrap next-steps now suggests `clerk auth login`

## Test plan
- [ ] Run `clerk auth login` and verify the intro banner shows `clerk auth login`
- [ ] Run `clerk init` in a new directory, skip auth, and verify the prompt mentions `clerk auth login`
- [ ] Run `clerk init` in a new directory with keyless mode and verify next steps show `clerk auth login`