### PR TITLE
fix(scripts): disable npm provenance for private repo

### DIFF
--- a/scripts/releaser/index.ts
+++ b/scripts/releaser/index.ts
@@ -74,7 +74,9 @@ async function generatePlatformPackage(target: Target, version: string): Promise
 }
 
 function publish(dir: string, dryRun: boolean, tag?: string): void {
-  const flags = ["npm", "publish", "--access", "public", "--provenance", "--ignore-scripts"];
+  // --provenance requires a public repository. Once this repo is made public and
+  // NODE_AUTH_TOKEN is removed in favour of OIDC trusted publishing, re-enable it.
+  const flags = ["npm", "publish", "--access", "public", "--ignore-scripts"];
   if (tag) flags.push("--tag", tag);
   if (dryRun) flags.push("--dry-run");
   run(flags, { cwd: dir });


### PR DESCRIPTION
## Summary

- Remove `--provenance` from `npm publish` in `scripts/releaser/index.ts`

## Why

`npm publish --provenance` requires the source repository to be public. `clerk/cli` is currently private, so sigstore rejects publishes with `E422 Unprocessable Entity`. The flag is removed with a comment pointing to when it should be re-enabled: once the repo is public and OIDC trusted publishing replaces `NODE_AUTH_TOKEN` (see the follow-up PR in this stack).