### PR TITLE
fix(release): make snapshot commit ids semver-safe for bunx

### DIFF
--- a/scripts/lib/prerelease-version.test.ts
+++ b/scripts/lib/prerelease-version.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test";
+import { replaceChangesetsCommit, toSemverSafeCommitIdentifier } from "./prerelease-version.ts";
+
+test("preserves alphanumeric short shas", () => {
+  expect(toSemverSafeCommitIdentifier("bba6a98")).toBe("bba6a98");
+});
+
+test("prefixes numeric-only short shas", () => {
+  expect(toSemverSafeCommitIdentifier("0405146")).toBe("g0405146");
+});
+
+test("replaces full commit with semver-safe short sha", () => {
+  expect(
+    replaceChangesetsCommit("1.0.1-canary.0123456789abcdef0123456789abcdef01234567", "0405146"),
+  ).toBe("1.0.1-canary.g0405146");
+});

--- a/scripts/lib/prerelease-version.ts
+++ b/scripts/lib/prerelease-version.ts
@@ -1,0 +1,10 @@
+export function toSemverSafeCommitIdentifier(shortSha: string): string {
+  // Semver treats all-digit prerelease identifiers as numeric. Prefix those so
+  // npm and Bun both preserve the exact version string instead of normalizing
+  // or rejecting values like "0405146".
+  return /^\d+$/.test(shortSha) ? `g${shortSha}` : shortSha;
+}
+
+export function replaceChangesetsCommit(version: string, shortSha: string): string {
+  return version.replace(/\b[a-f0-9]{40}\b/, toSemverSafeCommitIdentifier(shortSha));
+}

--- a/scripts/snapshot.ts
+++ b/scripts/snapshot.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 import { isPublished } from "./lib/npm.ts";
+import { replaceChangesetsCommit } from "./lib/prerelease-version.ts";
 
 const CHANGESET_CONFIG = join(import.meta.dir, "../.changeset/config.json");
 const WRAPPER_PKG = join(import.meta.dir, "../packages/cli/package.json");
@@ -53,8 +54,9 @@ try {
   const pkg = await Bun.file(WRAPPER_PKG).json();
 
   // Changesets substitutes `{commit}` in `prereleaseTemplate` with the full
-  // 40-char SHA from `git rev-parse HEAD`. Rewrite it to the short SHA so the
-  // published version string stays readable (e.g. `0.8.6-snapshot.a1b2c3d`).
+  // 40-char SHA from `git rev-parse HEAD`. Rewrite it to a short, semver-safe
+  // identifier so published versions stay readable and package managers agree
+  // on the exact prerelease string.
   const shortShaResult = Bun.spawnSync(["git", "rev-parse", "--short", "HEAD"], {
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -65,7 +67,7 @@ try {
   }
   const shortSha = shortShaResult.stdout.toString().trim();
   const originalVersion: string = pkg.version;
-  const finalVersion = originalVersion.replace(/\b[a-f0-9]{40}\b/, shortSha);
+  const finalVersion = replaceChangesetsCommit(originalVersion, shortSha);
   if (finalVersion !== originalVersion) {
     pkg.version = finalVersion;
     await Bun.write(WRAPPER_PKG, JSON.stringify(pkg, null, 2) + "\n");


### PR DESCRIPTION
## Summary

- `bunx clerk@1.0.1-canary.405146 --version` on `darwin-arm64` fails with `Unsupported or missing platform: darwin-arm64` even though `@clerk/cli-darwin-arm64@1.0.1-canary.405146` is published.
- Root cause: `scripts/snapshot.ts` rewrites Changesets' full commit SHA to `git rev-parse --short HEAD`. When the short SHA is numeric-only (for example `04051468` -> `0405146`), the published snapshot/canary tarballs embed a prerelease identifier like `1.0.1-canary.0405146`.
- npm still installs that graph, but Bun installs only the wrapper package, so the shim cannot resolve the platform package and exits before the CLI starts.

## Fix

- Extract the commit-suffix rewrite into a small helper in `scripts/lib/prerelease-version.ts`.
- Prefix numeric-only short SHAs with `g` before writing snapshot/canary versions so the prerelease identifier stays semver-safe and package managers agree on the exact version string.
- Add a regression test that covers alphanumeric SHAs, numeric-only SHAs, and the full replacement path.

## Test plan

- [x] `bun test scripts/lib/prerelease-version.test.ts`
- [x] `bun run scripts/run-tests.ts --pattern 'scripts/**/*.test.ts' --filter prerelease-version --concurrency 1`
- [x] `bunx tsc --noEmit -p scripts/tsconfig.json`
- [x] Reproduced the original failure locally with `bunx clerk@1.0.1-canary.405146 --version` on `darwin-arm64`.
- [ ] Publish a fresh canary from a numeric-only short SHA and verify `bunx clerk@<canary> --version` installs the platform package and runs successfully.
