### PR TITLE
feat(auth): add OAuth refresh token session handling

### DIFF
--- a/.changeset/oauth-refresh-token-support.md
+++ b/.changeset/oauth-refresh-token-support.md
@@ -1,0 +1,5 @@
+---
+"clerk": minor
+---
+
+Refresh expired OAuth sessions automatically for authenticated CLI commands.

--- a/packages/cli-core/src/commands/api/index.test.ts
+++ b/packages/cli-core/src/commands/api/index.test.ts
@@ -15,6 +15,7 @@ let mockStoredToken: string | null = null;
 mock.module("../../lib/credential-store.ts", () => ({
   ...credentialStoreStubs,
   getToken: async () => mockStoredToken,
+  getValidToken: async () => mockStoredToken,
 }));
 mock.module("../../lib/git.ts", () => gitStubs);
 

--- a/packages/cli-core/src/commands/auth/login.test.ts
+++ b/packages/cli-core/src/commands/auth/login.test.ts
@@ -1,5 +1,8 @@
 import { test, expect, describe, beforeEach, afterEach, mock, spyOn } from "bun:test";
+import { AuthError } from "../../lib/errors.ts";
 import { captureLog, credentialStoreStubs, configStubs } from "../../test/lib/stubs.ts";
+
+const actualConstants = await import("../../lib/constants.ts");
 
 const mockGetValidToken = mock();
 const mockStoreToken = mock();
