### PR TITLE
fix(init): tighten bootstrap flow (skip redundant confirm, put next steps last)

### DIFF
--- a/.changeset/init-adjustments.md
+++ b/.changeset/init-adjustments.md
@@ -2,4 +2,7 @@
 "clerk": patch
 ---
 
-Skip the redundant "Proceed?" scaffold confirmation when `clerk init` bootstraps a new project (via `--starter` or on an empty directory). The scaffold plan is still previewed; only the now-superfluous prompt is removed since the user already opted in by starting bootstrap.
+Tighten the `clerk init` bootstrap flow:
+
+- Skip the redundant "Proceed?" scaffold confirmation when bootstrapping a new project (via `--starter` or on an empty directory). The scaffold plan is still previewed; only the now-superfluous prompt is removed since the user already opted in by starting bootstrap.
+- Print bootstrap next steps (`cd <project>`, `<pm> dev`, etc.) after the optional "Install agent skills?" prompt so they remain the last thing visible when the command finishes.

--- a/.changeset/init-adjustments.md
+++ b/.changeset/init-adjustments.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Skip the redundant "Proceed?" scaffold confirmation when `clerk init` bootstraps a new project (via `--starter` or on an empty directory). The scaffold plan is still previewed; only the now-superfluous prompt is removed since the user already opted in by starting bootstrap.

--- a/packages/cli-core/src/commands/init/index.test.ts
+++ b/packages/cli-core/src/commands/init/index.test.ts
@@ -18,6 +18,7 @@ import * as scanMod from "./scan.ts";
 import * as heuristics from "./heuristics.ts";
 import * as skillsMod from "./skills.ts";
 import * as bootstrapMod from "./bootstrap.ts";
