### PR TITLE
fix(init): simplify auth/keyless flow and fix --starter

### DIFF
--- a/.changeset/more-init-fixes.md
+++ b/.changeset/more-init-fixes.md
@@ -5,5 +5,5 @@
 Fix `clerk init` prompt flow:
 
 - When you are signed in (OAuth or `CLERK_PLATFORM_API_KEY`), `clerk init` skips straight to the authenticated flow — no more "Skip authentication for now?" prompt.
-- When you are not signed in on a keyless-capable framework, `clerk init` now goes keyless automatically (previously prompted) and points you to `clerk auth login` for later.
+- When you are not signed in **during bootstrap** (new projects) on a keyless-capable framework, `clerk init` now goes keyless automatically (previously prompted) and points you to `clerk auth login` for later. Re-runs in an existing project still fall through to the authenticated flow so real keys can be pulled.
 - Keep `clerk init --starter` fully interactive — it no longer fails with "Non-interactive mode requires --framework" when running without `-y`.

--- a/.changeset/more-init-fixes.md
+++ b/.changeset/more-init-fixes.md
@@ -4,5 +4,5 @@
 
 Fix `clerk init` prompt flow:
 
-- Skip the keyless / skip-auth confirmation when you are already signed in.
+- Skip the keyless / skip-auth confirmation when you are already signed in (including via `CLERK_PLATFORM_API_KEY`).
 - Keep `clerk init --starter` fully interactive — it no longer fails with "Non-interactive mode requires --framework" when running without `-y`.

--- a/.changeset/more-init-fixes.md
+++ b/.changeset/more-init-fixes.md
@@ -1,0 +1,8 @@
+---
+"clerk": patch
+---
+
+Fix `clerk init` prompt flow:
+
+- Skip the keyless / skip-auth confirmation when you are already signed in.
+- Keep `clerk init --starter` fully interactive — it no longer fails with "Non-interactive mode requires --framework" when running without `-y`.

--- a/.changeset/more-init-fixes.md
+++ b/.changeset/more-init-fixes.md
@@ -4,5 +4,6 @@
 
 Fix `clerk init` prompt flow:
 
-- Skip the keyless / skip-auth confirmation when you are already signed in (including via `CLERK_PLATFORM_API_KEY`).
+- When you are signed in (OAuth or `CLERK_PLATFORM_API_KEY`), `clerk init` skips straight to the authenticated flow — no more "Skip authentication for now?" prompt.
+- When you are not signed in on a keyless-capable framework, `clerk init` now goes keyless automatically (previously prompted) and points you to `clerk auth login` for later.
 - Keep `clerk init --starter` fully interactive — it no longer fails with "Non-interactive mode requires --framework" when running without `-y`.

--- a/packages/cli-core/src/commands/init/README.md
+++ b/packages/cli-core/src/commands/init/README.md
@@ -45,11 +45,11 @@ Use `--prompt` to output a setup prompt for an AI agent without running init.
 
 1. **`--prompt`**: outputs a framework-specific prompt, then exits
 2. Gathers project context (framework, router variant, TypeScript, `src/` directory, package manager)
-3. **Human mode**: determines auth mode:
-   - If already authenticated and linked: uses authenticated mode automatically
-   - If authenticated but not linked: uses authenticated mode (runs `clerk link`)
-   - If not authenticated: asks user — "Continue with temporary keys (connect your account later)" or "Log in to an existing Clerk account"
-   - With `--yes` and not authenticated: skips authentication (connect your account later), including for non-keyless frameworks during bootstrap
+3. Determines auth mode from credential presence (no user prompt):
+   - **Authenticated** (OAuth token or `CLERK_PLATFORM_API_KEY` set): uses the authenticated flow — runs `clerk link` if not already linked and pulls real API keys into `.env` at the end
+   - **Bootstrap + keyless-capable framework + not authenticated**: automatically uses keyless mode — the app runs on auto-generated dev keys and the user can connect a Clerk account later with `clerk auth login`
+   - **Bootstrap + non-keyless framework + not authenticated** (with `--yes` or agent mode): skips authentication and prints manual setup instructions (run `clerk auth login` / `clerk link` / `clerk env pull` when ready)
+   - **Existing project + not authenticated**: runs the authenticated flow, which triggers an interactive login so real keys can be pulled
 4. **Authenticated mode only**: authenticates via `clerk auth login` (skipped if already authenticated) and links the project via `clerk link` (skipped if already linked)
 5. Displays detected framework and variant
 6. Detects existing auth libraries (NextAuth, Auth0, Supabase, Firebase, Passport, Better Auth, Kinde) and shows migration guidance
@@ -83,7 +83,7 @@ Detects the project's framework from `package.json` dependencies (checked top-to
 | `express`               | Express        | `@clerk/express`              | `CLERK_PUBLISHABLE_KEY`             | No      |
 | `fastify`               | Fastify        | `@clerk/fastify`              | `CLERK_PUBLISHABLE_KEY`             | No      |
 
