### PR TITLE
fix(ci): add scripts/lib/ to sign-macos sparse checkout

### DIFF
--- a/.github/workflows/sign-macos.yml
+++ b/.github/workflows/sign-macos.yml
@@ -35,6 +35,7 @@ jobs:
           sparse-checkout: |
             scripts/sign-macos.ts
             scripts/entitlements.plist
+            scripts/lib/
             scripts/releaser/
             bun.lock
             package.json


### PR DESCRIPTION
## Summary

- PR #134 moved shared helpers to `scripts/lib/` and updated `sign-macos.ts` to import from `./lib/targets.ts`
- The sparse checkout in `sign-macos.yml` was never updated, so the runner checked out `sign-macos.ts` but not the lib it depends on
- Fixes: `error: Cannot find module './lib/targets.ts' from '/Users/runner/work/cli/cli/scripts/sign-macos.ts'`

## Test plan

- [ ] Trigger a snapshot build after merge — the sign-macos job should complete without the missing module error