### PR TITLE
ci: pin GITHUB_TOKEN to contents:read in all workflows

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -14,6 +14,9 @@ on:
         type: string
         description: "Prefix for artifact names (e.g. 'clerk', 'clerk-canary', 'clerk-snapshot')"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: blacksmith-2vcpu-ubuntu-2404

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/sign-macos.yml
+++ b/.github/workflows/sign-macos.yml
@@ -19,6 +19,9 @@ on:
       APPLE_API_ISSUER_ID:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   sign:
     strategy:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -17,6 +17,9 @@ on:
           canary (darwin-arm64 + linux-x64 + linux-x64-musl), or
           snapshot (linux-x64 only).
 
+permissions:
+  contents: read
+
 jobs:
   resolve-matrix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add top-level `permissions: contents: read` to `ci.yml`, `build-binaries.yml`, `smoke-test.yml`, and `sign-macos.yml`.
- Matches the pin already on `release.yml` and the job-level pin on `enforce-changeset.yml`.
- Closes 8 CodeQL `actions/missing-workflow-permissions` alerts.

## Test plan

- [ ] CI runs green on this PR (workflows still only need read access to repo contents)