### PR TITLE
fix(auth): isolate unsigned macOS keychain entries

### DIFF
--- a/.changeset/clerk-cli-macos-keychain-password-prompt-issue.md
+++ b/.changeset/clerk-cli-macos-keychain-password-prompt-issue.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Prevent local unsigned macOS builds from sharing the release keychain entry.

--- a/packages/cli-core/src/lib/credential-store-signing.test.ts
+++ b/packages/cli-core/src/lib/credential-store-signing.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { isReleaseSignedMacosBinary } from "./credential-store.ts";
+
+describe("isReleaseSignedMacosBinary", () => {
+  test("returns false for unversioned dev builds", () => {
+    const output = `
+Executable=/tmp/clerk
+Identifier=clerk
+TeamIdentifier=L8SD6SB282
+`;
+
+    expect(isReleaseSignedMacosBinary(undefined, output)).toBe(false);
+  });
+
+  test("returns true for Clerk-signed release binaries", () => {
+    const output = `
+Executable=/tmp/clerk
+Identifier=clerk
+Authority=Developer ID Application: Clerk, Inc (L8SD6SB282)
+TeamIdentifier=L8SD6SB282
+`;
+
+    expect(isReleaseSignedMacosBinary("1.2.3", output)).toBe(true);
+  });
+
+  test("returns false for non-Clerk-signed binaries", () => {
+    const output = `
+Executable=/opt/homebrew/bin/bun
+Identifier=bun
+Authority=Developer ID Application: Oven SH (7FRXF46ZSN)
+TeamIdentifier=7FRXF46ZSN
+`;
+
+    expect(isReleaseSignedMacosBinary("1.2.3", output)).toBe(false);
+  });
+
+  test("returns false when the identifier does not match Clerk", () => {
+    const output = `
+Executable=/tmp/not-clerk
+Identifier=not-clerk
+TeamIdentifier=L8SD6SB282
+`;
+
+    expect(isReleaseSignedMacosBinary("1.2.3", output)).toBe(false);
+  });
+});

--- a/packages/cli-core/src/lib/credential-store.ts
+++ b/packages/cli-core/src/lib/credential-store.ts
@@ -12,9 +12,13 @@ import { mkdir, chmod, unlink } from "node:fs/promises";
 import { CREDENTIALS_FILE } from "./constants.ts";
 import { getCurrentEnvName } from "./environment.ts";
 import { log } from "./log.ts";
+import { resolveCliVersion } from "./version.ts";
 
 export const KEYCHAIN_SERVICE = "clerk-cli";
+export const LOCAL_DEV_KEYCHAIN_SERVICE = "clerk-cli-dev";
 export const KEYCHAIN_ACCOUNT = "oauth-access-token";
