### PR TITLE
feat(ci): add Slack failure notifications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,14 @@ jobs:
           CLERK_CLI_TEST_APP_ID: ${{ secrets.CLERK_CLI_TEST_APP_ID }}
           CLERK_PLATFORM_API_KEY: ${{ secrets.CLERK_PLATFORM_API_KEY }}
           CLERK_E2E_DEBUG: "1"
+
+  notify-failure:
+    if: >-
+      always() &&
+      contains(needs.*.result, 'failure')
+    needs: [build, lint, test, test-e2e]
+    uses: ./.github/workflows/notify-failure.yml
+    with:
+      workflow-name: CI
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,14 +113,3 @@ jobs:
           CLERK_CLI_TEST_APP_ID: ${{ secrets.CLERK_CLI_TEST_APP_ID }}
           CLERK_PLATFORM_API_KEY: ${{ secrets.CLERK_PLATFORM_API_KEY }}
           CLERK_E2E_DEBUG: "1"
-
-  notify-failure:
-    if: >-
-      always() &&
-      contains(needs.*.result, 'failure')
-    needs: [build, lint, test, test-e2e]
-    uses: ./.github/workflows/notify-failure.yml
-    with:
-      workflow-name: CI
-    secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -11,6 +11,9 @@ on:
       SLACK_WEBHOOK_URL:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   notify:
     runs-on: blacksmith-2vcpu-ubuntu-2404

--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -1,0 +1,25 @@
+name: Notify Failure
+
+on:
+  workflow_call:
+    inputs:
+      workflow-name:
+        required: true
+        type: string
+        description: Human-readable workflow name for the Slack message
+    secrets:
+      SLACK_WEBHOOK_URL:
+        required: true
+
+jobs:
+  notify:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - name: Notify Slack
+        run: bun scripts/slack.ts --workflow "${{ inputs.workflow-name }}" --status failure
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
       - name: Notify Slack
-        run: bun scripts/slack.ts --workflow "${{ inputs.workflow-name }}" --status failure
+        run: bun scripts/slack.ts --status failure
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          WORKFLOW_NAME: ${{ inputs.workflow-name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,17 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
+  notify-stable-failure:
+    if: >-
+      always() &&
+      contains(needs.*.result, 'failure')
+    needs: [versioning, build, sign-macos, smoke-test, publish-npm, publish-github, homebrew]
+    uses: ./.github/workflows/notify-failure.yml
+    with:
+      workflow-name: Stable release
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
   # ─── Canary release ────────────────────────────────────────────────
 
   canary-version:
@@ -280,6 +291,25 @@ jobs:
           CANARY_VERSION: ${{ needs.canary-version.outputs.version }}
           ARTIFACTS_DIR: ${{ github.workspace }}/dist/artifacts
           GH_TOKEN: ${{ github.token }}
+
+  notify-canary-failure:
+    if: >-
+      always() &&
+      contains(needs.*.result, 'failure')
+    needs:
+      [
+        canary-version,
+        canary-build,
+        canary-sign-macos,
+        canary-smoke-test,
+        canary-publish-github,
+        canary-publish-npm,
+      ]
+    uses: ./.github/workflows/notify-failure.yml
+    with:
+      workflow-name: Canary release
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   # ═══════════════════════════════════════════════════════════════════════
   # PR comment (!snapshot) → snapshot release

--- a/scripts/slack.ts
+++ b/scripts/slack.ts
@@ -1,0 +1,72 @@
+/**
+ * Post a failure notification to Slack via an incoming webhook.
+ *
+ * Usage:
+ *   bun scripts/slack.ts --workflow <name> --status <status>
+ *
+ * Required env vars:
+ *   SLACK_WEBHOOK_URL   — Slack incoming webhook URL
+ *   GITHUB_REPOSITORY   — e.g. "clerk/cli"
+ *   GITHUB_SHA          — commit SHA that triggered the run
+ *   GITHUB_ACTOR        — user who triggered the run
+ *   GITHUB_SERVER_URL   — e.g. "https://github.com"
+ *   GITHUB_RUN_ID       — workflow run ID (used to build the logs link)
+ */
+
+import { parseArgs } from "node:util";
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    workflow: { type: "string" },
+    status: { type: "string" },
+  },
+});
+
+if (!values.workflow || !values.status) {
+  throw new Error("Usage: bun scripts/slack.ts --workflow <name> --status <status>");
+}
+
+const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+if (!webhookUrl) {
+  throw new Error("SLACK_WEBHOOK_URL is required");
+}
+
+const repo = process.env.GITHUB_REPOSITORY ?? "clerk/cli";
+const sha = process.env.GITHUB_SHA ?? "unknown";
+const actor = process.env.GITHUB_ACTOR ?? "unknown";
+const serverUrl = process.env.GITHUB_SERVER_URL ?? "https://github.com";
+const runId = process.env.GITHUB_RUN_ID ?? "0";
+const logsUrl = `${serverUrl}/${repo}/actions/runs/${runId}`;
+
+const payload = {
+  blocks: [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: [
+          `*:red_circle: ${values.workflow} failed*`,
+          `*Repo:* \`${repo}\``,
+          `*Status:* \`${values.status}\``,
+          `*Commit:* \`${sha.slice(0, 7)}\``,
+          `*Triggered by:* \`${actor}\``,
+          `*Run:* <${logsUrl}|View logs>`,
+        ].join("\n"),
+      },
+    },
+  ],
+};
+
+const res = await fetch(webhookUrl, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(payload),
+});
+
+if (!res.ok) {
+  const body = await res.text();
+  throw new Error(`Slack webhook failed (${res.status}): ${body}`);
+}
+
+console.log("Slack notification sent.");