-The **Keyless** column indicates whether the framework's Clerk SDK supports keyless mode (auto-generated temporary dev keys). Frameworks without keyless support require API keys and always force authentication during `clerk init`, even with `--yes`.
+The **Keyless** column indicates whether the framework's Clerk SDK supports keyless mode (auto-generated temporary dev keys). Keyless auto-selection only applies during bootstrap (new projects) — re-running `clerk init` in an existing project always uses the authenticated flow (prompting login when signed out) so real keys can be pulled via `clerk env pull`. During bootstrap of a non-keyless framework with `--yes` and no credentials, `clerk init` skips authentication and prints manual setup instructions instead of blocking on a login prompt.
 
 Package manager is detected from lock files: `bun.lockb`/`bun.lock` → bun, `yarn.lock` → yarn, `pnpm-lock.yaml` → pnpm, else npm.
 

--- a/packages/cli-core/src/commands/init/bootstrap.test.ts
+++ b/packages/cli-core/src/commands/init/bootstrap.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, describe, spyOn, afterAll } from "bun:test";
 import { BOOTSTRAP_REGISTRY } from "./bootstrap-registry.ts";
-import { resolvePackageManager } from "./bootstrap.ts";
+import { promptAndBootstrap, resolvePackageManager } from "./bootstrap.ts";
 
 function entryFor(dep: string) {
   const entry = BOOTSTRAP_REGISTRY.find((e) => e.dep === dep);
@@ -164,5 +164,28 @@ describe("resolvePackageManager", () => {
     whichSpy.mockReturnValue(null);
 
     expect(resolvePackageManager()).toBe("npm");
+  });
+});
+
+describe("promptAndBootstrap", () => {
+  test("throws a usage-exit CliError when skipConfirm is set without a framework override", async () => {
+    await expect(
+      promptAndBootstrap("/tmp", undefined, { skipConfirm: true }),
+    ).rejects.toMatchObject({
+      name: "CliError",
+      exitCode: 2,
+      message: expect.stringContaining("Non-interactive mode requires --framework"),
+    });
+  });
+
+  test("guard still fires when implicitBootstrap is combined with skipConfirm", async () => {
+    // --starter -y path: implicitBootstrap + skipConfirm. Guard still applies.
+    await expect(
+      promptAndBootstrap("/tmp", undefined, { skipConfirm: true, implicitBootstrap: true }),
+    ).rejects.toMatchObject({
+      name: "CliError",
+      exitCode: 2,
+      message: expect.stringContaining("--framework"),
+    });
   });
 });

--- a/packages/cli-core/src/commands/init/bootstrap.ts
+++ b/packages/cli-core/src/commands/init/bootstrap.ts
@@ -141,7 +141,10 @@ export async function askSkipAuth(): Promise<boolean> {
 }
 
 export type BootstrapOverrides = {
+  /** Non-interactive mode: require --framework, auto-resolve PM/name, skip all prompts. */
   skipConfirm: boolean;
+  /** User already opted into bootstrapping (e.g. via --starter) — skip the "create a new one?" confirm without implying non-interactive mode. */
+  implicitBootstrap?: boolean;
   pmOverride?: PackageManager;
   nameOverride?: string;
 };
