### PR TITLE
fix(ci): upgrade npm publish jobs to Node.js LTS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,10 +85,8 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "lts/*"
           registry-url: "https://registry.npmjs.org"
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@11
       - run: bun install --frozen-lockfile
 
       - uses: actions/download-artifact@v8
@@ -230,10 +228,8 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "lts/*"
           registry-url: "https://registry.npmjs.org"
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@11
       - run: bun install --frozen-lockfile
 
       - uses: actions/download-artifact@v8

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -116,10 +116,8 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "lts/*"
           registry-url: "https://registry.npmjs.org"
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@11
       - run: bun install --frozen-lockfile
 
       - uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary

- Switch `node-version` from `"22"` to `"lts/*"` in both `publish-npm` and `canary-publish-npm` jobs
- Remove the `npm install -g npm@11` upgrade step (Node 24 LTS ships npm 11 already)

## Why

`node:22` resolved to Node 22.22.2, which ships with a broken bundled npm (missing `promise-retry` in its internal dependency tree). This caused the upgrade step to fail before any publishing could happen. Node 24 LTS (`lts/*`) does not have this issue and already includes npm 11.