--- a/scripts/slack.ts
+++ b/scripts/slack.ts
@@ -2,15 +2,18 @@
  * Post a failure notification to Slack via an incoming webhook.
  *
  * Usage:
- *   bun scripts/slack.ts --workflow <name> --status <status>
+ *   bun scripts/slack.ts --status <status>
+ *
+ * The workflow name is read from the WORKFLOW_NAME env var.
  *
  * Required env vars:
- *   SLACK_WEBHOOK_URL   — Slack incoming webhook URL
- *   GITHUB_REPOSITORY   — e.g. "clerk/cli"
- *   GITHUB_SHA          — commit SHA that triggered the run
- *   GITHUB_ACTOR        — user who triggered the run
- *   GITHUB_SERVER_URL   — e.g. "https://github.com"
- *   GITHUB_RUN_ID       — workflow run ID (used to build the logs link)
+ *   SLACK_WEBHOOK_URL   - Slack incoming webhook URL
+ *   WORKFLOW_NAME       - Human-readable workflow name for the Slack message
+ *   GITHUB_REPOSITORY   - e.g. "clerk/cli"
+ *   GITHUB_SHA          - commit SHA that triggered the run
+ *   GITHUB_ACTOR        - user who triggered the run
+ *   GITHUB_SERVER_URL   - e.g. "https://github.com"
+ *   GITHUB_RUN_ID       - workflow run ID (used to build the logs link)
  */
 
 import { parseArgs } from "node:util";
@@ -18,13 +21,17 @@ import { parseArgs } from "node:util";
 const { values } = parseArgs({
   args: Bun.argv.slice(2),
   options: {
-    workflow: { type: "string" },
     status: { type: "string" },
   },
 });
 
-if (!values.workflow || !values.status) {
-  throw new Error("Usage: bun scripts/slack.ts --workflow <name> --status <status>");
+const workflow = process.env.WORKFLOW_NAME;
+if (!workflow) {
+  throw new Error("WORKFLOW_NAME env var is required");
+}
+
+if (!values.status) {
+  throw new Error("Usage: bun scripts/slack.ts --status <status>");
 }
 
 const webhookUrl = process.env.SLACK_WEBHOOK_URL;
@@ -46,7 +53,7 @@ const payload = {
       text: {
         type: "mrkdwn",
         text: [
-          `*:red_circle: ${values.workflow} failed*`,
+          `*:red_circle: ${workflow} failed*`,
           `*Repo:* \`${repo}\``,
           `*Status:* \`${values.status}\``,
           `*Commit:* \`${sha.slice(0, 7)}\``,


### PR DESCRIPTION
## Summary

- Add `scripts/slack.ts` that posts block-kit formatted failure messages to a Slack incoming webhook
- Extract a reusable `notify-failure.yml` workflow to keep notification steps DRY across CI, stable release, and canary release pipelines

## Requirements

Requires a `SLACK_WEBHOOK_URL` repository secret.

## Test plan

- [ ] Verify `notify-failure.yml` is triggered when a CI job fails
- [ ] Verify Slack message format renders correctly
- [ ] Confirm no regressions in existing CI or release workflows