### PR TITLE
fix(homebrew): desc must not start with formula name

### DIFF
--- a/scripts/lib/homebrew.test.ts
+++ b/scripts/lib/homebrew.test.ts
@@ -82,6 +82,34 @@ describe("renderFormula", () => {
 
     expect(result).toContain("keg_only :versioned_formula");
   });
+
+  // Homebrew's FormulaAudit/Desc rule rejects descriptions that start with
+  // the formula name (case-insensitive). Breaking this causes `brew style`
+  // failures in the homebrew-stable tap's CI.
+  test("desc does not start with the formula name", () => {
+    const unversioned = renderFormula({
+      version: "1.2.3",
+      checksums: {
+        "darwin-arm64": "aaaa",
+        "darwin-x64": "bbbb",
+        "linux-arm64": "cccc",
+        "linux-x64": "dddd",
+      },
+    });
+    expect(unversioned).not.toMatch(/desc "clerk\b/i);
+
+    const versioned = renderFormula({
+      version: "1.2.3",
+      checksums: {
+        "darwin-arm64": "aaaa",
+        "darwin-x64": "bbbb",
+        "linux-arm64": "cccc",
+        "linux-x64": "dddd",
+      },
+      major: 1,
+    });
+    expect(versioned).not.toMatch(/desc "clerk\b/i);
+  });
 });
 
 describe("computeChecksum", () => {

--- a/scripts/lib/homebrew.ts
+++ b/scripts/lib/homebrew.ts
@@ -31,7 +31,7 @@ export function renderFormula(input: FormulaInput): string {
   const kegOnly = major != null ? "\n  keg_only :versioned_formula" : "";
 
   return `class ${className} < Formula
-  desc "Clerk command-line interface"
+  desc "Command-line interface for Clerk"
   homepage "https://clerk.com"
   version "${version}"
   license "MIT"${kegOnly}


### PR DESCRIPTION
## Summary
- Rephrase the generated Homebrew formula `desc` so it no longer starts with `Clerk`, which violates Homebrew's `FormulaAudit/Desc` rule and is causing `brew test-bot` failures in the `homebrew-stable` tap (e.g. the 0.8.4 release).
- Add a regression test asserting the rendered `desc` never starts with the formula name, for both unversioned and versioned formulas.

## Test plan
- [x] `bun run format`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` (71 passed, incl. new regression)
- [ ] After merge and next release, verify `brew test-bot` is green in the homebrew-stable tap