### PR TITLE
ci: enforce changeset presence on pull requests

### DIFF
--- a/.github/workflows/enforce-changeset.yml
+++ b/.github/workflows/enforce-changeset.yml
@@ -8,7 +8,7 @@ jobs:
   enforce-changeset:
     name: Enforce Changeset
     # Skip the auto-generated Version Packages PR (it consumes changesets, doesn't add them).
-    if: github.event.pull_request.title != 'ci(repo): Version Packages'
+    if: "${{ github.event.pull_request.title != 'ci(repo): Version Packages' }}"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/enforce-changeset.yml
+++ b/.github/workflows/enforce-changeset.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   enforce-changeset:
     name: Enforce Changeset
+    permissions:
+      contents: read
     # Skip the auto-generated Version Packages PR (it consumes changesets, doesn't add them).
     if: "${{ github.event.pull_request.title != 'ci(repo): Version Packages' }}"
     runs-on: ubuntu-latest

--- a/.github/workflows/enforce-changeset.yml
+++ b/.github/workflows/enforce-changeset.yml
@@ -1,0 +1,19 @@
+name: Enforce Changeset
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  enforce-changeset:
+    name: Enforce Changeset
+    # Skip the auto-generated Version Packages PR (it consumes changesets, doesn't add them).
+    if: github.event.pull_request.title != 'ci(repo): Version Packages'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - run: bun changeset status --since=origin/${{ github.base_ref }}


### PR DESCRIPTION
## Summary

Adds a \`pull_request\`-scoped workflow that runs \`bun changeset status --since=origin/<base>\` and fails when a PR touches tracked packages without a corresponding \`.changeset/*.md\` file.

The check skips the auto-generated \`ci(repo): Version Packages\` PR so the release flow doesn't gate on itself.

Contributors whose change doesn't need a release (dependabot, docs-only, infra-only edits) can satisfy the check with \`bun changeset --empty\`. Making the job a required status check in branch protection turns it into a hard merge gate; without that, it's an advisory signal.

## Test plan

- [ ] This PR touches only a workflow file (no tracked packages changed), so the new check should pass on itself with no changeset added
- [ ] Open a follow-up PR that edits \`packages/cli-core/\` without a changeset and confirm the \`Enforce Changeset\` check fails
- [ ] Add a changeset (or \`bun changeset --empty\`) and confirm it passes