### PR TITLE
fix(doctor): check config at the CLI's canonical path

### DIFF
--- a/.changeset/doctor-fixes.md
+++ b/.changeset/doctor-fixes.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Fix `clerk doctor` falsely reporting the CLI config file as missing. The check was looking at a legacy path (`~/.clerk/config.json`) instead of the platform-appropriate location used by the rest of the CLI.

--- a/packages/cli-core/src/commands/doctor/README.md
+++ b/packages/cli-core/src/commands/doctor/README.md
@@ -33,7 +33,7 @@ clerk doctor --fix       # Offer to auto-fix issues
 | Linked application    | Project        | Linked application ID is accessible via the API                    |
 | Instances             | Project        | Configured dev/prod instance IDs match the application's instances |
 | Environment variables | Environment    | .env.local or .env has Clerk keys                                  |
-| CLI configuration     | Configuration  | ~/.clerk/config.json exists and parses                             |
+| CLI configuration     | Configuration  | CLI config file exists and parses                                  |
 | Shell completion      | Configuration  | Shell autocompletion is installed for the detected shell           |
 
 ## Auto-Fix (`--fix`)

--- a/packages/cli-core/src/commands/doctor/checks.ts
+++ b/packages/cli-core/src/commands/doctor/checks.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { getConfigFile } from "../../lib/config.ts";
 import { fetchUserInfo } from "../../lib/token-exchange.ts";
 import { errorMessage, isAuthError, PlapiError } from "../../lib/errors.ts";
 import { detectPublishableKeyName, detectSecretKeyName } from "../../lib/framework.ts";
@@ -300,11 +301,6 @@ export async function checkConfigFile(ctx: DoctorContext): Promise<CheckResult> 
       remedy: `Check the JSON syntax in ${configFile}, or delete it and re-run \`clerk auth login\`.`,
     });
   }
-}
-
-function getConfigFile(): string {
-  const homeDir = process.env.CLERK_CONFIG_DIR ?? join(homedir(), ".clerk");
-  return join(homeDir, "config.json");
 }
 
 // ── CLI version check ─────────────────────────────────────────────────────────

--- a/packages/cli-core/src/commands/doctor/doctor.test.ts
+++ b/packages/cli-core/src/commands/doctor/doctor.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { ApiError, AuthError } from "../../lib/errors.ts";
+import { _setConfigDir } from "../../lib/config.ts";
 import { gitStubs, tokenExchangeStubs, stubFetch } from "../../test/lib/stubs.ts";
 import type { CheckResult, CheckStatus, DoctorContext, ResolvedProfile } from "./types.ts";
 import type { Application } from "../../lib/plapi.ts";
@@ -157,6 +158,7 @@ afterEach(async () => {
   process.cwd = originalCwd;
   process.env = { ...originalEnv };
   globalThis.fetch = originalFetch;
+  _setConfigDir(undefined);
   await rm(tempDir, { recursive: true, force: true });
 });
 
