### PR TITLE
feat(init): add --app flag to link to a specific application

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Commands:
 
 clerk init
   --framework <name>   Framework to set up (skips auto-detection)
+  --app <id>           Link to a specific Clerk application by ID
   --starter            Bootstrap a new project from a starter template
   --prompt             Output a prompt for an AI agent to integrate Clerk
   --yes                Skip confirmation prompts
@@ -57,6 +58,7 @@ clerk init
   Examples:
     $ clerk init                       Auto-detect framework and set up Clerk
     $ clerk init --framework next      Set up for Next.js (skips detection)
+    $ clerk init --app app_123         Link to a specific Clerk application
     $ clerk init --starter             Create a new project with Clerk
     $ clerk init --prompt              Output a setup prompt for an AI agent
     $ clerk init -y                    Skip all confirmation prompts

--- a/packages/cli-core/src/cli-program.ts
+++ b/packages/cli-core/src/cli-program.ts
@@ -88,6 +88,7 @@ export function createProgram() {
         FRAMEWORK_NAMES,
       ),
     )
+    .option("--app <id>", "Link to a specific Clerk application by ID")
     .option("--prompt", "Output a prompt for an AI agent to integrate Clerk")
     .option("--starter", "Create a new project from a starter template")
     .option("-y, --yes", "Skip confirmation prompts")
