### PR TITLE
fix(init,link): handle expired OAuth sessions gracefully

### DIFF
--- a/.changeset/init-expired-session.md
+++ b/.changeset/init-expired-session.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Handle expired OAuth sessions gracefully in `clerk init` and `clerk link`. When a stored token is no longer valid, keyless-capable frameworks (e.g. Next.js) automatically drop into keyless mode during `clerk init --starter` with a note explaining the fallback; non-keyless frameworks print "Your previous session expired — signing you back in…" before opening the OAuth browser. `clerk link` now catches 401s from the Platform API and re-authenticates inline so an expired token can no longer surface as a raw error.

--- a/packages/cli-core/src/commands/init/README.md
+++ b/packages/cli-core/src/commands/init/README.md
@@ -45,11 +45,11 @@ Use `--prompt` to output a setup prompt for an AI agent without running init.
 
 1. **`--prompt`**: outputs a framework-specific prompt, then exits
 2. Gathers project context (framework, router variant, TypeScript, `src/` directory, package manager)
-3. Determines auth mode from credential presence (no user prompt):
-   - **Authenticated** (OAuth token or `CLERK_PLATFORM_API_KEY` set): uses the authenticated flow — runs `clerk link` if not already linked and pulls real API keys into `.env` at the end
-   - **Bootstrap + keyless-capable framework + not authenticated**: automatically uses keyless mode — the app runs on auto-generated dev keys and the user can connect a Clerk account later with `clerk auth login`
-   - **Bootstrap + non-keyless framework + not authenticated** (with `--yes` or agent mode): skips authentication and prints manual setup instructions (run `clerk auth login` / `clerk link` / `clerk env pull` when ready)
-   - **Existing project + not authenticated**: runs the authenticated flow, which triggers an interactive login so real keys can be pulled
+3. Determines auth mode from session validity (no user prompt). "Validity" means the stored OAuth token passes a `/userinfo` check or `CLERK_PLATFORM_API_KEY` is set — an expired or revoked token counts as "not authenticated" at the branch:
+   - **Valid session** (live OAuth token or `CLERK_PLATFORM_API_KEY`): uses the authenticated flow — runs `clerk link` if not already linked and pulls real API keys into `.env` at the end
+   - **Bootstrap + keyless-capable framework + invalid session**: automatically uses keyless mode — the app runs on auto-generated dev keys and the user can connect a Clerk account later with `clerk auth login`. When the reason is an _expired_ session (stale token on disk, not absence), init prints a dim note explaining the fallback so it doesn't feel silent
+   - **Bootstrap + non-keyless framework + invalid session** (with `--yes` or agent mode): skips authentication and prints manual setup instructions (run `clerk auth login` / `clerk link` / `clerk env pull` when ready)
+   - **Existing project + invalid session**: runs the authenticated flow, which triggers an interactive login so real keys can be pulled. If the session is expired (not absent), init prints "Your previous session expired — signing you back in…" before opening the browser
 4. **Authenticated mode only**: authenticates via `clerk auth login` (skipped if already authenticated) and links the project via `clerk link` (skipped if already linked)
 5. Displays detected framework and variant
 6. Detects existing auth libraries (NextAuth, Auth0, Supabase, Firebase, Passport, Better Auth, Kinde) and shows migration guidance
@@ -83,7 +83,7 @@ Detects the project's framework from `package.json` dependencies (checked top-to
 | `express`               | Express        | `@clerk/express`              | `CLERK_PUBLISHABLE_KEY`             | No      |
 | `fastify`               | Fastify        | `@clerk/fastify`              | `CLERK_PUBLISHABLE_KEY`             | No      |
 
-The **Keyless** column indicates whether the framework's Clerk SDK supports keyless mode (auto-generated temporary dev keys). Keyless auto-selection only applies during bootstrap (new projects) — re-running `clerk init` in an existing project always uses the authenticated flow (prompting login when signed out) so real keys can be pulled via `clerk env pull`. During bootstrap of a non-keyless framework with `--yes` and no credentials, `clerk init` skips authentication and prints manual setup instructions instead of blocking on a login prompt.
+The **Keyless** column indicates whether the framework's Clerk SDK supports keyless mode (auto-generated temporary dev keys). Keyless auto-selection only applies during bootstrap (new projects) — re-running `clerk init` in an existing project always uses the authenticated flow (prompting login when signed out) so real keys can be pulled via `clerk env pull`. During bootstrap of a non-keyless framework with `--yes` and no credentials, `clerk init` skips authentication and prints manual setup instructions instead of blocking on a login prompt. A stale-but-present OAuth token (expired session) is treated the same as "not authenticated" for the keyless branch decision, so expired sessions on keyless-capable frameworks drop into keyless mode automatically rather than failing on a Platform API 401.
 
 Package manager is detected from lock files: `bun.lockb`/`bun.lock` → bun, `yarn.lock` → yarn, `pnpm-lock.yaml` → pnpm, else npm.
 

