### PR TITLE
chore(conductor): copy .env-profiles.json into workspace on setup

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "setup": "cp \"$CONDUCTOR_ROOT_PATH/.env.local\" .env.local && bun install",
+    "setup": "cp \"$CONDUCTOR_ROOT_PATH/.env.local\" .env.local && cp \"$CONDUCTOR_ROOT_PATH/.env-profiles.json\" .env-profiles.json && bun install",
     "run": "bun run dev -- init"
   }
 }


### PR DESCRIPTION
## Summary
- Extend the Conductor setup script to copy `.env-profiles.json` from the root workspace alongside `.env.local` so new workspaces have the profile config available.

## Test plan
- [ ] Spin up a new Conductor workspace and confirm `.env-profiles.json` is present after setup.