### PR TITLE
chore(rules): add logging rule to enforce log.* over console.*

### DIFF
--- a/.claude/rules/logging.md
+++ b/.claude/rules/logging.md
@@ -8,8 +8,10 @@ alwaysApply: false
 All output goes through the `log` object from `src/lib/log.ts`. **Never use `console.log`, `console.error`, `console.warn`, `console.info`, or `process.stderr.write` directly** — use `log.*` methods so output respects log levels, throttling, and test capture.
 
 ```ts
-import { log } from "../../lib/log.ts";
+import { log } from "<relative-path>/lib/log.ts";
 ```
+
+Adjust the relative path to `lib/log.ts` based on the file's location under `packages/cli-core/src/`.
 
 ## Which method to use
 
@@ -19,7 +21,7 @@ import { log } from "../../lib/log.ts";
 | `log.info()`    | stderr     | Status messages                                 |
 | `log.success()` | stderr     | Completion confirmations (green)                |
 | `log.warn()`    | stderr     | Warnings (yellow)                               |
-| `log.error()`   | stderr     | Errors (red, auto-prefixed `error: `)           |
+| `log.error()`   | stderr     | Errors (red, auto-prefixed `error:`)            |
 | `log.debug()`   | stderr     | Diagnostic info, only with `--verbose`          |
 | `log.raw()`     | stderr     | Machine-readable JSON for agent mode            |
 | `log.blank()`   | stderr     | Blank line                                      |

--- a/.claude/rules/logging.md
+++ b/.claude/rules/logging.md
@@ -1,0 +1,67 @@
+---
+description: Logging conventions — use log.* instead of console.* in all CLI source files
+paths:
+  - "packages/cli-core/src/**/*.ts"
+alwaysApply: false
+---
+
+All output goes through the `log` object from `src/lib/log.ts`. **Never use `console.log`, `console.error`, `console.warn`, `console.info`, or `process.stderr.write` directly** — use `log.*` methods so output respects log levels, throttling, and test capture.
+
+```ts
+import { log } from "../../lib/log.ts";
+```
+
+## Which method to use
+
+| Method          | Stream     | When to use                                     |
+| --------------- | ---------- | ----------------------------------------------- |
+| `log.data()`    | **stdout** | Pipeable output (JSON, lists, machine-readable) |
+| `log.info()`    | stderr     | Status messages                                 |
+| `log.success()` | stderr     | Completion confirmations (green)                |
+| `log.warn()`    | stderr     | Warnings (yellow)                               |
+| `log.error()`   | stderr     | Errors (red, auto-prefixed `error: `)           |
+| `log.debug()`   | stderr     | Diagnostic info, only with `--verbose`          |
+| `log.raw()`     | stderr     | Machine-readable JSON for agent mode            |
+| `log.blank()`   | stderr     | Blank line                                      |
+
+`log.data()` writes to **stdout** — this is what gets piped (e.g., `clerk apps list | jq`). Everything else writes to **stderr** as UI for humans. Never mix these.
+
+## Debug logging
+
+`log.debug()` is gated by `--verbose`. Use for diagnostic details (request URLs, timing, intermediate state):
+
+```ts
+log.debug(`Fetching instance ${instanceId}…`);
+```
+
+## Tagged loggers
+
+`log.withTag()` adds scoped context in complex flows:
+
+```ts
+const apiLog = log.withTag("api");
+apiLog.info("Fetching config…"); // [api] Fetching config…
+```
+
+## Inline highlighting
+
+Backtick-wrapped text auto-highlights in cyan:
+
+```ts
+log.info("Linked to `my-app` on `development`");
+```
+
+## Testing log output
+
+Use `captureLog()` from `src/test/lib/stubs.ts`. Capture is scoped via `AsyncLocalStorage` — no teardown needed:
+
+```ts
+import { captureLog } from "../../test/lib/stubs.ts";
+
+test("outputs result", async () => {
+  const captured = captureLog();
+  await captured.run(() => myCommand());
+  expect(captured.out).toContain("expected stdout"); // log.data()
+  expect(captured.err).toContain("expected stderr"); // log.info/warn/etc.
+});
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,66 +86,9 @@ When creating or modifying a command, evaluate whether it needs an agent mode. C
 
 ## Logging
 
-All output goes through the `log` object from `packages/cli-core/src/lib/log.ts`. **Never use `console.log`, `console.error`, or `process.stderr.write` directly** — use `log.*` methods so output respects log levels, throttling, and test capture.
+All output goes through the `log` object from `packages/cli-core/src/lib/log.ts`. **Never use `console.log`, `console.error`, `console.warn`, `console.info`, or `process.stderr.write` directly** — use `log.*` methods so output respects log levels, throttling, and test capture.
 
-```ts
-import { log } from "../../lib/log.ts";
-```
-
-### Which method to use
-
-| Method          | Stream     | When to use                                     |
-| --------------- | ---------- | ----------------------------------------------- |
-| `log.data()`    | **stdout** | Pipeable output (JSON, lists, machine-readable) |
-| `log.info()`    | stderr     | Status messages                                 |
-| `log.success()` | stderr     | Completion confirmations (green)                |
-| `log.warn()`    | stderr     | Warnings (yellow)                               |
-| `log.error()`   | stderr     | Errors (red, auto-prefixed `error: `)           |
-| `log.debug()`   | stderr     | Diagnostic info, only with `--verbose`          |
-| `log.raw()`     | stderr     | Machine-readable JSON for agent mode            |
-| `log.blank()`   | stderr     | Blank line                                      |
-
-`log.data()` writes to **stdout** — this is what gets piped (e.g., `clerk apps list | jq`). Everything else writes to **stderr** as UI for humans. Never mix these.
-
-### Debug logging
-
-`log.debug()` is gated by `--verbose`. Use for diagnostic details (request URLs, timing, intermediate state):
-
-```ts
-log.debug(`Fetching instance ${instanceId}…`);
-```
-
-### Tagged loggers
-
-`log.withTag()` adds scoped context in complex flows:
-
-```ts
-const apiLog = log.withTag("api");
-apiLog.info("Fetching config…"); // [api] Fetching config…
-```
-
-### Inline highlighting
-
-Backtick-wrapped text auto-highlights in cyan:
-
-```ts
-log.info("Linked to `my-app` on `development`");
-```
-
-### Testing log output
-
-Use `captureLog()` from `packages/cli-core/src/test/lib/stubs.ts`. Capture is scoped via `AsyncLocalStorage` — no teardown needed:
-
-```ts
-import { captureLog } from "../../test/lib/stubs.ts";
-
-test("outputs result", async () => {
-  const captured = captureLog();
-  await captured.run(() => myCommand());
-  expect(captured.out).toContain("expected stdout"); // log.data()
-  expect(captured.err).toContain("expected stderr"); // log.info/warn/etc.
-});
-```
+See [.claude/rules/logging.md](.claude/rules/logging.md) for the full method reference, debug logging, tagged loggers, inline highlighting, and testing patterns.
 
 ## Error Handling
 


### PR DESCRIPTION
## Summary

- Adds `.claude/rules/logging.md` targeting `packages/cli-core/src/**/*.ts`
- Rule instructs Claude to use `log.*` from `src/lib/log.ts` instead of `console.log`, `console.error`, etc.
- Mirrors the logging table, method selection guidance, debug/tagged/highlight patterns, and `captureLog()` testing docs already in CLAUDE.md

## Test plan

- [ ] Verify the rule file appears in `.claude/rules/` alongside peers
- [ ] Confirm the `paths` glob correctly matches source files in `packages/cli-core/src/`