+import * as nextStepsMod from "../../lib/next-steps.ts";
 import { init } from "./index.ts";
 
 const FAKE_CTX = {
@@ -211,6 +212,31 @@ describe("init", () => {
     await init({});
 
     expect(previewMod.previewAndConfirm).toHaveBeenCalled();
+  });
+
+  test("bootstrap prints next steps after skills install", async () => {
+    setup({ email: "test@test.com" });
+    setupBootstrapSuccess();
+    spyOn(scaffoldMod, "scaffold").mockResolvedValue({
+      actions: [{ type: "create", path: "app/layout.tsx", content: "", description: "" }],
+      postInstructions: [],
+    });
+
+    const callOrder: string[] = [];
+    spies.push(
+      spyOn(skillsMod, "installSkills").mockImplementation(async () => {
+        callOrder.push("installSkills");
+      }),
+    );
+    spies.push(
+      spyOn(nextStepsMod, "printNextSteps").mockImplementation(() => {
+        callOrder.push("printNextSteps");
+      }),
+    );
+
+    await init({});
+
+    expect(callOrder.indexOf("installSkills")).toBeLessThan(callOrder.indexOf("printNextSteps"));
   });
 
   test("blank dir with keyless framework auto-selects keyless when unauthenticated", async () => {

--- a/packages/cli-core/src/commands/init/index.test.ts
+++ b/packages/cli-core/src/commands/init/index.test.ts
@@ -169,6 +169,50 @@ describe("init", () => {
     expect(heuristics.printKeylessInfo).not.toHaveBeenCalled();
   });
 
+  test("bootstrap flow skips scaffold Proceed? prompt (user already opted in)", async () => {
+    setup({ email: "test@test.com" });
+    setupBootstrapSuccess();
+    spyOn(scaffoldMod, "scaffold").mockResolvedValue({
+      actions: [{ type: "create", path: "app/layout.tsx", content: "", description: "" }],
+      postInstructions: [],
+    });
+
+    await init({});
+
+    expect(bootstrapMod.promptAndBootstrap).toHaveBeenCalled();
+    expect(previewMod.previewAndConfirm).not.toHaveBeenCalled();
+    expect(previewMod.previewPlan).toHaveBeenCalled();
+  });
+
+  test("--starter skips scaffold Proceed? prompt even without -y", async () => {
+    setup({ email: "test@test.com" });
+    spyOn(context, "gatherContext").mockResolvedValue(FAKE_CTX);
+    spyOn(config, "resolveProfile").mockResolvedValue({ profile: { appId: "app_123" } } as never);
+    spyOn(scaffoldMod, "scaffold").mockResolvedValue({
+      actions: [{ type: "create", path: "app/layout.tsx", content: "", description: "" }],
+      postInstructions: [],
+    });
+
+    await init({ starter: true });
+
+    expect(previewMod.previewAndConfirm).not.toHaveBeenCalled();
+    expect(previewMod.previewPlan).toHaveBeenCalled();
+  });
+
+  test("existing project without -y still prompts scaffold Proceed?", async () => {
+    setup({ email: "test@test.com" });
+    spyOn(context, "gatherContext").mockResolvedValue(FAKE_CTX);
+    spyOn(config, "resolveProfile").mockResolvedValue({ profile: { appId: "app_123" } } as never);
+    spyOn(scaffoldMod, "scaffold").mockResolvedValue({
+      actions: [{ type: "create", path: "app/layout.tsx", content: "", description: "" }],
+      postInstructions: [],
+    });
+
+    await init({});
+
+    expect(previewMod.previewAndConfirm).toHaveBeenCalled();
+  });
+
   test("blank dir with keyless framework auto-selects keyless when unauthenticated", async () => {
     setup();
 

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -100,7 +100,10 @@ export async function init(options: InitOptions = {}) {
 
   // Short-circuit on a fully-clean re-run so env pull / skills prompt don't
   // execute when there's nothing to do.
-  const { alreadySetUp } = await detectAndInstall(ctx.cwd, ctx, overrides.skipConfirm);
+  // Bootstrap implies consent — the user already opted into project creation, so
+  // skip the scaffold "Proceed?" prompt as well.
+  const skipScaffoldConfirm = overrides.skipConfirm || bootstrap != null;
+  const { alreadySetUp } = await detectAndInstall(ctx.cwd, ctx, skipScaffoldConfirm);
 
   if (alreadySetUp) {
     log.success("\nClerk is already set up in this project.");

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -120,13 +120,15 @@ export async function init(options: InitOptions = {}) {
     printKeylessInfo();
   }
 
-  if (bootstrap) {
-    printBootstrapNextSteps(bootstrap, keyless);
-  }
-
   if (options.skills !== false) {
     bar();
     await installSkills(ctx.cwd, ctx.framework.dep, ctx.packageManager, overrides.skipConfirm);
+  }
+
+  // Next steps print last so they stay on screen as the final thing the user sees.
+  if (bootstrap) {
+    bar();
+    printBootstrapNextSteps(bootstrap, keyless);
   }
 
   outro("Done");


### PR DESCRIPTION
## Summary

Two small bootstrap-flow polish fixes for `clerk init`:

- **Skip redundant "Proceed?" during bootstrap.** When bootstrapping a new project (either `--starter` or implicit bootstrap on an empty directory), the user already opted into project creation, so the secondary `? Proceed?` scaffold prompt is dropped. The scaffold preview (`CREATE`/`MODIFY` list) is still printed.
- **Next steps print last.** Moved the bootstrap next-steps block (`→ cd <project>`, `→ <pm> dev`, `→ clerk auth login`) to run after the "Install agent skills?" prompt, so those steps stay on-screen as the final thing the user sees when the command finishes.

Existing-project flows are unchanged.

## Test plan

- [x] `bun run format` / `lint` / `typecheck` / `test` pass
- [x] Unit tests cover:
  - Implicit bootstrap skips scaffold "Proceed?"
  - `--starter` without `-y` skips scaffold "Proceed?"
  - Existing-project flow still prompts "Proceed?" (regression guard)
- [ ] Manual: `clerk init --starter` in a fresh tmpdir — confirm no "Proceed?" after preview; confirm `→ cd … / → <pm> dev` appears as the final block before `└ Done`
- [ ] Manual: `clerk init` in an empty dir → same verification as above
- [ ] Manual: `clerk init` in an existing linked project → "Proceed?" still appears; no bootstrap next steps printed (unchanged behavior)