### PR TITLE
chore(test): refresh e2e fixtures

### DIFF
--- a/test/e2e/fixtures/nextjs-app-router/package.json
+++ b/test/e2e/fixtures/nextjs-app-router/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@clerk/nextjs": "latest",
-    "next": "16.2.0",
+    "next": "16.2.3",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },

--- a/test/e2e/fixtures/nextjs-pages-router/package.json
+++ b/test/e2e/fixtures/nextjs-pages-router/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@clerk/nextjs": "latest",
-    "next": "16.2.0",
+    "next": "16.2.3",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },

--- a/test/e2e/fixtures/nuxt/package.json
+++ b/test/e2e/fixtures/nuxt/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@clerk/nuxt": "latest",
     "nuxt": "^4.4.2",
-    "vue": "^3.5.30",
-    "vue-router": "^5.0.3"
+    "vue": "^3.5.32",
+    "vue-router": "^5.0.4"
   }
 }

--- a/test/e2e/fixtures/react/index.html
+++ b/test/e2e/fixtures/react/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>clerk-fixture-react-edgdlc</title>
+    <title>clerk-fixture-react-b1bnwe</title>
   </head>
   <body>
     <div id="root"></div>

--- a/test/e2e/fixtures/react/package.json
+++ b/test/e2e/fixtures/react/package.json
@@ -16,16 +16,16 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
-    "@types/node": "^24.12.0",
+    "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.0",
+    "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
-    "typescript": "~5.9.3",
-    "typescript-eslint": "^8.56.1",
-    "vite": "^8.0.0"
+    "typescript": "~6.0.2",
+    "typescript-eslint": "^8.58.0",
+    "vite": "^8.0.4"
   }
 }

--- a/test/e2e/fixtures/react/tsconfig.app.json
+++ b/test/e2e/fixtures/react/tsconfig.app.json
@@ -1,10 +1,9 @@
 {
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "target": "ES2023",
-    "useDefineForClassFields": true,
+    "target": "es2023",
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
+    "module": "esnext",
     "types": ["vite/client"],
     "skipLibCheck": true,
 
@@ -17,12 +16,10 @@
     "jsx": "react-jsx",
 
     /* Linting */
-    "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noFallthroughCasesInSwitch": true
   },
   "include": ["src"]
 }

--- a/test/e2e/fixtures/react/tsconfig.node.json
+++ b/test/e2e/fixtures/react/tsconfig.node.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "target": "ES2023",
+    "target": "es2023",
     "lib": ["ES2023"],
-    "module": "ESNext",
+    "module": "esnext",
     "types": ["node"],
     "skipLibCheck": true,
 
@@ -15,12 +15,10 @@
     "noEmit": true,
 
     /* Linting */
-    "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noFallthroughCasesInSwitch": true
   },
   "include": ["vite.config.ts"]
 }

--- a/test/e2e/fixtures/tanstack-start/src/router.tsx
+++ b/test/e2e/fixtures/tanstack-start/src/router.tsx
@@ -4,7 +4,6 @@ import { routeTree } from "./routeTree.gen";
 export function getRouter() {
   const router = createTanStackRouter({
     routeTree,
-
     scrollRestoration: true,
     defaultPreload: "intent",
     defaultPreloadStaleTime: 0,

--- a/test/e2e/fixtures/vue/index.html
+++ b/test/e2e/fixtures/vue/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>clerk-fixture-vue-yixq27</title>
+    <title>clerk-fixture-vue-dbfu2t</title>
   </head>
   <body>
     <div id="app"></div>

--- a/test/e2e/fixtures/vue/package.json
+++ b/test/e2e/fixtures/vue/package.json
@@ -10,14 +10,14 @@
   },
   "dependencies": {
     "@clerk/vue": "latest",
-    "vue": "^3.5.30"
+    "vue": "^3.5.32"
   },
   "devDependencies": {
-    "@types/node": "^24.12.0",
+    "@types/node": "^24.12.2",
     "@vitejs/plugin-vue": "^6.0.5",
-    "@vue/tsconfig": "^0.9.0",
-    "typescript": "~5.9.3",
-    "vite": "^8.0.0",
-    "vue-tsc": "^3.2.5"
+    "@vue/tsconfig": "^0.9.1",
+    "typescript": "~6.0.2",
+    "vite": "^8.0.4",
+    "vue-tsc": "^3.2.6"
   }
 }

--- a/test/e2e/fixtures/vue/src/App.vue
+++ b/test/e2e/fixtures/vue/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import HelloWorld from "./components/HelloWorld.vue";
+import HelloWorld from './components/HelloWorld.vue'
 </script>
 
 <template>

--- a/test/e2e/fixtures/vue/src/components/HelloWorld.vue
+++ b/test/e2e/fixtures/vue/src/components/HelloWorld.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { ref } from "vue";
-import viteLogo from "../assets/vite.svg";
-import heroImg from "../assets/hero.png";
-import vueLogo from "../assets/vue.svg";
+import { ref } from 'vue'
+import viteLogo from '../assets/vite.svg'
+import heroImg from '../assets/hero.png'
+import vueLogo from '../assets/vue.svg'
 
-const count = ref(0);
+const count = ref(0)
 </script>
 
 <template>

--- a/test/e2e/fixtures/vue/tsconfig.app.json
+++ b/test/e2e/fixtures/vue/tsconfig.app.json
@@ -5,12 +5,10 @@
     "types": ["vite/client"],
 
     /* Linting */
-    "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noFallthroughCasesInSwitch": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
 }

--- a/test/e2e/fixtures/vue/tsconfig.node.json
+++ b/test/e2e/fixtures/vue/tsconfig.node.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "target": "ES2023",
+    "target": "es2023",
     "lib": ["ES2023"],
-    "module": "ESNext",
+    "module": "esnext",
     "types": ["node"],
     "skipLibCheck": true,
 
@@ -15,12 +15,10 @@
     "noEmit": true,
 
     /* Linting */
-    "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noFallthroughCasesInSwitch": true
   },
   "include": ["vite.config.ts"]
 }


### PR DESCRIPTION
Automated refresh of E2E test fixtures via the `refresh-fixtures` workflow.

Generated by `bun run e2e:refresh-fixtures`. Review the diff for any
unexpected framework changes (especially major version bumps in
upstream scaffolders) before merging.

Triggered by: workflow_dispatch on refs/heads/main