### PR TITLE
feat(scripts): add typecheck script for scripts/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run format:check
       - run: bun run lint
+      - run: bun run typecheck
 
   test:
     name: Test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ After modifying files, run these commands to match what CI enforces on pull requ
 ```sh
 bun run format       # Format with oxfmt (writes changes)
 bun run lint         # Lint with oxlint
+bun run typecheck    # Type-check all packages and scripts
 bun run test         # Run unit tests
 bun run test:e2e:op  # Run E2E tests with secrets resolved from 1Password (preferred locally)
 bun run test:e2e     # Run E2E tests with env vars already set (used by CI)

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:e2e": "bun run scripts/run-tests.ts --pattern 'test/e2e/*.test.ts' --retries 1",
     "test:e2e:op": "bun run scripts/run-e2e-op.ts",
     "e2e:refresh-fixtures": "bun run scripts/refresh-e2e-fixtures.ts",
-    "typecheck": "tsc --noEmit -p scripts/tsconfig.json",
+    "typecheck": "bun run --filter @clerk/cli-core typecheck && tsc --noEmit -p scripts/tsconfig.json",
     "lint": "bun run --filter @clerk/cli-core lint && oxlint -c .oxlintrc.json scripts/",
     "format": "bun run --filter @clerk/cli-core format && oxfmt --write scripts/",
     "format:check": "bun run --filter @clerk/cli-core format:check && oxfmt --check scripts/",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:e2e": "bun run scripts/run-tests.ts --pattern 'test/e2e/*.test.ts' --retries 1",
     "test:e2e:op": "bun run scripts/run-e2e-op.ts",
     "e2e:refresh-fixtures": "bun run scripts/refresh-e2e-fixtures.ts",
+    "typecheck": "tsc --noEmit -p scripts/tsconfig.json",
     "lint": "bun run --filter @clerk/cli-core lint && oxlint -c .oxlintrc.json scripts/",
     "format": "bun run --filter @clerk/cli-core format && oxfmt --write scripts/",
     "format:check": "bun run --filter @clerk/cli-core format:check && oxfmt --check scripts/",

--- a/packages/cli-core/package.json
+++ b/packages/cli-core/package.json
@@ -10,6 +10,7 @@
     "build": "bun build ./src/cli.ts --outfile ./dist/cli.js --target node --external @napi-rs/keyring",
     "build:compile": "bun build --compile --no-compile-autoload-dotenv ./src/cli.ts --outfile ./dist/clerk",
     "dev": "bun run ./src/cli.ts",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "lint": "oxlint src/",
     "format": "oxfmt --write src/",
     "format:check": "oxfmt --check src/"

--- a/packages/cli-core/src/commands/api/catalog.test.ts
+++ b/packages/cli-core/src/commands/api/catalog.test.ts
@@ -146,13 +146,13 @@ describe("filterEndpoints", () => {
   test("filters by summary", () => {
     const results = filterEndpoints(catalog, "retrieve");
     expect(results.length).toBe(1);
-    expect(results[0].operationId).toBe("GetUser");
+    expect(results[0]!.operationId).toBe("GetUser");
   });
 
   test("filters by tag", () => {
     const results = filterEndpoints(catalog, "organizations");
     expect(results.length).toBe(1);
-    expect(results[0].tag).toBe("Organizations");
+    expect(results[0]!.tag).toBe("Organizations");
   });
 
   test("is case-insensitive", () => {

--- a/packages/cli-core/src/commands/api/interactive.test.ts
+++ b/packages/cli-core/src/commands/api/interactive.test.ts
@@ -158,8 +158,8 @@ describe("apiInteractive", () => {
     await runApiInteractive({});
 
     expect(fetchCalls.length).toBe(1);
-    expect(fetchCalls[0].url).toContain("/v1/users");
-    expect(fetchCalls[0].method).toBe("GET");
+    expect(fetchCalls[0]!.url).toContain("/v1/users");
+    expect(fetchCalls[0]!.method).toBe("GET");
   });
 
   test("prompts for path parameters", async () => {
@@ -180,7 +180,7 @@ describe("apiInteractive", () => {
     await runApiInteractive({});
 
     expect(fetchCalls.length).toBe(1);
-    expect(fetchCalls[0].url).toContain("/v1/users/user_abc123");
+    expect(fetchCalls[0]!.url).toContain("/v1/users/user_abc123");
   });
 
   test("aborts when user declines confirmation", async () => {

--- a/packages/cli-core/src/commands/init/frameworks/astro.test.ts
+++ b/packages/cli-core/src/commands/init/frameworks/astro.test.ts
@@ -15,6 +15,7 @@ function makeCtx(overrides?: Partial<ProjectContext>): ProjectContext {
       name: "Astro",
       sdk: "@clerk/astro",
       envVar: "PUBLIC_CLERK_PUBLISHABLE_KEY",
+      envFile: ".env",
     },
     typescript: true,
     srcDir: false,

--- a/packages/cli-core/src/commands/init/frameworks/nextjs-app.test.ts
+++ b/packages/cli-core/src/commands/init/frameworks/nextjs-app.test.ts
@@ -15,6 +15,7 @@ function makeCtx(overrides?: Partial<ProjectContext>): ProjectContext {
       name: "Next.js",
       sdk: "@clerk/nextjs",
       envVar: "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+      envFile: ".env",
     },
     variant: "app-router",
     typescript: true,

--- a/packages/cli-core/src/commands/init/frameworks/nextjs-pages.test.ts
+++ b/packages/cli-core/src/commands/init/frameworks/nextjs-pages.test.ts
@@ -15,6 +15,7 @@ function makeCtx(overrides?: Partial<ProjectContext>): ProjectContext {
       name: "Next.js",
       sdk: "@clerk/nextjs",
       envVar: "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+      envFile: ".env",
     },
     variant: "pages-router",
     typescript: true,

--- a/packages/cli-core/src/commands/init/frameworks/nuxt.test.ts
+++ b/packages/cli-core/src/commands/init/frameworks/nuxt.test.ts
@@ -15,6 +15,7 @@ function makeCtx(overrides?: Partial<ProjectContext>): ProjectContext {
       name: "Nuxt",
       sdk: "@clerk/nuxt",
       envVar: "NUXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+      envFile: ".env",
     },
     typescript: true,
     srcDir: false,

--- a/packages/cli-core/src/commands/init/frameworks/react-router.test.ts
+++ b/packages/cli-core/src/commands/init/frameworks/react-router.test.ts
@@ -15,6 +15,7 @@ function makeCtx(overrides?: Partial<ProjectContext>): ProjectContext {
       name: "React Router",
       sdk: "@clerk/react-router",
       envVar: "VITE_CLERK_PUBLISHABLE_KEY",
+      envFile: ".env.local",
     },
     typescript: true,
     srcDir: false,

--- a/packages/cli-core/src/commands/init/frameworks/react-router.ts
+++ b/packages/cli-core/src/commands/init/frameworks/react-router.ts
@@ -226,7 +226,7 @@ function ensureRouteImported(source: string): string {
   const importMatch = source.match(
     /import\s*\{([^}]*)\}\s*from\s*["']@react-router\/dev\/routes["']/,
   );
-  if (!importMatch || /\broute\b/.test(importMatch[1])) return source;
+  if (!importMatch || !importMatch[1] || /\broute\b/.test(importMatch[1])) return source;
 
   return source.replace(
     /(\bimport\s*\{[^}]*)(\}\s*from\s*["']@react-router\/dev\/routes["'])/,
@@ -301,7 +301,7 @@ function injectRouteEntries(
   // Strategy 1: canonical create-react-router pattern.
   const canonicalPattern = /export default \[([^\]]*)\]\s*satisfies\s*RouteConfig\s*;/s;
   const canonical = source.match(canonicalPattern);
-  if (canonical) {
+  if (canonical && canonical[1] !== undefined) {
     const innerContent = canonical[1].trimEnd();
     const separator = innerContent.length > 0 && !innerContent.endsWith(",") ? "," : "";
     const newInner = `${innerContent}${separator}\n  ${newEntries},\n`;
@@ -311,7 +311,7 @@ function injectRouteEntries(
   // Strategy 2: any `export default [...]` array (no satisfies).
   const simplePattern = /(export\s+default\s+\[)([\s\S]*?)(\]\s*;)/;
   const simple = source.match(simplePattern);
-  if (simple) {
+  if (simple && simple[2] !== undefined) {
     const innerContent = simple[2].trimEnd();
     const separator = innerContent.length > 0 && !innerContent.endsWith(",") ? "," : "";
     const newInner = `${innerContent}${separator}\n  ${newEntries},\n`;

--- a/packages/cli-core/src/commands/init/frameworks/react.test.ts
+++ b/packages/cli-core/src/commands/init/frameworks/react.test.ts
@@ -15,6 +15,7 @@ function makeCtx(overrides?: Partial<ProjectContext>): ProjectContext {
       name: "React",
       sdk: "@clerk/react",
       envVar: "VITE_CLERK_PUBLISHABLE_KEY",
+      envFile: ".env.local",
     },
     typescript: true,
     srcDir: true,

--- a/packages/cli-core/src/commands/init/frameworks/tanstack-start.test.ts
+++ b/packages/cli-core/src/commands/init/frameworks/tanstack-start.test.ts
@@ -15,6 +15,7 @@ function makeCtx(overrides?: Partial<ProjectContext>): ProjectContext {
       name: "TanStack Start",
       sdk: "@clerk/tanstack-react-start",
       envVar: "VITE_CLERK_PUBLISHABLE_KEY",
+      envFile: ".env.local",
     },
     typescript: true,
     srcDir: true,

--- a/packages/cli-core/src/commands/init/frameworks/transformations.ts
+++ b/packages/cli-core/src/commands/init/frameworks/transformations.ts
@@ -77,7 +77,7 @@ export function wrapBodyWithProvider(content: string, provider: string): string 
   const match = bodyPattern.exec(content);
   if (!match) return content;
 
-  const [fullMatch, bodyIndent, openTag, inner, closeTag] = match;
+  const [fullMatch, bodyIndent = "", openTag, inner = "", closeTag] = match;
   const providerIndent = bodyIndent + "  ";
   const contentIndent = providerIndent + "  ";
 

--- a/packages/cli-core/src/commands/init/frameworks/vue.test.ts
+++ b/packages/cli-core/src/commands/init/frameworks/vue.test.ts
@@ -15,6 +15,7 @@ function makeCtx(overrides?: Partial<ProjectContext>): ProjectContext {
       name: "Vue",
       sdk: "@clerk/vue",
       envVar: "VITE_CLERK_PUBLISHABLE_KEY",
+      envFile: ".env.local",
     },
     typescript: true,
     srcDir: true,

--- a/packages/cli-core/src/commands/init/heuristics.ts
+++ b/packages/cli-core/src/commands/init/heuristics.ts
@@ -17,7 +17,7 @@ export async function installSdk(ctx: ProjectContext): Promise<void> {
   // The package manager is detected from lockfiles, which can exist without
   // the actual binary being installed (e.g. teammate committed bun.lock, you
   // only have npm). Fail fast with a useful message rather than a raw ENOENT.
-  const pmBinary = addCmd.split(" ")[0];
+  const pmBinary = addCmd.split(" ")[0] ?? addCmd;
   if (Bun.which(pmBinary) === null) {
     log.warn(
       `${pmBinary} is not installed but the project's lockfile suggests it. ` +

