### PR TITLE
fix(ci): pin Bun to 1.3.11 for binary builds

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -22,7 +22,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
+      # Pinned: Bun 1.3.12 produces darwin-arm64 binaries that macOS codesign
+      # rejects ("invalid or unsupported format for signature"). Test signing
+      # before bumping. See: https://github.com/clerk/cli/actions/runs/24247669246
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.11"
       - run: bun install --frozen-lockfile
 
       - name: Build all targets


### PR DESCRIPTION
## Summary

- Pin Bun to 1.3.11 in `build-binaries.yml` to fix macOS code signing failures on darwin-arm64

## What happened

Bun 1.3.12 ([released April 10](https://github.com/oven-sh/bun/releases/tag/bun-v1.3.12)) produces darwin-arm64 cross-compiled binaries that macOS `codesign` rejects with **"invalid or unsupported format for signature"**.

Evidence:
- Same commit (`28b720e`) [succeeded with Bun 1.3.11](https://github.com/clerk/cli/actions/runs/24220056812) and [failed with Bun 1.3.12](https://github.com/clerk/cli/actions/runs/24247669246)
- Only darwin-arm64 is affected — darwin-x64 signed fine in the failing run
- Bun 1.3.12 includes [oven-sh/bun#26923](https://github.com/oven-sh/bun/pull/26923) which modifies `StandaloneModuleGraph.zig`, the module responsible for embedding data into compiled binaries across all platforms