### PR TITLE
fix(auth): recover from concurrent session refreshes

### DIFF
--- a/.changeset/calm-snails-protect.md
+++ b/.changeset/calm-snails-protect.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Avoid deleting refreshed OAuth credentials when parallel CLI processes race to refresh the same expired session.

--- a/packages/cli-core/src/lib/credential-store.test.ts
+++ b/packages/cli-core/src/lib/credential-store.test.ts
@@ -112,6 +112,32 @@ describe("credential-store", () => {
     });
   });
 
+  test("getValidToken reuses a newer stored session after invalid_grant from another refresh", async () => {
+    const session = {
+      accessToken: "expired-access-token",
+      refreshToken: "refresh-token",
+      expiresAt: Date.now() - 60_000,
+      tokenType: "Bearer",
+    };
+    const refreshedSession = {
+      accessToken: "other-process-access-token",
+      refreshToken: "other-process-refresh-token",
+      expiresAt: Date.now() + 60_000,
+      tokenType: "Bearer",
+    };
+    await storeToken(session);
+
+    mockRefreshAccessToken.mockImplementation(async () => {
+      setTimeout(() => {
+        void storeToken(refreshedSession);
+      }, 5);
+      throw new ApiError(400, "invalid_grant");
+    });
+
+    expect(await getValidToken()).toBe("other-process-access-token");
+    expect(await getStoredSession()).toEqual(refreshedSession);
+  });
+
   test("getValidToken deletes stored credentials when refresh returns invalid_grant", async () => {
     const session = {
       accessToken: "expired-access-token",

--- a/packages/cli-core/src/lib/credential-store.test.ts
+++ b/packages/cli-core/src/lib/credential-store.test.ts
@@ -112,7 +112,7 @@ describe("credential-store", () => {
     });
   });
 
-  test("getValidToken reuses a newer stored session after invalid_grant from another refresh", async () => {
+  test("getValidToken recovers from a concurrent refresh race when another process completes the refresh first (invalid_grant)", async () => {
     const session = {
       accessToken: "expired-access-token",
       refreshToken: "refresh-token",

--- a/packages/cli-core/src/lib/credential-store.ts
+++ b/packages/cli-core/src/lib/credential-store.ts
@@ -294,15 +294,6 @@ function sessionExpiredError(): AuthError {
   return new AuthError({ reason: "session_expired" });
 }
 
-function sessionFingerprint(session: OAuthSession): string {
-  return JSON.stringify([
-    session.accessToken,
-    session.refreshToken,
-    session.expiresAt,
-    session.tokenType,
-  ]);
-}
-
 function isInvalidGrant(error: unknown): boolean {
   return (
     error instanceof ApiError &&
@@ -328,16 +319,29 @@ async function getValidAccessToken(session: OAuthSession): Promise<string> {
   return refreshStoredSession(session);
 }
 
-async function recoverFromInvalidGrant(session: OAuthSession): Promise<string | null> {
-  const originalFingerprint = sessionFingerprint(session);
-
+/**
+ * Detect whether a sibling process has already refreshed the OAuth session
+ * after our own refresh failed with `invalid_grant`. Polls the credential
+ * store on a short retry budget; returns the new access token if a different
+ * (non-expired) session appears, otherwise returns `null`.
+ *
+ * Race window: two CLI invocations whose stored session is expired will both
+ * try to redeem the same refresh token. The first wins and rotates; the
+ * second sees `invalid_grant`. We wait briefly for the winner's persisted
+ * session to become visible and reuse it instead of forcing a re-auth.
+ *
+ * Detection compares refresh tokens because the OAuth server rotates them on
+ * every successful exchange, so a different refresh token implies a new
+ * session was written by another process.
+ */
+async function awaitConcurrentRefresh(session: OAuthSession): Promise<string | null> {
   for (const delayMs of [0, ...INVALID_GRANT_RETRY_DELAYS_MS]) {
     if (delayMs > 0) {
       await sleep(delayMs);
     }
 
     const storedSession = await getStoredSession();
-    if (!storedSession || sessionFingerprint(storedSession) === originalFingerprint) {
+    if (!storedSession || storedSession.refreshToken === session.refreshToken) {
       continue;
     }
 
@@ -359,7 +363,7 @@ async function refreshStoredSession(session: OAuthSession): Promise<string> {
   } catch (error) {
     if (isInvalidGrant(error)) {
       try {
-        const recoveredToken = await recoverFromInvalidGrant(session);
+        const recoveredToken = await awaitConcurrentRefresh(session);
         if (recoveredToken) {
           return recoveredToken;
         }

--- a/packages/cli-core/src/lib/credential-store.ts
+++ b/packages/cli-core/src/lib/credential-store.ts
@@ -342,7 +342,10 @@ async function recoverFromInvalidGrant(session: OAuthSession): Promise<string | 
     }
 
     log.debug("credentials: detected a newer stored session after invalid_grant");
-    return getValidAccessToken(storedSession);
+    if (isExpiredSession(storedSession)) {
+      continue;
+    }
+    return storedSession.accessToken;
   }
 
   return null;
@@ -355,9 +358,13 @@ async function refreshStoredSession(session: OAuthSession): Promise<string> {
     tokenResponse = await refreshAccessToken(session.refreshToken);
   } catch (error) {
     if (isInvalidGrant(error)) {
-      const recoveredToken = await recoverFromInvalidGrant(session);
-      if (recoveredToken) {
-        return recoveredToken;
+      try {
+        const recoveredToken = await recoverFromInvalidGrant(session);
+        if (recoveredToken) {
+          return recoveredToken;
+        }
+      } catch {
+        log.debug("credentials: recovery from invalid_grant failed, cleaning up");
       }
       await deleteToken();
       throw sessionExpiredError();

--- a/packages/cli-core/src/lib/credential-store.ts
+++ b/packages/cli-core/src/lib/credential-store.ts
@@ -7,6 +7,7 @@
  * File fallback: "credentials.<envName>"
  */
 
+import { setTimeout as sleep } from "node:timers/promises";
 import { dirname, join } from "node:path";
 import { mkdir, chmod, writeFile, unlink } from "node:fs/promises";
 import { CREDENTIALS_FILE } from "./constants.ts";
@@ -27,6 +28,7 @@ export const KEYCHAIN_ACCOUNT = "oauth-access-token";
 const RELEASE_MACOS_TEAM_ID = "L8SD6SB282";
 const RELEASE_MACOS_IDENTIFIER = "clerk";
 const JWT_EXPIRY_LEEWAY_MS = 30_000;
+const INVALID_GRANT_RETRY_DELAYS_MS = [25, 50, 100];
 
 export interface OAuthSession {
   accessToken: string;
@@ -292,6 +294,15 @@ function sessionExpiredError(): AuthError {
   return new AuthError({ reason: "session_expired" });
 }
 
+function sessionFingerprint(session: OAuthSession): string {
+  return JSON.stringify([
+    session.accessToken,
+    session.refreshToken,
+    session.expiresAt,
+    session.tokenType,
+  ]);
+}
+
 function isInvalidGrant(error: unknown): boolean {
   return (
     error instanceof ApiError &&
@@ -309,6 +320,34 @@ async function readStoredValue(): Promise<string | null> {
   return fileGet();
 }
 
+async function getValidAccessToken(session: OAuthSession): Promise<string> {
+  if (!isExpiredSession(session)) {
+    return session.accessToken;
+  }
+
+  return refreshStoredSession(session);
+}
+
+async function recoverFromInvalidGrant(session: OAuthSession): Promise<string | null> {
+  const originalFingerprint = sessionFingerprint(session);
+
+  for (const delayMs of [0, ...INVALID_GRANT_RETRY_DELAYS_MS]) {
+    if (delayMs > 0) {
+      await sleep(delayMs);
+    }
+
+    const storedSession = await getStoredSession();
+    if (!storedSession || sessionFingerprint(storedSession) === originalFingerprint) {
+      continue;
+    }
+
+    log.debug("credentials: detected a newer stored session after invalid_grant");
+    return getValidAccessToken(storedSession);
+  }
+
+  return null;
+}
+
 async function refreshStoredSession(session: OAuthSession): Promise<string> {
   let tokenResponse: TokenResponse;
   try {
@@ -316,6 +355,10 @@ async function refreshStoredSession(session: OAuthSession): Promise<string> {
     tokenResponse = await refreshAccessToken(session.refreshToken);
   } catch (error) {
     if (isInvalidGrant(error)) {
+      const recoveredToken = await recoverFromInvalidGrant(session);
+      if (recoveredToken) {
+        return recoveredToken;
+      }
       await deleteToken();
       throw sessionExpiredError();
     }
@@ -391,11 +434,7 @@ export async function getValidToken(): Promise<string | null> {
     return null;
   }
 
-  if (!isExpiredSession(session)) {
-    return session.accessToken;
-  }
-
-  return refreshStoredSession(session);
+  return getValidAccessToken(session);
 }
 
 export async function deleteToken(): Promise<void> {


### PR DESCRIPTION
## Summary

Follow-up to #205. When two separate `clerk` processes start from the same expired OAuth session, they can both race into `refreshStoredSession()`. If one process refreshes successfully and rotates the refresh token, the loser sees `invalid_grant` and, in the current implementation, deletes the credentials that the winner just rewrote.

This PR keeps the existing refresh flow but hardens the `invalid_grant` path so a losing process re-reads the credential store before treating the session as dead. If another process already stored a newer session, the loser reuses that session instead of deleting credentials and forcing a re-auth.

## Fix

- Add a small recovery path for `invalid_grant` in `credential-store.ts`.
- Capture the failing session's refresh token, then re-read the store with a short retry window (`25ms`, `50ms`, `100ms`) before deleting anything. A different refresh token implies a sibling process already rotated the session.
- If a newer session appears during that window, treat it as the winner of the race and continue with its access token instead of clearing auth state.
- Keep the existing cleanup behavior for the real expired-session case where the store never changes.
- Add regression coverage for both paths and a patch changeset for the follow-up fix.

## Test plan

- [x] `bunx tsc -p packages/cli-core/tsconfig.json --noEmit`
- [x] `bun test packages/cli-core/src/lib/credential-store.test.ts`
- [x] `bun test packages/cli-core/src/lib/plapi.test.ts packages/cli-core/src/lib/token-exchange.test.ts packages/cli-core/src/commands/auth/login.test.ts packages/cli-core/src/commands/doctor/doctor.test.ts packages/cli-core/src/commands/whoami/index.test.ts`
- [x] Added a regression test that simulates another process winning the refresh race and verifies the loser reuses the newer stored session.