--- a/packages/cli-core/src/commands/init/index.test.ts
+++ b/packages/cli-core/src/commands/init/index.test.ts
@@ -27,6 +27,7 @@ const FAKE_CTX = {
     name: "React",
     sdk: "@clerk/react",
     envVar: "VITE_CLERK_PUBLISHABLE_KEY",
+    envFile: ".env.local" as const,
   },
   typescript: true,
   srcDir: false,
@@ -181,6 +182,7 @@ describe("init", () => {
       name: "Next.js",
       sdk: "@clerk/nextjs",
       envVar: "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+      envFile: ".env" as const,
     };
     setup({ email: "test@test.com" });
     spyOn(frameworkMod, "lookupFramework").mockReturnValue(fwOverride);
@@ -230,7 +232,7 @@ describe("init", () => {
     spyOn(context, "gatherContext").mockResolvedValueOnce(null).mockResolvedValueOnce(bootstrapCtx);
 
     spyOn(scaffoldMod, "scaffold").mockResolvedValue({
-      actions: [{ type: "write", path: "app/layout.tsx", content: "" }],
+      actions: [{ type: "create", path: "app/layout.tsx", content: "", description: "" }],
       postInstructions: [],
     });
 
@@ -296,7 +298,7 @@ describe("init", () => {
 
     gatherContextSpy.mockResolvedValue(mockCtx);
     spyOn(scaffoldMod, "scaffold").mockResolvedValue({
-      actions: [{ type: "write", path: "app/layout.tsx", content: "" }],
+      actions: [{ type: "create", path: "app/layout.tsx", content: "", description: "" }],
       postInstructions: [],
     });
 

--- a/packages/cli-core/src/commands/init/prompts/index.ts
+++ b/packages/cli-core/src/commands/init/prompts/index.ts
@@ -33,7 +33,7 @@ const TEMPLATES = {
 } satisfies Record<string, string>;
 
 type TemplateName = keyof typeof TEMPLATES;
-type FrameworkTemplateName = Exclude<TemplateName, "generic" | "generic-fallback">;
+type FrameworkTemplateName = Exclude<TemplateName, "generic">;
 type FrameworkPromptInfo = { template: FrameworkTemplateName; docsUrl: string };
 
 function loadTemplate(name: TemplateName): string {

--- a/packages/cli-core/src/lib/auth-server.ts
+++ b/packages/cli-core/src/lib/auth-server.ts
@@ -147,7 +147,7 @@ export function startAuthServer(expectedState: string): AuthServerResult {
   });
 
   return {
-    port: server.port,
+    port: server.port!,
     waitForCallback: () => callbackPromise,
     stop: () => {
       clearTimeout(timeout);

--- a/packages/cli-core/src/lib/constants.ts
+++ b/packages/cli-core/src/lib/constants.ts
@@ -12,7 +12,7 @@ import envPaths from "env-paths";
 // ── File paths ──────────────────────────────────────────────────────────────
 
 const clerkConfigDir = process.env.CLERK_CONFIG_DIR;
-const paths = envPaths("clerk-cli", { suffix: false });
+const paths = envPaths("clerk-cli", { suffix: "" });
 
 export const CONFIG_FILE = join(clerkConfigDir ?? paths.config, "config.json");
 export const CREDENTIALS_FILE = join(clerkConfigDir ?? paths.data, "credentials");

--- a/packages/cli-core/src/lib/dotenv.ts
+++ b/packages/cli-core/src/lib/dotenv.ts
@@ -42,8 +42,8 @@ export function parseEnvFile(content: string): EnvLine[] {
     if (line.trim() === "") return { type: "blank" };
     const match = line.match(ENTRY_RE);
     if (!match) return { type: "comment", raw: line };
-    const key = match[2];
-    let value = match[3];
+    const key = match[2]!;
+    let value = match[3]!;
     // Strip surrounding quotes
     if (
       (value.startsWith('"') && value.endsWith('"')) ||
@@ -59,7 +59,7 @@ export function mergeEnvVars(lines: EnvLine[], vars: Record<string, string>): En
   const remaining = { ...vars };
   const result = lines.map((line): EnvLine => {
     if (line.type !== "entry" || !(line.key in remaining)) return line;
-    const value = remaining[line.key];
+    const value = remaining[line.key]!;
     delete remaining[line.key];
     return { type: "entry", key: line.key, value, raw: `${line.key}=${value}` };
   });

--- a/packages/cli-core/src/lib/help.ts
+++ b/packages/cli-core/src/lib/help.ts
@@ -106,7 +106,7 @@ export function clerkHelpConfig(): Partial<Help> {
           helper.formatItem(
             helper.styleSubcommandTerm(term),
             termWidth,
-            helper.styleSubcommandDescription(cmdData[i].description),
+            helper.styleSubcommandDescription(cmdData[i]!.description),
             helper,
           ),
         );

--- a/packages/cli-core/src/lib/log.test.ts
+++ b/packages/cli-core/src/lib/log.test.ts
@@ -205,7 +205,7 @@ describe("withTag", () => {
     });
 
     expect(cap.stderr).toHaveLength(1);
-    const [output] = cap.stderr;
+    const [output] = cap.stderr as [string];
     const tagEnd = output.indexOf("]");
     const afterTagBeforeMessage = output.slice(tagEnd + 1, output.indexOf("broken"));
     expect(afterTagBeforeMessage).not.toContain("\x1b[0m");
@@ -234,7 +234,7 @@ describe("inline highlighting", () => {
     });
 
     expect(cap.stderr).toHaveLength(1);
-    const [output] = cap.stderr;
+    const [output] = cap.stderr as [string];
     const beforeBacktick = output.indexOf("\x1b[36m");
     const afterBacktick = output.indexOf("clerk link") + "clerk link".length;
     const highlightRegion = output.slice(beforeBacktick, afterBacktick + 10);

--- a/packages/cli-core/src/lib/log.ts
+++ b/packages/cli-core/src/lib/log.ts
@@ -146,9 +146,17 @@ function writeln(stream: NodeJS.WriteStream, channel: "stdout" | "stderr", msg: 
 
 // ── Tagged child logger ──────────────────────────────────────────────────
 
-export type Logger = typeof log & {
-  withTag(tag: string): Logger;
-};
+export interface Logger {
+  info(msg: string): void;
+  success(msg: string): void;
+  warn(msg: string): void;
+  error(msg: string): void;
+  debug(msg: string): void;
+  blank(): void;
+  raw(msg: string): void;
+  data(msg: string): void;
+  withTag(childTag: string): Logger;
+}
 
 function createLogger(tag?: string): Logger {
   function formatTag(msg: string): string {

--- a/packages/cli-core/src/lib/plapi.test.ts
+++ b/packages/cli-core/src/lib/plapi.test.ts
@@ -105,8 +105,8 @@ describe("plapi", () => {
       expect(true).toBe(false); // should not reach
     } catch (error) {
       expect(error).toBeInstanceOf(PlapiError);
-      expect((error as PlapiError).status).toBe(404);
-      expect((error as PlapiError).body).toBe("Not Found");
+      expect((error as InstanceType<typeof PlapiError>).status).toBe(404);
+      expect((error as InstanceType<typeof PlapiError>).body).toBe("Not Found");
     }
   });
 
@@ -179,7 +179,7 @@ describe("plapi", () => {
         expect(true).toBe(false);
       } catch (error) {
         expect(error).toBeInstanceOf(PlapiError);
-        expect((error as PlapiError).status).toBe(400);
+        expect((error as InstanceType<typeof PlapiError>).status).toBe(400);
       }
     });
   });
@@ -241,7 +241,7 @@ describe("plapi", () => {
         expect(true).toBe(false);
       } catch (error) {
         expect(error).toBeInstanceOf(PlapiError);
-        expect((error as PlapiError).status).toBe(422);
+        expect((error as InstanceType<typeof PlapiError>).status).toBe(422);
       }
     });
   });
@@ -282,7 +282,7 @@ describe("plapi", () => {
         expect(true).toBe(false);
       } catch (error) {
         expect(error).toBeInstanceOf(PlapiError);
-        expect((error as PlapiError).status).toBe(404);
+        expect((error as InstanceType<typeof PlapiError>).status).toBe(404);
       }
     });
   });
@@ -339,7 +339,7 @@ describe("plapi", () => {
         expect(true).toBe(false);
       } catch (error) {
         expect(error).toBeInstanceOf(PlapiError);
-        expect((error as PlapiError).status).toBe(400);
+        expect((error as InstanceType<typeof PlapiError>).status).toBe(400);
       }
     });
   });
