### PR TITLE
chore: test release flow with cli@0.8.4 baseline

### DIFF
--- a/.changeset/release-process-test.md
+++ b/.changeset/release-process-test.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Test patch release flow.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerk",
-  "version": "0.0.2",
+  "version": "0.8.4",
   "private": true,
   "description": "Clerk CLI",
   "keywords": [


### PR DESCRIPTION
## Summary

- Manually bump `packages/cli` from `0.0.2` to `0.8.4` to simulate a post-release baseline.
- Add a patch changeset so the next release run bumps to `0.8.5`.
- Smoke-tests the changesets-driven release workflow end-to-end.

## Test plan

- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun changeset status --since=origin/main` reports `clerk` patch bump
- [ ] Verify the release workflow produces `0.8.5` from this baseline