### PR TITLE
chore: remove deploy command ahead of public release

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Commands:
   switch-env  [environment]                  Switch the active Clerk CLI environment
   completion  [shell]                        Generate shell autocompletion script
   update      [options]                      Update the Clerk CLI to the latest version
-  deploy      [options]                      Deploy your Clerk application (hidden)
 
 clerk init
   --framework <name>     Framework to set up (skips auto-detection)
@@ -199,9 +198,6 @@ clerk update
     $ clerk update                       Update to the latest stable release
     $ clerk update --channel canary      Update to the latest canary release
     $ clerk update --yes                 Update without confirmation prompt
-
-clerk deploy
-  --debug              Show debug output
 ```
 
 ## Open Questions

--- a/packages/cli-core/src/cli-program.ts
+++ b/packages/cli-core/src/cli-program.ts
@@ -6,7 +6,6 @@ import { login } from "./commands/auth/login.ts";
 import { logout } from "./commands/auth/logout.ts";
 import { whoami } from "./commands/whoami/index.ts";
 import { pull } from "./commands/env/pull.ts";
-import { deploy } from "./commands/deploy/index.ts";
 import { configPull } from "./commands/config/pull.ts";
 import { configPatch, configPut } from "./commands/config/push.ts";
 import { configSchema } from "./commands/config/schema.ts";
@@ -495,12 +494,6 @@ Tutorial — enable completions for your shell:
       { command: "clerk update --yes", description: "Update without confirmation prompt" },
     ])
     .action(update);
-
-  program
-    .command("deploy", { hidden: true })
-    .description("Deploy your Clerk application")
-    .option("--debug", "Show debug output")
-    .action(deploy);
 
   return program;
 }

--- a/packages/cli-core/src/lib/open.ts
+++ b/packages/cli-core/src/lib/open.ts
@@ -1,7 +1,7 @@
 /**
  * Cross-platform "open this URL in the user's browser" helper.
  *
- * Used by the auth login OAuth flow and by deploy's docs-link redirects.
+ * Used by the auth login OAuth flow.
  * Both call sites previously used `Bun.spawn(["open", url])` (macOS only)
  * or a small per-file lookup table that fell back to `xdg-open` blindly.
  * That fails hard on:

--- a/packages/cli-core/src/test/integration/completion.test.ts
+++ b/packages/cli-core/src/test/integration/completion.test.ts
@@ -38,10 +38,6 @@ describe("generateCompletions", () => {
       expect(names).toContain("--mode");
     });
 
-    test("excludes hidden commands", () => {
-      expect(completionNames("")).not.toContain("deploy");
-    });
-
     test("completes partial subcommand name", () => {
       const names = completionNames("au");
       expect(names).toContain("auth");


### PR DESCRIPTION
## Summary

- Unregisters the WIP `deploy` command from the CLI program so it's not accessible to users
- Preserves the POC implementation in `commands/deploy/` for future development
- Cleans up deploy references in README, completion tests, and comments

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun run test` passes (pre-existing plapi test failures unrelated)
- [x] Completion tests pass without the removed hidden-command assertion
- [ ] Verify `clerk deploy` is no longer recognized as a command

🤖 Generated with [Claude Code](https://claude.com/claude-code)