@@ -375,7 +375,7 @@ describe("plapi", () => {
         expect(true).toBe(false);
       } catch (error) {
         expect(error).toBeInstanceOf(PlapiError);
-        expect((error as PlapiError).status).toBe(403);
+        expect((error as InstanceType<typeof PlapiError>).status).toBe(403);
       }
     });
   });

--- a/packages/cli-core/src/lib/runners.ts
+++ b/packages/cli-core/src/lib/runners.ts
@@ -95,9 +95,9 @@ export function detectAvailableRunners(): Runner[] {
 export function runnerForPackageManager(
   packageManager: ProjectContext["packageManager"] | undefined,
 ): Runner {
-  if (!packageManager) return KNOWN_RUNNERS[0];
+  if (!packageManager) return KNOWN_RUNNERS[0]!;
   const id = PM_TO_RUNNER[packageManager];
-  return KNOWN_RUNNERS.find((r) => r.id === id) ?? KNOWN_RUNNERS[0];
+  return KNOWN_RUNNERS.find((r) => r.id === id) ?? KNOWN_RUNNERS[0]!;
 }
 
 /**

--- a/packages/cli-core/src/lib/spinner.ts
+++ b/packages/cli-core/src/lib/spinner.ts
@@ -62,7 +62,7 @@ function createSpinner() {
       }
       stream.write("\x1b[?25l"); // hide cursor
       timer = setInterval(() => {
-        const char = cyan(FRAMES[frame++ % FRAMES.length]);
+        const char = cyan(FRAMES[frame++ % FRAMES.length]!);
         stream.write(`\r\x1b[K${char}  ${message}`);
       }, INTERVAL);
     },

--- a/packages/cli-core/src/lib/token-exchange.test.ts
+++ b/packages/cli-core/src/lib/token-exchange.test.ts
@@ -20,7 +20,7 @@ describe("exchangeCodeForToken", () => {
         status: 200,
         headers: { "Content-Type": "application/json" },
       });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const result = await exchangeCodeForToken({
       code: "auth-code",
@@ -31,7 +31,7 @@ describe("exchangeCodeForToken", () => {
     expect(result).toEqual(tokenResponse);
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
 
-    const [, calledInit] = (globalThis.fetch as ReturnType<typeof mock>).mock.calls[0];
+    const [, calledInit] = (globalThis.fetch as unknown as ReturnType<typeof mock>).mock.calls[0]!;
     expect(calledInit.method).toBe("POST");
     expect(calledInit.headers["Content-Type"]).toBe("application/x-www-form-urlencoded");
 
@@ -52,7 +52,7 @@ describe("exchangeCodeForToken", () => {
 
     globalThis.fetch = mock(async () => {
       return new Response(JSON.stringify(tokenResponse), { status: 200 });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const result = await exchangeCodeForToken({
       code: "code",
@@ -66,7 +66,7 @@ describe("exchangeCodeForToken", () => {
   test("throws on non-OK response with status code", async () => {
     globalThis.fetch = mock(async () => {
       return new Response("invalid_grant", { status: 400 });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     await expect(
       exchangeCodeForToken({
@@ -80,7 +80,7 @@ describe("exchangeCodeForToken", () => {
   test("includes error body in thrown message", async () => {
     globalThis.fetch = mock(async () => {
       return new Response("detailed error info", { status: 401 });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     await expect(
       exchangeCodeForToken({
@@ -103,7 +103,7 @@ describe("fetchUserInfo", () => {
         JSON.stringify({ sub: "user_abc", email: "user@example.com", name: "Test" }),
         { status: 200 },
       );
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const result = await fetchUserInfo("valid-token");
     expect(result).toEqual({ userId: "user_abc", email: "user@example.com" });
@@ -112,18 +112,18 @@ describe("fetchUserInfo", () => {
   test("sends Bearer token in Authorization header", async () => {
     globalThis.fetch = mock(async () => {
       return new Response(JSON.stringify({ sub: "u", email: "e" }), { status: 200 });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     await fetchUserInfo("my-secret-token");
 
-    const [, init] = (globalThis.fetch as ReturnType<typeof mock>).mock.calls[0];
+    const [, init] = (globalThis.fetch as unknown as ReturnType<typeof mock>).mock.calls[0]!;
     expect(init.headers.Authorization).toBe("Bearer my-secret-token");
   });
 
   test("throws on non-OK response with status code", async () => {
     globalThis.fetch = mock(async () => {
       return new Response("Unauthorized", { status: 401 });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     await expect(fetchUserInfo("expired-token")).rejects.toThrow("API error (401)");
   });
@@ -131,7 +131,7 @@ describe("fetchUserInfo", () => {
   test("includes response body in error message", async () => {
     globalThis.fetch = mock(async () => {
       return new Response("token_revoked", { status: 403 });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     await expect(fetchUserInfo("bad")).rejects.toThrow("token_revoked");
   });

--- a/packages/cli-core/src/test/integration/config-management.test.ts
+++ b/packages/cli-core/src/test/integration/config-management.test.ts
@@ -34,7 +34,9 @@ test.each([{ mode: "human" }, { mode: "agent" }])(
 
     // Pull config
     const { stdout: pullOutput } = await clerk("--mode", mode, "config", "pull");
-    expect(pullOutput).toContain(`"lifetime": ${MOCK_CONFIG.session.lifetime}`);
+    expect(pullOutput).toContain(
+      `"lifetime": ${(MOCK_CONFIG.session as { lifetime: number }).lifetime}`,
+    );
 
     // Pull schema
     http.mock({

--- a/scripts/sign-macos.test.ts
+++ b/scripts/sign-macos.test.ts
@@ -37,13 +37,13 @@ describe("getDarwinTargets", () => {
   test("filters to darwin-arm64 when specified", () => {
     const result = getDarwinTargets("darwin-arm64");
     expect(result.length).toBe(1);
-    expect(result[0].name).toBe("darwin-arm64");
+    expect(result[0]!.name).toBe("darwin-arm64");
   });
 
   test("filters to darwin-x64 when specified", () => {
     const result = getDarwinTargets("darwin-x64");
     expect(result.length).toBe(1);
-    expect(result[0].name).toBe("darwin-x64");
+    expect(result[0]!.name).toBe("darwin-x64");
   });
 
   test("throws for an invalid target", () => {

--- a/scripts/sign-macos.ts
+++ b/scripts/sign-macos.ts
@@ -216,7 +216,7 @@ if (import.meta.main) {
       KEYCHAIN_NAME,
     ]);
     const identityMatch = identityOutput.match(/"([^"]+)"/);
-    if (!identityMatch) {
+    if (!identityMatch?.[1]) {
       throw new Error(`No codesigning identity found in keychain.\nOutput: ${identityOutput}`);
     }
     const identity = identityMatch[1];

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Adds a `tsconfig.json` for `scripts/` and a `typecheck` package script so the release/signing scripts get type-checked independently of the main packages
- Fixes minor type errors surfaced by the new check

## Test plan

- [ ] `bun run typecheck` passes in the `scripts/` directory
- [ ] Existing `sign-macos` tests still pass