### PR TITLE
fix(auth): authorize with default scopes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,6 @@
 # ── OAuth ────────────────────────────────────────────────────────────────────
 # CLERK_OAUTH_CLIENT_ID=your_client_id
 # CLERK_OAUTH_BASE_URL=https://your-dev-instance.clerk.accounts.dev
-# CLERK_OAUTH_SCOPES=profile email
 
 # ── Platform API ─────────────────────────────────────────────────────────────
 # CLERK_PLATFORM_API_KEY=your_platform_api_key

--- a/.env.local.example
+++ b/.env.local.example
@@ -5,7 +5,6 @@
 # ── OAuth ────────────────────────────────────────────────────────────────────
 CLERK_OAUTH_CLIENT_ID=AoIrcWIr840sy5pY
 CLERK_OAUTH_BASE_URL=https://clerk.prod.lclclerk.com
-# CLERK_OAUTH_SCOPES=profile email
 
 # ── Backend API ─────────────────────────────────────────────────────────────-
 CLERK_BACKEND_API_URL=https://api.lclclerk.com

--- a/packages/cli-core/src/lib/environment.ts
+++ b/packages/cli-core/src/lib/environment.ts
@@ -98,7 +98,8 @@ export function getOAuthConfig() {
   const baseUrl = process.env.CLERK_OAUTH_BASE_URL ?? env.oauthBaseUrl;
   return {
     clientId: process.env.CLERK_OAUTH_CLIENT_ID ?? env.oauthClientId,
-    scopes: process.env.CLERK_OAUTH_SCOPES ?? "profile email",
+    // Unless scopes are explicitly set, use the default scopes
+    scopes: process.env.CLERK_OAUTH_SCOPES ?? "",
     authorizeUrl: new URL("/oauth/authorize", baseUrl).href,
     tokenUrl: new URL("/oauth/token", baseUrl).href,
     userinfoUrl: new URL("/oauth/userinfo", baseUrl).href,


### PR DESCRIPTION
because the CLI at this time is not in a position to know what scopes to request

When we request an empty (or missing) scope parameter the Authorization Server will use a default set of scopes appropriate for the CLI.

This is important because we want to enumerate permissions being granted in the Consent screen

<img width="303" height="733" alt="CleanShot 2026-04-16 at 12 42 29@2x" src="https://github.com/user-attachments/assets/7b1c9051-13c1-4089-b040-60fe9ea3b548" />
