### PR TITLE
feat(scripts): add Homebrew distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,30 @@ jobs:
             gh release upload "$tag" "${dir}clerk-${target}${ext}" --clobber
           done
 
+  homebrew:
+    needs: [versioning, build, sign-macos, smoke-test, publish-npm]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: clerk-{darwin-arm64,darwin-x64,linux-arm64,linux-x64}
+          path: dist/artifacts
+
+      - name: Publish Homebrew formula
+        run: bun run scripts/homebrew.ts --version "$VERSION"
+        env:
+          VERSION: ${{ needs.versioning.outputs.version }}
+          ARTIFACTS_DIR: ${{ github.workspace }}/dist/artifacts
+          GH_TOKEN: ${{ github.token }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
   # ─── Canary release ────────────────────────────────────────────────
 
   canary-version:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ The Clerk command-line interface.
 
 ## Installation
 
+### Homebrew (macOS / Linux)
+
+```sh
+brew install clerk/stable/clerk
+```
+
+### npm
+
 ```sh
 npm install -g clerk
 ```

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -6,24 +6,25 @@ This document describes how the Clerk CLI is built, versioned, and published.
 
 ```
 push to main
-  → changesets/action creates/updates "Version Packages" PR
-    → merge "Version Packages" PR
-      → check-release.ts detects unpublished version
-        → build job: cross-compile all 8 targets (~5.5s total)
-          → sign-macos job: code sign + notarize darwin binaries
-            → smoke-test job: verify binaries on native runners
-              → publish-npm: generate platform packages + publish wrapper
-              → upload-github-assets: attach binaries to the GitHub Release
-  → (if no stable release needed) canary.ts versions packages
-    → build → sign-macos → smoke-test subset → upload GitHub pre-release → publish @canary (npm)
+  -> changesets/action creates/updates "Version Packages" PR
+    -> merge "Version Packages" PR
+      -> check-release.ts detects unpublished version
+        -> build job: cross-compile all 8 targets (~5.5s total)
+          -> sign-macos job: code sign + notarize darwin binaries
+            -> smoke-test job: verify binaries on native runners
+              -> publish-npm: generate platform packages + publish wrapper
+                -> upload-github-assets: attach binaries to the GitHub Release
+                -> homebrew: create archives, upload, render formula, push to clerk/homebrew-stable
+  -> (if no stable release needed) canary.ts versions packages
+    -> build -> sign-macos -> smoke-test subset -> upload GitHub pre-release -> publish @canary (npm)
 
 PR comment "!snapshot [name]"
-  → snapshot.ts versions packages from PR branch
-    → build job: cross-compile binaries
-      → sign-macos job: code sign + notarize darwin binaries
-        → smoke-test job: verify linux-x64 binary
-          → publish-npm: publish @snapshot packages
-            → post installation comment on PR
+  -> snapshot.ts versions packages from PR branch
+    -> build job: cross-compile binaries
+      -> sign-macos job: code sign + notarize darwin binaries
+        -> smoke-test job: verify linux-x64 binary
+          -> publish-npm: publish @snapshot packages
+            -> post installation comment on PR
 ```
 
 ## Architecture
@@ -192,6 +193,14 @@ Publishing uses [npm OIDC trusted publishing](https://docs.npmjs.com/trusted-pub
 
 Attaches the compiled binaries to the GitHub Release for direct download. Binaries are uploaded with display names following the `clerk-<target>` convention (e.g., `clerk-darwin-arm64`, `clerk-win32-x64.exe`).
 
+### 6. Homebrew Job
+
+Creates `.tar.gz` archives of the 4 Homebrew-relevant binaries (darwin-arm64, darwin-x64, linux-arm64, linux-x64) downloaded directly from Actions artifacts, uploads them to the GitHub Release, computes SHA256 checksums, renders `Formula/clerk.rb`, and pushes the result to `clerk/homebrew-stable`. The push uses the `HOMEBREW_TAP_TOKEN` secret (a fine-grained PAT or GitHub App token with `contents: write` on `clerk/homebrew-stable`).
+
+This job runs in parallel with `publish-github` since both depend on `publish-npm` (which creates the GitHub Release).
+
+Install: `brew install clerk/stable/clerk`
+
 ## Key Files
 
 | File                                   | Purpose                                                                        |
@@ -209,6 +218,8 @@ Attaches the compiled binaries to the GitHub Release for direct download. Binari
 | `scripts/canary.ts`                    | Versions packages for canary channel using Changesets snapshots                |
 | `scripts/snapshot.ts`                  | Versions packages for snapshot channel using Changesets snapshots              |
 | `scripts/check-release.ts`             | Detects if a stable release is needed (compares version to npm registry)       |
+| `scripts/homebrew.ts`                  | Creates Homebrew archives, uploads to release, renders and pushes formula      |
+| `scripts/homebrew-formula.ts`          | Renders `Formula/clerk.rb` from version + checksums                            |
 | `.changeset/config.json`               | Changesets configuration                                                       |
 | `.github/workflows/build-binaries.yml` | Reusable workflow for cross-compiling binaries (called by release + snapshot)  |
 | `.github/workflows/sign-macos.yml`     | Reusable workflow for macOS code signing and notarization                      |
@@ -221,6 +232,7 @@ The target list exists in these places that must stay in sync:
 
 1. `scripts/releaser/targets.ts` -- used by the releaser to generate platform packages and by `scripts/build.ts` to cross-compile binaries
 2. `.github/workflows/smoke-test.yml` preset definitions -- defines the target matrix for each preset (`stable`, `canary`, `snapshot`)
+3. `scripts/homebrew.ts` -- the `HOMEBREW_TARGETS` array of Homebrew-relevant targets (darwin-arm64, darwin-x64, linux-arm64, linux-x64)
 
 If you add or remove a target, update both of these. Note that the smoke-test presets may not cover every target if a native runner isn't available (e.g., `win32-arm64`).
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -219,12 +219,12 @@ Install: `brew install clerk/stable/clerk`
 | `scripts/snapshot.ts`                  | Versions packages for snapshot channel using Changesets snapshots              |
 | `scripts/check-release.ts`             | Detects if a stable release is needed (compares version to npm registry)       |
 | `scripts/homebrew.ts`                  | Creates Homebrew archives, uploads to release, renders and pushes formula      |
-| `scripts/homebrew-formula.ts`          | Renders `Formula/clerk.rb` from version + checksums                            |
+| `scripts/lib/homebrew.ts`              | Homebrew formula renderer, target list, and helper utilities                   |
 | `.changeset/config.json`               | Changesets configuration                                                       |
 | `.github/workflows/build-binaries.yml` | Reusable workflow for cross-compiling binaries (called by release + snapshot)  |
 | `.github/workflows/sign-macos.yml`     | Reusable workflow for macOS code signing and notarization                      |
 | `.github/workflows/smoke-test.yml`     | Reusable workflow for smoke-testing binaries (called by release + snapshot)    |
-| `.github/workflows/release.yml`        | GitHub Actions release, canary, and snapshot workflow                           |
+| `.github/workflows/release.yml`        | GitHub Actions release, canary, and snapshot workflow                          |
 
 ## Keeping Targets in Sync
 
@@ -232,9 +232,9 @@ The target list exists in these places that must stay in sync:
 
 1. `scripts/releaser/targets.ts` -- used by the releaser to generate platform packages and by `scripts/build.ts` to cross-compile binaries
 2. `.github/workflows/smoke-test.yml` preset definitions -- defines the target matrix for each preset (`stable`, `canary`, `snapshot`)
-3. `scripts/homebrew.ts` -- the `HOMEBREW_TARGETS` array of Homebrew-relevant targets (darwin-arm64, darwin-x64, linux-arm64, linux-x64)
+3. `scripts/lib/homebrew.ts` -- the `HOMEBREW_TARGETS` array of Homebrew-relevant targets (darwin-arm64, darwin-x64, linux-arm64, linux-x64)
 
-If you add or remove a target, update both of these. Note that the smoke-test presets may not cover every target if a native runner isn't available (e.g., `win32-arm64`).
+If you add or remove a target, update all three of these. Note that the smoke-test presets may not cover every target if a native runner isn't available (e.g., `win32-arm64`).
 
 ## Local Development
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "nano-staged": {
     "*.{ts,tsx,js,jsx}": [
       "oxfmt --write",
-      "oxlint"
+      "oxlint -c .oxlintrc.json"
     ],
     "*.{md,json,css}": "oxfmt --write"
   },

--- a/scripts/homebrew.ts
+++ b/scripts/homebrew.ts
@@ -12,37 +12,28 @@ import {
 } from "./lib/homebrew.ts";
 import { run } from "./lib/npm.ts";
 
-const ARTIFACTS_DIR = process.env.ARTIFACTS_DIR ?? join(import.meta.dir, "../dist/artifacts");
+const DEFAULT_ARTIFACTS_DIR =
+  process.env.ARTIFACTS_DIR ?? join(import.meta.dir, "../dist/artifacts");
 
-function parseCliArgs(): {
-  version: string;
-  artifactsDir: string;
-  tapRepo: string;
-  dryRun: boolean;
-} {
-  const { values } = parseArgs({
-    args: Bun.argv.slice(2),
-    options: {
-      version: { type: "string" },
-      "artifacts-dir": { type: "string" },
-      "tap-repo": { type: "string" },
-      "dry-run": { type: "boolean", default: false },
-    },
-  });
+const { values } = parseArgs({
+  options: {
+    version: { type: "string" },
+    "artifacts-dir": { type: "string" },
+    "tap-repo": { type: "string" },
+    "dry-run": { type: "boolean", default: false },
+  },
+  strict: true,
+});
 
-  if (!values.version) {
-    throw new Error("--version is required");
-  }
-
-  return {
-    version: values.version,
-    artifactsDir: values["artifacts-dir"] ?? ARTIFACTS_DIR,
-    tapRepo: values["tap-repo"] ?? "clerk/homebrew-stable",
-    dryRun: values["dry-run"]!,
-  };
+if (!values.version) {
+  console.error("--version is required.");
+  process.exit(1);
 }
 
-const { version, artifactsDir, tapRepo, dryRun } = parseCliArgs();
+const version = values.version;
+const artifactsDir = values["artifacts-dir"] ?? DEFAULT_ARTIFACTS_DIR;
+const tapRepo = values["tap-repo"] ?? "clerk/homebrew-stable";
+const dryRun = values["dry-run"]!;
 
 console.log(`Homebrew distribution: v${version}${dryRun ? " (dry run)" : ""}`);
 console.log(`Artifacts dir: ${artifactsDir}`);

--- a/scripts/homebrew.ts
+++ b/scripts/homebrew.ts
@@ -6,6 +6,7 @@ import {
   renderFormula,
   createArchive,
   computeChecksum,
+  parseMajorVersion,
   HOMEBREW_TARGETS,
   type FormulaInput,
 } from "./lib/homebrew.ts";
@@ -86,8 +87,14 @@ const formula = renderFormula({ version, checksums });
 console.log("\nRendered formula:");
 console.log(formula);
 
+const major = parseMajorVersion(version);
+const versionedFormula = renderFormula({ version, checksums, major });
+console.log("\nRendered versioned formula:");
+console.log(versionedFormula);
+
 if (dryRun) {
   console.log("[dry-run] Skipping tap clone and push.");
+  console.log(`[dry-run] Would write Formula/clerk.rb and Formula/clerk@${major}.rb`);
 } else {
   const token = process.env.HOMEBREW_TAP_TOKEN;
   if (!token) {
@@ -114,9 +121,13 @@ if (dryRun) {
   await writeFile(formulaPath, formula, "utf-8");
   console.log(`Wrote formula to ${formulaPath}`);
 
+  const versionedFormulaPath = join(formulaDir, `clerk@${major}.rb`);
+  await writeFile(versionedFormulaPath, versionedFormula, "utf-8");
+  console.log(`Wrote versioned formula to ${versionedFormulaPath}`);
+
   run(["git", "config", "user.name", "clerk-bot"], { cwd: tapWorkDir });
   run(["git", "config", "user.email", "bot@clerk.com"], { cwd: tapWorkDir });
-  run(["git", "add", "Formula/clerk.rb"], { cwd: tapWorkDir });
+  run(["git", "add", "Formula/clerk.rb", `Formula/clerk@${major}.rb`], { cwd: tapWorkDir });
 
   const diffResult = Bun.spawnSync(["git", "diff", "--cached", "--quiet"], {
     cwd: tapWorkDir,

--- a/scripts/homebrew.ts
+++ b/scripts/homebrew.ts
@@ -35,6 +35,11 @@ const artifactsDir = values["artifacts-dir"] ?? DEFAULT_ARTIFACTS_DIR;
 const tapRepo = values["tap-repo"] ?? "clerk/homebrew-stable";
 const dryRun = values["dry-run"]!;
 
+if (!dryRun && !process.env.HOMEBREW_TAP_TOKEN) {
+  console.error("HOMEBREW_TAP_TOKEN is required (use --dry-run to skip).");
+  process.exit(1);
+}
+
 console.log(`Homebrew distribution: v${version}${dryRun ? " (dry run)" : ""}`);
 console.log(`Artifacts dir: ${artifactsDir}`);
 console.log(`Tap repo: ${tapRepo}`);
@@ -87,15 +92,12 @@ if (dryRun) {
   console.log("[dry-run] Skipping tap clone and push.");
   console.log(`[dry-run] Would write Formula/clerk.rb and Formula/clerk@${major}.rb`);
 } else {
-  const token = process.env.HOMEBREW_TAP_TOKEN;
-  if (!token) {
-    throw new Error("HOMEBREW_TAP_TOKEN env var is required for pushing to tap");
-  }
+  const token = process.env.HOMEBREW_TAP_TOKEN!;
 
   const tapWorkDir = join(workDir, "tap-workdir");
   console.log(`Cloning tap repo ${tapRepo}...`);
   run(["git", "clone", `https://github.com/${tapRepo}.git`, tapWorkDir]);
-  run(
+  const setUrlResult = Bun.spawnSync(
     [
       "git",
       "remote",
@@ -103,8 +105,11 @@ if (dryRun) {
       "origin",
       `https://x-access-token:${token}@github.com/${tapRepo}.git`,
     ],
-    { cwd: tapWorkDir },
+    { cwd: tapWorkDir, stdio: ["ignore", "pipe", "pipe"] },
   );
+  if (setUrlResult.exitCode !== 0) {
+    throw new Error("Failed to configure authenticated remote for tap repo");
+  }
 
   const formulaDir = join(tapWorkDir, "Formula");
   await mkdir(formulaDir, { recursive: true });

--- a/scripts/homebrew.ts
+++ b/scripts/homebrew.ts
@@ -1,0 +1,136 @@
+import { mkdtemp, writeFile, mkdir } from "node:fs/promises";
+import { join, basename } from "node:path";
+import { tmpdir } from "node:os";
+import { parseArgs } from "node:util";
+import {
+  renderFormula,
+  createArchive,
+  computeChecksum,
+  HOMEBREW_TARGETS,
+  type FormulaInput,
+} from "./lib/homebrew.ts";
+import { run } from "./lib/npm.ts";
+
+const ARTIFACTS_DIR = process.env.ARTIFACTS_DIR ?? join(import.meta.dir, "../dist/artifacts");
+
+function parseCliArgs(): {
+  version: string;
+  artifactsDir: string;
+  tapRepo: string;
+  dryRun: boolean;
+} {
+  const { values } = parseArgs({
+    args: Bun.argv.slice(2),
+    options: {
+      version: { type: "string" },
+      "artifacts-dir": { type: "string" },
+      "tap-repo": { type: "string" },
+      "dry-run": { type: "boolean", default: false },
+    },
+  });
+
+  if (!values.version) {
+    throw new Error("--version is required");
+  }
+
+  return {
+    version: values.version,
+    artifactsDir: values["artifacts-dir"] ?? ARTIFACTS_DIR,
+    tapRepo: values["tap-repo"] ?? "clerk/homebrew-stable",
+    dryRun: values["dry-run"]!,
+  };
+}
+
+const { version, artifactsDir, tapRepo, dryRun } = parseCliArgs();
+
+console.log(`Homebrew distribution: v${version}${dryRun ? " (dry run)" : ""}`);
+console.log(`Artifacts dir: ${artifactsDir}`);
+console.log(`Tap repo: ${tapRepo}`);
+
+const workDir = await mkdtemp(join(tmpdir(), "homebrew-archives-"));
+console.log(`Work directory: ${workDir}`);
+
+const archivePaths = new Map<string, string>();
+
+for (const target of HOMEBREW_TARGETS) {
+  const binaryPath = join(artifactsDir, `clerk-${target.name}`, "clerk");
+  const archivePath = join(workDir, `homebrew-clerk-${target.name}.tar.gz`);
+  console.log(`Creating archive for ${target.name}...`);
+  createArchive(binaryPath, archivePath);
+  archivePaths.set(target.name, archivePath);
+}
+
+const tagName = `v${version}`;
+for (const target of HOMEBREW_TARGETS) {
+  const archivePath = archivePaths.get(target.name)!;
+  if (dryRun) {
+    console.log(`[dry-run] Would upload ${basename(archivePath)} to ${tagName}`);
+  } else {
+    console.log(`Uploading ${basename(archivePath)} to ${tagName}...`);
+    run(["gh", "release", "upload", tagName, archivePath, "--clobber"]);
+  }
+}
+
+console.log("Computing checksums...");
+const checksums = {} as FormulaInput["checksums"];
+for (const target of HOMEBREW_TARGETS) {
+  const archivePath = archivePaths.get(target.name)!;
+  checksums[target.name] = await computeChecksum(archivePath);
+}
+
+for (const target of HOMEBREW_TARGETS) {
+  console.log(`  ${target.name}: ${checksums[target.name]}`);
+}
+
+const formula = renderFormula({ version, checksums });
+console.log("\nRendered formula:");
+console.log(formula);
+
+if (dryRun) {
+  console.log("[dry-run] Skipping tap clone and push.");
+} else {
+  const token = process.env.HOMEBREW_TAP_TOKEN;
+  if (!token) {
+    throw new Error("HOMEBREW_TAP_TOKEN env var is required for pushing to tap");
+  }
+
+  const tapWorkDir = join(workDir, "tap-workdir");
+  console.log(`Cloning tap repo ${tapRepo}...`);
+  run(["git", "clone", `https://github.com/${tapRepo}.git`, tapWorkDir]);
+  run(
+    [
+      "git",
+      "remote",
+      "set-url",
+      "origin",
+      `https://x-access-token:${token}@github.com/${tapRepo}.git`,
+    ],
+    { cwd: tapWorkDir },
+  );
+
+  const formulaDir = join(tapWorkDir, "Formula");
+  await mkdir(formulaDir, { recursive: true });
+  const formulaPath = join(formulaDir, "clerk.rb");
+  await writeFile(formulaPath, formula, "utf-8");
+  console.log(`Wrote formula to ${formulaPath}`);
+
+  run(["git", "config", "user.name", "clerk-bot"], { cwd: tapWorkDir });
+  run(["git", "config", "user.email", "bot@clerk.com"], { cwd: tapWorkDir });
+  run(["git", "add", "Formula/clerk.rb"], { cwd: tapWorkDir });
+
+  const diffResult = Bun.spawnSync(["git", "diff", "--cached", "--quiet"], {
+    cwd: tapWorkDir,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  if (diffResult.exitCode === 0) {
+    console.log("No changes to formula, skipping commit and push.");
+  } else {
+    console.log(`Committing and pushing formula for clerk ${version}...`);
+    run(["git", "commit", "-m", `clerk ${version}`], { cwd: tapWorkDir });
+    run(["git", "push", "origin", "main"], { cwd: tapWorkDir });
+    console.log("Pushed formula to tap.");
+  }
+}
+
+console.log("Done!");

--- a/scripts/lib/homebrew.test.ts
+++ b/scripts/lib/homebrew.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { renderFormula, computeChecksum, createArchive } from "./homebrew.ts";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+describe("renderFormula", () => {
+  test("renders formula with version and checksums", () => {
+    const result = renderFormula({
+      version: "1.2.3",
+      checksums: {
+        "darwin-arm64": "aaaa",
+        "darwin-x64": "bbbb",
+        "linux-arm64": "cccc",
+        "linux-x64": "dddd",
+      },
+    });
+
+    expect(result).toContain('version "1.2.3"');
+    expect(result).toContain(
+      "https://github.com/clerk/cli/releases/download/v1.2.3/homebrew-clerk-darwin-arm64.tar.gz",
+    );
+    expect(result).toContain('sha256 "aaaa"');
+    expect(result).toContain(
+      "https://github.com/clerk/cli/releases/download/v1.2.3/homebrew-clerk-darwin-x64.tar.gz",
+    );
+    expect(result).toContain('sha256 "bbbb"');
+    expect(result).toContain(
+      "https://github.com/clerk/cli/releases/download/v1.2.3/homebrew-clerk-linux-arm64.tar.gz",
+    );
+    expect(result).toContain('sha256 "cccc"');
+    expect(result).toContain(
+      "https://github.com/clerk/cli/releases/download/v1.2.3/homebrew-clerk-linux-x64.tar.gz",
+    );
+    expect(result).toContain('sha256 "dddd"');
+    expect(result).toContain('bin.install "clerk"');
+    expect(result).toContain("assert_match version.to_s");
+  });
+
+  test("output is valid Ruby (class Clerk < Formula)", () => {
+    const result = renderFormula({
+      version: "0.1.0",
+      checksums: {
+        "darwin-arm64": "a".repeat(64),
+        "darwin-x64": "b".repeat(64),
+        "linux-arm64": "c".repeat(64),
+        "linux-x64": "d".repeat(64),
+      },
+    });
+
+    expect(result).toStartWith("class Clerk < Formula\n");
+    expect(result).toEndWith("end\n");
+  });
+});
+
+describe("computeChecksum", () => {
+  test("returns sha256 hex digest", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "homebrew-test-"));
+    const file = join(dir, "test.bin");
+    await Bun.write(file, "hello world");
+    const hash = await computeChecksum(file);
+    // sha256("hello world") = b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+    expect(hash).toBe("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9");
+    await rm(dir, { recursive: true });
+  });
+});
+
+describe("createArchive", () => {
+  test("creates a tar.gz containing a file named clerk", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "homebrew-test-"));
+    const binaryPath = join(dir, "clerk");
+    await Bun.write(binaryPath, "fake binary content");
+
+    const archivePath = join(dir, "test.tar.gz");
+    createArchive(binaryPath, archivePath);
+
+    expect(await Bun.file(archivePath).exists()).toBe(true);
+
+    // Verify archive contains "clerk"
+    const result = Bun.spawnSync(["tar", "tzf", archivePath], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const files = result.stdout.toString().trim().split("\n");
+    expect(files).toContain("clerk");
+
+    await rm(dir, { recursive: true });
+  });
+});

--- a/scripts/lib/homebrew.test.ts
+++ b/scripts/lib/homebrew.test.ts
@@ -51,6 +51,37 @@ describe("renderFormula", () => {
     expect(result).toStartWith("class Clerk < Formula\n");
     expect(result).toEndWith("end\n");
   });
+
+  test("versioned formula uses ClerkATN class name", () => {
+    const result = renderFormula({
+      version: "1.2.3",
+      checksums: {
+        "darwin-arm64": "aaaa",
+        "darwin-x64": "bbbb",
+        "linux-arm64": "cccc",
+        "linux-x64": "dddd",
+      },
+      major: 1,
+    });
+
+    expect(result).toStartWith("class ClerkAT1 < Formula\n");
+    expect(result).not.toContain("class Clerk <");
+  });
+
+  test("versioned formula includes keg_only", () => {
+    const result = renderFormula({
+      version: "2.0.0",
+      checksums: {
+        "darwin-arm64": "aaaa",
+        "darwin-x64": "bbbb",
+        "linux-arm64": "cccc",
+        "linux-x64": "dddd",
+      },
+      major: 2,
+    });
+
+    expect(result).toContain("keg_only :versioned_formula");
+  });
 });
 
 describe("computeChecksum", () => {

--- a/scripts/lib/homebrew.test.ts
+++ b/scripts/lib/homebrew.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { renderFormula, computeChecksum, createArchive } from "./homebrew.ts";
+import { renderFormula, computeChecksum, createArchive, parseMajorVersion } from "./homebrew.ts";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -84,5 +84,19 @@ describe("createArchive", () => {
     expect(files).toContain("clerk");
 
     await rm(dir, { recursive: true });
+  });
+});
+
+describe("parseMajorVersion", () => {
+  test("extracts major from semver", () => {
+    expect(parseMajorVersion("1.2.3")).toBe(1);
+  });
+
+  test("handles zero major", () => {
+    expect(parseMajorVersion("0.5.1")).toBe(0);
+  });
+
+  test("handles major-only version", () => {
+    expect(parseMajorVersion("3")).toBe(3);
   });
 });

--- a/scripts/lib/homebrew.test.ts
+++ b/scripts/lib/homebrew.test.ts
@@ -99,4 +99,8 @@ describe("parseMajorVersion", () => {
   test("handles major-only version", () => {
     expect(parseMajorVersion("3")).toBe(3);
   });
+
+  test("throws on invalid version", () => {
+    expect(() => parseMajorVersion("")).toThrow("Invalid version string");
+  });
 });

--- a/scripts/lib/homebrew.ts
+++ b/scripts/lib/homebrew.ts
@@ -1,3 +1,4 @@
+import { copyFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { targets } from "./targets.ts";
@@ -72,7 +73,7 @@ end
  * Extracts the major version number from a semver string.
  */
 export function parseMajorVersion(version: string): number {
-  const major = parseInt(version.split(".")[0], 10);
+  const major = parseInt(version.split(".")[0] ?? "", 10);
   if (Number.isNaN(major)) {
     throw new Error(`Invalid version string: "${version}"`);
   }
@@ -88,20 +89,10 @@ export function createArchive(binaryPath: string, archivePath: string): void {
     tmpdir(),
     `homebrew-stage-${Date.now()}-${Math.random().toString(36).slice(2)}`,
   );
-  const result = Bun.spawnSync(["mkdir", "-p", stageDir], {
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  if (result.exitCode !== 0) {
-    throw new Error(`mkdir failed (exit ${result.exitCode}): ${result.stderr.toString().trim()}`);
-  }
+  mkdirSync(stageDir, { recursive: true });
 
   const stagedBinary = join(stageDir, "clerk");
-  const cpResult = Bun.spawnSync(["cp", binaryPath, stagedBinary], {
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  if (cpResult.exitCode !== 0) {
-    throw new Error(`cp failed (exit ${cpResult.exitCode}): ${cpResult.stderr.toString().trim()}`);
-  }
+  copyFileSync(binaryPath, stagedBinary);
 
   const tarResult = Bun.spawnSync(["tar", "czf", archivePath, "-C", stageDir, "clerk"], {
     stdio: ["ignore", "pipe", "pipe"],

--- a/scripts/lib/homebrew.ts
+++ b/scripts/lib/homebrew.ts
@@ -65,6 +65,13 @@ end
 }
 
 /**
+ * Extracts the major version number from a semver string.
+ */
+export function parseMajorVersion(version: string): number {
+  return parseInt(version.split(".")[0], 10);
+}
+
+/**
  * Creates a tar.gz archive containing just the binary renamed to "clerk".
  * Stages the rename in a temp directory so the archive entry name is always "clerk".
  */

--- a/scripts/lib/homebrew.ts
+++ b/scripts/lib/homebrew.ts
@@ -1,0 +1,109 @@
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { targets } from "./targets.ts";
+
+// Homebrew supports macOS and Linux (glibc only). Derive the subset from the
+// canonical targets list so adding/removing a target in targets.ts automatically
+// updates the Homebrew build.
+type HomebrewTarget = (typeof targets)[number] & { os: "darwin" | "linux"; libc?: "glibc" };
+export type HomebrewTargetName = HomebrewTarget["name"];
+
+export const HOMEBREW_TARGETS = targets.filter(
+  (t): t is HomebrewTarget =>
+    (t.os === "darwin" || t.os === "linux") && (!("libc" in t) || t.libc !== "musl"),
+);
+
+export interface FormulaInput {
+  version: string;
+  checksums: Record<HomebrewTargetName, string>;
+}
+
+function assetUrl(version: string, target: string): string {
+  return `https://github.com/clerk/cli/releases/download/v${version}/homebrew-clerk-${target}.tar.gz`;
+}
+
+export function renderFormula(input: FormulaInput): string {
+  const { version, checksums } = input;
+
+  return `class Clerk < Formula
+  desc "The Clerk CLI"
+  homepage "https://clerk.com"
+  version "${version}"
+  license "MIT"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "${assetUrl(version, "darwin-arm64")}"
+      sha256 "${checksums["darwin-arm64"]}"
+    end
+    if Hardware::CPU.intel?
+      url "${assetUrl(version, "darwin-x64")}"
+      sha256 "${checksums["darwin-x64"]}"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "${assetUrl(version, "linux-arm64")}"
+      sha256 "${checksums["linux-arm64"]}"
+    end
+    if Hardware::CPU.intel?
+      url "${assetUrl(version, "linux-x64")}"
+      sha256 "${checksums["linux-x64"]}"
+    end
+  end
+
+  def install
+    bin.install "clerk"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/clerk --version")
+  end
+end
+`;
+}
+
+/**
+ * Creates a tar.gz archive containing just the binary renamed to "clerk".
+ * Stages the rename in a temp directory so the archive entry name is always "clerk".
+ */
+export function createArchive(binaryPath: string, archivePath: string): void {
+  const stageDir = join(
+    tmpdir(),
+    `homebrew-stage-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  const result = Bun.spawnSync(["mkdir", "-p", stageDir], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(`mkdir failed (exit ${result.exitCode}): ${result.stderr.toString().trim()}`);
+  }
+
+  const stagedBinary = join(stageDir, "clerk");
+  const cpResult = Bun.spawnSync(["cp", binaryPath, stagedBinary], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (cpResult.exitCode !== 0) {
+    throw new Error(`cp failed (exit ${cpResult.exitCode}): ${cpResult.stderr.toString().trim()}`);
+  }
+
+  const tarResult = Bun.spawnSync(["tar", "czf", archivePath, "-C", stageDir, "clerk"], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (tarResult.exitCode !== 0) {
+    throw new Error(
+      `tar failed (exit ${tarResult.exitCode}): ${tarResult.stderr.toString().trim()}`,
+    );
+  }
+}
+
+/**
+ * Reads a file and returns its SHA256 hex digest.
+ */
+export async function computeChecksum(filePath: string): Promise<string> {
+  const buffer = await Bun.file(filePath).arrayBuffer();
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(buffer);
+  return hasher.digest("hex");
+}

--- a/scripts/lib/homebrew.ts
+++ b/scripts/lib/homebrew.ts
@@ -68,7 +68,11 @@ end
  * Extracts the major version number from a semver string.
  */
 export function parseMajorVersion(version: string): number {
-  return parseInt(version.split(".")[0], 10);
+  const major = parseInt(version.split(".")[0], 10);
+  if (Number.isNaN(major)) {
+    throw new Error(`Invalid version string: "${version}"`);
+  }
+  return major;
 }
 
 /**

--- a/scripts/lib/homebrew.ts
+++ b/scripts/lib/homebrew.ts
@@ -16,6 +16,7 @@ export const HOMEBREW_TARGETS = targets.filter(
 export interface FormulaInput {
   version: string;
   checksums: Record<HomebrewTargetName, string>;
+  major?: number;
 }
 
 function assetUrl(version: string, target: string): string {
@@ -23,13 +24,16 @@ function assetUrl(version: string, target: string): string {
 }
 
 export function renderFormula(input: FormulaInput): string {
-  const { version, checksums } = input;
+  const { version, checksums, major } = input;
 
-  return `class Clerk < Formula
+  const className = major != null ? `ClerkAT${major}` : "Clerk";
+  const kegOnly = major != null ? "\n  keg_only :versioned_formula" : "";
+
+  return `class ${className} < Formula
   desc "The Clerk CLI"
   homepage "https://clerk.com"
   version "${version}"
-  license "MIT"
+  license "MIT"${kegOnly}
 
   on_macos do
     if Hardware::CPU.arm?

--- a/scripts/lib/homebrew.ts
+++ b/scripts/lib/homebrew.ts
@@ -31,28 +31,28 @@ export function renderFormula(input: FormulaInput): string {
   const kegOnly = major != null ? "\n  keg_only :versioned_formula" : "";
 
   return `class ${className} < Formula
-  desc "The Clerk CLI"
+  desc "Clerk command-line interface"
   homepage "https://clerk.com"
   version "${version}"
   license "MIT"${kegOnly}
 
   on_macos do
-    if Hardware::CPU.arm?
+    on_arm do
       url "${assetUrl(version, "darwin-arm64")}"
       sha256 "${checksums["darwin-arm64"]}"
     end
-    if Hardware::CPU.intel?
+    on_intel do
       url "${assetUrl(version, "darwin-x64")}"
       sha256 "${checksums["darwin-x64"]}"
     end
   end
 
   on_linux do
-    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    on_arm do
       url "${assetUrl(version, "linux-arm64")}"
       sha256 "${checksums["linux-arm64"]}"
     end
-    if Hardware::CPU.intel?
+    on_intel do
       url "${assetUrl(version, "linux-x64")}"
       sha256 "${checksums["linux-x64"]}"
     end

--- a/scripts/lib/targets.ts
+++ b/scripts/lib/targets.ts
@@ -12,7 +12,7 @@ export interface Target {
 // Target names use Node.js ${process.platform}-${process.arch} convention so the wrapper
 // shim (packages/cli/bin/clerk) can derive package names without a lookup table.
 // Used by scripts/build.ts, scripts/sign-macos.ts, and scripts/releaser.ts.
-export const targets: Target[] = [
+export const targets = [
   {
     name: "darwin-arm64",
     bunTarget: "bun-darwin-arm64",
@@ -81,7 +81,7 @@ export const targets: Target[] = [
     ext: ".exe",
     verifyPattern: /PE32\+.*x86-64/,
   },
-];
+] as const satisfies Target[];
 
 export const SCOPE = "@clerk";
 export const PKG_PREFIX = "cli";


### PR DESCRIPTION
## Summary

- Adds a Homebrew distribution library (`scripts/lib/homebrew.ts`) that renders Ruby formula files from platform binary metadata
- Supports versioned formulas (e.g., `clerk@2.rb`) alongside the latest (`clerk.rb`) for major-version pinning
- Adds the `scripts/homebrew.ts` entry point and a CI job in the release workflow to generate and push formulas to a tap repo
- Documents the Homebrew distribution flow in `README.md` and `docs/releasing.md`

## Test plan

- [ ] `bun test scripts/lib/homebrew.test.ts` passes
- [ ] Formula rendering produces valid Ruby syntax for all platform targets
- [ ] Versioned formula (`clerk@N.rb`) is generated alongside `clerk.rb`