### PR TITLE
chore: hide switch-env from help menu

### DIFF
--- a/packages/cli-core/src/cli-program.ts
+++ b/packages/cli-core/src/cli-program.ts
@@ -424,7 +424,7 @@ export function createProgram() {
     .action(doctor);
 
   program
-    .command("switch-env")
+    .command("switch-env", { hidden: true })
     .description("Switch the active Clerk CLI environment")
     .argument("[environment]", "Environment to switch to (e.g. production, staging)")
     .setExamples([


### PR DESCRIPTION
## Summary
- Marks the `switch-env` command as hidden so it no longer appears in `clerk --help` output
- The command remains functional when invoked directly

## Test plan
- [ ] Run `clerk --help` and verify `switch-env` is not listed
- [ ] Run `clerk switch-env` and verify it still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)