+const RELEASE_MACOS_TEAM_ID = "L8SD6SB282";
+const RELEASE_MACOS_IDENTIFIER = "clerk";
 
 function keychainAccount(): string {
   const envName = getCurrentEnvName();
@@ -29,6 +33,7 @@ function credentialsFile(): string {
 }
 
 let keyringModule: typeof import("@napi-rs/keyring") | null | undefined;
+let keychainServicePromise: Promise<string> | undefined;
 
 async function getKeyring(): Promise<typeof import("@napi-rs/keyring") | null> {
   if (keyringModule !== undefined) return keyringModule;
@@ -41,15 +46,56 @@ async function getKeyring(): Promise<typeof import("@napi-rs/keyring") | null> {
   }
 }
 
+export function isReleaseSignedMacosBinary(
+  cliVersion: string | undefined,
+  codesignOutput: string,
+): boolean {
+  if (!cliVersion) return false;
+  return (
+    codesignOutput.includes(`TeamIdentifier=${RELEASE_MACOS_TEAM_ID}`) &&
+    codesignOutput.includes(`Identifier=${RELEASE_MACOS_IDENTIFIER}`)
+  );
+}
+
+async function resolveKeychainService(): Promise<string> {
+  if (process.platform !== "darwin") return KEYCHAIN_SERVICE;
+  if (keychainServicePromise) return keychainServicePromise;
+
+  keychainServicePromise = (async () => {
+    const cliVersion = resolveCliVersion();
+    if (!cliVersion) {
+      log.debug(
+        `credentials: using local macOS keychain namespace (service=${LOCAL_DEV_KEYCHAIN_SERVICE}, reason=unversioned-cli)`,
+      );
+      return LOCAL_DEV_KEYCHAIN_SERVICE;
+    }
+
+    const proc = Bun.spawnSync(["codesign", "-dvvv", process.execPath], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const codesignOutput = `${proc.stdout.toString()}${proc.stderr.toString()}`;
+
+    if (proc.exitCode === 0 && isReleaseSignedMacosBinary(cliVersion, codesignOutput)) {
+      return KEYCHAIN_SERVICE;
+    }
+
+    log.debug(
+      `credentials: using local macOS keychain namespace (service=${LOCAL_DEV_KEYCHAIN_SERVICE}, execPath=${process.execPath})`,
+    );
+    return LOCAL_DEV_KEYCHAIN_SERVICE;
+  })();
+
+  return keychainServicePromise;
+}
+
 async function keyringStore(token: string): Promise<boolean> {
   const mod = await getKeyring();
   if (!mod) return false;
+  const service = await resolveKeychainService();
   const account = keychainAccount();
-  log.debug(
-    `credentials: storing token in keyring (service=${KEYCHAIN_SERVICE}, account=${account})`,
-  );
+  log.debug(`credentials: storing token in keyring (service=${service}, account=${account})`);
   try {
-    const entry = new mod.Entry(KEYCHAIN_SERVICE, account);
+    const entry = new mod.Entry(service, account);
     entry.setPassword(token);
     return true;
   } catch {
@@ -64,10 +110,11 @@ async function keyringGet(): Promise<string | null> {
     log.debug("credentials: keyring not available");
     return null;
   }
+  const service = await resolveKeychainService();
   const account = keychainAccount();
-  log.debug(`credentials: checking keyring (service=${KEYCHAIN_SERVICE}, account=${account})`);
+  log.debug(`credentials: checking keyring (service=${service}, account=${account})`);
   try {
-    const entry = new mod.Entry(KEYCHAIN_SERVICE, account);
+    const entry = new mod.Entry(service, account);
     const token = entry.getPassword();
     log.debug(`credentials: ${token ? "found token in keyring" : "no token in keyring"}`);
     return token;
@@ -80,12 +127,11 @@ async function keyringGet(): Promise<string | null> {
 async function keyringDelete(): Promise<boolean> {
   const mod = await getKeyring();
   if (!mod) return false;
+  const service = await resolveKeychainService();
   const account = keychainAccount();
-  log.debug(
-    `credentials: deleting token from keyring (service=${KEYCHAIN_SERVICE}, account=${account})`,
-  );
+  log.debug(`credentials: deleting token from keyring (service=${service}, account=${account})`);
   try {
-    const entry = new mod.Entry(KEYCHAIN_SERVICE, account);
+    const entry = new mod.Entry(service, account);
     entry.deletePassword();
     return true;
   } catch {

--- a/packages/cli-core/src/test/integration/lib/harness.ts
+++ b/packages/cli-core/src/test/integration/lib/harness.ts
@@ -53,7 +53,9 @@ mock.module(
       },
       _setTokenOverride: () => {},
       KEYCHAIN_SERVICE: "clerk-cli",
+      LOCAL_DEV_KEYCHAIN_SERVICE: "clerk-cli-dev",
       KEYCHAIN_ACCOUNT: "oauth-access-token",
+      isReleaseSignedMacosBinary: () => true,
     }) satisfies typeof import("../../../lib/credential-store.ts"),
 );
 


### PR DESCRIPTION
## Summary

On macOS, local and unsigned CLI builds were writing OAuth tokens under the same Keychain service name (`clerk-cli`) as the signed release binary. macOS binds Keychain item ACLs to the code signature of the writer, so a later read from a differently signed (or unsigned) binary triggers a login-password prompt, and an accepted prompt grants that build permanent access to the release credential entry.

Net effect: running a locally compiled `clerk` (via `bun run build:compile`, `bun run src/cli.ts`, or a Bun-launched script) after a signed release login would either pop a password prompt or silently contaminate the release Keychain entry with a dev-build ACL.

## Fix

- Reserve the `clerk-cli` Keychain service for binaries that codesign-verify as an official release: `TeamIdentifier=L8SD6SB282` **and** `Identifier=clerk`, with `CLI_VERSION` populated (i.e. built by the release workflow, not `0.0.0-dev`).
- Route every other darwin invocation (unversioned dev builds, unsigned local compiles, `bun run` from source, non-Clerk signatures) to a new `clerk-cli-dev` service. Linux and Windows paths are unchanged.
- The classifier (`isReleaseSignedMacosBinary`) is a pure function over the `codesign -dvvv` output + `CLI_VERSION`, so it is covered by unit tests without shelling out. The per-process lookup is memoized in a promise so we run `codesign` at most once per CLI run.

Existing release credentials are not migrated. A developer who had previously approved a prompt will find their dev logins now live in `clerk-cli-dev`; the release `clerk` keeps using `clerk-cli` as before.

## Test plan

- [x] `bun test packages/cli-core/src/lib/credential-store-signing.test.ts` (new classifier: dev/unversioned, release, non-Clerk signer, mismatched identifier)
- [x] `bun test packages/cli-core/src/lib/credential-store.test.ts`
- [x] `bun run format:check`, `bun run lint`, `bun run typecheck`, `bun run test`
- [ ] Manual on a Mac with a prior signed-release login: run a locally compiled `clerk whoami`, confirm no password prompt and `--verbose` reports the `clerk-cli-dev` service; then run the signed release `clerk whoami` and confirm it still reads from `clerk-cli`.