### PR TITLE
feat(help): surface agent skill install in `clerk --help`

### DIFF
--- a/.changeset/improve-help-commands.md
+++ b/.changeset/improve-help-commands.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Surface the bundled agent skill in `clerk --help` and bare `clerk` output with a tip pointing to `clerk skill install`, so users discover how to give AI coding agents Clerk context.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Commands:
   completion  [shell]                        Generate shell autocompletion script
   update      [options]                      Update the Clerk CLI to the latest version
 
+Give AI agents better Clerk context: install the Clerk skills
+  $ clerk skill install
+
 clerk init
   --framework <name>     Framework to set up (skips auto-detection)
   --pm <manager>         Package manager to use (skips prompt/auto-detection)

--- a/packages/cli-core/src/cli-program.ts
+++ b/packages/cli-core/src/cli-program.ts
@@ -55,7 +55,13 @@ export function createProgram() {
       "--mode <mode>",
       "Force interaction mode (human or agent). Defaults to auto-detect based on TTY.",
     )
-    .option("--verbose", "Show detailed output (enables debug messages)");
+    .option("--verbose", "Show detailed output (enables debug messages)")
+    .addHelpText(
+      "after",
+      `
+Give AI agents better Clerk context: install the Clerk skills
+  $ clerk skill install`,
+    );
 
   program.hook("preAction", async () => {
     // Reset log level at the start of each command invocation so a previous


### PR DESCRIPTION
## Summary

- Adds a one-line tip under the `Commands:` section of `clerk --help` (and bare `clerk` with no subcommand) pointing to `clerk skill install`. Rendered via Commander's `addHelpText('after', …)` on the root program, so both paths pick it up without duplicating the string.
- Keeps the existing custom help formatter (`clerkHelpConfig` in `packages/cli-core/src/lib/help.ts`) untouched — the tip composes as Commander's "after" hook around the custom `formatHelp`.
- Mirrors the tip in `README.md`'s help snippet to keep the usage docs in sync with the live output (per `.claude/rules/commands.md`).

Before:
```
Commands:
  ...
  update      [options]                      Update the Clerk CLI to the latest version
  help        [command]                      Display help for command
```

After:
```
Commands:
  ...
  update      [options]                      Update the Clerk CLI to the latest version
  help        [command]                      Display help for command

Give AI agents better Clerk context: install the Clerk skills
  $ clerk skill install
```

## Test plan

- [x] `bun run src/cli.ts --help` shows the tip after `help  [command]`
- [x] `bun run src/cli.ts` (no args) shows the same tip and exits 1 (unchanged)
- [x] Subcommand help pages (`clerk init --help`, `clerk config --help`, etc.) are unaffected
- [x] `bun run format`, `bun run lint`, `bun run typecheck`, and `bun run test` all pass locally