### PR TITLE
fix(pkce): use rejection sampling to remove modulo bias

### DIFF
--- a/.changeset/pkce-unbiased-random.md
+++ b/.changeset/pkce-unbiased-random.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Fix biased character distribution in PKCE code verifier generation. Replaces `byte % CHARSET.length` with rejection sampling so every character in the 66-entry charset is equally likely, restoring full entropy.

--- a/packages/cli-core/src/lib/pkce.test.ts
+++ b/packages/cli-core/src/lib/pkce.test.ts
@@ -18,6 +18,27 @@ describe("PKCE", () => {
     expect(a).not.toBe(b);
   });
 
+  test("generateCodeVerifier produces an unbiased distribution", () => {
+    // With 66 charset entries and 256-byte modulo, a naive `byte % 66`
+    // over-represents the first 58 characters by ~33%. Rejection sampling
+    // should keep per-character counts within ~10% of uniform over a
+    // large sample.
+    const CHARSET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
+    const counts = new Map<string, number>(CHARSET.split("").map((c) => [c, 0]));
+    const iterations = 2000;
+    for (let i = 0; i < iterations; i++) {
+      for (const ch of generateCodeVerifier()) {
+        counts.set(ch, (counts.get(ch) ?? 0) + 1);
+      }
+    }
+    const total = iterations * 43;
+    const expected = total / CHARSET.length;
+    const tolerance = expected * 0.1;
+    for (const [, count] of counts) {
+      expect(Math.abs(count - expected)).toBeLessThan(tolerance);
+    }
+  });
+
   test("generateCodeChallenge produces valid base64url S256 hash", async () => {
     const verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
     const challenge = await generateCodeChallenge(verifier);

--- a/packages/cli-core/src/lib/pkce.ts
+++ b/packages/cli-core/src/lib/pkce.ts
@@ -5,14 +5,21 @@
 
 const VERIFIER_LENGTH = 43;
 const CHARSET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
+// Largest multiple of CHARSET.length that fits in a byte. Values >= this
+// would map non-uniformly via modulo, so reject them (rejection sampling).
+const REJECTION_THRESHOLD = 256 - (256 % CHARSET.length);
 
 export function generateCodeVerifier(): string {
-  const bytes = crypto.getRandomValues(new Uint8Array(VERIFIER_LENGTH));
-  let verifier = "";
-  for (const byte of bytes) {
-    verifier += CHARSET[byte % CHARSET.length];
+  const verifier: string[] = [];
+  while (verifier.length < VERIFIER_LENGTH) {
+    const bytes = crypto.getRandomValues(new Uint8Array(VERIFIER_LENGTH));
+    for (const byte of bytes) {
+      if (byte >= REJECTION_THRESHOLD) continue;
+      verifier.push(CHARSET.charAt(byte % CHARSET.length));
+      if (verifier.length === VERIFIER_LENGTH) break;
+    }
   }
-  return verifier;
+  return verifier.join("");
 }
 
 export async function generateCodeChallenge(verifier: string): Promise<string> {


### PR DESCRIPTION
## Summary

- Replace `byte % CHARSET.length` in `generateCodeVerifier` with rejection sampling. The 66-character PKCE charset does not divide evenly into 256, so the naive modulo biased the first 58 characters to appear ~33% more often than the last 8.
- Restores uniform distribution and full RFC 7636 entropy without affecting the public API.
- Flagged by CodeQL: `js/biased-cryptographic-random`.

## Test plan

- [x] `bun test packages/cli-core/src/lib/pkce.test.ts`
- [x] New test asserts per-character counts stay within 10% of uniform over 2000 verifiers
- [x] `bun run typecheck`