@@ -97,6 +98,10 @@ export function createProgram() {
       {
         command: "clerk init --framework next",
         description: "Set up for Next.js (skips detection)",
+      },
+      {
+        command: "clerk init --app app_123",
+        description: "Link to a specific Clerk application",
       },
       { command: "clerk init --starter", description: "Create a new project with Clerk" },
       { command: "clerk init --prompt", description: "Output a setup prompt for an AI agent" },

--- a/packages/cli-core/src/commands/init/README.md
+++ b/packages/cli-core/src/commands/init/README.md
@@ -6,6 +6,7 @@ Initializes Clerk in a project by authenticating the user, linking a Clerk appli
 
 ```sh
 clerk init
+clerk init --app app_123
 clerk init --framework next
 clerk init --starter
 clerk init --starter --framework next
@@ -20,6 +21,7 @@ clerk init --no-skills
 | Option               | Description                                                                                                                                                                           |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--framework <name>` | Framework to set up (skips auto-detection). Valid values: `next`, `astro`, `nuxt`, `tanstack-start`, `react-router`, `vue`, `expo`, `react`, `javascript`, `js`, `express`, `fastify` |
+| `--app <id>`         | Link to a specific Clerk application by ID (skips the interactive app picker). If the repo is already linked to a different application, prompts to re-link.                          |
 | `--starter`          | Bootstrap a new project from a starter template (runs the framework generator, installs deps, and scaffolds Clerk)                                                                    |
 | `--prompt`           | Output a prompt for an AI agent to integrate Clerk, then exit                                                                                                                         |
 | `-y, --yes`          | Skip confirmation prompts (also skips authentication after bootstrap, letting you connect your account later)                                                                         |

--- a/packages/cli-core/src/commands/init/index.test.ts
+++ b/packages/cli-core/src/commands/init/index.test.ts
@@ -111,7 +111,19 @@ describe("init", () => {
     await init({ yes: true });
 
     expect(loginMod.login).toHaveBeenCalledWith({ showNextSteps: false });
-    expect(linkMod.link).toHaveBeenCalledWith({ skipIfLinked: true });
+    expect(linkMod.link).toHaveBeenCalledWith({ skipIfLinked: true, app: undefined });
+  });
+
+  test("forwards --app to link when provided", async () => {
+    setup({ email: "test@test.com" });
+    spyOn(context, "gatherContext").mockResolvedValue(FAKE_CTX);
+    spyOn(config, "resolveProfile").mockResolvedValue({
+      profile: { appId: "app_other" },
+    } as never);
+
+    await init({ yes: true, app: "app_abc" });
+
+    expect(linkMod.link).toHaveBeenCalledWith({ skipIfLinked: true, app: "app_abc" });
   });
 
   test("agent mode prints guidance without auth/bootstrap", async () => {

--- a/packages/cli-core/src/commands/init/index.test.ts
+++ b/packages/cli-core/src/commands/init/index.test.ts
@@ -126,6 +126,16 @@ describe("init", () => {
     expect(linkMod.link).toHaveBeenCalledWith({ skipIfLinked: true, app: "app_abc" });
   });
 
+  test("forwards --app to link when no profile exists", async () => {
+    setup({ email: "test@test.com" });
+    spyOn(context, "gatherContext").mockResolvedValue(FAKE_CTX);
+    // resolveProfile already returns undefined by default in setup()
+
+    await init({ yes: true, app: "app_abc" });
+
+    expect(linkMod.link).toHaveBeenCalledWith({ skipIfLinked: true, app: "app_abc" });
+  });
+
   test("agent mode prints guidance without auth/bootstrap", async () => {
     const { captured } = setup({ isAgent: true });
 

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -49,7 +49,7 @@ export async function init(options: InitOptions = {}) {
 
   if (options.prompt || isAgent()) {
     log.data(
-      "Run `clerk init -y` to automatically detect the framework, install the Clerk SDK, and scaffold authentication files without interactive prompts. Pass `--app <id>` to link to a specific Clerk application.",
+      "Run `clerk init -y` to automatically detect the framework, install the Clerk SDK, and scaffold authentication files without interactive prompts.",
     );
     return;
   }

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -49,7 +49,7 @@ export async function init(options: InitOptions = {}) {
 
   if (options.prompt || isAgent()) {
     log.data(
-      "Run `clerk init -y` to automatically detect the framework, install the Clerk SDK, and scaffold authentication files without interactive prompts.",
+      "Run `clerk init -y` to automatically detect the framework, install the Clerk SDK, and scaffold authentication files without interactive prompts. Pass `--app <id>` to link to a specific Clerk application.",
     );
     return;
   }

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -37,6 +37,7 @@ type InitOptions = {
   prompt?: boolean;
   skills?: boolean;
   starter?: boolean;
+  app?: string;
 };
 
 export async function init(options: InitOptions = {}) {
@@ -74,7 +75,7 @@ export async function init(options: InitOptions = {}) {
 
   if (!keyless) {
     bar();
-    await authenticateAndLink(ctx.cwd);
+    await authenticateAndLink(ctx.cwd, options.app);
   }
 
   // Short-circuit on a fully-clean re-run so env pull / skills prompt don't
@@ -190,11 +191,13 @@ async function resolveAuthLabel(): Promise<string> {
   return "";
 }
 
-async function authenticateAndLink(cwd: string): Promise<void> {
+async function authenticateAndLink(cwd: string, app: string | undefined): Promise<void> {
   const label = await resolveAuthLabel();
   const profile = await resolveProfile(cwd);
 
-  if (label && profile) {
+  const alreadyOnRequestedApp = profile && (!app || profile.profile.appId === app);
+
+  if (label && alreadyOnRequestedApp) {
     log.info(dim(`${label} · Linked to ${profile.profile.appId}`));
     return;
   }
@@ -203,7 +206,7 @@ async function authenticateAndLink(cwd: string): Promise<void> {
     log.info(dim(label));
   }
 
-  await link({ skipIfLinked: true });
+  await link({ skipIfLinked: true, app });
 }
 
 // --- Detect & install ---

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -34,11 +34,11 @@ import type { ProjectContext } from "./frameworks/types.js";
 type InitOptions = {
   /** Framework to set up (skips auto-detection). */
   framework?: string;
-  /** Skip confirmation prompts (also skips authentication after bootstrap). */
+  /** Skip confirmation prompts (in bootstrap mode, also skips authentication so you can connect your account later). */
   yes?: boolean;
   /** Output a prompt for an AI agent to integrate Clerk, then exit. */
   prompt?: boolean;
-  /** Whether to install the optional agent skills (default: true; `--no-skills` sets false). */
+  /** Install the optional agent skills (set to false via `--no-skills` to skip). */
   skills?: boolean;
   /** Create a new project from a starter template. */
   starter?: boolean;

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -32,11 +32,17 @@ import {
 import type { ProjectContext } from "./frameworks/types.js";
 
 type InitOptions = {
+  /** Framework to set up (skips auto-detection). */
   framework?: string;
+  /** Skip confirmation prompts (also skips authentication after bootstrap). */
   yes?: boolean;
+  /** Output a prompt for an AI agent to integrate Clerk, then exit. */
   prompt?: boolean;
+  /** Whether to install the optional agent skills (default: true; `--no-skills` sets false). */
   skills?: boolean;
+  /** Create a new project from a starter template. */
   starter?: boolean;
+  /** Link to a specific Clerk application by ID (skips the interactive picker). */
   app?: string;
 };
 

--- a/packages/cli-core/src/commands/link/index.test.ts
+++ b/packages/cli-core/src/commands/link/index.test.ts
@@ -226,6 +226,58 @@ describe("link", () => {
     });
   });
 
+  describe("skipIfLinked", () => {
+    test("returns early when linked and no --app given", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockResolveProfile.mockResolvedValue({
+        path: "/repo/.git",
+        profile: { workspaceId: "", appId: "app_existing", instances: { development: "ins_1" } },
+      });
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await runLink({ skipIfLinked: true });
+
+      expect(captured.err).toContain("Already linked");
+      expect(mockConfirm).not.toHaveBeenCalled();
+      expect(mockFetchApplication).not.toHaveBeenCalled();
+      expect(mockSetProfile).not.toHaveBeenCalled();
+    });
+
+    test("returns early when linked to the same app as --app", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockResolveProfile.mockResolvedValue({
+        path: "/repo/.git",
+        profile: { workspaceId: "", appId: "app_123", instances: { development: "ins_1" } },
+      });
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await runLink({ skipIfLinked: true, app: "app_123" });
+
+      expect(captured.err).toContain("Already linked");
+      expect(mockConfirm).not.toHaveBeenCalled();
+      expect(mockFetchApplication).not.toHaveBeenCalled();
+      expect(mockSetProfile).not.toHaveBeenCalled();
+    });
+
+    test("falls through to re-link prompt when --app differs from existing link", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockResolveProfile.mockResolvedValue({
+        path: "/repo/.git",
+        profile: { workspaceId: "", appId: "app_existing", instances: { development: "ins_1" } },
+      });
+      mockGetToken.mockResolvedValue("token");
+      mockFetchApplication.mockResolvedValue(mockApp);
+      mockConfirm.mockResolvedValue(true);
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await runLink({ skipIfLinked: true, app: "app_123" });
+
+      expect(mockConfirm).toHaveBeenCalled();
+      expect(mockFetchApplication).toHaveBeenCalledWith("app_123");
+      expect(mockSetProfile).toHaveBeenCalled();
+    });
+  });
+
   describe("authentication", () => {
     test("calls login when no token exists", async () => {
       mockIsAgent.mockReturnValue(false);

--- a/packages/cli-core/src/commands/link/index.ts
+++ b/packages/cli-core/src/commands/link/index.ts
@@ -62,8 +62,9 @@ export async function link(options: LinkOptions = {}): Promise<void> {
   const displayPath = repoRoot ?? cwd;
 
   const existing = await resolveProfile(cwd);
+  const targetsDifferentApp = options.app && existing && options.app !== existing.profile.appId;
 
-  if (existing && options.skipIfLinked) {
+  if (existing && options.skipIfLinked && !targetsDifferentApp) {
     printExistingStatus(existing, normalizedRemote);
     return;
   }


### PR DESCRIPTION
## Summary

- Adds `--app <id>` to `clerk init` so the Clerk dashboard can render a copy-paste command that links a repo to a specific application.
- Tightens the `skipIfLinked` short-circuit in `clerk link` so an explicit `--app` that differs from an existing link falls through to the re-link prompt instead of being silently ignored.

## Behavior

| Repo state | `clerk init --app X` |
|---|---|
| Not linked | Links to `X` silently |
| Linked to `X` already | No-op: prints "Already linked to X" and proceeds |
| Linked to a different app | Prompts "Re-link to X?" (default No) |
| `X` doesn't exist / no access | Errors via `Failed to fetch application` before scaffolding |

Note: `-y` does not currently auto-confirm the re-link prompt — `link()` has no `yes` plumbing. The dashboard copy-paste flow does not use `-y`, so the safety prompt is desired. Threading `yes` through `link()` is a separate follow-up if a future need arises.

## Test plan

- [x] Unit tests in `packages/cli-core/src/commands/link/index.test.ts` cover the three `skipIfLinked` branches (no `--app`, matching `--app`, differing `--app`)
- [x] Unit tests in `packages/cli-core/src/commands/init/index.test.ts` cover `--app` forwarding with and without an existing profile
- [x] Manual: fresh repo with `--app <id>` links + scaffolds (no picker)
- [x] Manual: same app re-run is a silent no-op
- [x] Manual: different app prompts `Re-link to X?` defaulting to No
- [x] Manual: invalid `--app` errors out before scaffolding