### PR TITLE
fix(build): install all platform keyring bindings for cross-compile

### DIFF
--- a/.changeset/fix-keyring-cross-compile.md
+++ b/.changeset/fix-keyring-cross-compile.md
@@ -1,0 +1,8 @@
+---
+"clerk": patch
+---
+
+Store macOS credentials in the system Keychain instead of a plaintext file.
+
+- Previously, macOS builds silently stored the OAuth token in `~/Library/Application Support/clerk-cli/credentials` because cross-compiled binaries were missing the native Keychain binding.
+- Run `clerk login` after upgrading so the CLI writes a fresh token into the Keychain and removes the old plaintext file.

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -31,7 +31,14 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.11"
-      - run: bun install --frozen-lockfile
+      # --cpu=* --os=* forces bun to install every platform's optional deps,
+      # not just the Linux host's. Cross-compiling with bun build --compile
+      # embeds each target's native bindings (e.g. @napi-rs/keyring-<target>)
+      # into the executable; without this flag the darwin and win32 bindings
+      # are absent from node_modules and the bundler silently replaces them
+      # with throw stubs, leaving those binaries unable to reach the OS
+      # keychain and falling back to plaintext-file credential storage.
+      - run: bun install --frozen-lockfile --cpu='*' --os='*'
 
       - name: Build all targets
         env:

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -2,7 +2,14 @@ import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 import { DEV_CLI_VERSION } from "../packages/cli-core/src/lib/version.ts";
-import { targets } from "./lib/targets.ts";
+import { type Target, targets } from "./lib/targets.ts";
+
+function keyringBindingPath(target: Target): string {
+  const libcSuffix = target.libc === "musl" ? "-musl" : target.libc === "glibc" ? "-gnu" : "";
+  const winSuffix = target.os === "win32" ? "-msvc" : "";
+  const bindingName = `${target.os}-${target.cpu}${libcSuffix}${winSuffix}`;
+  return join("node_modules", "@napi-rs", `keyring-${bindingName}`, `keyring.${bindingName}.node`);
+}
 
 const { values } = parseArgs({
   args: Bun.argv.slice(2),
@@ -45,6 +52,27 @@ const selectedTargets = targetFilter
 if (selectedTargets.length === 0) {
   throw new Error(
     `Unknown target: ${targetFilter}\nAvailable targets: ${targets.map((t) => t.bunTarget).join(", ")}`,
+  );
+}
+
+// Cross-compile embeds each target's @napi-rs/keyring native binding into
+// the output. A default `bun install` on any single host skips the bindings
+// for other platforms (optional deps are filtered by os/cpu), so without a
+// platform-unfiltered install the darwin/win32/arm64 builds would silently
+// ship without the binding and fall back to plaintext-file credentials at
+// runtime. Fail fast here so the dev sees the actionable fix.
+const bindingChecks = await Promise.all(
+  selectedTargets.map(async (t) => {
+    const path = keyringBindingPath(t);
+    return { target: t, path, exists: await Bun.file(path).exists() };
+  }),
+);
+const missingBindings = bindingChecks.filter((check) => !check.exists);
+if (missingBindings.length > 0) {
+  const list = missingBindings.map(({ target, path }) => `  - ${target.name}: ${path}`).join("\n");
+  throw new Error(
+    `Missing @napi-rs/keyring native bindings for:\n${list}\n\n` +
+      `Run \`bun install --frozen-lockfile --cpu='*' --os='*'\` to install every platform's optional deps.`,
   );
 }
 


### PR DESCRIPTION
## Summary

Cross-compiled macOS and Windows CLI binaries were silently falling back to plaintext-file credential storage instead of using the OS keychain.

Root cause: the build runs on a Linux CI host. Default `bun install` skips `@napi-rs/keyring` optional deps whose `os` or `cpu` field doesn't match the host, so the darwin and win32 bindings are not in `node_modules` when the cross-compile runs. Bun then rewrites the unresolved `require()` calls to throw stubs and the bundle ships without the native binding. At runtime, the `import()` fails, the catch swallows the error, and the CLI falls back to `~/Library/Application Support/clerk-cli/credentials` (chmod 600).

## Fix

- `bun install --frozen-lockfile --cpu='*' --os='*'` in `.github/workflows/build-binaries.yml` so every target's binding is installed before the Linux host bundles each target.
- Preflight check in `scripts/build.ts` so local `build:compile:all` runs on a developer Mac also fail fast with the install command if a required binding is missing.

Lockfile unchanged; `--frozen-lockfile` still holds.

## Test plan

- [x] Reproduced the failure in a Docker `ubuntu:24.04` + Bun 1.3.11 container matching CI, then applied the fix and confirmed every target bundle embeds its platform's native `.node` asset.
- [x] Pulled the Docker-built `darwin-arm64` binary onto a Mac, signed with a real Team ID + `scripts/entitlements.plist`, and confirmed `clerk whoami --verbose` reports `found token in keyring`.
- [x] Removed two bindings and reran `scripts/build.ts`; preflight check fired with the expected error and install hint.
- [x] `bun run format:check`, `bun run lint`, `bun run typecheck`, `bun run test` all pass.
- [ ] Validate a released canary on a clean Mac and confirm new logins land in the Keychain.