### PR TITLE
feat(push): dry-run diff

### DIFF
--- a/packages/cli-core/src/commands/config/push.test.ts
+++ b/packages/cli-core/src/commands/config/push.test.ts
@@ -525,11 +525,12 @@ describe("config push", () => {
 
   // --- Dry run ---
 
-  test("dry-run prints payload without calling API", async () => {
-    let fetchCalled = false;
-    stubFetch(async () => {
-      fetchCalled = true;
-      return new Response(JSON.stringify(mockResponse), { status: 200 });
+  test("dry-run fetches current config and shows diff without mutating", async () => {
+    let mutatingCallMade = false;
+    stubFetch(async (_input, init) => {
+      if (init?.method && init.method !== "GET") mutatingCallMade = true;
+      const body = init?.method && init.method !== "GET" ? mockResponse : currentConfig;
+      return new Response(JSON.stringify(body), { status: 200 });
     });
 
     await setProfile(process.cwd(), {
@@ -542,9 +543,24 @@ describe("config push", () => {
       json: '{"session":{"lifetime":3600}}',
       dryRun: true,
     });
-    expect(fetchCalled).toBe(false);
-    expect(captured.err).toContain("[dry-run]");
-    expect(captured.out).toContain(JSON.stringify({ session: { lifetime: 3600 } }, null, 2));
+    expect(mutatingCallMade).toBe(false);
+    expect(captured.err).toContain("[dry-run] Would PATCH");
+    expect(captured.err).toContain("- 604800");
+    expect(captured.err).toContain("+ 3600");
+  });
+
+  test("dry-run reports no changes when payload matches current", async () => {
+    await setProfile(process.cwd(), {
+      workspaceId: "org_1",
+      appId: "app_1",
+      instances: { development: "ins_dev" },
+    });
+
+    await runConfigPatch({
+      json: '{"session":{"lifetime":604800}}',
+      dryRun: true,
+    });
+    expect(captured.err).toContain("[dry-run] No changes detected");
   });
 
   test("dry-run for put shows PUT method", async () => {
@@ -554,7 +570,7 @@ describe("config push", () => {
       instances: { development: "ins_dev" },
     });
 
-    await runConfigPut({ json: '{"a":1}', dryRun: true });
+    await runConfigPut({ json: '{"session":{"lifetime":3600}}', dryRun: true });
     expect(captured.err).toContain("[dry-run] Would PUT");
   });
 

--- a/packages/cli-core/src/commands/config/push.ts
+++ b/packages/cli-core/src/commands/config/push.ts
@@ -72,48 +72,26 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
   // Strip config_version — it's returned by pull but not accepted by the backend
   delete configPayload.config_version;
 
-  if (options.dryRun) {
-    const currentConfig = await withSpinner("Fetching current config...", () =>
-      withApiContext(
-        fetchInstanceConfig(ctx.appId, ctx.instanceId),
-        "Failed to fetch current config",
-      ),
-    );
-    delete currentConfig.config_version;
-
-    const isPatch = op.method === "PATCH";
-    const hasChanges = hasConfigChanges(currentConfig, configPayload, isPatch);
-
-    if (!hasChanges) {
-      log.info("[dry-run] No changes detected");
-      return;
-    }
-
-    log.info(`\n[dry-run] Would ${op.method} config on ${ctx.appLabel} (${ctx.instanceLabel}):\n`);
-    printDiff(currentConfig, configPayload, isPatch);
-    return;
-  }
-
   const currentConfig = await withSpinner("Fetching current config...", () =>
     withApiContext(
       fetchInstanceConfig(ctx.appId, ctx.instanceId),
       "Failed to fetch current config",
     ),
   );
-
-  // Strip config_version from current config to match the payload normalization above
   delete currentConfig.config_version;
 
   const isPatch = op.method === "PATCH";
-  const hasChanges = hasConfigChanges(currentConfig, configPayload, isPatch);
 
-  if (!hasChanges) {
-    log.info("No changes detected");
+  if (!hasConfigChanges(currentConfig, configPayload, isPatch)) {
+    log.info(options.dryRun ? "[dry-run] No changes detected" : "No changes detected");
     return;
   }
 
-  log.info(`\n${op.verb} config on ${ctx.appLabel} (${ctx.instanceLabel}):\n`);
+  const prefix = options.dryRun ? `[dry-run] Would ${op.method}` : op.verb;
+  log.info(`\n${prefix} config on ${ctx.appLabel} (${ctx.instanceLabel}):\n`);
   printDiff(currentConfig, configPayload, isPatch);
+
+  if (options.dryRun) return;
 
   if (isHuman() && !options.yes) {
     if (op.warning) {

--- a/packages/cli-core/src/commands/config/push.ts
+++ b/packages/cli-core/src/commands/config/push.ts
@@ -73,8 +73,24 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
   delete configPayload.config_version;
 
   if (options.dryRun) {
-    log.info(`[dry-run] Would ${op.method} config on ${ctx.appLabel} (${ctx.instanceLabel}):`);
-    log.data(JSON.stringify(configPayload, null, 2));
+    const currentConfig = await withSpinner("Fetching current config...", () =>
+      withApiContext(
+        fetchInstanceConfig(ctx.appId, ctx.instanceId),
+        "Failed to fetch current config",
+      ),
+    );
+    delete currentConfig.config_version;
+
+    const isPatch = op.method === "PATCH";
+    const hasChanges = hasConfigChanges(currentConfig, configPayload, isPatch);
+
+    if (!hasChanges) {
+      log.info("[dry-run] No changes detected");
+      return;
+    }
+
+    log.info(`\n[dry-run] Would ${op.method} config on ${ctx.appLabel} (${ctx.instanceLabel}):\n`);
+    printDiff(currentConfig, configPayload, isPatch);
     return;
   }
 

--- a/packages/cli-core/src/test/integration/config-put.test.ts
+++ b/packages/cli-core/src/test/integration/config-put.test.ts
@@ -104,6 +104,11 @@ test("config put aborted when user declines confirmation", async () => {
 });
 
 test("config put --dry-run shows payload without sending request", async () => {
+  // Mock the current config endpoint (needed for the diff preview)
+  http.mock({
+    "/config": { session: { lifetime: 604800 } },
+  });
+
   const { stdout, stderr } = await clerk(
     "--mode",
     "human",
@@ -115,8 +120,9 @@ test("config put --dry-run shows payload without sending request", async () => {
   );
 
   expect(stderr).toContain("[dry-run]");
-  expect(stdout).toContain('"lifetime": 3600');
+  expect(stderr).toContain("3600");
 
-  // No requests sent
-  expect(http.requests.length).toBe(0);
+  // No PUT request sent
+  const putReqs = http.requests.filter((r) => r.method === "PUT");
+  expect(putReqs.length).toBe(0);
 });

--- a/packages/cli-core/src/test/integration/dry-run.test.ts
+++ b/packages/cli-core/src/test/integration/dry-run.test.ts
@@ -45,9 +45,15 @@ test.each([{ mode: "human" }, { mode: "agent" }])(
 );
 
 test.each([{ mode: "human" }, { mode: "agent" }])(
-  "config patch dry-run sends no requests ($mode mode)",
+  "config patch dry-run fetches config and shows diff ($mode mode)",
   async ({ mode }) => {
-    const { stdout, stderr } = await clerk(
+    http.stub(async (_url, init) => {
+      const isGet = !init?.method || init.method === "GET";
+      const body = isGet ? { session: { lifetime: 604800 } } : {};
+      return new Response(JSON.stringify(body), { status: 200 });
+    });
+
+    const { stderr } = await clerk(
       "--mode",
       mode,
       "config",
@@ -56,9 +62,13 @@ test.each([{ mode: "human" }, { mode: "agent" }])(
       '{"session":{"lifetime":3600}}',
       "--dry-run",
     );
-    expect(http.requests.length).toBe(0);
+    const getReqs = http.requests.filter((r) => r.method === "GET");
+    const patchReqs = http.requests.filter((r) => r.method === "PATCH");
+    expect(getReqs.length).toBe(1);
+    expect(patchReqs.length).toBe(0);
     expect(stderr).toContain("[dry-run]");
-    expect(stdout).toContain('"lifetime": 3600');
+    expect(stderr).toContain("604800");
+    expect(stderr).toContain("3600");
   },
 );
 


### PR DESCRIPTION
We already support diffs on push (patch/put). Add diffs for dry-runs as well.

Sample output (includes color/dim/bolding):

```
[LOCAL]
◇  Fetching current config

[dry-run] Would PATCH config on My Application (development):

  connection_oauth_google:
    enabled:
      - true
      + false
```