### PR TITLE
fix(skill): fix clerk skill install failing on published releases

### DIFF
--- a/.changeset/skill-install-frontmatter.md
+++ b/.changeset/skill-install-frontmatter.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Fix `clerk skill install` failing with `No valid skills found` on published releases. The bundled skill's frontmatter now parses as strict YAML.

--- a/packages/cli-core/src/commands/skill/install.test.ts
+++ b/packages/cli-core/src/commands/skill/install.test.ts
@@ -2,6 +2,7 @@ import { test, expect, describe } from "bun:test";
 import { existsSync } from "node:fs";
 import { readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
+import YAML from "yaml";
 import { buildSkillsArgs, renderSkillVersionPlaceholder, withStagedClerkSkill } from "./install.ts";
 
 describe("buildSkillsArgs", () => {
@@ -132,6 +133,27 @@ describe("withStagedClerkSkill version rendering", () => {
         const content = await readFile(join(stageDir, rel), "utf8");
         expect(content, rel).not.toContain("{{CLI_VERSION}}");
       }
+    });
+  });
+});
+
+describe("bundled SKILL.md frontmatter", () => {
+  // Regression guard: the upstream `skills` CLI parses SKILL.md frontmatter as
+  // strict YAML and silently drops skills whose frontmatter fails to parse.
+  // An unquoted `: ` inside the description (e.g. `raw HTTP: it handles`)
+  // triggers "Nested mappings are not allowed in compact mappings" and makes
+  // `clerk skill install` fail with "No valid skills found".
+  test("parses as YAML with name and description strings", async () => {
+    await withStagedClerkSkill(undefined, async (stageDir) => {
+      const content = await readFile(join(stageDir, "clerk/SKILL.md"), "utf8");
+      const frontmatter = content.match(/^---\n([\s\S]*?)\n---/)?.[1];
+      expect(frontmatter, "SKILL.md must have YAML frontmatter").toBeDefined();
+
+      const parsed = YAML.parse(frontmatter!);
+      expect(typeof parsed.name).toBe("string");
+      expect(typeof parsed.description).toBe("string");
+      expect(parsed.name.length).toBeGreaterThan(0);
+      expect(parsed.description.length).toBeGreaterThan(0);
     });
   });
 });

--- a/skills/clerk/SKILL.md
+++ b/skills/clerk/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: clerk
-description: 'Operate the Clerk CLI (`clerk` binary) for authentication, user/org/session management, instance config, env keys, and any Clerk Backend or Platform API call. Use when the user mentions Clerk management tasks, "list clerk users", "create a clerk user", "update organization", "pull clerk config", "clerk env pull", "clerk doctor", "clerk api", or any ad-hoc Clerk API request. Prefer the CLI over raw HTTP: it handles auth, key resolution, app/instance targeting, and formatting automatically.'
+description: >-
+  Operate the Clerk CLI (`clerk` binary) for authentication, user/org/session management,
+  instance config, env keys, and any Clerk Backend or Platform API call. Use when the user
+  mentions Clerk management tasks, "list clerk users", "create a clerk user", "update
+  organization", "pull clerk config", "clerk env pull", "clerk doctor", "clerk api", or
+  any ad-hoc Clerk API request. Prefer the CLI over raw HTTP: it handles auth, key
+  resolution, app/instance targeting, and formatting automatically.
 ---
 
 # Clerk CLI

--- a/skills/clerk/SKILL.md
+++ b/skills/clerk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clerk
-description: Operate the Clerk CLI (`clerk` binary) for authentication, user/org/session management, instance config, env keys, and any Clerk Backend or Platform API call. Use when the user mentions Clerk management tasks, "list clerk users", "create a clerk user", "update organization", "pull clerk config", "clerk env pull", "clerk doctor", "clerk api", or any ad-hoc Clerk API request. Prefer the CLI over raw HTTP: it handles auth, key resolution, app/instance targeting, and formatting automatically.
+description: 'Operate the Clerk CLI (`clerk` binary) for authentication, user/org/session management, instance config, env keys, and any Clerk Backend or Platform API call. Use when the user mentions Clerk management tasks, "list clerk users", "create a clerk user", "update organization", "pull clerk config", "clerk env pull", "clerk doctor", "clerk api", or any ad-hoc Clerk API request. Prefer the CLI over raw HTTP: it handles auth, key resolution, app/instance targeting, and formatting automatically.'
 ---
 
 # Clerk CLI


### PR DESCRIPTION
## Summary

- `bunx clerk@canary skill install` fails with `No valid skills found` because the bundled SKILL.md description contains `raw HTTP: it handles`. Strict YAML frontmatter parsers treat the unquoted `: ` as a nested mapping and reject the document, so the upstream `skills` CLI drops the skill as invalid.
- Rewrite the description as a YAML folded block scalar (`>-`) so the whole value is a plain scalar regardless of internal punctuation, including future prose containing an apostrophe.
- Add a regression test that parses the staged SKILL.md frontmatter via the already-present `yaml` dep, so a future stray `: ` fails locally instead of at install time.

## Test plan

- [x] `bun run test`, `bun run typecheck`, `bun run lint`, `bun run format:check`
- [x] Manual: `bunx skills@1.5.1 add <staged-dir>` against the fix now completes with `Done!` (reproduced in a temp dir, both with the CLI's own staging flow and a minimal stand-in)
- [ ] Re-verify once a canary publishes: `bunx clerk@<canary> skill install` in a fresh temp dir