### PR TITLE
feat(plapi): stamp from_source=cli on authenticated app creation

### DIFF
--- a/.changeset/cli-attribution-stamp.md
+++ b/.changeset/cli-attribution-stamp.md
@@ -1,0 +1,5 @@
+---
+"clerk": minor
+---
+
+Stamp authenticated CLI app creation with `from_source=cli` so apps created through Clerk CLI flows are attributable in Clerk's analytics. The value is set on the PLAPI request body and persists to `applications.from_source`. Requires matching PLAPI support to be deployed server-side.

--- a/packages/cli-core/src/lib/plapi.test.ts
+++ b/packages/cli-core/src/lib/plapi.test.ts
@@ -305,7 +305,7 @@ describe("plapi", () => {
       await createApplication("My App");
       expect(capturedMethod).toBe("POST");
       expect(capturedUrl).toBe("https://api.clerk.com/v1/platform/applications");
-      expect(JSON.parse(capturedBody)).toEqual({ name: "My App" });
+      expect(JSON.parse(capturedBody)).toEqual({ name: "My App", from_source: "cli" });
     });
 
     test("sends Content-Type and Authorization headers", async () => {

--- a/packages/cli-core/src/lib/plapi.ts
+++ b/packages/cli-core/src/lib/plapi.ts
@@ -9,6 +9,19 @@ import { CliError, PlapiError, ERROR_CODE } from "./errors.ts";
 import { loggedFetch } from "./fetch.ts";
 import { log } from "./log.ts";
 
+/**
+ * Canonical attribution marker written to `applications.from_source` when the
+ * CLI creates an application through PLAPI. Surfaces in BigQuery via
+ * `dim_applications.from_source` for growth analytics. Do not change without
+ * coordinating with the growth-data team — the value is consumed by dbt
+ * models and dashboards downstream.
+ */
+const CLI_FROM_SOURCE = "cli";
+
+/**
+ * Validate that a key has the expected prefix and suggest the correct key type
+ * if the user mixed them up.
+ */
 export function validateKeyPrefix(key: string, expected: "ak_" | "sk_"): void {
   if (key.startsWith(expected)) return;
 
@@ -167,7 +180,9 @@ export const patchInstanceConfig = (
 
 export async function createApplication(name: string): Promise<Application> {
   const url = new URL("/v1/platform/applications", getPlapiBaseUrl());
-  const response = await plapiFetch("POST", url, { body: JSON.stringify({ name }) });
+  const response = await plapiFetch("POST", url, {
+    body: JSON.stringify({ name, from_source: CLI_FROM_SOURCE }),
+  });
   return response.json() as Promise<Application>;
 }
 

--- a/packages/cli-core/src/lib/plapi.ts
+++ b/packages/cli-core/src/lib/plapi.ts
@@ -13,7 +13,7 @@ import { log } from "./log.ts";
  * Canonical attribution marker written to `applications.from_source` when the
  * CLI creates an application through PLAPI. Surfaces in BigQuery via
  * `dim_applications.from_source` for growth analytics. Do not change without
- * coordinating with the growth-data team — the value is consumed by dbt
+ * coordinating with the growth-data team - the value is consumed by dbt
  * models and dashboards downstream.
  */
 const CLI_FROM_SOURCE = "cli";


### PR DESCRIPTION
Phase 2 of the CLI Tier 1 attribution plan. Phase 1 (clerk_go#18277) makes POST /v1/platform/applications accept an optional from_source field and persist it to applications.from_source. This PR is the CLI counterpart: every authenticated app the CLI creates now stamps from_source: "cli" so those apps are identifiable in BigQuery dim_applications for growth analytics.

Phase 1 PR: https://github.com/clerk/clerk_go/pull/18277

## How

- Export a single canonical CLI_FROM_SOURCE = "cli" constant from packages/cli-core/src/lib/plapi.ts.
- createApplication() includes from_source: CLI_FROM_SOURCE on the POST body. Signature unchanged, so both call sites (clerk apps create and the create-new branch of clerk link) keep working without edits.

Canonical value matches what PR #157 (auto-claim keyless) already sends on its accountless POST body.

## Test plan

- [x] Updated plapi.test.ts body-shape assertion.
- [x] Added guardrail test pinning the literal to the exported constant.
- [x] apps/create.test.ts and link/index.test.ts still pass (signature unchanged).
- [x] bun run test green (72 suites).
- [x] bun run format:check, bun run lint, bun run typecheck all clean.
- [x] bun changeset status --since=origin/main — clerk bumps minor.

## Rollout

Backwards-compatible. If this ships before Phase 1 deploys, PLAPI silently ignores the unknown field. Once Phase 1 deploys, stamps start appearing in applications.from_source.