@@ -542,7 +544,7 @@ describe("checkEnvVars", () => {
 
 describe("checkConfigFile", () => {
   test("pass when config is valid", async () => {
-    process.env.CLERK_CONFIG_DIR = tempDir;
+    _setConfigDir(tempDir);
     await Bun.write(
       join(tempDir, "config.json"),
       JSON.stringify({ profiles: { "/a": {} }, auth: { userId: "u_1" } }),
@@ -557,7 +559,7 @@ describe("checkConfigFile", () => {
   });
 
   test("warn when config file does not exist", async () => {
-    process.env.CLERK_CONFIG_DIR = join(tempDir, "nonexistent");
+    _setConfigDir(join(tempDir, "nonexistent"));
     const ctx = createMockContext();
     const result = await checkConfigFile(ctx);
     expectCheck(result, {
@@ -569,7 +571,7 @@ describe("checkConfigFile", () => {
   });
 
   test("fail when config has invalid JSON", async () => {
-    process.env.CLERK_CONFIG_DIR = tempDir;
+    _setConfigDir(tempDir);
     await Bun.write(join(tempDir, "config.json"), "{ invalid json }");
     const ctx = createMockContext();
     const result = await checkConfigFile(ctx);

--- a/packages/cli-core/src/commands/env/README.md
+++ b/packages/cli-core/src/commands/env/README.md
@@ -31,7 +31,7 @@ sequenceDiagram
         CLI->>API: GET /v1/platform/applications/{appId}
         API-->>CLI: { instances }
     else Resolve project profile
-        CLI->>FS: Read ~/.clerk/config.json
+        CLI->>FS: Read CLI config file
         FS-->>CLI: { appId, instances }
     end
 

--- a/packages/cli-core/src/commands/switch-env/README.md
+++ b/packages/cli-core/src/commands/switch-env/README.md
@@ -24,7 +24,7 @@ clerk switch-env production
 - When called without an argument in interactive mode, shows an interactive picker listing available environments.
 - When called without an argument in non-interactive mode (agent, piped stdin), prints the current environment and available options.
 - Validates the environment name against the set of available profiles (injected at build time via `CLI_ENV_PROFILES`).
-- Persists the selection in `~/.clerk/config.json` under the `environment` key.
+- Persists the selection in the CLI config file under the `environment` key.
 - All subsequent commands use the selected environment's API endpoints and OAuth client.
 - If no auth token exists for the target environment, prints a reminder to run `clerk auth login`.
 

--- a/packages/cli-core/src/commands/switch-env/index.ts
+++ b/packages/cli-core/src/commands/switch-env/index.ts
@@ -1,7 +1,7 @@
 /**
  * Switch the active Clerk CLI environment (e.g. production, staging).
  *
- * Persists the choice in ~/.clerk/config.json so all subsequent commands
+ * Persists the choice in the CLI config file so all subsequent commands
  * use the selected environment's API endpoints and OAuth credentials.
  * Auth tokens are stored per-environment, so switching back does not
  * require re-authentication.

--- a/packages/cli-core/src/commands/unlink/README.md
+++ b/packages/cli-core/src/commands/unlink/README.md
@@ -20,7 +20,7 @@ clerk unlink --yes
 1. Resolves the current profile by checking the normalized remote URL, then git-common-dir, then walking up from the working directory
 2. If no profile is found, exits with an error
 3. Prompts for confirmation (unless `--yes` is passed)
-4. Removes the profile entry from `~/.clerk/config.json`
+4. Removes the profile entry from the CLI config file
 
 ## Agent Mode
 

--- a/packages/cli-core/src/lib/config.ts
+++ b/packages/cli-core/src/lib/config.ts
@@ -15,10 +15,10 @@ let overrideConfigFile: string | undefined;
 
 /** Test-only: override the config file path. Pass undefined to reset. */
 export function _setConfigDir(dir: string | undefined): void {
-  overrideConfigFile = dir ? `${dir}/config.json` : undefined;
+  overrideConfigFile = dir ? join(dir, "config.json") : undefined;
 }
 
-function configFile(): string {
+export function getConfigFile(): string {
   return overrideConfigFile ?? CONFIG_FILE;
 }
 
@@ -70,7 +70,7 @@ function migrateRawConfig(raw: Record<string, unknown>): ClerkConfig {
 }
 
 export async function readConfig(): Promise<ClerkConfig> {
-  const path = configFile();
+  const path = getConfigFile();
   log.debug(`config: reading ${path}`);
   const file = Bun.file(path);
   if (!(await file.exists())) return defaultConfig();
@@ -83,7 +83,7 @@ export async function readConfig(): Promise<ClerkConfig> {
 }
 
 export async function writeConfig(config: ClerkConfig): Promise<void> {
-  const path = configFile();
+  const path = getConfigFile();
   log.debug(`config: writing ${path}`);
   await mkdir(dirname(path), { recursive: true });
   await Bun.write(path, JSON.stringify(config, null, 2) + "\n");


### PR DESCRIPTION
## Summary

- `clerk doctor` was hardcoded to look for `~/.clerk/config.json`, but the CLI migrated to `env-paths` and now writes config to the platform-specific location (e.g. `~/Library/Preferences/clerk-cli/` on macOS). Signed-in, linked users saw a false "config does not exist" warning that pushed AI agents like codex into unnecessary re-auth loops ([slack context](https://clerk.slack.com/)).
- Export `getConfigFile()` from `lib/config.ts` as the single source of truth for the path. Use it in `checkConfigFile` (replacing a duplicated local implementation) and migrate the doctor test from mutating `CLERK_CONFIG_DIR` at call time to the canonical `_setConfigDir()` hook used by the rest of the codebase.
- Sweep stale `~/.clerk/config.json` references from four package READMEs and one doc comment — the path is now platform-specific and shouldn't be hardcoded in prose.

## Test plan

- [x] `bun run format` — clean
- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun run typecheck` — exit 0
- [x] `bun run test` — 79 passed / 0 failed
- [x] Manually verify on macOS: `rm -f ~/.clerk/config.json && clerk doctor` no longer warns about the missing legacy path for signed-in users