### PR TITLE
fix(init): register --app option shown in help examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ clerk init
   --framework <name>     Framework to set up (skips auto-detection)
   --pm <manager>         Package manager to use (skips prompt/auto-detection)
   --name <project-name>  Project name for --starter (skips prompt)
+  --app <id>             Application ID to link (skips interactive picker)
   --starter              Bootstrap a new project from a starter template
   --prompt               Output a prompt for an AI agent to integrate Clerk
   --yes                  Skip confirmation prompts
@@ -62,6 +63,7 @@ clerk init
   Examples:
     $ clerk init                                      Auto-detect framework and set up Clerk
     $ clerk init --framework next                     Set up for Next.js (skips detection)
+    $ clerk init --app app_123                        Link to a specific Clerk application
     $ clerk init --starter                            Create a new project with Clerk
     $ clerk init --starter --framework next --pm bun  Bootstrap with Bun
     $ clerk init --prompt                             Output a setup prompt for an AI agent

--- a/packages/cli-core/src/cli-program.ts
+++ b/packages/cli-core/src/cli-program.ts
@@ -102,6 +102,7 @@ export function createProgram() {
       ).choices(["bun", "pnpm", "yarn", "npm"]),
     )
     .option("--name <project-name>", "Project name for --starter (skips prompt)")
+    .option("--app <id>", "Application ID to link (skips interactive picker)")
     .option("--prompt", "Output a prompt for an AI agent to integrate Clerk")
     .option("--starter", "Create a new project from a starter template")
     .option("-y, --yes", "Skip confirmation prompts")

--- a/packages/cli-core/src/commands/init/README.md
+++ b/packages/cli-core/src/commands/init/README.md
@@ -24,6 +24,7 @@ clerk init --no-skills
 | `--framework <name>`    | Framework to set up (skips auto-detection). Valid values: `next`, `astro`, `nuxt`, `tanstack-start`, `react-router`, `vue`, `expo`, `react`, `javascript`, `js`, `express`, `fastify` |
 | `--pm <manager>`        | Package manager to use. Valid values: `bun`, `pnpm`, `yarn`, `npm`. Skips the PM prompt (bootstrap) or overrides lockfile detection (existing project)                                |
 | `--name <project-name>` | Project name for `--starter` (skips prompt). Must be lowercase, no spaces, no path separators                                                                                         |
+| `--app <id>`            | Application ID to link (skips the interactive app picker during authenticated linking)                                                                                                |
 | `--starter`             | Bootstrap a new project from a starter template (runs the framework generator, installs deps, and scaffolds Clerk)                                                                    |
 | `--prompt`              | Output a prompt for an AI agent to integrate Clerk, then exit                                                                                                                         |
 | `-y, --yes`             | Skip confirmation prompts (also skips authentication after bootstrap, letting you connect your account later)                                                                         |

--- a/packages/cli-core/src/test/integration/completion.test.ts
+++ b/packages/cli-core/src/test/integration/completion.test.ts
@@ -138,6 +138,11 @@ describe("generateCompletions", () => {
       expect(names).toContain("--framework");
     });
 
+    test("registers --app on init (advertised in examples, wired to authenticateAndLink)", () => {
+      const names = completionNames("init", "--");
+      expect(names).toContain("--app");
+    });
+
     test("completes partial option name", () => {
       const names = completionNames("--ver");
       expect(names).toContain("--verbose");

--- a/packages/cli-core/src/test/integration/init-options.test.ts
+++ b/packages/cli-core/src/test/integration/init-options.test.ts
@@ -1,0 +1,20 @@
+/**
+ * init CLI option registration
+ * Exercises `clerk init` through the real Commander program to catch
+ * options that are advertised in help/examples but never registered.
+ */
+
+import { test, expect } from "bun:test";
+import { useIntegrationTestHarness, clerk } from "./lib/harness.ts";
+
+useIntegrationTestHarness();
+
+test("init accepts --app without rejecting it as an unknown option", async () => {
+  // --prompt exits before any auth/link/scaffold side effects. If --app is
+  // not registered with Commander, parseAsync throws `commander.unknownOption`
+  // before --prompt can short-circuit, and `clerk` (strict) throws.
+  const { stdout, stderr, exitCode } = await clerk("init", "--app", "app_123", "--prompt");
+  expect(exitCode).toBe(0);
+  expect(stderr).not.toContain("unknown option");
+  expect(stdout).toContain("clerk init -y");
+});


### PR DESCRIPTION
## Summary

`clerk init --app <id>` was advertised in the help examples and wired through to `authenticateAndLink`, but the option was never registered with Commander. Running it errored with `unknown option '--app'` instead of linking to the supplied app.

This PR:
- Registers `--app <id>` on the `init` command, matching the description already used by `clerk link`
- Adds two regression guards at different layers:
  - A completion-tree test asserting `--app` is part of `init`'s registered options
  - An integration test that invokes `clerk init --app app_123 --prompt` through the real Commander program and fails if the option isn't registered (verified by temporarily reverting the fix)
- Syncs the `init` command README and the root README's `clerk init` help block (which was also missing the `--app app_123` example)

No behavioral change beyond making the advertised flag actually reach the already-wired runtime path.

## Test plan

- [ ] `bun run src/cli.ts init --help` lists `--app <id>` in Options and Examples
- [ ] `bun run test` passes (both regression tests included)
- [ ] Manual: `clerk init --app app_xxx` in a test project skips the interactive picker