### PR TITLE
fix(e2e): drop unused @tailwindcss/typography from tanstack fixture

### DIFF
--- a/test/e2e/fixtures/tanstack-start/package.json
+++ b/test/e2e/fixtures/tanstack-start/package.json
@@ -26,7 +26,6 @@
     "tailwindcss": "^4.1.18"
   },
   "devDependencies": {
-    "@tailwindcss/typography": "^0.5.16",
     "@tanstack/devtools-vite": "latest",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.0",

--- a/test/e2e/fixtures/tanstack-start/src/styles.css
+++ b/test/e2e/fixtures/tanstack-start/src/styles.css
@@ -1,6 +1,5 @@
 @import url("https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,700&family=Manrope:wght@400;500;600;700;800&display=swap");
 @import "tailwindcss";
-@plugin "@tailwindcss/typography";
 
 @theme {
   --font-sans: "Manrope", ui-sans-serif, system-ui, sans-serif;


### PR DESCRIPTION
## Summary

- Removes the `@plugin "@tailwindcss/typography";` directive from the TanStack Start E2E fixture's `styles.css` and drops the matching devDependency.
- Unblocks the E2E CI job, which started failing on main the moment `tailwindcss@4.2.3` was published (2026-04-20, ~9 minutes before the first failing run).

## Why

The TanStack scaffold emits the `@plugin` directive by default, but no `prose` classes are used anywhere in the fixture source, so it was dead weight. Tailwind 4.2.3 regressed module resolution during the Vite SSR build pass (the client build still succeeded), so the directive caused `Cannot find module '@tailwindcss/typography'` even though the package was correctly installed. Bisected: 4.2.0 / 4.2.2 pass, 4.2.3 fails. Likely upstream culprit: [`fix(vite): resolve tsconfig paths in CSS and JS resolvers` (#19803)](https://github.com/tailwindlabs/tailwindcss/pull/19803).

Since the plugin was never actually exercised, removing it is a cleaner fix than pinning Tailwind. A refresh of the fixture (via `@tanstack/cli@latest`) will re-introduce the directive, but at that point Tailwind should have shipped a fix or the scaffold will have changed.

## Test plan

- [x] Reproduced failure locally against the fixture with \`tailwindcss@4.2.3\`.
- [x] Verified fixture builds cleanly (client + SSR) with \`tailwindcss@4.2.3\` after the fix.
- [x] \`bun run format:check\`, \`bun run lint\`, \`bun run typecheck\`, \`bun run test\` all pass.
- [ ] Full E2E CI run on the PR.