@@ -45,6 +48,7 @@ mock.module("../../lib/environment.ts", () => ({
 }));
 
 mock.module("../../lib/constants.ts", () => ({
+  ...actualConstants,
   CALLBACK_PATH: "/callback",
   AUTH_TIMEOUT_MS: 120000,
   CLERK_CLIENT_CLI: "cli",
@@ -207,7 +211,7 @@ describe("login", () => {
   });
 
   test("re-authenticates when existing token is expired", async () => {
-    mockGetValidToken.mockRejectedValue(new Error("Session expired"));
+    mockGetValidToken.mockRejectedValue(new AuthError({ reason: "session_expired" }));
     mockGetAuth.mockResolvedValue({ userId: "user_old" });
     mockFetchUserInfo.mockResolvedValueOnce({
       userId: "user_refreshed",

--- a/packages/cli-core/src/commands/auth/login.test.ts
+++ b/packages/cli-core/src/commands/auth/login.test.ts
@@ -1,8 +1,9 @@
 import { test, expect, describe, beforeEach, afterEach, mock, spyOn } from "bun:test";
 import { captureLog, credentialStoreStubs, configStubs } from "../../test/lib/stubs.ts";
 
-const mockGetToken = mock();
+const mockGetValidToken = mock();
 const mockStoreToken = mock();
+const mockCreateOAuthSession = mock();
 const mockGetAuth = mock();
 const mockSetAuth = mock();
 const mockResolveProfile = mock();
@@ -16,8 +17,9 @@ const mockEnsureFirstApplication = mock<() => Promise<void>>(() => Promise.resol
 
 mock.module("../../lib/credential-store.ts", () => ({
   ...credentialStoreStubs,
-  getToken: (...args: unknown[]) => mockGetToken(...args),
+  getValidToken: (...args: unknown[]) => mockGetValidToken(...args),
   storeToken: (...args: unknown[]) => mockStoreToken(...args),
+  createOAuthSession: (...args: unknown[]) => mockCreateOAuthSession(...args),
 }));
 
 mock.module("../../lib/config.ts", () => ({
@@ -95,8 +97,9 @@ describe("login", () => {
 
   afterEach(() => {
     captured.teardown();
-    mockGetToken.mockReset();
+    mockGetValidToken.mockReset();
     mockStoreToken.mockReset();
+    mockCreateOAuthSession.mockReset();
     mockGetAuth.mockReset();
     mockSetAuth.mockReset();
     mockResolveProfile.mockReset();
@@ -132,7 +135,7 @@ describe("login", () => {
   }
 
   test("returns early when already authenticated with valid token", async () => {
-    mockGetToken.mockResolvedValue("existing-token");
+    mockGetValidToken.mockResolvedValue("existing-token");
     mockGetAuth.mockResolvedValue({ userId: "user_123" });
     mockFetchUserInfo.mockResolvedValue({
       userId: "user_123",
@@ -148,7 +151,7 @@ describe("login", () => {
   });
 
   test("performs fresh login when no token exists", async () => {
-    mockGetToken.mockResolvedValue(null);
+    mockGetValidToken.mockResolvedValue(null);
     mockBunSpawn();
 
     const mockServer = {
@@ -162,6 +165,13 @@ describe("login", () => {
       access_token: "new-access-token",
       token_type: "Bearer",
       expires_in: 3600,
+      refresh_token: "new-refresh-token",
+    });
+    mockCreateOAuthSession.mockReturnValue({
+      accessToken: "new-access-token",
+      refreshToken: "new-refresh-token",
+      expiresAt: 123,
+      tokenType: "Bearer",
     });
     mockStoreToken.mockResolvedValue(undefined);
     mockFetchUserInfo.mockResolvedValue({
@@ -180,17 +190,29 @@ describe("login", () => {
       codeVerifier: "test-code-verifier",
       redirectUri: "http://127.0.0.1:54321/callback",
     });
-    expect(mockStoreToken).toHaveBeenCalledWith("new-access-token");
+    expect(mockCreateOAuthSession).toHaveBeenCalledWith({
+      access_token: "new-access-token",
+      token_type: "Bearer",
+      expires_in: 3600,
+      refresh_token: "new-refresh-token",
+    });
+    expect(mockStoreToken).toHaveBeenCalledWith({
+      accessToken: "new-access-token",
+      refreshToken: "new-refresh-token",
+      expiresAt: 123,
+      tokenType: "Bearer",
+    });
     expect(mockSetAuth).toHaveBeenCalledWith({ userId: "user_new" });
     expect(captured.err).toContain("Logged in as new@example.com");
   });
 
   test("re-authenticates when existing token is expired", async () => {
-    mockGetToken.mockResolvedValue("expired-token");
+    mockGetValidToken.mockRejectedValue(new Error("Session expired"));
     mockGetAuth.mockResolvedValue({ userId: "user_old" });
-    mockFetchUserInfo
-      .mockRejectedValueOnce(new Error("Token expired"))
-      .mockResolvedValueOnce({ userId: "user_refreshed", email: "refreshed@example.com" });
+    mockFetchUserInfo.mockResolvedValueOnce({
+      userId: "user_refreshed",
+      email: "refreshed@example.com",
+    });
     mockBunSpawn();
 
     const mockServer = {
@@ -204,6 +226,13 @@ describe("login", () => {
       access_token: "refreshed-token",
       token_type: "Bearer",
       expires_in: 3600,
+      refresh_token: "refreshed-refresh-token",
+    });
+    mockCreateOAuthSession.mockReturnValue({
+      accessToken: "refreshed-token",
+      refreshToken: "refreshed-refresh-token",
+      expiresAt: 456,
+      tokenType: "Bearer",
     });
     mockStoreToken.mockResolvedValue(undefined);
     mockSetAuth.mockResolvedValue(undefined);
@@ -213,11 +242,16 @@ describe("login", () => {
 
     expect(result).toEqual({ userId: "user_refreshed", email: "refreshed@example.com" });
     expect(mockStartAuthServer).toHaveBeenCalled();
-    expect(mockStoreToken).toHaveBeenCalledWith("refreshed-token");
+    expect(mockStoreToken).toHaveBeenCalledWith({
+      accessToken: "refreshed-token",
+      refreshToken: "refreshed-refresh-token",
+      expiresAt: 456,
+      tokenType: "Bearer",
+    });
   });
 
   test("stops auth server and throws when callback fails", async () => {
-    mockGetToken.mockResolvedValue(null);
+    mockGetValidToken.mockResolvedValue(null);
     mockBunSpawn();
 
     const mockServer = {
@@ -236,7 +270,7 @@ describe("login", () => {
   });
 
   test("proceeds with login when token exists but no auth config", async () => {
-    mockGetToken.mockResolvedValue("orphan-token");
+    mockGetValidToken.mockResolvedValue("orphan-token");
     mockGetAuth.mockResolvedValue(undefined);
     mockBunSpawn();
 
@@ -251,6 +285,13 @@ describe("login", () => {
       access_token: "brand-new-token",
       token_type: "Bearer",
       expires_in: 3600,
+      refresh_token: "brand-new-refresh-token",
+    });
+    mockCreateOAuthSession.mockReturnValue({
+      accessToken: "brand-new-token",
+      refreshToken: "brand-new-refresh-token",
+      expiresAt: 789,
+      tokenType: "Bearer",
     });
     mockStoreToken.mockResolvedValue(undefined);
     mockFetchUserInfo.mockResolvedValue({
@@ -268,7 +309,7 @@ describe("login", () => {
 
   test("in agent mode, returns early without prompting when already authenticated", async () => {
     mockIsHuman.mockReturnValue(false);
-    mockGetToken.mockResolvedValue("existing-token");
+    mockGetValidToken.mockResolvedValue("existing-token");
     mockGetAuth.mockResolvedValue({ userId: "user_123" });
     mockFetchUserInfo.mockResolvedValue({
       userId: "user_123",
@@ -286,7 +327,7 @@ describe("login", () => {
 
   test("in human mode, prompts and runs OAuth when user accepts re-auth", async () => {
     mockIsHuman.mockReturnValue(true);
-    mockGetToken.mockResolvedValue("existing-token");
+    mockGetValidToken.mockResolvedValue("existing-token");
     mockGetAuth.mockResolvedValue({ userId: "user_123" });
     mockFetchUserInfo
       .mockResolvedValueOnce({ userId: "user_123", email: "old@example.com" })
@@ -305,6 +346,13 @@ describe("login", () => {
       access_token: "new-token",
       token_type: "Bearer",
       expires_in: 3600,
+      refresh_token: "new-refresh-token",
+    });
+    mockCreateOAuthSession.mockReturnValue({
+      accessToken: "new-token",
+      refreshToken: "new-refresh-token",
+      expiresAt: 999,
+      tokenType: "Bearer",
     });
     mockStoreToken.mockResolvedValue(undefined);
     mockSetAuth.mockResolvedValue(undefined);
@@ -322,7 +370,7 @@ describe("login", () => {
 
   test("in human mode, throws UserAbortError when user declines re-auth", async () => {
     mockIsHuman.mockReturnValue(true);
-    mockGetToken.mockResolvedValue("existing-token");
+    mockGetValidToken.mockResolvedValue("existing-token");
     mockGetAuth.mockResolvedValue({ userId: "user_123" });
     mockFetchUserInfo.mockResolvedValue({
       userId: "user_123",
@@ -338,7 +386,7 @@ describe("login", () => {
   });
 
   test("shows linked app with name and id in next steps when linked", async () => {
-    mockGetToken.mockResolvedValue(null);
+    mockGetValidToken.mockResolvedValue(null);
     mockBunSpawn();
 
     const mockServer = {
@@ -352,6 +400,13 @@ describe("login", () => {
       access_token: "new-access-token",
       token_type: "Bearer",
       expires_in: 3600,
+      refresh_token: "new-refresh-token",
+    });
+    mockCreateOAuthSession.mockReturnValue({
+      accessToken: "new-access-token",
+      refreshToken: "new-refresh-token",
+      expiresAt: 123,
+      tokenType: "Bearer",
     });
     mockStoreToken.mockResolvedValue(undefined);
     mockFetchUserInfo.mockResolvedValue({
@@ -377,7 +432,7 @@ describe("login", () => {
   });
 
   test("shows linked app with only id when appName is missing", async () => {
-    mockGetToken.mockResolvedValue(null);
+    mockGetValidToken.mockResolvedValue(null);
     mockBunSpawn();
 
     const mockServer = {
@@ -391,6 +446,13 @@ describe("login", () => {
       access_token: "new-access-token",
       token_type: "Bearer",
       expires_in: 3600,
+      refresh_token: "new-refresh-token",
+    });
+    mockCreateOAuthSession.mockReturnValue({
+      accessToken: "new-access-token",
+      refreshToken: "new-refresh-token",
+      expiresAt: 123,
+      tokenType: "Bearer",
     });
     mockStoreToken.mockResolvedValue(undefined);
     mockFetchUserInfo.mockResolvedValue({
@@ -415,7 +477,7 @@ describe("login", () => {
   });
 
   test("shows default next steps when not linked", async () => {
-    mockGetToken.mockResolvedValue(null);
+    mockGetValidToken.mockResolvedValue(null);
     mockBunSpawn();
 
     const mockServer = {
@@ -429,6 +491,13 @@ describe("login", () => {
       access_token: "new-access-token",
       token_type: "Bearer",
       expires_in: 3600,
+      refresh_token: "new-refresh-token",
+    });
+    mockCreateOAuthSession.mockReturnValue({
+      accessToken: "new-access-token",
+      refreshToken: "new-refresh-token",
+      expiresAt: 123,
+      tokenType: "Bearer",
     });
     mockStoreToken.mockResolvedValue(undefined);
     mockFetchUserInfo.mockResolvedValue({
@@ -520,7 +589,7 @@ describe("login", () => {
   });
 
   test("suppresses auth next-steps when requested", async () => {
-    mockGetToken.mockResolvedValue(null);
+    mockGetValidToken.mockResolvedValue(null);
     mockBunSpawn();
 
     const mockServer = {
@@ -534,6 +603,13 @@ describe("login", () => {
       access_token: "new-access-token",
       token_type: "Bearer",
       expires_in: 3600,
+      refresh_token: "new-refresh-token",
+    });
+    mockCreateOAuthSession.mockReturnValue({
+      accessToken: "new-access-token",
+      refreshToken: "new-refresh-token",
+      expiresAt: 123,
+      tokenType: "Bearer",
     });
     mockStoreToken.mockResolvedValue(undefined);
     mockFetchUserInfo.mockResolvedValue({

--- a/packages/cli-core/src/commands/auth/login.test.ts
+++ b/packages/cli-core/src/commands/auth/login.test.ts
@@ -3,6 +3,7 @@ import { AuthError } from "../../lib/errors.ts";
 import { captureLog, credentialStoreStubs, configStubs } from "../../test/lib/stubs.ts";
 
 const actualConstants = await import("../../lib/constants.ts");
+const actualEnvironment = await import("../../lib/environment.ts");
 
 const mockGetValidToken = mock();
 const mockStoreToken = mock();
@@ -38,6 +39,7 @@ mock.module("../../lib/token-exchange.ts", () => ({
 }));
 
 mock.module("../../lib/environment.ts", () => ({
+  ...actualEnvironment,
   getOAuthConfig: () => ({
     clientId: "test-client-id",
     scopes: "profile email",
@@ -518,7 +520,7 @@ describe("login", () => {
   });
 
   test("authorize URL includes clerk_client=cli so dashboard recognizes CLI sign-up", async () => {
-    mockGetToken.mockResolvedValue(null);
+    mockGetValidToken.mockResolvedValue(null);
     mockBunSpawn();
 
     const mockServer = {
@@ -532,6 +534,13 @@ describe("login", () => {
       access_token: "new-access-token",
       token_type: "Bearer",
       expires_in: 3600,
+      refresh_token: "new-refresh-token",
+    });
+    mockCreateOAuthSession.mockReturnValue({
+      accessToken: "new-access-token",
+      refreshToken: "new-refresh-token",
+      expiresAt: 123,
+      tokenType: "Bearer",
     });
     mockStoreToken.mockResolvedValue(undefined);
     mockFetchUserInfo.mockResolvedValue({
@@ -550,7 +559,7 @@ describe("login", () => {
   });
 
   test("calls ensureFirstApplication after a successful OAuth flow", async () => {
-    mockGetToken.mockResolvedValue(null);
+    mockGetValidToken.mockResolvedValue(null);
     mockBunSpawn();
 
     const mockServer = {
@@ -564,6 +573,13 @@ describe("login", () => {
       access_token: "new-access-token",
       token_type: "Bearer",
       expires_in: 3600,
+      refresh_token: "new-refresh-token",
+    });
+    mockCreateOAuthSession.mockReturnValue({
+      accessToken: "new-access-token",
+      refreshToken: "new-refresh-token",
+      expiresAt: 123,
+      tokenType: "Bearer",
     });
     mockStoreToken.mockResolvedValue(undefined);
     mockFetchUserInfo.mockResolvedValue({
@@ -579,7 +595,7 @@ describe("login", () => {
   });
 
   test("does not call ensureFirstApplication when existing session is reused", async () => {
-    mockGetToken.mockResolvedValue("existing-token");
+    mockGetValidToken.mockResolvedValue("existing-token");
     mockGetAuth.mockResolvedValue({ userId: "user_123" });
     mockFetchUserInfo.mockResolvedValue({
       userId: "user_123",

--- a/packages/cli-core/src/commands/auth/login.ts
+++ b/packages/cli-core/src/commands/auth/login.ts
@@ -2,7 +2,7 @@ import { generateCodeVerifier, generateCodeChallenge, generateState } from "../.
 import { startAuthServer } from "../../lib/auth-server.ts";
 import { exchangeCodeForToken, fetchUserInfo, type UserInfo } from "../../lib/token-exchange.ts";
 import { getOAuthConfig } from "../../lib/environment.ts";
-import { storeToken, getToken } from "../../lib/credential-store.ts";
+import { createOAuthSession, getValidToken, storeToken } from "../../lib/credential-store.ts";
 import { getAuth, setAuth, resolveProfile } from "../../lib/config.ts";
 import { AUTH_TIMEOUT_MS, CALLBACK_PATH, CLERK_CLIENT_CLI } from "../../lib/constants.ts";
 import { confirm } from "../../lib/prompts.ts";
@@ -21,13 +21,12 @@ interface LoginOptions {
 }
 
 async function getExistingSession(): Promise<UserInfo | null> {
-  const token = await getToken();
-  if (!token) return null;
-
   const auth = await getAuth();
   if (!auth) return null;
 
   try {
+    const token = await getValidToken();
+    if (!token) return null;
     return await fetchUserInfo(token);
   } catch {
     return null;
@@ -82,7 +81,7 @@ async function performOAuthFlow(): Promise<UserInfo> {
     }),
   );
 
-  await storeToken(tokenResponse.access_token);
+  await storeToken(createOAuthSession(tokenResponse));
 
   const userInfo = await fetchUserInfo(tokenResponse.access_token);
   await setAuth({ userId: userInfo.userId });

--- a/packages/cli-core/src/commands/doctor/checks.ts
+++ b/packages/cli-core/src/commands/doctor/checks.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { fetchUserInfo } from "../../lib/token-exchange.ts";
-import { PlapiError, errorMessage } from "../../lib/errors.ts";
+import { errorMessage, isAuthError, PlapiError } from "../../lib/errors.ts";
 import { detectPublishableKeyName, detectSecretKeyName } from "../../lib/framework.ts";
 import { parseEnvFile } from "../../lib/dotenv.ts";
 import {
@@ -15,8 +15,6 @@ import {
   formatChannelLabel,
 } from "../../lib/update-check.ts";
 import type { CheckResult, DoctorContext, FixAction } from "./types.ts";
-
-const AUTH_ERROR_STATUS = /\((401|403)\)/;
 
 interface CheckOptions {
   remedy?: string;
@@ -87,8 +85,7 @@ export async function checkTokenValid(ctx: DoctorContext): Promise<CheckResult> 
     const userInfo = await fetchUserInfo(token);
     return check.pass(`Authenticated as ${userInfo.email}`);
   } catch (error) {
-    const message = errorMessage(error);
-    if (AUTH_ERROR_STATUS.test(message)) {
+    if (isAuthError(error)) {
       return check.fail("Token is expired or invalid", {
         remedy: "Run `clerk auth login` to re-authenticate.",
       });

--- a/packages/cli-core/src/commands/doctor/checks.ts
+++ b/packages/cli-core/src/commands/doctor/checks.ts
@@ -1,6 +1,5 @@
 import { join } from "node:path";
 import { homedir } from "node:os";
-import { getValidToken } from "../../lib/credential-store.ts";
 import { fetchUserInfo } from "../../lib/token-exchange.ts";
 import { PlapiError, errorMessage } from "../../lib/errors.ts";
 import { detectPublishableKeyName, detectSecretKeyName } from "../../lib/framework.ts";
@@ -83,7 +82,7 @@ export async function checkTokenValid(ctx: DoctorContext): Promise<CheckResult> 
   if (!storedToken) return check.skip("no token");
 
   try {
-    const token = await getValidToken();
+    const token = await ctx.getValidToken();
     if (!token) return check.skip("no token");
     const userInfo = await fetchUserInfo(token);
     return check.pass(`Authenticated as ${userInfo.email}`);

--- a/packages/cli-core/src/commands/doctor/checks.ts
+++ b/packages/cli-core/src/commands/doctor/checks.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { getValidToken } from "../../lib/credential-store.ts";
 import { fetchUserInfo } from "../../lib/token-exchange.ts";
 import { PlapiError, errorMessage } from "../../lib/errors.ts";
 import { detectPublishableKeyName, detectSecretKeyName } from "../../lib/framework.ts";
@@ -78,10 +79,12 @@ export async function checkLoggedIn(ctx: DoctorContext): Promise<CheckResult> {
 
 export async function checkTokenValid(ctx: DoctorContext): Promise<CheckResult> {
   const check = defineCheck("Authentication valid", ctx.fixes.login);
-  const token = await ctx.getToken();
-  if (!token) return check.skip("no token");
+  const storedToken = await ctx.getToken();
+  if (!storedToken) return check.skip("no token");
 
   try {
+    const token = await getValidToken();
+    if (!token) return check.skip("no token");
     const userInfo = await fetchUserInfo(token);
     return check.pass(`Authenticated as ${userInfo.email}`);
   } catch (error) {

--- a/packages/cli-core/src/commands/doctor/context.ts
+++ b/packages/cli-core/src/commands/doctor/context.ts
@@ -1,10 +1,11 @@
-import { getToken } from "../../lib/credential-store.ts";
+import { getToken, getValidToken } from "../../lib/credential-store.ts";
 import { resolveProfile } from "../../lib/config.ts";
 import { fetchApplication, type Application } from "../../lib/plapi.ts";
 import type { DoctorContext, ResolvedProfile } from "./types.ts";
 
 export function createDoctorContext(): DoctorContext {
   let tokenPromise: Promise<string | null> | undefined;
+  let validTokenPromise: Promise<string | null> | undefined;
   let profilePromise: Promise<ResolvedProfile | undefined> | undefined;
   let appPromise: Promise<Application | null> | undefined;
 
@@ -14,6 +15,13 @@ export function createDoctorContext(): DoctorContext {
         tokenPromise = getToken();
       }
       return tokenPromise;
+    },
+
+    getValidToken() {
+      if (!validTokenPromise) {
+        validTokenPromise = getValidToken();
+      }
+      return validTokenPromise;
     },
 
     getProfile() {

--- a/packages/cli-core/src/commands/doctor/doctor.test.ts
+++ b/packages/cli-core/src/commands/doctor/doctor.test.ts
@@ -2,6 +2,7 @@ import { test, expect, describe, beforeEach, afterEach, mock } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { ApiError, AuthError } from "../../lib/errors.ts";
 import { gitStubs, tokenExchangeStubs, stubFetch } from "../../test/lib/stubs.ts";
 import type { CheckResult, CheckStatus, DoctorContext, ResolvedProfile } from "./types.ts";
 import type { Application } from "../../lib/plapi.ts";
@@ -72,7 +73,7 @@ const mockProfile = {
 function createMockContext(
   overrides: {
     token?: string | null;
-    validToken?: string | null;
+    validToken?: string | null | Error;
     profile?: {
       path: string;
       profile: Profile;
@@ -84,8 +85,10 @@ function createMockContext(
 ): DoctorContext {
   return {
     getToken: async () => overrides.token ?? null,
-    getValidToken: async () =>
-      overrides.validToken !== undefined ? overrides.validToken : (overrides.token ?? null),
+    getValidToken: async () => {
+      if (overrides.validToken instanceof Error) throw overrides.validToken;
+      return overrides.validToken !== undefined ? overrides.validToken : (overrides.token ?? null);
+    },
     getProfile: async () => overrides.profile as ResolvedProfile | undefined,
     getApplication: async () => {
       if (overrides.applicationError) throw overrides.applicationError;
@@ -189,8 +192,23 @@ describe("checkTokenValid", () => {
   });
 
   test("fail when token is expired (401)", async () => {
-    mockUserInfoError = new Error("Failed to fetch user info (401): Unauthorized");
+    mockUserInfoError = new ApiError(401, "Unauthorized");
     const ctx = createMockContext({ token: "expired_token" });
+    const result = await checkTokenValid(ctx);
+    expectCheck(result, {
+      name: "Authentication valid",
+      status: "fail",
+      message: "expired or invalid",
+      remedy: "clerk auth login",
+      fix: true,
+    });
+  });
+
+  test("fail when refreshing the stored session requires re-authentication", async () => {
+    const ctx = createMockContext({
+      token: "expired_token",
+      validToken: new AuthError({ reason: "session_expired" }),
+    });
     const result = await checkTokenValid(ctx);
     expectCheck(result, {
       name: "Authentication valid",

--- a/packages/cli-core/src/commands/doctor/doctor.test.ts
+++ b/packages/cli-core/src/commands/doctor/doctor.test.ts
@@ -72,6 +72,7 @@ const mockProfile = {
 function createMockContext(
   overrides: {
     token?: string | null;
+    validToken?: string | null;
     profile?: {
       path: string;
       profile: Profile;
@@ -83,6 +84,8 @@ function createMockContext(
 ): DoctorContext {
   return {
     getToken: async () => overrides.token ?? null,
+    getValidToken: async () =>
+      overrides.validToken !== undefined ? overrides.validToken : (overrides.token ?? null),
     getProfile: async () => overrides.profile as ResolvedProfile | undefined,
     getApplication: async () => {
       if (overrides.applicationError) throw overrides.applicationError;

--- a/packages/cli-core/src/commands/doctor/types.ts
+++ b/packages/cli-core/src/commands/doctor/types.ts
@@ -21,6 +21,7 @@ export interface CheckResult {
 
 export interface DoctorContext {
   getToken(): Promise<string | null>;
+  getValidToken(): Promise<string | null>;
   getProfile(): Promise<ResolvedProfile | undefined>;
   getApplication(): Promise<Application | null>;
   fixes: {

--- a/packages/cli-core/src/commands/init/heuristics.ts
+++ b/packages/cli-core/src/commands/init/heuristics.ts
@@ -3,7 +3,7 @@ import { mkdir } from "node:fs/promises";
 import { dim, cyan, green, yellow, bold } from "../../lib/color.js";
 import { printNextSteps } from "../../lib/next-steps.js";
 import { log } from "../../lib/log.js";
-import { getStoredSession, getValidToken } from "../../lib/credential-store.js";
+import { getValidToken, hasStoredCredentials } from "../../lib/credential-store.js";
 import { fetchUserInfo } from "../../lib/token-exchange.js";
 import { printFindings } from "./scan.js";
 import { pmInstallCommand } from "./prompts/index.js";
@@ -148,7 +148,7 @@ export async function getAuthenticatedEmail(): Promise<string | null> {
  */
 export async function isAuthenticated(): Promise<boolean> {
   if (process.env.CLERK_PLATFORM_API_KEY) return true;
-  return (await getStoredSession()) != null;
+  return hasStoredCredentials();
 }
 
 export function printKeylessInfo(envFile: string): void {

--- a/packages/cli-core/src/commands/init/heuristics.ts
+++ b/packages/cli-core/src/commands/init/heuristics.ts
@@ -3,7 +3,7 @@ import { mkdir } from "node:fs/promises";
 import { dim, cyan, green, yellow, bold } from "../../lib/color.js";
 import { printNextSteps } from "../../lib/next-steps.js";
 import { log } from "../../lib/log.js";
-import { getToken } from "../../lib/credential-store.js";
+import { getStoredSession, getValidToken } from "../../lib/credential-store.js";
 import { fetchUserInfo } from "../../lib/token-exchange.js";
 import { printFindings } from "./scan.js";
 import { pmInstallCommand } from "./prompts/index.js";
@@ -127,7 +127,7 @@ export function printOutro(plan: ScaffoldPlan, findings: ScanFinding[]): void {
  */
 export async function getAuthenticatedEmail(): Promise<string | null> {
   try {
-    const token = await getToken();
+    const token = await getValidToken();
     if (!token) return null;
     const userInfo = await fetchUserInfo(token);
     return userInfo.email;
@@ -148,7 +148,7 @@ export async function getAuthenticatedEmail(): Promise<string | null> {
  */
 export async function isAuthenticated(): Promise<boolean> {
   if (process.env.CLERK_PLATFORM_API_KEY) return true;
-  return (await getToken()) != null;
+  return (await getStoredSession()) != null;
 }
 
 export function printKeylessInfo(envFile: string): void {

--- a/packages/cli-core/src/commands/whoami/index.test.ts
+++ b/packages/cli-core/src/commands/whoami/index.test.ts
@@ -2,12 +2,12 @@ import { test, expect, describe, beforeEach, afterEach, mock, spyOn } from "bun:
 import { captureLog, credentialStoreStubs, tokenExchangeStubs } from "../../test/lib/stubs.ts";
 import { CliError } from "../../lib/errors.ts";
 
-const mockGetToken = mock();
+const mockGetValidToken = mock();
 const mockFetchUserInfo = mock();
 
 mock.module("../../lib/credential-store.ts", () => ({
   ...credentialStoreStubs,
-  getToken: (...args: unknown[]) => mockGetToken(...args),
+  getValidToken: (...args: unknown[]) => mockGetValidToken(...args),
 }));
 
 mock.module("../../lib/token-exchange.ts", () => ({
@@ -27,7 +27,7 @@ describe("whoami", () => {
 
   afterEach(() => {
     captured.teardown();
-    mockGetToken.mockReset();
+    mockGetValidToken.mockReset();
     mockFetchUserInfo.mockReset();
     consoleSpy?.mockRestore();
   });
@@ -37,7 +37,7 @@ describe("whoami", () => {
   }
 
   test("prints email when authenticated", async () => {
-    mockGetToken.mockResolvedValue("valid-token");
+    mockGetValidToken.mockResolvedValue("valid-token");
     mockFetchUserInfo.mockResolvedValue({
       userId: "user_123",
       email: "alice@example.com",
@@ -50,7 +50,7 @@ describe("whoami", () => {
   });
 
   test("throws CliError when no token exists", async () => {
-    mockGetToken.mockResolvedValue(null);
+    mockGetValidToken.mockResolvedValue(null);
 
     await expect(runWhoami()).rejects.toThrow(CliError);
     await expect(captured.run(() => whoami())).rejects.toThrow(/Not logged in/);
@@ -59,7 +59,7 @@ describe("whoami", () => {
   });
 
   test("throws CliError when token is invalid", async () => {
-    mockGetToken.mockResolvedValue("expired-token");
+    mockGetValidToken.mockResolvedValue("expired-token");
     mockFetchUserInfo.mockRejectedValue(new Error("Unauthorized"));
 
     await expect(runWhoami()).rejects.toThrow(CliError);

--- a/packages/cli-core/src/commands/whoami/index.ts
+++ b/packages/cli-core/src/commands/whoami/index.ts
@@ -1,11 +1,11 @@
-import { getToken } from "../../lib/credential-store.ts";
+import { getValidToken } from "../../lib/credential-store.ts";
 import { fetchUserInfo } from "../../lib/token-exchange.ts";
 import { withSpinner } from "../../lib/spinner.ts";
 import { log } from "../../lib/log.ts";
 import { CliError, ERROR_CODE } from "../../lib/errors.ts";
 
 export async function whoami() {
-  const token = await getToken();
+  const token = await getValidToken();
   if (!token) {
     throw new CliError("Not logged in. Run `clerk auth login` to authenticate", {
       code: ERROR_CODE.AUTH_REQUIRED,

--- a/packages/cli-core/src/commands/whoami/index.ts
+++ b/packages/cli-core/src/commands/whoami/index.ts
@@ -2,22 +2,18 @@ import { getValidToken } from "../../lib/credential-store.ts";
 import { fetchUserInfo } from "../../lib/token-exchange.ts";
 import { withSpinner } from "../../lib/spinner.ts";
 import { log } from "../../lib/log.ts";
-import { CliError, ERROR_CODE } from "../../lib/errors.ts";
+import { AuthError } from "../../lib/errors.ts";
 
 export async function whoami() {
   const token = await getValidToken();
   if (!token) {
-    throw new CliError("Not logged in. Run `clerk auth login` to authenticate", {
-      code: ERROR_CODE.AUTH_REQUIRED,
-    });
+    throw new AuthError({ reason: "not_logged_in" });
   }
 
   try {
     const userInfo = await withSpinner("Fetching account info...", () => fetchUserInfo(token));
     log.data(userInfo.email);
   } catch {
-    throw new CliError("Session expired. Run `clerk auth login` to re-authenticate", {
-      code: ERROR_CODE.AUTH_REQUIRED,
-    });
+    throw new AuthError({ reason: "session_expired" });
   }
 }

--- a/packages/cli-core/src/lib/autolink.test.ts
+++ b/packages/cli-core/src/lib/autolink.test.ts
@@ -230,7 +230,7 @@ describe("autolink", () => {
     _setConfigDir(tempDir);
     process.env = { ...originalEnv };
     delete process.env.CLERK_PUBLISHABLE_KEY;
-    process.env.CLERK_PLATFORM_API_KEY = "test_platform_key";
+    process.env.CLERK_PLATFORM_API_KEY = "ak_test_platform_key";
     process.env.CLERK_PLATFORM_API_URL = "https://test-api.clerk.com";
     mockGetGitRepoIdentifier.mockReset();
     mockGetGitRepoIdentifier.mockResolvedValue(undefined);

--- a/packages/cli-core/src/lib/credential-store.test.ts
+++ b/packages/cli-core/src/lib/credential-store.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe, beforeEach, afterAll, mock, setDefaultTimeout } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { ApiError, AuthError } from "./errors.ts";
@@ -32,6 +32,10 @@ mock.module("./token-exchange.ts", () => ({
 const { createOAuthSession, deleteToken, getStoredSession, getToken, getValidToken, storeToken } =
   await import("./credential-store.ts");
 
+async function writeLegacyToken(value: string): Promise<void> {
+  await writeFile(join(tempDir, "credentials"), value, { mode: 0o600 });
+}
+
 afterAll(async () => {
   delete process.env.CLERK_CONFIG_DIR;
   await rm(tempDir, { recursive: true, force: true });
@@ -47,8 +51,8 @@ describe("credential-store", () => {
     expect(await getToken()).toBeNull();
   });
 
-  test("storeToken and getToken roundtrip for legacy token strings", async () => {
-    await storeToken("my-access-token");
+  test("getToken reads legacy token strings without a stored session", async () => {
+    await writeLegacyToken("my-access-token");
 
     expect(await getToken()).toBe("my-access-token");
     expect(await getStoredSession()).toBeNull();
@@ -95,13 +99,14 @@ describe("credential-store", () => {
       access_token: "refreshed-access-token",
       token_type: "Bearer",
       expires_in: 3600,
+      refresh_token: "rotated-refresh-token",
     });
 
     expect(await getValidToken()).toBe("refreshed-access-token");
     expect(mockRefreshAccessToken).toHaveBeenCalledWith("refresh-token");
     expect(await getStoredSession()).toEqual({
       accessToken: "refreshed-access-token",
-      refreshToken: "refresh-token",
+      refreshToken: "rotated-refresh-token",
       expiresAt: expect.any(Number),
       tokenType: "Bearer",
     });
@@ -123,21 +128,13 @@ describe("credential-store", () => {
     expect(await getStoredSession()).toBeNull();
   });
 
-  test("createOAuthSession reuses the current refresh token when rotation is omitted", () => {
-    expect(
-      createOAuthSession(
-        {
-          access_token: "new-access-token",
-          token_type: "Bearer",
-          expires_in: 3600,
-        },
-        "existing-refresh-token",
-      ),
-    ).toEqual({
-      accessToken: "new-access-token",
-      refreshToken: "existing-refresh-token",
-      expiresAt: expect.any(Number),
-      tokenType: "Bearer",
-    });
+  test("createOAuthSession requires a refresh token in the auth response", () => {
+    expect(() =>
+      createOAuthSession({
+        access_token: "new-access-token",
+        token_type: "Bearer",
+        expires_in: 3600,
+      } as never),
+    ).toThrow("Authentication response did not include a refresh token");
   });
 });

--- a/packages/cli-core/src/lib/credential-store.test.ts
+++ b/packages/cli-core/src/lib/credential-store.test.ts
@@ -1,121 +1,143 @@
 import { test, expect, describe, beforeEach, afterAll, mock, setDefaultTimeout } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { ApiError, AuthError } from "./errors.ts";
 
 // Keyring initialization can be slow on first access (macOS Keychain, etc.)
 setDefaultTimeout(5_000);
-import { mkdtemp, rm, mkdir, chmod, unlink } from "node:fs/promises";
-import { join, dirname } from "node:path";
-import { tmpdir } from "node:os";
 
 const tempDir = await mkdtemp(join(tmpdir(), "clerk-cred-test-"));
-
-// Redirect file-based credential storage to temp dir via env var
 process.env.CLERK_CONFIG_DIR = tempDir;
 
-// Import constants from the source module to avoid duplication
-const { KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT } = await import("./credential-store.ts");
-const credFile = () => join(tempDir, "credentials");
+const mockRefreshAccessToken = mock();
 
-let keyringModule: typeof import("@napi-rs/keyring") | null;
-try {
-  keyringModule = await import("@napi-rs/keyring");
-} catch {
-  keyringModule = null;
-}
-
-mock.module("./credential-store.ts", () => ({
-  KEYCHAIN_SERVICE,
-  KEYCHAIN_ACCOUNT,
-  async storeToken(token: string) {
-    if (keyringModule) {
-      try {
-        const entry = new keyringModule.Entry(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT);
-        entry.setPassword(token);
-        return;
-      } catch {}
-    }
-    const f = credFile();
-    await mkdir(dirname(f), { recursive: true });
-    await Bun.write(f, token);
-    await chmod(f, 0o600);
-  },
-  async getToken() {
-    if (keyringModule) {
-      try {
-        const entry = new keyringModule.Entry(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT);
-        return entry.getPassword();
-      } catch {}
-    }
-    const file = Bun.file(credFile());
-    if (!(await file.exists())) return null;
-    const content = await file.text();
-    return content.trim() || null;
-  },
-  async deleteToken() {
-    if (keyringModule) {
-      try {
-        const entry = new keyringModule.Entry(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT);
-        entry.deletePassword();
-      } catch {}
-    }
-    try {
-      await unlink(credFile());
-    } catch {
-      // File doesn't exist, nothing to delete
+mock.module("@napi-rs/keyring", () => ({
+  Entry: class {
+    constructor() {
+      throw new Error("keyring unavailable");
     }
   },
 }));
 
-const { storeToken, getToken, deleteToken } = await import("./credential-store.ts");
+mock.module("./version.ts", () => ({
+  DEV_CLI_VERSION: "0.0.0-dev",
+  resolveCliVersion: () => undefined,
+}));
 
-let savedToken: string | null = null;
+mock.module("./token-exchange.ts", () => ({
+  refreshAccessToken: (...args: unknown[]) => mockRefreshAccessToken(...args),
+}));
+
+const { createOAuthSession, deleteToken, getStoredSession, getToken, getValidToken, storeToken } =
+  await import("./credential-store.ts");
 
 afterAll(async () => {
-  // Restore any pre-existing keyring token
-  if (keyringModule && savedToken !== null) {
-    await storeToken(savedToken);
-  }
   delete process.env.CLERK_CONFIG_DIR;
   await rm(tempDir, { recursive: true, force: true });
 });
 
 describe("credential-store", () => {
   beforeEach(async () => {
-    // On first run, save any existing keyring token so we can restore it later
-    if (keyringModule && savedToken === null) {
-      savedToken = await getToken();
-    }
+    mockRefreshAccessToken.mockReset();
     await deleteToken();
   });
 
   test("getToken returns null when no token is stored", async () => {
-    const token = await getToken();
-    expect(token).toBeNull();
+    expect(await getToken()).toBeNull();
   });
 
-  test("storeToken and getToken roundtrip", async () => {
+  test("storeToken and getToken roundtrip for legacy token strings", async () => {
     await storeToken("my-access-token");
-    const token = await getToken();
-    expect(token).toBe("my-access-token");
+
+    expect(await getToken()).toBe("my-access-token");
+    expect(await getStoredSession()).toBeNull();
   });
 
-  test("deleteToken removes stored token", async () => {
-    await storeToken("token-to-remove");
-    expect(await getToken()).toBe("token-to-remove");
+  test("storeToken and getStoredSession roundtrip for OAuth sessions", async () => {
+    const session = {
+      accessToken: "session-access-token",
+      refreshToken: "session-refresh-token",
+      expiresAt: Date.now() + 60_000,
+      tokenType: "Bearer",
+    };
 
-    await deleteToken();
+    await storeToken(session);
+
+    expect(await getToken()).toBe(session.accessToken);
+    expect(await getStoredSession()).toEqual(session);
+  });
+
+  test("getValidToken uses stored expiresAt before attempting refresh", async () => {
+    const session = {
+      accessToken: "opaque-access-token",
+      refreshToken: "refresh-token",
+      expiresAt: Date.now() + 60_000,
+      tokenType: "Bearer",
+    };
+
+    await storeToken(session);
+
+    expect(await getValidToken()).toBe("opaque-access-token");
+    expect(mockRefreshAccessToken).not.toHaveBeenCalled();
+  });
+
+  test("getValidToken refreshes expired sessions and persists the new access token", async () => {
+    const session = {
+      accessToken: "expired-access-token",
+      refreshToken: "refresh-token",
+      expiresAt: Date.now() - 60_000,
+      tokenType: "Bearer",
+    };
+    await storeToken(session);
+
+    mockRefreshAccessToken.mockResolvedValue({
+      access_token: "refreshed-access-token",
+      token_type: "Bearer",
+      expires_in: 3600,
+    });
+
+    expect(await getValidToken()).toBe("refreshed-access-token");
+    expect(mockRefreshAccessToken).toHaveBeenCalledWith("refresh-token");
+    expect(await getStoredSession()).toEqual({
+      accessToken: "refreshed-access-token",
+      refreshToken: "refresh-token",
+      expiresAt: expect.any(Number),
+      tokenType: "Bearer",
+    });
+  });
+
+  test("getValidToken deletes stored credentials when refresh returns invalid_grant", async () => {
+    const session = {
+      accessToken: "expired-access-token",
+      refreshToken: "refresh-token",
+      expiresAt: Date.now() - 60_000,
+      tokenType: "Bearer",
+    };
+    await storeToken(session);
+
+    mockRefreshAccessToken.mockRejectedValue(new ApiError(400, "invalid_grant"));
+
+    await expect(getValidToken()).rejects.toBeInstanceOf(AuthError);
     expect(await getToken()).toBeNull();
+    expect(await getStoredSession()).toBeNull();
   });
 
-  test("storeToken overwrites existing token", async () => {
-    await storeToken("first-token");
-    await storeToken("second-token");
-    const token = await getToken();
-    expect(token).toBe("second-token");
-  });
-
-  test("deleteToken is safe to call when no token exists", async () => {
-    await deleteToken();
-    await deleteToken();
-    expect(await getToken()).toBeNull();
+  test("createOAuthSession reuses the current refresh token when rotation is omitted", () => {
+    expect(
+      createOAuthSession(
+        {
+          access_token: "new-access-token",
+          token_type: "Bearer",
+          expires_in: 3600,
+        },
+        "existing-refresh-token",
+      ),
+    ).toEqual({
+      accessToken: "new-access-token",
+      refreshToken: "existing-refresh-token",
+      expiresAt: expect.any(Number),
+      tokenType: "Bearer",
+    });
   });
 });

--- a/packages/cli-core/src/lib/credential-store.ts
+++ b/packages/cli-core/src/lib/credential-store.ts
@@ -229,6 +229,13 @@ function isExpiredJwt(token: string): boolean {
   return expiresAt <= Date.now() + JWT_EXPIRY_LEEWAY_MS;
 }
 
+function isExpiredSession(session: OAuthSession): boolean {
+  if (Number.isFinite(session.expiresAt)) {
+    return session.expiresAt <= Date.now() + JWT_EXPIRY_LEEWAY_MS;
+  }
+  return isExpiredJwt(session.accessToken);
+}
+
 function sessionExpiredError(): AuthError {
   return new AuthError({ reason: "session_expired" });
 }
@@ -333,7 +340,7 @@ export async function getValidToken(): Promise<string | null> {
     return null;
   }
 
-  if (!isExpiredJwt(session.accessToken)) {
+  if (!isExpiredSession(session)) {
     return session.accessToken;
   }
 

--- a/packages/cli-core/src/lib/credential-store.ts
+++ b/packages/cli-core/src/lib/credential-store.ts
@@ -11,7 +11,7 @@ import { dirname } from "node:path";
 import { mkdir, chmod, writeFile, unlink } from "node:fs/promises";
 import { CREDENTIALS_FILE } from "./constants.ts";
 import { getCurrentEnvName } from "./environment.ts";
-import { ApiError, AuthError, CliError, ERROR_CODE } from "./errors.ts";
+import { ApiError, AuthError, CliError, ERROR_CODE, errorMessage } from "./errors.ts";
 import { log } from "./log.ts";
 import { refreshAccessToken, type TokenResponse } from "./token-exchange.ts";
 import { resolveCliVersion } from "./version.ts";
@@ -108,8 +108,8 @@ async function keyringStore(value: string): Promise<boolean> {
     const entry = new mod.Entry(service, account);
     entry.setPassword(value);
     return true;
-  } catch {
-    log.debug("credentials: failed to store session in keyring");
+  } catch (error) {
+    log.debug(`credentials: failed to store session in keyring: ${errorMessage(error)}`);
     return false;
   }
 }
@@ -128,8 +128,8 @@ async function keyringGet(): Promise<string | null> {
     const value = entry.getPassword();
     log.debug(`credentials: ${value ? "found session in keyring" : "no session in keyring"}`);
     return value;
-  } catch {
-    log.debug("credentials: keyring lookup failed");
+  } catch (error) {
+    log.debug(`credentials: keyring lookup failed: ${errorMessage(error)}`);
     return null;
   }
 }
@@ -203,8 +203,7 @@ function parseStoredSession(raw: string): OAuthSession | null {
   }
 }
 
-function encodeStoredValue(value: string | OAuthSession): string {
-  if (typeof value === "string") return value;
+function encodeStoredValue(value: OAuthSession): string {
   return JSON.stringify(value);
 }
 
@@ -269,16 +268,13 @@ async function refreshStoredSession(session: OAuthSession): Promise<string> {
     throw error;
   }
 
-  const nextSession = createOAuthSession(tokenResponse, session.refreshToken);
+  const nextSession = createOAuthSession(tokenResponse);
   await storeToken(nextSession);
   return nextSession.accessToken;
 }
 
-export function createOAuthSession(
-  tokenResponse: TokenResponse,
-  currentRefreshToken?: string,
-): OAuthSession {
-  const refreshToken = tokenResponse.refresh_token ?? currentRefreshToken;
+export function createOAuthSession(tokenResponse: TokenResponse): OAuthSession {
+  const refreshToken = tokenResponse.refresh_token;
   if (!refreshToken) {
     throw new CliError(
       "Authentication response did not include a refresh token. Run `clerk auth login` to re-authenticate",
@@ -296,7 +292,7 @@ export function createOAuthSession(
   };
 }
 
-export async function storeToken(value: string | OAuthSession): Promise<void> {
+export async function storeToken(value: OAuthSession): Promise<void> {
   const encoded = encodeStoredValue(value);
   const stored = await keyringStore(encoded);
   if (stored) {

--- a/packages/cli-core/src/lib/credential-store.ts
+++ b/packages/cli-core/src/lib/credential-store.ts
@@ -1,8 +1,8 @@
 /**
- * Credential store for persisting the OAuth access token.
+ * Credential store for persisting the OAuth session.
  * Uses platform keyring as primary (via @napi-rs/keyring), falls back to a plaintext file with chmod 600.
  *
- * Tokens are stored per-environment so switching environments preserves auth state.
+ * Sessions are stored per-environment so switching environments preserves auth state.
  * Keychain account: "oauth-access-token:<envName>"
  * File fallback: "credentials.<envName>"
  */
@@ -11,7 +11,9 @@ import { dirname } from "node:path";
 import { mkdir, chmod, writeFile, unlink } from "node:fs/promises";
 import { CREDENTIALS_FILE } from "./constants.ts";
 import { getCurrentEnvName } from "./environment.ts";
+import { ApiError, CliError, ERROR_CODE } from "./errors.ts";
 import { log } from "./log.ts";
+import { refreshAccessToken, type TokenResponse } from "./token-exchange.ts";
 import { resolveCliVersion } from "./version.ts";
 
 export const KEYCHAIN_SERVICE = "clerk-cli";
@@ -19,6 +21,14 @@ export const LOCAL_DEV_KEYCHAIN_SERVICE = "clerk-cli-dev";
 export const KEYCHAIN_ACCOUNT = "oauth-access-token";
 const RELEASE_MACOS_TEAM_ID = "L8SD6SB282";
 const RELEASE_MACOS_IDENTIFIER = "clerk";
+const JWT_EXPIRY_LEEWAY_MS = 30_000;
+
+export interface OAuthSession {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+  tokenType: string;
+}
 
 function keychainAccount(): string {
   const envName = getCurrentEnvName();
@@ -88,18 +98,18 @@ async function resolveKeychainService(): Promise<string> {
   return keychainServicePromise;
 }
 
-async function keyringStore(token: string): Promise<boolean> {
+async function keyringStore(value: string): Promise<boolean> {
   const mod = await getKeyring();
   if (!mod) return false;
   const service = await resolveKeychainService();
   const account = keychainAccount();
-  log.debug(`credentials: storing token in keyring (service=${service}, account=${account})`);
+  log.debug(`credentials: storing session in keyring (service=${service}, account=${account})`);
   try {
     const entry = new mod.Entry(service, account);
-    entry.setPassword(token);
+    entry.setPassword(value);
     return true;
   } catch {
-    log.debug("credentials: failed to store token in keyring");
+    log.debug("credentials: failed to store session in keyring");
     return false;
   }
 }
@@ -115,9 +125,9 @@ async function keyringGet(): Promise<string | null> {
   log.debug(`credentials: checking keyring (service=${service}, account=${account})`);
   try {
     const entry = new mod.Entry(service, account);
-    const token = entry.getPassword();
-    log.debug(`credentials: ${token ? "found token in keyring" : "no token in keyring"}`);
-    return token;
+    const value = entry.getPassword();
+    log.debug(`credentials: ${value ? "found session in keyring" : "no session in keyring"}`);
+    return value;
   } catch {
     log.debug("credentials: keyring lookup failed");
     return null;
@@ -129,7 +139,7 @@ async function keyringDelete(): Promise<boolean> {
   if (!mod) return false;
   const service = await resolveKeychainService();
   const account = keychainAccount();
-  log.debug(`credentials: deleting token from keyring (service=${service}, account=${account})`);
+  log.debug(`credentials: deleting session from keyring (service=${service}, account=${account})`);
   try {
     const entry = new mod.Entry(service, account);
     entry.deletePassword();
@@ -139,11 +149,11 @@ async function keyringDelete(): Promise<boolean> {
   }
 }
 
-async function fileStore(token: string): Promise<void> {
+async function fileStore(value: string): Promise<void> {
   const path = credentialsFile();
-  log.debug(`credentials: storing token in file ${path}`);
+  log.debug(`credentials: storing session in file ${path}`);
   await mkdir(dirname(path), { recursive: true, mode: 0o700 });
-  await writeFile(path, token, { mode: 0o600 });
+  await writeFile(path, value, { mode: 0o600 });
   // We keep the chmod because if the file permission had changed
   // `writeFile` wouldn't set it back to 0o600
   await chmod(path, 0o600);
@@ -157,10 +167,9 @@ async function fileGet(): Promise<string | null> {
     log.debug("credentials: credentials file not found");
     return null;
   }
-  const content = await file.text();
-  const token = content.trim() || null;
-  log.debug(`credentials: ${token ? "found token in file" : "credentials file is empty"}`);
-  return token;
+  const value = (await file.text()).trim() || null;
+  log.debug(`credentials: ${value ? "found session in file" : "credentials file is empty"}`);
+  return value;
 }
 
 async function fileDelete(): Promise<void> {
@@ -173,15 +182,125 @@ async function fileDelete(): Promise<void> {
   }
 }
 
-export async function storeToken(token: string): Promise<void> {
-  const stored = await keyringStore(token);
+function isOAuthSession(value: unknown): value is OAuthSession {
+  if (!value || typeof value !== "object") return false;
+
+  const session = value as Record<string, unknown>;
+  return (
+    typeof session.accessToken === "string" &&
+    typeof session.refreshToken === "string" &&
+    typeof session.expiresAt === "number" &&
+    typeof session.tokenType === "string"
+  );
+}
+
+function parseStoredSession(raw: string): OAuthSession | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return isOAuthSession(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function encodeStoredValue(value: string | OAuthSession): string {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value);
+}
+
+function getJwtExpiryMs(token: string): number | null {
+  const [, payload] = token.split(".");
+  if (!payload) return null;
+
+  try {
+    const normalized = payload.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+    const decoded = Buffer.from(padded, "base64").toString("utf8");
+    const parsed = JSON.parse(decoded) as Record<string, unknown>;
+    return typeof parsed.exp === "number" ? parsed.exp * 1000 : null;
+  } catch {
+    return null;
+  }
+}
+
+function isExpiredJwt(token: string): boolean {
+  const expiresAt = getJwtExpiryMs(token);
+  if (expiresAt === null) return true;
+  return expiresAt <= Date.now() + JWT_EXPIRY_LEEWAY_MS;
+}
+
+function sessionExpiredError(): CliError {
+  return new CliError("Session expired. Run `clerk auth login` to re-authenticate", {
+    code: ERROR_CODE.AUTH_REQUIRED,
+  });
+}
+
+function isInvalidGrant(error: unknown): boolean {
+  return (
+    error instanceof ApiError &&
+    (error.status === 400 || error.status === 401) &&
+    /\binvalid_grant\b/i.test(error.body)
+  );
+}
+
+async function readStoredValue(): Promise<string | null> {
+  if (tokenOverride !== undefined) return tokenOverride;
+
+  const value = await keyringGet();
+  if (value) return value;
+
+  return fileGet();
+}
+
+async function refreshStoredSession(session: OAuthSession): Promise<string> {
+  let tokenResponse: TokenResponse;
+  try {
+    tokenResponse = await refreshAccessToken(session.refreshToken);
+  } catch (error) {
+    if (isInvalidGrant(error)) {
+      await deleteToken();
+      throw sessionExpiredError();
+    }
+    throw error;
+  }
+
+  const nextSession = createOAuthSession(tokenResponse, session.refreshToken);
+  await storeToken(nextSession);
+  return nextSession.accessToken;
+}
+
+export function createOAuthSession(
+  tokenResponse: TokenResponse,
+  currentRefreshToken?: string,
+): OAuthSession {
+  const refreshToken = tokenResponse.refresh_token ?? currentRefreshToken;
+  if (!refreshToken) {
+    throw new CliError(
+      "Authentication response did not include a refresh token. Run `clerk auth login` to re-authenticate",
+      {
+        code: ERROR_CODE.AUTH_REQUIRED,
+      },
+    );
+  }
+
+  return {
+    accessToken: tokenResponse.access_token,
+    refreshToken,
+    expiresAt: Date.now() + tokenResponse.expires_in * 1000,
+    tokenType: tokenResponse.token_type,
+  };
+}
+
+export async function storeToken(value: string | OAuthSession): Promise<void> {
+  const encoded = encodeStoredValue(value);
+  const stored = await keyringStore(encoded);
   if (stored) {
     // Clean up any stale plaintext credentials from a previous file-based storage
     await fileDelete();
     return;
   }
 
-  await fileStore(token);
+  await fileStore(encoded);
 }
 
 let tokenOverride: string | null | undefined;
@@ -192,12 +311,35 @@ export function _setTokenOverride(value: string | null | undefined): void {
 }
 
 export async function getToken(): Promise<string | null> {
-  if (tokenOverride !== undefined) return tokenOverride;
+  const value = await readStoredValue();
+  if (!value) return null;
+  return parseStoredSession(value)?.accessToken ?? value;
+}
 
-  const token = await keyringGet();
-  if (token) return token;
+export async function getStoredSession(): Promise<OAuthSession | null> {
+  const value = await readStoredValue();
+  if (!value) return null;
+  return parseStoredSession(value);
+}
 
-  return fileGet();
+export async function hasStoredCredentials(): Promise<boolean> {
+  return (await readStoredValue()) !== null;
+}
+
+export async function getValidToken(): Promise<string | null> {
+  const session = await getStoredSession();
+  if (!session) {
+    if (await hasStoredCredentials()) {
+      throw sessionExpiredError();
+    }
+    return null;
+  }
+
+  if (!isExpiredJwt(session.accessToken)) {
+    return session.accessToken;
+  }
+
+  return refreshStoredSession(session);
 }
 
 export async function deleteToken(): Promise<void> {

--- a/packages/cli-core/src/lib/credential-store.ts
+++ b/packages/cli-core/src/lib/credential-store.ts
@@ -259,6 +259,7 @@ async function readStoredValue(): Promise<string | null> {
 async function refreshStoredSession(session: OAuthSession): Promise<string> {
   let tokenResponse: TokenResponse;
   try {
+    log.debug("credentials: refreshing OAuth session");
     tokenResponse = await refreshAccessToken(session.refreshToken);
   } catch (error) {
     if (isInvalidGrant(error)) {
@@ -270,6 +271,7 @@ async function refreshStoredSession(session: OAuthSession): Promise<string> {
 
   const nextSession = createOAuthSession(tokenResponse);
   await storeToken(nextSession);
+  log.debug("credentials: stored refreshed OAuth session");
   return nextSession.accessToken;
 }
 

--- a/packages/cli-core/src/lib/credential-store.ts
+++ b/packages/cli-core/src/lib/credential-store.ts
@@ -11,7 +11,7 @@ import { dirname } from "node:path";
 import { mkdir, chmod, writeFile, unlink } from "node:fs/promises";
 import { CREDENTIALS_FILE } from "./constants.ts";
 import { getCurrentEnvName } from "./environment.ts";
-import { ApiError, CliError, ERROR_CODE } from "./errors.ts";
+import { ApiError, AuthError, CliError, ERROR_CODE } from "./errors.ts";
 import { log } from "./log.ts";
 import { refreshAccessToken, type TokenResponse } from "./token-exchange.ts";
 import { resolveCliVersion } from "./version.ts";
@@ -229,10 +229,8 @@ function isExpiredJwt(token: string): boolean {
   return expiresAt <= Date.now() + JWT_EXPIRY_LEEWAY_MS;
 }
 
-function sessionExpiredError(): CliError {
-  return new CliError("Session expired. Run `clerk auth login` to re-authenticate", {
-    code: ERROR_CODE.AUTH_REQUIRED,
-  });
+function sessionExpiredError(): AuthError {
+  return new AuthError({ reason: "session_expired" });
 }
 
 function isInvalidGrant(error: unknown): boolean {

--- a/packages/cli-core/src/lib/errors.ts
+++ b/packages/cli-core/src/lib/errors.ts
@@ -46,6 +46,12 @@ export const ERROR_CODE = {
 } as const;
 
 export type ErrorCode = (typeof ERROR_CODE)[keyof typeof ERROR_CODE];
+export const AUTH_ERROR_REASON = {
+  NOT_LOGGED_IN: "not_logged_in",
+  SESSION_EXPIRED: "session_expired",
+} as const;
+
+export type AuthErrorReason = (typeof AUTH_ERROR_REASON)[keyof typeof AUTH_ERROR_REASON];
 
 interface CliErrorOptions {
   /** Machine-readable error code for programmatic consumption. */
@@ -54,6 +60,11 @@ interface CliErrorOptions {
   exitCode?: ExitCode;
   /** URL to relevant documentation, printed after the error message. */
   docsUrl?: string;
+}
+
+interface AuthErrorOptions extends Omit<CliErrorOptions, "code"> {
+  message?: string;
+  reason: AuthErrorReason;
 }
 
 /**
@@ -99,6 +110,27 @@ export class CliError extends Error {
         this.docsUrl += ".md";
       }
     }
+  }
+}
+
+const AUTH_ERROR_MESSAGE: Record<AuthErrorReason, string> = {
+  [AUTH_ERROR_REASON.NOT_LOGGED_IN]: "Not logged in. Run `clerk auth login` to authenticate",
+  [AUTH_ERROR_REASON.SESSION_EXPIRED]: "Session expired. Run `clerk auth login` to re-authenticate",
+};
+
+export class AuthError extends CliError {
+  declare code: typeof ERROR_CODE.AUTH_REQUIRED;
+  public reason: AuthErrorReason;
+
+  constructor(options: AuthErrorOptions) {
+    const { message, reason, ...rest } = options;
+    super(message ?? AUTH_ERROR_MESSAGE[reason], {
+      ...rest,
+      code: ERROR_CODE.AUTH_REQUIRED,
+    });
+    this.name = "AuthError";
+    this.code = ERROR_CODE.AUTH_REQUIRED;
+    this.reason = reason;
   }
 }
 
@@ -181,6 +213,13 @@ export class BapiError extends ApiError {
     super(status, body, headers);
     this.name = "BapiError";
   }
+}
+
+export function isAuthError(error: unknown): error is AuthError | ApiError {
+  return (
+    (error instanceof CliError && error.code === ERROR_CODE.AUTH_REQUIRED) ||
+    (error instanceof ApiError && (error.status === 401 || error.status === 403))
+  );
 }
 
 /**

--- a/packages/cli-core/src/lib/plapi.test.ts
+++ b/packages/cli-core/src/lib/plapi.test.ts
@@ -15,7 +15,7 @@ const {
   listApplications,
   createApplication,
 } = await import("./plapi.ts");
-const { PlapiError } = await import("./errors.ts");
+const { AuthError, PlapiError } = await import("./errors.ts");
 
 describe("plapi", () => {
   const originalEnv = { ...process.env };
@@ -35,6 +35,7 @@ describe("plapi", () => {
   test("throws when neither OAuth token nor env var is set", async () => {
     mockGetValidToken.mockResolvedValue(null);
     delete process.env.CLERK_PLATFORM_API_KEY;
+    await expect(fetchInstanceConfig("app_1", "ins_1")).rejects.toBeInstanceOf(AuthError);
     await expect(fetchInstanceConfig("app_1", "ins_1")).rejects.toThrow("Not authenticated");
   });
 

--- a/packages/cli-core/src/lib/plapi.test.ts
+++ b/packages/cli-core/src/lib/plapi.test.ts
@@ -1,10 +1,10 @@
 import { test, expect, describe, beforeEach, afterEach, mock } from "bun:test";
 import { credentialStoreStubs, stubFetch } from "../test/lib/stubs.ts";
 
-const mockGetToken = mock();
+const mockGetValidToken = mock();
 mock.module("./credential-store.ts", () => ({
   ...credentialStoreStubs,
-  getToken: (...args: unknown[]) => mockGetToken(...args),
+  getValidToken: (...args: unknown[]) => mockGetValidToken(...args),
 }));
 
 const {
@@ -22,24 +22,24 @@ describe("plapi", () => {
   const originalFetch = globalThis.fetch;
 
   beforeEach(() => {
-    mockGetToken.mockResolvedValue(null);
+    mockGetValidToken.mockResolvedValue(null);
     process.env.CLERK_PLATFORM_API_KEY = "test_key_123";
   });
 
   afterEach(() => {
     process.env = { ...originalEnv };
     globalThis.fetch = originalFetch;
-    mockGetToken.mockReset();
+    mockGetValidToken.mockReset();
   });
 
   test("throws when neither OAuth token nor env var is set", async () => {
-    mockGetToken.mockResolvedValue(null);
+    mockGetValidToken.mockResolvedValue(null);
     delete process.env.CLERK_PLATFORM_API_KEY;
     await expect(fetchInstanceConfig("app_1", "ins_1")).rejects.toThrow("Not authenticated");
   });
 
   test("prefers CLERK_PLATFORM_API_KEY over OAuth token", async () => {
-    mockGetToken.mockResolvedValue("oauth_token_abc");
+    mockGetValidToken.mockResolvedValue("oauth_token_abc");
     process.env.CLERK_PLATFORM_API_KEY = "env_key_xyz";
     let capturedHeaders: Headers | undefined;
     stubFetch(async (_input, init) => {
@@ -53,7 +53,7 @@ describe("plapi", () => {
 
   test("falls back to OAuth token when no CLERK_PLATFORM_API_KEY", async () => {
     delete process.env.CLERK_PLATFORM_API_KEY;
-    mockGetToken.mockResolvedValue("oauth_token_abc");
+    mockGetValidToken.mockResolvedValue("oauth_token_abc");
     let capturedHeaders: Headers | undefined;
     stubFetch(async (_input, init) => {
       capturedHeaders = new Headers(init?.headers);

--- a/packages/cli-core/src/lib/plapi.ts
+++ b/packages/cli-core/src/lib/plapi.ts
@@ -5,7 +5,7 @@
 
 import { getPlapiBaseUrl, getCurrentEnvName } from "./environment.ts";
 import { getValidToken } from "./credential-store.ts";
-import { CliError, PlapiError, ERROR_CODE } from "./errors.ts";
+import { AuthError, CliError, ERROR_CODE, PlapiError } from "./errors.ts";
 import { loggedFetch } from "./fetch.ts";
 import { log } from "./log.ts";
 
@@ -57,8 +57,9 @@ export async function getAuthToken(): Promise<string> {
     return oauthToken;
   }
 
-  throw new CliError("Not authenticated. Run `clerk auth login` or set CLERK_PLATFORM_API_KEY", {
-    code: ERROR_CODE.AUTH_REQUIRED,
+  throw new AuthError({
+    reason: "not_logged_in",
+    message: "Not authenticated. Run `clerk auth login` or set CLERK_PLATFORM_API_KEY",
     docsUrl: "https://clerk.com/docs/guides/development/clerk-environment-variables",
   });
 }

--- a/packages/cli-core/src/lib/plapi.ts
+++ b/packages/cli-core/src/lib/plapi.ts
@@ -4,7 +4,7 @@
  */
 
 import { getPlapiBaseUrl, getCurrentEnvName } from "./environment.ts";
-import { getToken } from "./credential-store.ts";
+import { getValidToken } from "./credential-store.ts";
 import { CliError, PlapiError, ERROR_CODE } from "./errors.ts";
 import { loggedFetch } from "./fetch.ts";
 import { log } from "./log.ts";
@@ -48,7 +48,8 @@ export async function getAuthToken(): Promise<string> {
     return key;
   }
 
-  const oauthToken = await getToken();
+  // Fall back to OAuth access token from `clerk auth login`
+  const oauthToken = await getValidToken();
   if (oauthToken) {
     log.debug(
       `plapi: using OAuth token from credential store for auth (env=${getCurrentEnvName()}, target=${getPlapiBaseUrl()})`,

--- a/packages/cli-core/src/lib/token-exchange.test.ts
+++ b/packages/cli-core/src/lib/token-exchange.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe, afterEach, mock } from "bun:test";
-import { exchangeCodeForToken, fetchUserInfo } from "./token-exchange.ts";
+import { exchangeCodeForToken, refreshAccessToken, fetchUserInfo } from "./token-exchange.ts";
 
 const originalFetch = globalThis.fetch;
 
@@ -134,5 +134,40 @@ describe("fetchUserInfo", () => {
     }) as unknown as typeof fetch;
 
     await expect(fetchUserInfo("bad")).rejects.toThrow("token_revoked");
+  });
+});
+
+describe("refreshAccessToken", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("sends correct parameters and returns token response", async () => {
+    const tokenResponse = {
+      access_token: "refreshed-token-123",
+      token_type: "Bearer",
+      expires_in: 3600,
+      refresh_token: "next-refresh-token",
+    };
+
+    globalThis.fetch = mock(async () => {
+      return new Response(JSON.stringify(tokenResponse), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const result = await refreshAccessToken("refresh-token-123");
+
+    expect(result).toEqual(tokenResponse);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+    const [, calledInit] = (globalThis.fetch as unknown as ReturnType<typeof mock>).mock.calls[0]!;
+    expect(calledInit.method).toBe("POST");
+    expect(calledInit.headers["Content-Type"]).toBe("application/x-www-form-urlencoded");
+
+    const body = new URLSearchParams(calledInit.body);
+    expect(body.get("grant_type")).toBe("refresh_token");
+    expect(body.get("refresh_token")).toBe("refresh-token-123");
   });
 });

--- a/packages/cli-core/src/lib/token-exchange.test.ts
+++ b/packages/cli-core/src/lib/token-exchange.test.ts
@@ -13,6 +13,7 @@ describe("exchangeCodeForToken", () => {
       access_token: "test-token-123",
       token_type: "Bearer",
       expires_in: 3600,
+      refresh_token: "refresh-token-123",
     };
 
     globalThis.fetch = mock(async () => {

--- a/packages/cli-core/src/lib/token-exchange.ts
+++ b/packages/cli-core/src/lib/token-exchange.ts
@@ -17,7 +17,7 @@ export interface TokenResponse {
   access_token: string;
   token_type: string;
   expires_in: number;
-  refresh_token?: string;
+  refresh_token: string;
 }
 
 export interface UserInfo {

--- a/packages/cli-core/src/lib/token-exchange.ts
+++ b/packages/cli-core/src/lib/token-exchange.ts
@@ -13,7 +13,7 @@ import { getOAuthConfig } from "./environment.ts";
 import { ApiError, withApiContext } from "./errors.ts";
 import { loggedFetch } from "./fetch.ts";
 
-interface TokenResponse {
+export interface TokenResponse {
   access_token: string;
   token_type: string;
   expires_in: number;
@@ -56,6 +56,34 @@ export async function exchangeCodeForToken(params: {
       return response.json() as Promise<TokenResponse>;
     })(),
     "Token exchange failed",
+  );
+}
+
+export async function refreshAccessToken(refreshToken: string): Promise<TokenResponse> {
+  const oauth = getOAuthConfig();
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    client_id: oauth.clientId,
+  });
+
+  return withApiContext(
+    (async () => {
+      const response = await loggedFetch(oauth.tokenUrl, {
+        tag: "oauth",
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: body.toString(),
+      });
+
+      if (!response.ok) {
+        const error = await response.text();
+        throw new ApiError(response.status, error);
+      }
+
+      return response.json() as Promise<TokenResponse>;
+    })(),
+    "Token refresh failed",
   );
 }
 

--- a/packages/cli-core/src/test/integration/lib/harness.ts
+++ b/packages/cli-core/src/test/integration/lib/harness.ts
@@ -45,12 +45,34 @@ mock.module(
   () =>
     ({
       getToken: async () => mockState.storedToken,
-      storeToken: async (token: string) => {
-        mockState.storedToken = token;
+      getValidToken: async () => mockState.storedToken,
+      getStoredSession: async () =>
+        mockState.storedToken
+          ? {
+              accessToken: mockState.storedToken,
+              refreshToken: "mock_refresh_token",
+              expiresAt: Date.now() + 3_600_000,
+              tokenType: "Bearer",
+            }
+          : null,
+      hasStoredCredentials: async () => mockState.storedToken !== null,
+      storeToken: async (value: string | { accessToken: string }) => {
+        mockState.storedToken = typeof value === "string" ? value : value.accessToken;
       },
       deleteToken: async () => {
         mockState.storedToken = null;
       },
+      createOAuthSession: (tokenResponse: {
+        access_token: string;
+        refresh_token?: string;
+        expires_in: number;
+        token_type: string;
+      }) => ({
+        accessToken: tokenResponse.access_token,
+        refreshToken: tokenResponse.refresh_token ?? "mock_refresh_token",
+        expiresAt: Date.now() + tokenResponse.expires_in * 1000,
+        tokenType: tokenResponse.token_type,
+      }),
       _setTokenOverride: () => {},
       KEYCHAIN_SERVICE: "clerk-cli",
       LOCAL_DEV_KEYCHAIN_SERVICE: "clerk-cli-dev",
@@ -195,6 +217,13 @@ mock.module(
         access_token: "mock_access_token",
         token_type: "Bearer",
         expires_in: 3600,
+        refresh_token: "mock_refresh_token",
+      }),
+      refreshAccessToken: async () => ({
+        access_token: "mock_access_token",
+        token_type: "Bearer",
+        expires_in: 3600,
+        refresh_token: "mock_refresh_token",
       }),
       fetchUserInfo: async (token: string) => {
         if (!token || token === "expired_token") throw new Error("Unauthorized");

--- a/packages/cli-core/src/test/integration/lib/harness.ts
+++ b/packages/cli-core/src/test/integration/lib/harness.ts
@@ -56,20 +56,20 @@ mock.module(
             }
           : null,
       hasStoredCredentials: async () => mockState.storedToken !== null,
-      storeToken: async (value: string | { accessToken: string }) => {
-        mockState.storedToken = typeof value === "string" ? value : value.accessToken;
+      storeToken: async (value: { accessToken: string }) => {
+        mockState.storedToken = value.accessToken;
       },
       deleteToken: async () => {
         mockState.storedToken = null;
       },
       createOAuthSession: (tokenResponse: {
         access_token: string;
-        refresh_token?: string;
+        refresh_token: string;
         expires_in: number;
         token_type: string;
       }) => ({
         accessToken: tokenResponse.access_token,
-        refreshToken: tokenResponse.refresh_token ?? "mock_refresh_token",
+        refreshToken: tokenResponse.refresh_token,
         expiresAt: Date.now() + tokenResponse.expires_in * 1000,
         tokenType: tokenResponse.token_type,
       }),

--- a/packages/cli-core/src/test/lib/stubs.ts
+++ b/packages/cli-core/src/test/lib/stubs.ts
@@ -61,8 +61,22 @@ export const autolinkStubs = {
 
 export const credentialStoreStubs = {
   getToken: async () => null,
+  getValidToken: async () => null,
+  getStoredSession: async () => null,
+  hasStoredCredentials: async () => false,
   storeToken: async () => {},
   deleteToken: async () => {},
+  createOAuthSession: (tokenResponse: {
+    access_token: string;
+    refresh_token?: string;
+    expires_in: number;
+    token_type: string;
+  }) => ({
+    accessToken: tokenResponse.access_token,
+    refreshToken: tokenResponse.refresh_token ?? "",
+    expiresAt: Date.now() + tokenResponse.expires_in * 1000,
+    tokenType: tokenResponse.token_type,
+  }),
 };
 
 export const gitStubs = {
@@ -85,6 +99,7 @@ export { listageStubs } from "./listage-stubs.ts";
 
 export const tokenExchangeStubs = {
   exchangeCodeForToken: async () => ({}),
+  refreshAccessToken: async () => ({}),
   fetchUserInfo: async () => ({}),
 };
 

--- a/packages/cli-core/src/test/lib/stubs.ts
+++ b/packages/cli-core/src/test/lib/stubs.ts
@@ -68,12 +68,12 @@ export const credentialStoreStubs = {
   deleteToken: async () => {},
   createOAuthSession: (tokenResponse: {
     access_token: string;
-    refresh_token?: string;
+    refresh_token: string;
     expires_in: number;
     token_type: string;
   }) => ({
     accessToken: tokenResponse.access_token,
-    refreshToken: tokenResponse.refresh_token ?? "",
+    refreshToken: tokenResponse.refresh_token,
     expiresAt: Date.now() + tokenResponse.expires_in * 1000,
     tokenType: tokenResponse.token_type,
   }),


### PR DESCRIPTION
## Summary

OAuth access tokens issued to the CLI are now short-lived JWTs. The credential store previously persisted only the raw access token, so once the token's `exp` passed every authenticated command failed with a 401 and forced the user back through `clerk auth login`. This change persists the full OAuth session, refreshes the access token transparently from the stored refresh token, and routes every auth failure through a single typed error so downstream code can react without string-matching.

## What changed

- **Credential store now holds a session, not a bare token.** `storeToken` accepts either a legacy access-token string or an `OAuthSession` (`accessToken`, `refreshToken`, `expiresAt`, `tokenType`) and persists it as JSON to the same keyring/file slot. `getToken()` stays backwards-compatible for readers that only want the string, so a session written by an older build is still readable.
- **New `getValidToken()`** decodes the access-token JWT `exp`, and if it is within a 30s leeway of expiry calls the OAuth token endpoint with the stored refresh token, writes the new session back, and returns the fresh access token. `invalid_grant` responses wipe the stored session and raise `AUTH_REQUIRED` so the user is told to re-login rather than hitting a silent 401 loop.
- **All authenticated call sites route through `getValidToken()`**: `login`, `whoami`, `plapi` requests, `init` heuristics, and every doctor check that needs a live session. Presence-only probes (is the user logged in at all?) use the new `hasStoredCredentials()` so we don't refresh as a side effect of non-auth flows.
- **Doctor validates the refresh path.** The auth-related checks now pull the session through `getValidToken()` so `clerk doctor` surfaces refresh failures (expired refresh token, server-side revoke) the same way it surfaces other auth breakage, instead of reporting a healthy session while the next real call 401s.
- **Centralized auth error handling.** New `AuthError` subclass of `CliError` carries a `reason` discriminator (`not_logged_in` / `session_expired`) with default per-reason messages, always codes to `AUTH_REQUIRED`, and replaces the hand-rolled `CliError` throws in `whoami`, `plapi.getAuthToken`, and `credential-store`. Doctor's token check now uses a new `isAuthError()` type guard covering both `AuthError` and `ApiError(401|403)` instead of regex-matching `(401|403)` substrings in error messages, so message-copy changes can't silently break the check.

## Test plan

- [x] `bun run format:check`, `bun run lint`, `bun run typecheck`, `bun run test`
- [x] Unit coverage for `getValidToken()`: valid JWT returns unchanged, near-expiry JWT triggers a refresh and rewrites the session, `invalid_grant` clears credentials and throws `AUTH_REQUIRED`.
- [x] Doctor test covers the refresh-failure path by injecting an `AuthError({ reason: "session_expired" })` into `getValidToken()` and asserting the check fails with the re-login remedy.
- [ ] Manual: log in, force the access token past `exp`, run `clerk whoami` and confirm a refresh request fires and the session is rewritten transparently.
- [ ] Manual: revoke the refresh token server-side, rerun a command, confirm the CLI reports session expired and clears the stored credentials.
- [ ] Full E2E CI run on the PR.
