### PR TITLE
fix(release): await homebrew publish commands

### DIFF
--- a/.changeset/homebrew-await-commands.md
+++ b/.changeset/homebrew-await-commands.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Fix the stable release Homebrew publish step so it awaits each release upload and tap repository command before moving to the next step. This prevents the Homebrew workflow from racing past `gh release upload`, `git clone`, and the follow-up git operations while publishing a release.

--- a/scripts/homebrew.ts
+++ b/scripts/homebrew.ts
@@ -64,7 +64,7 @@ for (const target of HOMEBREW_TARGETS) {
     console.log(`[dry-run] Would upload ${basename(archivePath)} to ${tagName}`);
   } else {
     console.log(`Uploading ${basename(archivePath)} to ${tagName}...`);
-    run(["gh", "release", "upload", tagName, archivePath, "--clobber"]);
+    await run(["gh", "release", "upload", tagName, archivePath, "--clobber"]);
   }
 }
 
@@ -96,7 +96,7 @@ if (dryRun) {
 
   const tapWorkDir = join(workDir, "tap-workdir");
   console.log(`Cloning tap repo ${tapRepo}...`);
-  run(["git", "clone", `https://github.com/${tapRepo}.git`, tapWorkDir]);
+  await run(["git", "clone", `https://github.com/${tapRepo}.git`, tapWorkDir]);
   const setUrlResult = Bun.spawnSync(
     [
       "git",
@@ -121,9 +121,9 @@ if (dryRun) {
   await writeFile(versionedFormulaPath, versionedFormula, "utf-8");
   console.log(`Wrote versioned formula to ${versionedFormulaPath}`);
 
-  run(["git", "config", "user.name", "clerk-bot"], { cwd: tapWorkDir });
-  run(["git", "config", "user.email", "bot@clerk.com"], { cwd: tapWorkDir });
-  run(["git", "add", "Formula/clerk.rb", `Formula/clerk@${major}.rb`], { cwd: tapWorkDir });
+  await run(["git", "config", "user.name", "clerk-bot"], { cwd: tapWorkDir });
+  await run(["git", "config", "user.email", "bot@clerk.com"], { cwd: tapWorkDir });
+  await run(["git", "add", "Formula/clerk.rb", `Formula/clerk@${major}.rb`], { cwd: tapWorkDir });
 
   const diffResult = Bun.spawnSync(["git", "diff", "--cached", "--quiet"], {
     cwd: tapWorkDir,
@@ -134,8 +134,8 @@ if (dryRun) {
     console.log("No changes to formula, skipping commit and push.");
   } else {
     console.log(`Committing and pushing formula for clerk ${version}...`);
-    run(["git", "commit", "-m", `clerk ${version}`], { cwd: tapWorkDir });
-    run(["git", "push", "origin", "main"], { cwd: tapWorkDir });
+    await run(["git", "commit", "-m", `clerk ${version}`], { cwd: tapWorkDir });
+    await run(["git", "push", "origin", "main"], { cwd: tapWorkDir });
     console.log("Pushed formula to tap.");
   }
 }


### PR DESCRIPTION
## Summary

The stable release workflow's `homebrew` job did run in GitHub Actions run `#327`, but `scripts/homebrew.ts` was firing its async shell commands without awaiting them. That let the script race past `gh release upload`, `git clone`, and the later git operations, which made the job fail while publishing the Homebrew tap.

## Fix

- await each `run(...)` call in `scripts/homebrew.ts`
- serialize the GitHub Release uploads before computing checksums and updating the tap repo
- ensure the tap clone, git config, add, commit, and push steps finish before the script advances

## Test plan

- [x] `bun test scripts/lib/homebrew.test.ts`
- [x] `bunx tsc --noEmit -p scripts/tsconfig.json`
- [x] Verified the failing Actions log for run `24797651889` / job `72572381605` and confirmed the crash path was inside `scripts/homebrew.ts`