@@ -154,15 +157,20 @@ export type BootstrapResult = {
 
 /**
  * Interactive bootstrap flow.
- * When skipConfirm is true (e.g. --starter flag, -y, or agent mode), skips the
- * "create a new one?" prompt and auto-resolves PM/project name when not overridden.
+ * `skipConfirm` means non-interactive: requires --framework and auto-resolves PM/project name.
+ * `implicitBootstrap` only skips the initial "create a new one?" confirm — the rest of the flow stays interactive.
  */
 export async function promptAndBootstrap(
   cwd: string,
   frameworkOverride: FrameworkInfo | undefined,
-  { skipConfirm = false, pmOverride, nameOverride }: BootstrapOverrides = { skipConfirm: false },
+  {
+    skipConfirm = false,
+    implicitBootstrap = false,
+    pmOverride,
+    nameOverride,
+  }: BootstrapOverrides = { skipConfirm: false },
 ): Promise<BootstrapResult> {
-  if (!skipConfirm) {
+  if (!skipConfirm && !implicitBootstrap) {
     const wantBootstrap = await confirm({
       message: "No project detected. Would you like to create a new one?",
       default: true,

--- a/packages/cli-core/src/commands/init/bootstrap.ts
+++ b/packages/cli-core/src/commands/init/bootstrap.ts
@@ -135,7 +135,7 @@ export async function confirmOverwrite(cwd: string): Promise<void> {
 export type BootstrapOverrides = {
   /** Non-interactive mode: require --framework, auto-resolve PM/name, skip all prompts. */
   skipConfirm: boolean;
-  /** User already opted into bootstrapping (e.g. via --starter) — skip the "create a new one?" confirm without implying non-interactive mode. */
+  /** User already opted into bootstrapping (e.g. via --starter) — skip the "create a new one?" confirm without implying non-interactive mode. Ignored when `skipConfirm` is true (which already implies implicit bootstrap). */
   implicitBootstrap?: boolean;
   pmOverride?: PackageManager;
   nameOverride?: string;

--- a/packages/cli-core/src/commands/init/bootstrap.ts
+++ b/packages/cli-core/src/commands/init/bootstrap.ts
@@ -132,14 +132,6 @@ export async function confirmOverwrite(cwd: string): Promise<void> {
   if (!proceed) throwUserAbort();
 }
 
-export async function askSkipAuth(): Promise<boolean> {
-  return confirm({
-    message:
-      "Skip authentication for now? (you can connect your Clerk account later with `clerk auth login`)",
-    default: true,
-  });
-}
-
 export type BootstrapOverrides = {
   /** Non-interactive mode: require --framework, auto-resolve PM/name, skip all prompts. */
   skipConfirm: boolean;

--- a/packages/cli-core/src/commands/init/heuristics.ts
+++ b/packages/cli-core/src/commands/init/heuristics.ts
@@ -136,6 +136,16 @@ export async function getAuthenticatedEmail(): Promise<string | null> {
   }
 }
 
+/**
+ * True if the user has any form of credentials configured — either a stored
+ * OAuth token or a `CLERK_PLATFORM_API_KEY` env var. Used to decide whether to
+ * skip keyless/skip-auth prompts during `clerk init`.
+ */
+export async function isAuthenticated(): Promise<boolean> {
+  if (process.env.CLERK_PLATFORM_API_KEY) return true;
+  return (await getAuthenticatedEmail()) != null;
+}
+
 export function printKeylessInfo(): void {
   const lines = [
     "\n  Your app will work immediately — Clerk generates temporary dev keys automatically.",

--- a/packages/cli-core/src/commands/init/heuristics.ts
+++ b/packages/cli-core/src/commands/init/heuristics.ts
@@ -137,13 +137,18 @@ export async function getAuthenticatedEmail(): Promise<string | null> {
 }
 
 /**
- * True if the user has any form of credentials configured — either a stored
- * OAuth token or a `CLERK_PLATFORM_API_KEY` env var. Used to decide whether to
- * skip keyless/skip-auth prompts during `clerk init`.
+ * True if the user has any form of credentials configured locally — either a
+ * stored OAuth token or a `CLERK_PLATFORM_API_KEY` env var. Used to pick
+ * between the authenticated and keyless flows in `clerk init`.
+ *
+ * This is a pure credential-presence check: it does not hit the network, so
+ * an expired token or a Clerk API outage won't silently demote the user into
+ * keyless. Token validity is resolved later by the actual auth/link/pull
+ * calls, which surface real errors instead of swallowing them.
  */
 export async function isAuthenticated(): Promise<boolean> {
   if (process.env.CLERK_PLATFORM_API_KEY) return true;
-  return (await getAuthenticatedEmail()) != null;
+  return (await getToken()) != null;
 }
 
 export function printKeylessInfo(): void {

--- a/packages/cli-core/src/commands/init/index.test.ts
+++ b/packages/cli-core/src/commands/init/index.test.ts
@@ -186,6 +186,61 @@ describe("init", () => {
     expect(bootstrapMod.askSkipAuth).toHaveBeenCalled();
   });
 
+  test("bootstrap with keyless framework skips askSkipAuth when already authenticated", async () => {
+    setup({ email: "user@example.com" });
+
+    const keylessCtx = {
+      ...FAKE_CTX,
+      framework: { ...FAKE_CTX.framework, supportsKeyless: true },
+    };
+    spyOn(context, "gatherContext").mockResolvedValueOnce(null).mockResolvedValueOnce(keylessCtx);
+
+    await init({});
+
+    expect(heuristics.getAuthenticatedEmail).toHaveBeenCalled();
+    expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
+    expect(heuristics.printKeylessInfo).not.toHaveBeenCalled();
+    expect(linkMod.link).toHaveBeenCalled();
+  });
+
+  test("-y flag with keyless framework uses authenticated flow when signed in", async () => {
+    setup({ email: "user@example.com" });
+
+    const keylessCtx = {
+      ...FAKE_CTX,
+      framework: { ...FAKE_CTX.framework, supportsKeyless: true },
+    };
+    spyOn(context, "gatherContext").mockResolvedValueOnce(null).mockResolvedValueOnce(keylessCtx);
+
+    await init({ yes: true });
+
+    expect(heuristics.getAuthenticatedEmail).toHaveBeenCalled();
+    expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
+    expect(heuristics.printKeylessInfo).not.toHaveBeenCalled();
+  });
+
+  test("-y flag with keyless framework goes keyless when not authenticated", async () => {
+    setup();
+
+    const keylessCtx = {
+      ...FAKE_CTX,
+      existingClerk: false,
+      framework: { ...FAKE_CTX.framework, supportsKeyless: true },
+    };
+    spyOn(context, "gatherContext").mockResolvedValueOnce(null).mockResolvedValueOnce(keylessCtx);
+    spyOn(scaffoldMod, "scaffold").mockResolvedValue({
+      actions: [{ type: "create", path: "middleware.ts", content: "", description: "" }],
+      postInstructions: [],
+    });
+
+    await init({ yes: true });
+
+    expect(heuristics.getAuthenticatedEmail).toHaveBeenCalled();
+    expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
+    expect(heuristics.printKeylessInfo).toHaveBeenCalled();
+    expect(linkMod.link).not.toHaveBeenCalled();
+  });
+
   test("-y flag skips auth prompt and defaults to unauthenticated mode", async () => {
     setup();
     setupBootstrapSuccess();
@@ -194,7 +249,8 @@ describe("init", () => {
 
     expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalled();
     expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
-    expect(heuristics.getAuthenticatedEmail).not.toHaveBeenCalled();
+    // getAuthenticatedEmail is called during skipAuth check
+    expect(heuristics.getAuthenticatedEmail).toHaveBeenCalled();
   });
 
   test("-y flag skips auth for frameworks without keyless support in bootstrap", async () => {
@@ -219,8 +275,8 @@ describe("init", () => {
     expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalled();
     // Should not ask about skipping auth — keyless not supported
     expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
-    // Should skip auth in non-interactive bootstrap — user connects later
-    expect(heuristics.getAuthenticatedEmail).not.toHaveBeenCalled();
+    // getAuthenticatedEmail is called during skipAuth check, returns null → skip auth
+    expect(heuristics.getAuthenticatedEmail).toHaveBeenCalled();
     expect(loginMod.login).not.toHaveBeenCalled();
     expect(heuristics.printKeylessInfo).not.toHaveBeenCalled();
   });
@@ -254,6 +310,45 @@ describe("init", () => {
 
     expect(bootstrapMod.promptAndBootstrap).not.toHaveBeenCalled();
     expect(context.hasPackageJson).not.toHaveBeenCalled();
+  });
+
+  test("existing repo with keyless framework skips askSkipAuth when signed in", async () => {
+    setup({ email: "user@example.com" });
+
+    const keylessCtx = {
+      ...FAKE_CTX,
+      framework: { ...FAKE_CTX.framework, supportsKeyless: true },
+    };
+    spyOn(context, "gatherContext").mockResolvedValue(keylessCtx);
+    spyOn(config, "resolveProfile").mockResolvedValue({ profile: { appId: "app_123" } } as never);
+
+    await init({ yes: true });
+
+    expect(bootstrapMod.promptAndBootstrap).not.toHaveBeenCalled();
+    expect(heuristics.getAuthenticatedEmail).toHaveBeenCalled();
+    expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
+    expect(heuristics.printKeylessInfo).not.toHaveBeenCalled();
+  });
+
+  test("existing repo with keyless framework prompts askSkipAuth when not signed in", async () => {
+    setup();
+
+    const keylessCtx = {
+      ...FAKE_CTX,
+      existingClerk: false,
+      framework: { ...FAKE_CTX.framework, supportsKeyless: true },
+    };
+    spyOn(context, "gatherContext").mockResolvedValue(keylessCtx);
+    spyOn(scaffoldMod, "scaffold").mockResolvedValue({
+      actions: [{ type: "create", path: "middleware.ts", content: "", description: "" }],
+      postInstructions: [],
+    });
+
+    await init({});
+
+    expect(bootstrapMod.promptAndBootstrap).not.toHaveBeenCalled();
+    expect(heuristics.getAuthenticatedEmail).toHaveBeenCalled();
+    expect(bootstrapMod.askSkipAuth).toHaveBeenCalled();
   });
 
   test("passes frameworkOverride to bootstrap when provided", async () => {

--- a/packages/cli-core/src/commands/init/index.test.ts
+++ b/packages/cli-core/src/commands/init/index.test.ts
@@ -346,7 +346,11 @@ describe("init", () => {
     expect(heuristics.printKeylessInfo).not.toHaveBeenCalled();
   });
 
-  test("existing repo with keyless framework auto-selects keyless when not signed in", async () => {
+  test("existing repo with keyless framework uses authenticated flow when not signed in", async () => {
+    // Keyless auto-selection is scoped to bootstrap (new-project) flows. On an
+    // existing repo, an unauthenticated re-run should fall through to the
+    // authenticated flow (which prompts login) rather than silently skip
+    // `env pull` and scaffold permissive middleware.
     setup();
 
     const keylessCtx = {
@@ -359,13 +363,20 @@ describe("init", () => {
       actions: [{ type: "create", path: "middleware.ts", content: "", description: "" }],
       postInstructions: [],
     });
+    spyOn(loginMod, "login").mockResolvedValue({
+      userId: "user_1",
+      email: "test@test.com",
+    } as never);
 
     await init({});
 
     expect(bootstrapMod.promptAndBootstrap).not.toHaveBeenCalled();
     expect(heuristics.isAuthenticated).toHaveBeenCalled();
-    expect(heuristics.printKeylessInfo).toHaveBeenCalled();
-    expect(linkMod.link).not.toHaveBeenCalled();
+    expect(heuristics.printKeylessInfo).not.toHaveBeenCalled();
+    // Unauthenticated + existing repo → login + link run via authenticateAndLink.
+    expect(loginMod.login).toHaveBeenCalledWith({ showNextSteps: false });
+    expect(linkMod.link).toHaveBeenCalled();
+    expect(pullMod.pull).toHaveBeenCalled();
   });
 
   test("passes frameworkOverride to bootstrap when provided", async () => {

--- a/packages/cli-core/src/commands/init/index.test.ts
+++ b/packages/cli-core/src/commands/init/index.test.ts
@@ -52,9 +52,11 @@ describe("init", () => {
     for (const s of spies) s.mockRestore();
   });
 
-  function setup(overrides: { email?: string | null; isAgent?: boolean } = {}) {
+  function setup(overrides: { email?: string | null; apiKey?: boolean; isAgent?: boolean } = {}) {
     const email = overrides.email ?? null;
+    const apiKey = overrides.apiKey ?? false;
     const agent = overrides.isAgent ?? false;
+    const authed = email != null || apiKey;
 
     captured = captureLog();
 
@@ -75,6 +77,7 @@ describe("init", () => {
       spyOn(scanMod, "detectAuthLibraries").mockReturnValue(undefined),
       spyOn(scanMod, "scanForIssues").mockResolvedValue([]),
       spyOn(heuristics, "getAuthenticatedEmail").mockResolvedValue(email),
+      spyOn(heuristics, "isAuthenticated").mockResolvedValue(authed),
       spyOn(heuristics, "printKeylessInfo").mockReturnValue(undefined),
       spyOn(heuristics, "installSdk").mockResolvedValue(undefined),
       spyOn(heuristics, "installDeps").mockResolvedValue(undefined),
@@ -197,7 +200,7 @@ describe("init", () => {
 
     await init({});
 
-    expect(heuristics.getAuthenticatedEmail).toHaveBeenCalled();
+    expect(heuristics.isAuthenticated).toHaveBeenCalled();
     expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
     expect(heuristics.printKeylessInfo).not.toHaveBeenCalled();
     expect(linkMod.link).toHaveBeenCalled();
@@ -214,9 +217,26 @@ describe("init", () => {
 
     await init({ yes: true });
 
-    expect(heuristics.getAuthenticatedEmail).toHaveBeenCalled();
+    expect(heuristics.isAuthenticated).toHaveBeenCalled();
     expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
     expect(heuristics.printKeylessInfo).not.toHaveBeenCalled();
+  });
+
+  test("-y flag with keyless framework uses authenticated flow when CLERK_PLATFORM_API_KEY is set", async () => {
+    setup({ apiKey: true });
+
+    const keylessCtx = {
+      ...FAKE_CTX,
+      framework: { ...FAKE_CTX.framework, supportsKeyless: true },
+    };
+    spyOn(context, "gatherContext").mockResolvedValueOnce(null).mockResolvedValueOnce(keylessCtx);
+
+    await init({ yes: true });
+
+    expect(heuristics.isAuthenticated).toHaveBeenCalled();
+    expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
+    expect(heuristics.printKeylessInfo).not.toHaveBeenCalled();
+    expect(linkMod.link).toHaveBeenCalled();
   });
 
   test("-y flag with keyless framework goes keyless when not authenticated", async () => {
@@ -235,7 +255,7 @@ describe("init", () => {
 
     await init({ yes: true });
 
-    expect(heuristics.getAuthenticatedEmail).toHaveBeenCalled();
+    expect(heuristics.isAuthenticated).toHaveBeenCalled();
     expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
     expect(heuristics.printKeylessInfo).toHaveBeenCalled();
     expect(linkMod.link).not.toHaveBeenCalled();
@@ -249,8 +269,8 @@ describe("init", () => {
 
     expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalled();
     expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
-    // getAuthenticatedEmail is called during skipAuth check
-    expect(heuristics.getAuthenticatedEmail).toHaveBeenCalled();
+    // isAuthenticated is called during skipAuth check
+    expect(heuristics.isAuthenticated).toHaveBeenCalled();
   });
 
   test("-y flag skips auth for frameworks without keyless support in bootstrap", async () => {
@@ -275,8 +295,8 @@ describe("init", () => {
     expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalled();
     // Should not ask about skipping auth — keyless not supported
     expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
-    // getAuthenticatedEmail is called during skipAuth check, returns null → skip auth
-    expect(heuristics.getAuthenticatedEmail).toHaveBeenCalled();
+    // isAuthenticated is called during skipAuth check, returns false → skip auth
+    expect(heuristics.isAuthenticated).toHaveBeenCalled();
     expect(loginMod.login).not.toHaveBeenCalled();
     expect(heuristics.printKeylessInfo).not.toHaveBeenCalled();
   });
@@ -325,7 +345,7 @@ describe("init", () => {
     await init({ yes: true });
 
     expect(bootstrapMod.promptAndBootstrap).not.toHaveBeenCalled();
-    expect(heuristics.getAuthenticatedEmail).toHaveBeenCalled();
+    expect(heuristics.isAuthenticated).toHaveBeenCalled();
     expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
     expect(heuristics.printKeylessInfo).not.toHaveBeenCalled();
   });
@@ -347,7 +367,7 @@ describe("init", () => {
     await init({});
 
     expect(bootstrapMod.promptAndBootstrap).not.toHaveBeenCalled();
-    expect(heuristics.getAuthenticatedEmail).toHaveBeenCalled();
+    expect(heuristics.isAuthenticated).toHaveBeenCalled();
     expect(bootstrapMod.askSkipAuth).toHaveBeenCalled();
   });
 

--- a/packages/cli-core/src/commands/init/index.test.ts
+++ b/packages/cli-core/src/commands/init/index.test.ts
@@ -90,7 +90,6 @@ describe("init", () => {
       spyOn(pullMod, "pull").mockResolvedValue(undefined),
       spyOn(bootstrapMod, "promptAndBootstrap").mockResolvedValue(FAKE_BOOTSTRAP),
       spyOn(bootstrapMod, "confirmOverwrite").mockResolvedValue(undefined),
-      spyOn(bootstrapMod, "askSkipAuth").mockResolvedValue(false),
     ];
 
     return { gatherContextSpy, captured };
@@ -145,7 +144,6 @@ describe("init", () => {
 
     await init({});
 
-    expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
     expect(previewMod.previewAndConfirm).not.toHaveBeenCalled();
     expect(bootstrapMod.promptAndBootstrap).not.toHaveBeenCalled();
   });
@@ -167,29 +165,35 @@ describe("init", () => {
     await init({});
 
     expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalled();
-    // React doesn't support keyless, so askSkipAuth is never called
-    expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
+    // React doesn't support keyless, so keyless flow isn't triggered
+    expect(heuristics.printKeylessInfo).not.toHaveBeenCalled();
   });
 
-  test("blank dir with keyless framework prompts askSkipAuth", async () => {
+  test("blank dir with keyless framework auto-selects keyless when unauthenticated", async () => {
     setup();
 
     const keylessCtx = {
       ...FAKE_CTX,
+      existingClerk: false,
       framework: {
         ...FAKE_CTX.framework,
         supportsKeyless: true,
       },
     };
     spyOn(context, "gatherContext").mockResolvedValueOnce(null).mockResolvedValueOnce(keylessCtx);
+    spyOn(scaffoldMod, "scaffold").mockResolvedValue({
+      actions: [{ type: "create", path: "middleware.ts", content: "", description: "" }],
+      postInstructions: [],
+    });
 
     await init({});
 
     expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalled();
-    expect(bootstrapMod.askSkipAuth).toHaveBeenCalled();
+    expect(heuristics.printKeylessInfo).toHaveBeenCalled();
+    expect(linkMod.link).not.toHaveBeenCalled();
   });
 
-  test("bootstrap with keyless framework skips askSkipAuth when already authenticated", async () => {
+  test("bootstrap with keyless framework goes authenticated when already signed in", async () => {
     setup({ email: "user@example.com" });
 
     const keylessCtx = {
@@ -201,7 +205,6 @@ describe("init", () => {
     await init({});
 
     expect(heuristics.isAuthenticated).toHaveBeenCalled();
-    expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
     expect(heuristics.printKeylessInfo).not.toHaveBeenCalled();
     expect(linkMod.link).toHaveBeenCalled();
   });
@@ -218,7 +221,6 @@ describe("init", () => {
     await init({ yes: true });
 
     expect(heuristics.isAuthenticated).toHaveBeenCalled();
-    expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
     expect(heuristics.printKeylessInfo).not.toHaveBeenCalled();
   });
 
@@ -234,7 +236,6 @@ describe("init", () => {
     await init({ yes: true });
 
     expect(heuristics.isAuthenticated).toHaveBeenCalled();
-    expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
     expect(heuristics.printKeylessInfo).not.toHaveBeenCalled();
     expect(linkMod.link).toHaveBeenCalled();
   });
@@ -256,7 +257,6 @@ describe("init", () => {
     await init({ yes: true });
 
     expect(heuristics.isAuthenticated).toHaveBeenCalled();
-    expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
     expect(heuristics.printKeylessInfo).toHaveBeenCalled();
     expect(linkMod.link).not.toHaveBeenCalled();
   });
@@ -268,7 +268,6 @@ describe("init", () => {
     await init({ yes: true });
 
     expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalled();
-    expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
     // isAuthenticated is called during skipAuth check
     expect(heuristics.isAuthenticated).toHaveBeenCalled();
   });
@@ -293,8 +292,6 @@ describe("init", () => {
     await init({ yes: true });
 
     expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalled();
-    // Should not ask about skipping auth — keyless not supported
-    expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
     // isAuthenticated is called during skipAuth check, returns false → skip auth
     expect(heuristics.isAuthenticated).toHaveBeenCalled();
     expect(loginMod.login).not.toHaveBeenCalled();
@@ -332,7 +329,7 @@ describe("init", () => {
     expect(context.hasPackageJson).not.toHaveBeenCalled();
   });
 
-  test("existing repo with keyless framework skips askSkipAuth when signed in", async () => {
+  test("existing repo with keyless framework uses authenticated flow when signed in", async () => {
     setup({ email: "user@example.com" });
 
     const keylessCtx = {
@@ -346,11 +343,10 @@ describe("init", () => {
 
     expect(bootstrapMod.promptAndBootstrap).not.toHaveBeenCalled();
     expect(heuristics.isAuthenticated).toHaveBeenCalled();
-    expect(bootstrapMod.askSkipAuth).not.toHaveBeenCalled();
     expect(heuristics.printKeylessInfo).not.toHaveBeenCalled();
   });
 
-  test("existing repo with keyless framework prompts askSkipAuth when not signed in", async () => {
+  test("existing repo with keyless framework auto-selects keyless when not signed in", async () => {
     setup();
 
     const keylessCtx = {
@@ -368,7 +364,8 @@ describe("init", () => {
 
     expect(bootstrapMod.promptAndBootstrap).not.toHaveBeenCalled();
     expect(heuristics.isAuthenticated).toHaveBeenCalled();
-    expect(bootstrapMod.askSkipAuth).toHaveBeenCalled();
+    expect(heuristics.printKeylessInfo).toHaveBeenCalled();
+    expect(linkMod.link).not.toHaveBeenCalled();
   });
 
   test("passes frameworkOverride to bootstrap when provided", async () => {

--- a/packages/cli-core/src/commands/init/index.test.ts
+++ b/packages/cli-core/src/commands/init/index.test.ts
@@ -380,11 +380,16 @@ describe("init", () => {
 
     await init({ starter: true, yes: true });
 
-    expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalledWith(expect.any(String), undefined, {
-      skipConfirm: true,
-      pmOverride: undefined,
-      nameOverride: undefined,
-    });
+    expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalledWith(
+      expect.any(String),
+      undefined,
+      expect.objectContaining({
+        skipConfirm: true,
+        implicitBootstrap: true,
+        pmOverride: undefined,
+        nameOverride: undefined,
+      }),
+    );
     // --yes skips confirmOverwrite
     expect(bootstrapMod.confirmOverwrite).not.toHaveBeenCalled();
   });
@@ -397,6 +402,20 @@ describe("init", () => {
     await init({ starter: true });
 
     expect(bootstrapMod.confirmOverwrite).toHaveBeenCalledWith(expect.any(String));
+  });
+
+  test("--starter without -y runs bootstrap interactively (does not require --framework)", async () => {
+    setup({ email: "test@test.com" });
+    spyOn(context, "gatherContext").mockResolvedValue(FAKE_CTX);
+    spyOn(config, "resolveProfile").mockResolvedValue({ profile: { appId: "app_123" } } as never);
+
+    await init({ starter: true });
+
+    expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalledWith(
+      expect.any(String),
+      undefined,
+      expect.objectContaining({ skipConfirm: false, implicitBootstrap: true }),
+    );
   });
 
   test("bootstrap passes project dir to installSkills, not original cwd", async () => {
@@ -477,11 +496,16 @@ describe("init", () => {
 
     await init({ starter: true, yes: true, pm: "bun", name: "my-project" });
 
-    expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalledWith(expect.any(String), undefined, {
-      skipConfirm: true,
-      pmOverride: "bun",
-      nameOverride: "my-project",
-    });
+    expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalledWith(
+      expect.any(String),
+      undefined,
+      expect.objectContaining({
+        skipConfirm: true,
+        implicitBootstrap: true,
+        pmOverride: "bun",
+        nameOverride: "my-project",
+      }),
+    );
   });
 
   test("agent mode skips all confirmations implicitly", async () => {

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -87,11 +87,11 @@ export async function init(options: InitOptions = {}) {
 
   await enrichProjectContext(ctx);
 
-  const keyless = await resolveKeylessMode(bootstrap, ctx);
+  const authed = await isAuthenticated();
+  const keyless = resolveKeylessMode(bootstrap, ctx, authed);
   ctx.keyless = keyless;
 
-  const skipAuth =
-    !keyless && bootstrap != null && overrides.skipConfirm && !(await isAuthenticated());
+  const skipAuth = !keyless && bootstrap != null && overrides.skipConfirm && !authed;
 
   if (!keyless && !skipAuth) {
     bar();
@@ -212,25 +212,31 @@ function printBootstrapManualSetupInfo(frameworkName: string): void {
 
 // --- Keyless ---
 
-async function resolveKeylessMode(
+function resolveKeylessMode(
   bootstrap: BootstrapResult | null,
   ctx: ProjectContext,
-): Promise<boolean> {
+  authed: boolean,
+): boolean {
+  // Auto-keyless is scoped to bootstrap (new-project) flows only. For existing
+  // projects, fall through to the authenticated flow so `clerk init` still
+  // runs `authenticateAndLink` and pulls real keys — even when signed out the
+  // user gets a login prompt rather than being silently dropped into keyless
+  // (which would skip `env pull` and could overwrite permissive middleware).
+  if (!bootstrap) return false;
+
   if (ctx.framework.supportsKeyless) {
     // Authenticated (OAuth token or CLERK_PLATFORM_API_KEY) — use the
     // authenticated flow so real keys get pulled into .env. Otherwise fall
     // back to keyless: the app runs on auto-generated dev keys and the user
     // can connect their account later via `clerk auth login`.
-    return !(await isAuthenticated());
+    return !authed;
   }
 
-  if (bootstrap) {
-    log.info(
-      dim(
-        `\n  ${ctx.framework.name} requires API keys — keyless mode is not yet supported for this framework.`,
-      ),
-    );
-  }
+  log.info(
+    dim(
+      `\n  ${ctx.framework.name} requires API keys — keyless mode is not yet supported for this framework.`,
+    ),
+  );
   return false;
 }
 

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -21,6 +21,7 @@ import {
   printOutro,
   printKeylessInfo,
   getAuthenticatedEmail,
+  isAuthenticated,
 } from "./heuristics.js";
 import { installSkills } from "./skills.js";
 import { intro, outro, bar, withSpinner } from "../../lib/spinner.js";
@@ -91,7 +92,7 @@ export async function init(options: InitOptions = {}) {
   ctx.keyless = keyless;
 
   const skipAuth =
-    !keyless && bootstrap != null && overrides.skipConfirm && !(await getAuthenticatedEmail());
+    !keyless && bootstrap != null && overrides.skipConfirm && !(await isAuthenticated());
 
   if (!keyless && !skipAuth) {
     bar();
@@ -218,9 +219,9 @@ async function resolveKeylessMode(
   skipConfirm: boolean,
 ): Promise<boolean> {
   if (ctx.framework.supportsKeyless) {
-    // Already authenticated — go straight to the authenticated flow.
-    const email = await getAuthenticatedEmail();
-    if (email) return false;
+    // Already authenticated (OAuth token or CLERK_PLATFORM_API_KEY) — go
+    // straight to the authenticated flow so real keys get pulled into .env.
+    if (await isAuthenticated()) return false;
 
     return skipConfirm || (await askSkipAuth());
   }

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -159,7 +159,7 @@ async function handleStarter(
     await confirmOverwrite(cwd);
   }
 
-  return bootstrapAndDetect(cwd, frameworkOverride, { ...overrides, skipConfirm: true });
+  return bootstrapAndDetect(cwd, frameworkOverride, { ...overrides, implicitBootstrap: true });
 }
 
 async function resolveProjectContext(

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -90,7 +90,8 @@ export async function init(options: InitOptions = {}) {
   const keyless = await resolveKeylessMode(bootstrap, ctx, overrides.skipConfirm);
   ctx.keyless = keyless;
 
-  const skipAuth = !keyless && bootstrap != null && overrides.skipConfirm;
+  const skipAuth =
+    !keyless && bootstrap != null && overrides.skipConfirm && !(await getAuthenticatedEmail());
 
   if (!keyless && !skipAuth) {
     bar();
@@ -216,17 +217,21 @@ async function resolveKeylessMode(
   ctx: ProjectContext,
   skipConfirm: boolean,
 ): Promise<boolean> {
-  if (!bootstrap) return false;
-
   if (ctx.framework.supportsKeyless) {
+    // Already authenticated — go straight to the authenticated flow.
+    const email = await getAuthenticatedEmail();
+    if (email) return false;
+
     return skipConfirm || (await askSkipAuth());
   }
 
-  log.info(
-    dim(
-      `\n  ${ctx.framework.name} requires API keys — keyless mode is not yet supported for this framework.`,
-    ),
-  );
+  if (bootstrap) {
+    log.info(
+      dim(
+        `\n  ${ctx.framework.name} requires API keys — keyless mode is not yet supported for this framework.`,
+      ),
+    );
+  }
   return false;
 }
 

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -28,7 +28,6 @@ import { intro, outro, bar, withSpinner } from "../../lib/spinner.js";
 import {
   promptAndBootstrap,
   confirmOverwrite,
-  askSkipAuth,
   type BootstrapOverrides,
   type BootstrapResult,
 } from "./bootstrap.js";
@@ -88,7 +87,7 @@ export async function init(options: InitOptions = {}) {
 
   await enrichProjectContext(ctx);
 
-  const keyless = await resolveKeylessMode(bootstrap, ctx, overrides.skipConfirm);
+  const keyless = await resolveKeylessMode(bootstrap, ctx);
   ctx.keyless = keyless;
 
   const skipAuth =
@@ -216,14 +215,13 @@ function printBootstrapManualSetupInfo(frameworkName: string): void {
 async function resolveKeylessMode(
   bootstrap: BootstrapResult | null,
   ctx: ProjectContext,
-  skipConfirm: boolean,
 ): Promise<boolean> {
   if (ctx.framework.supportsKeyless) {
-    // Already authenticated (OAuth token or CLERK_PLATFORM_API_KEY) — go
-    // straight to the authenticated flow so real keys get pulled into .env.
-    if (await isAuthenticated()) return false;
-
-    return skipConfirm || (await askSkipAuth());
+    // Authenticated (OAuth token or CLERK_PLATFORM_API_KEY) — use the
+    // authenticated flow so real keys get pulled into .env. Otherwise fall
+    // back to keyless: the app runs on auto-generated dev keys and the user
+    // can connect their account later via `clerk auth login`.
+    return !(await isAuthenticated());
   }
 
   if (bootstrap) {


### PR DESCRIPTION
## Summary

Four `clerk init` fixes on this branch:

- **Skip `askSkipAuth` and keyless flow when signed in.** If the user has an OAuth token, `clerk init` goes straight to the authenticated flow (auth + link + env pull).
- **Count `CLERK_PLATFORM_API_KEY` as authenticated.** Non-interactive / CI runs with an API key no longer fall through to keyless mode. A new `isAuthenticated()` helper covers both OAuth tokens and the env var.
- **Remove the "Skip authentication for now?" prompt.** The prompt added a step without meaningful choice — the unauthenticated path can't pull keys either way. Now the flow just follows auth state: signed in → authenticated flow + env pull; not signed in → keyless automatically (the keyless info message already points users to `clerk auth login` for later).
- **Keep `clerk init --starter` interactive without `--framework`.** Running `--starter` without `-y` no longer errors with "Non-interactive mode requires --framework" — it only implies "yes, bootstrap," not "skip every prompt."

Also suppresses the "keyless not supported" framework message outside the bootstrap flow.

## Test plan
- [x] `bun run test` — init suite covers the permutations (auth vs. not, API key vs. OAuth, bootstrap vs. existing repo, `--starter` with and without `-y`)
- [x] `bun run lint` / `bun run typecheck`
- [x] CI E2E suite passes (was failing on Astro / Next / TanStack / React Router before the API-key fix)
- [x] Manual: `clerk init` on a keyless framework while signed in → authenticated flow, no keyless prompt
- [x] Manual: `clerk init` on a keyless framework while signed out → keyless flow, no prompt
- [x] Manual: `clerk init` in an existing repo with keyless framework while signed in → no keyless prompt, env pulled
- [x] Manual: `clerk init --starter` (no `-y`) → interactive framework picker instead of an error