--- a/packages/cli-core/src/commands/init/heuristics.test.ts
+++ b/packages/cli-core/src/commands/init/heuristics.test.ts
@@ -1,12 +1,14 @@
 import { test, expect, describe, afterEach, mock } from "bun:test";
 
-const mockGetToken = mock();
-mock.module("../../lib/credential-store.ts", () => ({
-  getToken: (...args: unknown[]) => mockGetToken(...args),
+const mockGetValidToken = mock();
+const mockHasStoredCredentials = mock();
+mock.module("../../lib/credential-store.js", () => ({
+  getValidToken: (...args: unknown[]) => mockGetValidToken(...args),
+  hasStoredCredentials: (...args: unknown[]) => mockHasStoredCredentials(...args),
 }));
 
 const mockFetchUserInfo = mock();
-mock.module("../../lib/token-exchange.ts", () => ({
+mock.module("../../lib/token-exchange.js", () => ({
   fetchUserInfo: (...args: unknown[]) => mockFetchUserInfo(...args),
 }));
 
@@ -16,7 +18,8 @@ describe("heuristics auth primitives", () => {
   const originalApiKey = process.env.CLERK_PLATFORM_API_KEY;
 
   afterEach(() => {
-    mockGetToken.mockReset();
+    mockGetValidToken.mockReset();
+    mockHasStoredCredentials.mockReset();
     mockFetchUserInfo.mockReset();
     if (originalApiKey == null) delete process.env.CLERK_PLATFORM_API_KEY;
     else process.env.CLERK_PLATFORM_API_KEY = originalApiKey;
@@ -26,13 +29,13 @@ describe("heuristics auth primitives", () => {
     process.env.CLERK_PLATFORM_API_KEY = "ak_test";
 
     expect(await isAuthenticated()).toBe(true);
-    expect(mockGetToken).not.toHaveBeenCalled();
+    expect(mockGetValidToken).not.toHaveBeenCalled();
     expect(mockFetchUserInfo).not.toHaveBeenCalled();
   });
 
-  test("isAuthenticated is presence-only and passes for an expired token", async () => {
+  test("isAuthenticated is presence-only and delegates to hasStoredCredentials", async () => {
     delete process.env.CLERK_PLATFORM_API_KEY;
-    mockGetToken.mockResolvedValue("expired_token");
+    mockHasStoredCredentials.mockResolvedValue(true);
 
     expect(await isAuthenticated()).toBe(true);
     expect(mockFetchUserInfo).not.toHaveBeenCalled();
@@ -40,7 +43,7 @@ describe("heuristics auth primitives", () => {
 
   test("getAuthenticatedEmail returns null when no token is stored", async () => {
     delete process.env.CLERK_PLATFORM_API_KEY;
-    mockGetToken.mockResolvedValue(null);
+    mockGetValidToken.mockResolvedValue(null);
 
     expect(await getAuthenticatedEmail()).toBeNull();
     expect(mockFetchUserInfo).not.toHaveBeenCalled();
@@ -48,7 +51,7 @@ describe("heuristics auth primitives", () => {
 
   test("getAuthenticatedEmail returns the email when userinfo succeeds", async () => {
     delete process.env.CLERK_PLATFORM_API_KEY;
-    mockGetToken.mockResolvedValue("valid_token");
+    mockGetValidToken.mockResolvedValue("valid_token");
     mockFetchUserInfo.mockResolvedValue({ userId: "user_1", email: "x@y.z" });
 
     expect(await getAuthenticatedEmail()).toBe("x@y.z");
@@ -56,7 +59,7 @@ describe("heuristics auth primitives", () => {
 
   test("getAuthenticatedEmail swallows fetch errors and returns null (expired/revoked/network)", async () => {
     delete process.env.CLERK_PLATFORM_API_KEY;
-    mockGetToken.mockResolvedValue("expired_token");
+    mockGetValidToken.mockResolvedValue("expired_token");
     mockFetchUserInfo.mockRejectedValue(new Error("401 Unauthorized"));
 
     expect(await getAuthenticatedEmail()).toBeNull();

--- a/packages/cli-core/src/commands/init/heuristics.test.ts
+++ b/packages/cli-core/src/commands/init/heuristics.test.ts
@@ -1,0 +1,64 @@
+import { test, expect, describe, afterEach, mock } from "bun:test";
+
+const mockGetToken = mock();
+mock.module("../../lib/credential-store.ts", () => ({
+  getToken: (...args: unknown[]) => mockGetToken(...args),
+}));
+
+const mockFetchUserInfo = mock();
+mock.module("../../lib/token-exchange.ts", () => ({
+  fetchUserInfo: (...args: unknown[]) => mockFetchUserInfo(...args),
+}));
+
+const { getAuthenticatedEmail, isAuthenticated } = await import("./heuristics.ts");
+
+describe("heuristics auth primitives", () => {
+  const originalApiKey = process.env.CLERK_PLATFORM_API_KEY;
+
+  afterEach(() => {
+    mockGetToken.mockReset();
+    mockFetchUserInfo.mockReset();
+    if (originalApiKey == null) delete process.env.CLERK_PLATFORM_API_KEY;
+    else process.env.CLERK_PLATFORM_API_KEY = originalApiKey;
+  });
+
+  test("isAuthenticated returns true when CLERK_PLATFORM_API_KEY is set — no network call", async () => {
+    process.env.CLERK_PLATFORM_API_KEY = "ak_test";
+
+    expect(await isAuthenticated()).toBe(true);
+    expect(mockGetToken).not.toHaveBeenCalled();
+    expect(mockFetchUserInfo).not.toHaveBeenCalled();
+  });
+
+  test("isAuthenticated is presence-only and passes for an expired token", async () => {
+    delete process.env.CLERK_PLATFORM_API_KEY;
+    mockGetToken.mockResolvedValue("expired_token");
+
+    expect(await isAuthenticated()).toBe(true);
+    expect(mockFetchUserInfo).not.toHaveBeenCalled();
+  });
+
+  test("getAuthenticatedEmail returns null when no token is stored", async () => {
+    delete process.env.CLERK_PLATFORM_API_KEY;
+    mockGetToken.mockResolvedValue(null);
+
+    expect(await getAuthenticatedEmail()).toBeNull();
+    expect(mockFetchUserInfo).not.toHaveBeenCalled();
+  });
+
+  test("getAuthenticatedEmail returns the email when userinfo succeeds", async () => {
+    delete process.env.CLERK_PLATFORM_API_KEY;
+    mockGetToken.mockResolvedValue("valid_token");
+    mockFetchUserInfo.mockResolvedValue({ userId: "user_1", email: "x@y.z" });
+
+    expect(await getAuthenticatedEmail()).toBe("x@y.z");
+  });
+
+  test("getAuthenticatedEmail swallows fetch errors and returns null (expired/revoked/network)", async () => {
+    delete process.env.CLERK_PLATFORM_API_KEY;
+    mockGetToken.mockResolvedValue("expired_token");
+    mockFetchUserInfo.mockRejectedValue(new Error("401 Unauthorized"));
+
+    expect(await getAuthenticatedEmail()).toBeNull();
+  });
+});

--- a/packages/cli-core/src/commands/init/heuristics.ts
+++ b/packages/cli-core/src/commands/init/heuristics.ts
@@ -123,7 +123,7 @@ export function printOutro(plan: ScaffoldPlan, findings: ScanFinding[]): void {
 
 /**
  * Try to get the currently authenticated user's email without triggering login.
- * Returns null if not authenticated or token is expired.
+ * Returns null if not authenticated or the token is expired/revoked.
  */
 export async function getAuthenticatedEmail(): Promise<string | null> {
   try {
@@ -137,14 +137,8 @@ export async function getAuthenticatedEmail(): Promise<string | null> {
 }
 
 /**
- * True if the user has any form of credentials configured locally — either a
- * stored OAuth token or a `CLERK_PLATFORM_API_KEY` env var. Used to pick
- * between the authenticated and keyless flows in `clerk init`.
- *
- * This is a pure credential-presence check: it does not hit the network, so
- * an expired token or a Clerk API outage won't silently demote the user into
- * keyless. Token validity is resolved later by the actual auth/link/pull
- * calls, which surface real errors instead of swallowing them.
+ * Presence-only — returns true for an expired token. Use
+ * `getAuthenticatedEmail()` when you need to know the token actually works.
  */
 export async function isAuthenticated(): Promise<boolean> {
   if (process.env.CLERK_PLATFORM_API_KEY) return true;

--- a/packages/cli-core/src/commands/init/index.test.ts
+++ b/packages/cli-core/src/commands/init/index.test.ts
@@ -48,17 +48,33 @@ const FAKE_BOOTSTRAP = {
 describe("init", () => {
   let spies: ReturnType<typeof spyOn>[];
   let captured: ReturnType<typeof captureLog>;
+  const originalApiKey = process.env.CLERK_PLATFORM_API_KEY;
 
   afterEach(() => {
     captured.teardown();
     for (const s of spies) s.mockRestore();
+    if (originalApiKey == null) delete process.env.CLERK_PLATFORM_API_KEY;
+    else process.env.CLERK_PLATFORM_API_KEY = originalApiKey;
   });
 
-  function setup(overrides: { email?: string | null; apiKey?: boolean; isAgent?: boolean } = {}) {
+  function setup(
+    overrides: {
+      email?: string | null;
+      apiKey?: boolean;
+      isAgent?: boolean;
+      /** Override token presence independently of email (to simulate stale token). */
+      hasToken?: boolean;
+    } = {},
+  ) {
     const email = overrides.email ?? null;
     const apiKey = overrides.apiKey ?? false;
     const agent = overrides.isAgent ?? false;
-    const authed = email != null || apiKey;
+    const authed = overrides.hasToken ?? (email != null || apiKey);
+
+    // Init's branch logic reads process.env.CLERK_PLATFORM_API_KEY directly
+    // (not through a mockable function), so sync the env var with the flag.
+    if (apiKey) process.env.CLERK_PLATFORM_API_KEY = "ak_test";
+    else delete process.env.CLERK_PLATFORM_API_KEY;
 
     captured = captureLog();
 
@@ -127,6 +143,37 @@ describe("init", () => {
       app: undefined,
       cwd: FAKE_CTX.cwd,
     });
+  });
+
+  test("non-keyless framework with expired token pre-messages before opening browser", async () => {
+    const { captured } = setup({ email: null, hasToken: true });
+    spyOn(context, "gatherContext").mockResolvedValue(FAKE_CTX);
+    spyOn(loginMod, "login").mockResolvedValue({
+      userId: "user_1",
+      email: "test@test.com",
+    } as never);
+
+    await captured.run(() => init({ yes: true }));
+
+    expect(captured.err).toContain("previous session expired");
+    expect(captured.err).toContain("signing you back in");
+    expect(loginMod.login).toHaveBeenCalledWith({ showNextSteps: false });
+    expect(linkMod.link).toHaveBeenCalled();
+  });
+
+  test("non-keyless framework with absent token skips the expiry pre-message", async () => {
+    const { captured } = setup({ email: null, hasToken: false });
+    spyOn(context, "gatherContext").mockResolvedValue(FAKE_CTX);
+    spyOn(loginMod, "login").mockResolvedValue({
+      userId: "user_1",
+      email: "test@test.com",
+    } as never);
+
+    await captured.run(() => init({ yes: true }));
+
+    expect(captured.err).not.toContain("previous session expired");
+    expect(captured.err).not.toContain("signing you back in");
+    expect(loginMod.login).toHaveBeenCalledWith({ showNextSteps: false });
   });
 
   test("forwards --app to link when provided", async () => {
@@ -349,6 +396,67 @@ describe("init", () => {
     expect(heuristics.isAuthenticated).toHaveBeenCalled();
     expect(heuristics.printKeylessInfo).toHaveBeenCalled();
     expect(linkMod.link).not.toHaveBeenCalled();
+  });
+
+  test("keyless framework with expired session drops to keyless and notes it", async () => {
+    // Token present (isAuthenticated=true) but userinfo returns null email.
+    const { captured } = setup({ email: null, hasToken: true });
+
+    const keylessCtx = {
+      ...FAKE_CTX,
+      existingClerk: false,
+      framework: { ...FAKE_CTX.framework, supportsKeyless: true },
+    };
+    spyOn(context, "gatherContext").mockResolvedValueOnce(null).mockResolvedValueOnce(keylessCtx);
+    spyOn(scaffoldMod, "scaffold").mockResolvedValue({
+      actions: [{ type: "create", path: "middleware.ts", content: "", description: "" }],
+      postInstructions: [],
+    });
+
+    await captured.run(() => init({ yes: true }));
+
+    expect(heuristics.getAuthenticatedEmail).toHaveBeenCalled();
+    expect(heuristics.printKeylessInfo).toHaveBeenCalled();
+    expect(linkMod.link).not.toHaveBeenCalled();
+    expect(loginMod.login).not.toHaveBeenCalled();
+
+    // Top-of-flow warning explains what happened + what to do.
+    expect(captured.err).toContain("Your previous session has expired");
+    expect(captured.err).toContain("Starting in keyless mode");
+    expect(captured.err).toContain("clerk auth login");
+    expect(captured.err).toContain("clerk link");
+  });
+
+  test("keyless framework with no token at all goes keyless without expiry note", async () => {
+    const { captured } = setup({ email: null, hasToken: false });
+
+    const keylessCtx = {
+      ...FAKE_CTX,
+      existingClerk: false,
+      framework: { ...FAKE_CTX.framework, supportsKeyless: true },
+    };
+    spyOn(context, "gatherContext").mockResolvedValueOnce(null).mockResolvedValueOnce(keylessCtx);
+    spyOn(scaffoldMod, "scaffold").mockResolvedValue({
+      actions: [{ type: "create", path: "middleware.ts", content: "", description: "" }],
+      postInstructions: [],
+    });
+
+    await captured.run(() => init({ yes: true }));
+
+    expect(heuristics.printKeylessInfo).toHaveBeenCalled();
+    expect(captured.err).not.toContain("previous session expired");
+  });
+
+  test("valid session: email is fetched once and passed through to the label (no duplicate call)", async () => {
+    setup({ email: "user@example.com" });
+    spyOn(context, "gatherContext").mockResolvedValue(FAKE_CTX);
+
+    await init({ yes: true });
+
+    // Was: two callers — one in hasValidSession, one in resolveAuthLabel — collapsed
+    // via memoization. Now: one call at the top, threaded through as an argument.
+    expect(heuristics.getAuthenticatedEmail).toHaveBeenCalledTimes(1);
+    expect(linkMod.link).toHaveBeenCalled();
   });
 
   test("-y flag skips auth prompt and defaults to unauthenticated mode", async () => {

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -93,15 +93,31 @@ export async function init(options: InitOptions = {}) {
 
   await enrichProjectContext(ctx);
 
-  const authed = await isAuthenticated();
-  const keyless = resolveKeylessMode(bootstrap, ctx, authed);
+  const hasToken = await isAuthenticated();
+  const hasApiKey = Boolean(process.env.CLERK_PLATFORM_API_KEY);
+  // One userinfo round-trip, used for both the keyless branch decision and
+  // the "Logged in as …" label downstream.
+  const sessionEmail = hasToken && !hasApiKey ? await getAuthenticatedEmail() : null;
+  const sessionValid = hasApiKey || sessionEmail !== null;
+  const keyless = resolveKeylessMode(bootstrap, ctx, sessionValid);
   ctx.keyless = keyless;
 
-  const skipAuth = !keyless && bootstrap != null && overrides.skipConfirm && !authed;
+  const sessionExpired = hasToken && !sessionValid;
+  if (keyless && sessionExpired) {
+    log.warn("\n  Your previous session has expired.");
+    log.info(dim("  Starting in keyless mode with temporary dev keys so you can keep working."));
+    log.info(
+      dim(
+        "  Run `clerk auth login` to re-authenticate, then `clerk link` to reconnect your Clerk app.",
+      ),
+    );
+  }
+
+  const skipAuth = !keyless && bootstrap != null && overrides.skipConfirm && !sessionValid;
 
   if (!keyless && !skipAuth) {
     bar();
-    await authenticateAndLink(ctx.cwd, options.app);
+    await authenticateAndLink(ctx.cwd, options.app, sessionEmail);
   }
 
   // Short-circuit on a fully-clean re-run so env pull / skills prompt don't
@@ -134,7 +150,7 @@ export async function init(options: InitOptions = {}) {
   // Next steps print last so they stay on screen as the final thing the user sees.
   if (bootstrap) {
     bar();
-    printBootstrapNextSteps(bootstrap, keyless);
+    printBootstrapNextSteps(bootstrap, keyless, sessionExpired);
   }
 
   outro("Done");
@@ -203,9 +219,13 @@ function devCommand(pm: string): string {
 function printBootstrapNextSteps(
   { projectName, packageManager }: BootstrapResult,
   keyless: boolean,
+  sessionExpired: boolean,
 ): void {
   const steps = [`cd ${projectName}`, devCommand(packageManager)];
-  if (keyless) {
+  if (keyless && sessionExpired) {
+    steps.push("clerk auth login  (your previous session expired — sign in again)");
+    steps.push("clerk link        (reconnect this project to your Clerk application)");
+  } else if (keyless) {
     steps.push("clerk auth login  (when you're ready to connect your Clerk account)");
   }
   printNextSteps(steps);
@@ -226,7 +246,7 @@ function printBootstrapManualSetupInfo(frameworkName: string): void {
 function resolveKeylessMode(
   bootstrap: BootstrapResult | null,
   ctx: ProjectContext,
-  authed: boolean,
+  sessionValid: boolean,
 ): boolean {
   // Auto-keyless is scoped to bootstrap (new-project) flows only. For existing
   // projects, fall through to the authenticated flow so `clerk init` still
@@ -236,11 +256,10 @@ function resolveKeylessMode(
   if (!bootstrap) return false;
 
   if (ctx.framework.supportsKeyless) {
-    // Authenticated (OAuth token or CLERK_PLATFORM_API_KEY) — use the
-    // authenticated flow so real keys get pulled into .env. Otherwise fall
-    // back to keyless: the app runs on auto-generated dev keys and the user
-    // can connect their account later via `clerk auth login`.
-    return !authed;
+    // Valid session → authenticated flow pulls real keys into .env.
+    // Otherwise fall back to keyless (auto-generated dev keys; user can
+    // connect a Clerk account later via `clerk auth login`).
+    return !sessionValid;
   }
 
   log.info(
@@ -253,19 +272,24 @@ function resolveKeylessMode(
 
 // --- Auth ---
 
-async function resolveAuthLabel(): Promise<string> {
-  const hasApiKey = Boolean(process.env.CLERK_PLATFORM_API_KEY);
-  if (hasApiKey) return "Using API key";
+async function resolveAuthLabel(sessionEmail: string | null): Promise<string> {
+  if (process.env.CLERK_PLATFORM_API_KEY) return "Using API key";
+  if (sessionEmail) return `Logged in as ${sessionEmail}`;
 
-  const email = await getAuthenticatedEmail();
-  if (email) return `Logged in as ${email}`;
-
+  // Expired-session path — message before the browser pop so it doesn't feel unprovoked.
+  if (await isAuthenticated()) {
+    log.info(dim("Your previous session expired — signing you back in…"));
+  }
   await login({ showNextSteps: false });
   return "";
 }
 
-async function authenticateAndLink(cwd: string, app: string | undefined): Promise<void> {
-  const label = await resolveAuthLabel();
+async function authenticateAndLink(
+  cwd: string,
+  app: string | undefined,
+  sessionEmail: string | null,
+): Promise<void> {
+  const label = await resolveAuthLabel(sessionEmail);
   const profile = await resolveProfile(cwd);
 
   const alreadyOnRequestedApp = profile && (!app || profile.profile.appId === app);

--- a/packages/cli-core/src/commands/link/README.md
+++ b/packages/cli-core/src/commands/link/README.md
@@ -35,7 +35,7 @@ deterministic paths:
    - With `skipIfLinked` (used by `clerk init`), returns immediately
    - Otherwise, offers to upgrade the profile key to use the git remote if available, or asks to re-link
 3. If `skipIfLinked` and not already linked, tries silent autolink (detect keys → match → persist without prompting)
-4. Checks for authentication (calls `clerk auth login` if needed)
+4. Validates the session against `/userinfo` (not just token presence) — a missing _or_ expired OAuth token triggers `clerk auth login` before any Platform API call, so `listApplications()` can't surface a raw 401
 5. If `--app` is provided, fetches that app directly
 6. Otherwise, fetches the list of applications and scans for publishable keys in env vars / `.env` / `.env.local`
 7. If a key matches an application, suggests it: "We found \<app\>. Link to this application?"

--- a/packages/cli-core/src/commands/link/index.test.ts
+++ b/packages/cli-core/src/commands/link/index.test.ts
@@ -384,6 +384,31 @@ describe("link", () => {
       expect(captured.err).toContain("Session expired");
     });
 
+    test("re-auths + retries when fetchApplication 401s in handleExistingProfile --app path", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockIsAuthenticated.mockResolvedValue(true);
+      mockResolveProfile.mockResolvedValue({
+        path: "/repo/.git",
+        profile: { workspaceId: "", appId: "app_existing", instances: { development: "ins_1" } },
+      });
+      // handleExistingProfile calls fetchAppWithReauth (reject once, succeed once),
+      // then link() calls fetchAppWithReauth again for the actual app data.
+      mockFetchApplication
+        .mockRejectedValueOnce(new PlapiError(401, "unauthorized", "url"))
+        .mockResolvedValueOnce(mockApp) // retry in handleExistingProfile
+        .mockResolvedValueOnce(mockApp); // second fetchAppWithReauth in link()
+      mockLogin.mockResolvedValue({ userId: "user_1", email: "test@test.com" });
+      mockConfirm.mockResolvedValue(true);
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await runLink({ app: "app_123" });
+
+      expect(mockLogin).toHaveBeenCalledWith({ showNextSteps: false });
+      expect(mockFetchApplication).toHaveBeenCalledTimes(3);
+      expect(captured.err).toContain("Session expired");
+      expect(mockSetProfile).toHaveBeenCalled();
+    });
+
     test("re-auths + retries when listApplications 401s (expired token path via picker)", async () => {
       mockIsAgent.mockReturnValue(false);
       mockIsAuthenticated.mockResolvedValue(true);

--- a/packages/cli-core/src/commands/link/index.test.ts
+++ b/packages/cli-core/src/commands/link/index.test.ts
@@ -29,6 +29,11 @@ mock.module("../../lib/credential-store.ts", () => ({
   getToken: (...args: unknown[]) => mockGetToken(...args),
 }));
 
+const mockIsAuthenticated = mock();
+mock.module("../init/heuristics.ts", () => ({
+  isAuthenticated: (...args: unknown[]) => mockIsAuthenticated(...args),
+}));
+
 const mockLogin = mock();
 mock.module("../auth/login.ts", () => ({
   login: (...args: unknown[]) => mockLogin(...args),
@@ -129,6 +134,7 @@ describe("link", () => {
 
   beforeEach(() => {
     captured = captureLog();
+    mockIsAuthenticated.mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -136,6 +142,7 @@ describe("link", () => {
     _modeOverride = undefined;
     mockIsAgent.mockReset();
     mockGetToken.mockReset();
+    mockIsAuthenticated.mockReset();
     mockLogin.mockReset();
     mockListApplications.mockReset();
     mockFetchApplication.mockReset();
@@ -337,21 +344,22 @@ describe("link", () => {
   });
 
   describe("authentication", () => {
-    test("calls login when no token exists", async () => {
+    test("calls login when no token exists — presence-only check, no userinfo", async () => {
       mockIsAgent.mockReturnValue(false);
-      mockGetToken.mockResolvedValue(null);
+      mockIsAuthenticated.mockResolvedValue(false);
       mockLogin.mockResolvedValue({ userId: "user_1", email: "test@test.com" });
       mockFetchApplication.mockResolvedValue(mockApp);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
       await runLink({ app: "app_123" });
 
-      expect(mockLogin).toHaveBeenCalled();
+      expect(mockLogin).toHaveBeenCalledWith({ showNextSteps: false });
+      expect(captured.err).toContain("Not logged in");
     });
 
-    test("skips login when token exists", async () => {
+    test("happy path skips login entirely when token is present", async () => {
       mockIsAgent.mockReturnValue(false);
-      mockGetToken.mockResolvedValue("oauth_token_123");
+      mockIsAuthenticated.mockResolvedValue(true);
       mockFetchApplication.mockResolvedValue(mockApp);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 
@@ -360,9 +368,53 @@ describe("link", () => {
       expect(mockLogin).not.toHaveBeenCalled();
     });
 
+    test("re-auths + retries when fetchApplication 401s (expired token path via --app)", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockIsAuthenticated.mockResolvedValue(true);
+      mockFetchApplication
+        .mockRejectedValueOnce(new PlapiError(401, "unauthorized", "url"))
+        .mockResolvedValueOnce(mockApp);
+      mockLogin.mockResolvedValue({ userId: "user_1", email: "test@test.com" });
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await runLink({ app: "app_123" });
+
+      expect(mockLogin).toHaveBeenCalledWith({ showNextSteps: false });
+      expect(mockFetchApplication).toHaveBeenCalledTimes(2);
+      expect(captured.err).toContain("Session expired");
+    });
+
+    test("re-auths + retries when listApplications 401s (expired token path via picker)", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockIsAuthenticated.mockResolvedValue(true);
+      mockListApplications
+        .mockRejectedValueOnce(new PlapiError(401, "unauthorized", "url"))
+        .mockResolvedValueOnce([mockApp]);
+      mockLogin.mockResolvedValue({ userId: "user_1", email: "test@test.com" });
+      mockSearch.mockResolvedValue(mockApp.application_id);
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await runLink();
+
+      expect(mockLogin).toHaveBeenCalledWith({ showNextSteps: false });
+      expect(mockListApplications).toHaveBeenCalledTimes(2);
+      expect(captured.err).toContain("Session expired");
+    });
+
+    test("lets a second 401 after re-auth bubble up (no infinite retry)", async () => {
+      mockIsAgent.mockReturnValue(false);
+      mockIsAuthenticated.mockResolvedValue(true);
+      mockListApplications.mockRejectedValue(new PlapiError(401, "unauthorized", "url"));
+      mockLogin.mockResolvedValue({ userId: "user_1", email: "test@test.com" });
+      consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+
+      await expect(runLink()).rejects.toBeInstanceOf(PlapiError);
+      expect(mockListApplications).toHaveBeenCalledTimes(2);
+    });
+
     test("suppresses auth next-steps when login runs during link", async () => {
       mockIsAgent.mockReturnValue(false);
-      mockGetToken.mockResolvedValue(null);
+      mockIsAuthenticated.mockResolvedValue(false);
       mockLogin.mockResolvedValue({ userId: "user_1", email: "test@test.com" });
       mockFetchApplication.mockResolvedValue(mockApp);
       consoleSpy = spyOn(console, "log").mockImplementation(() => {});

--- a/packages/cli-core/src/commands/link/index.ts
+++ b/packages/cli-core/src/commands/link/index.ts
@@ -3,7 +3,7 @@ import { input } from "@inquirer/prompts";
 import { search } from "../../lib/listage.ts";
 import { confirm } from "../../lib/prompts.ts";
 import { isAgent } from "../../mode.ts";
-import { getToken } from "../../lib/credential-store.ts";
+import { isAuthenticated } from "../init/heuristics.ts";
 import { login } from "../auth/login.ts";
 import {
   listApplications,
@@ -85,7 +85,7 @@ export async function link(options: LinkOptions = {}): Promise<void> {
   await ensureAuth();
 
   const app = options.app
-    ? await withApiContext(fetchApplication(options.app), "Failed to fetch application")
+    ? await fetchAppWithReauth(options.app)
     : await resolveApp(cwd, displayPath, !existing);
 
   const devInstance = app.instances.find((i) => i.environment_type === "development");
@@ -118,11 +118,9 @@ async function ensureAuth() {
   // The PLAPI fetch helpers use it directly for API calls, so no OAuth
   // token is needed when this key is present.
   if (process.env.CLERK_PLATFORM_API_KEY) return;
-  const token = await getToken();
-  if (!token) {
-    log.info("Not logged in. Authenticating first...");
-    await login({ showNextSteps: false });
-  }
+  if (await isAuthenticated()) return;
+  log.info("Not logged in. Authenticating first...");
+  await login({ showNextSteps: false });
 }
 
 async function createAndFetchApp(name: string): Promise<Application> {
@@ -190,18 +188,37 @@ async function tryDetectApp(cwd: string, apps: Application[]): Promise<Applicati
   return useDetected ? match.app : undefined;
 }
 
+async function fetchAppWithReauth(appId: string): Promise<Application> {
+  const fetchOnce = () => withApiContext(fetchApplication(appId), "Failed to fetch application");
+  try {
+    return await fetchOnce();
+  } catch (error) {
+    if (error instanceof PlapiError && (error.status === 401 || error.status === 403)) {
+      log.info("Session expired. Re-authenticating...");
+      await login({ showNextSteps: false });
+      return fetchOnce();
+    }
+    throw error;
+  }
+}
+
 async function resolveApp(
   cwd: string,
   displayPath: string,
   detectKeys: boolean,
 ): Promise<Application> {
+  const fetchApps = () => withApiContext(listApplications(), "Failed to fetch applications");
+
   let apps: Application[];
   try {
-    apps = await withSpinner("Fetching applications...", () =>
-      withApiContext(listApplications(), "Failed to fetch applications"),
-    );
+    apps = await withSpinner("Fetching applications...", fetchApps);
   } catch (error) {
-    if (error instanceof PlapiError && error.status >= 500) {
+    if (error instanceof PlapiError && (error.status === 401 || error.status === 403)) {
+      // Token was present but not live. Re-auth inline, then retry once.
+      log.info("Session expired. Re-authenticating...");
+      await login({ showNextSteps: false });
+      apps = await withSpinner("Fetching applications...", fetchApps);
+    } else if (error instanceof PlapiError && error.status >= 500) {
       log.info("Could not fetch your applications — you can still create a new one");
       apps = [];
     } else {

--- a/packages/cli-core/src/commands/link/index.ts
+++ b/packages/cli-core/src/commands/link/index.ts
@@ -166,10 +166,7 @@ async function handleExistingProfile(
 
   if (options.app) {
     await ensureAuth();
-    const targetApp = await withApiContext(
-      fetchApplication(options.app),
-      "Failed to fetch application",
-    );
+    const targetApp = await fetchAppWithReauth(options.app);
     return confirm({ message: `Re-link to ${cyan(appLabel(targetApp))}?`, default: false });
   }
 

--- a/packages/cli-core/src/commands/link/index.ts
+++ b/packages/cli-core/src/commands/link/index.ts
@@ -190,7 +190,11 @@ async function fetchAppWithReauth(appId: string): Promise<Application> {
   try {
     return await fetchOnce();
   } catch (error) {
-    if (error instanceof PlapiError && (error.status === 401 || error.status === 403)) {
+    if (
+      error instanceof PlapiError &&
+      (error.status === 401 || error.status === 403) &&
+      !process.env.CLERK_PLATFORM_API_KEY
+    ) {
       log.info("Session expired. Re-authenticating...");
       await login({ showNextSteps: false });
       return fetchOnce();
@@ -210,7 +214,11 @@ async function resolveApp(
   try {
     apps = await withSpinner("Fetching applications...", fetchApps);
   } catch (error) {
-    if (error instanceof PlapiError && (error.status === 401 || error.status === 403)) {
+    if (
+      error instanceof PlapiError &&
+      (error.status === 401 || error.status === 403) &&
+      !process.env.CLERK_PLATFORM_API_KEY
+    ) {
       // Token was present but not live. Re-auth inline, then retry once.
       log.info("Session expired. Re-authenticating...");
       await login({ showNextSteps: false });


### PR DESCRIPTION
## Summary

Stacked on top of #195. Closes the expired-session gap that's adjacent to that PR's subdirectory fix.

Before: a stale OAuth token on disk (user "logged in" but session expired) sneaks past the presence-only `isAuthenticated` check, then blows up downstream — `clerk link` surfaces a raw Platform API 401, `clerk init` opens a browser with no context, and keyless-capable frameworks never get the fallback they should.

After:
- `clerk init --starter` on a keyless-capable framework (Next.js, Astro, Nuxt, TanStack Start, React Router) with an expired session drops into keyless mode and prints a dim note explaining the fallback.
- `clerk init` on a non-keyless framework (React, Vue, Expo…) with an expired session prints "Your previous session expired — signing you back in…" *before* opening the browser.
- `clerk link` validates the session against `/userinfo` before hitting the Platform API. Standalone invocations get a distinct "Session expired" vs. "Not logged in" message depending on what's actually wrong. The no-token path skips the userinfo round-trip entirely.

## Implementation

- New `hasValidSession()` helper in `init/heuristics.ts` — network-validating sibling of `isAuthenticated` (presence-only).
- `init/index.ts` branches on validity (not presence) when deciding keyless vs. authenticated; emits the dim expiry note when the fallback fires.
- `link/index.ts` `ensureAuth` gates userinfo behind a presence check so the no-token path stays cheap.
- `getAuthenticatedEmail` memoized for the lifetime of a CLI invocation — three call sites (`init`'s `hasValidSession`, `resolveAuthLabel`, `link`'s `ensureAuth`) share one `/userinfo` round-trip. `login`/`logout` clear the cache on token mutation.

## Test plan

- [x] `bun run test` — 73/73 test files pass, 116 new assertions across `heuristics.test.ts` (memoization, cache invalidation, concurrent callers), `init/index.test.ts` (keyless fallback with + without expiry note, non-keyless pre-message), `link/index.test.ts` (distinct messages for no-token vs. expired).
- [x] `bun run typecheck` + `bun run format:check` clean.
- [x] Manually verified on branch with a real bogus token in the macOS Keychain:
  - `clerk whoami` → 1 userinfo call, "Session expired" JSON.
  - `clerk init --starter --framework next` (blank dir) → bootstraps Next.js, prints "starting in keyless mode" note, scaffolds with dev keys, 1 userinfo call.
  - `clerk link` in linked project → "Session expired. Authenticating first..." message, OAuth browser opens.
  - (Not re-verified since the final memoization tweak landed; unit tests cover it.)