### PR TITLE
fix(link): pin "Create a new application" to the top of the picker

### DIFF
--- a/.changeset/link-cmd-reordering.md
+++ b/.changeset/link-cmd-reordering.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Move the "Create a new application" option to the top of the `clerk link` picker so it's visible without scrolling.

--- a/packages/cli-core/src/commands/link/README.md
+++ b/packages/cli-core/src/commands/link/README.md
@@ -42,7 +42,7 @@ deterministic paths:
    - If the user confirms (default), links to the detected app
    - If the user declines, falls through to the interactive picker
 8. If no match (or no apps exist), presents a searchable picker (type to filter by name)
-   - The picker always includes a "+ Create a new application" option pinned at the bottom
+   - The picker always includes a "+ Create a new application" option pinned at the top
    - Selecting it prompts for a name and creates the app via the Platform API
    - For non-interactive/CI/agent flows, create apps from the Clerk Dashboard or via the Platform API, then pass `--app <id>`
 9. Stores the profile in the config file keyed by the normalized remote URL

--- a/packages/cli-core/src/commands/link/index.test.ts
+++ b/packages/cli-core/src/commands/link/index.test.ts
@@ -469,9 +469,9 @@ describe("link", () => {
           source: (term: string | undefined) => { name: string; value: string }[];
         }) => {
           const results = config.source("my");
-          expect(results).toHaveLength(2); // 1 match + create option
-          expect(results[0]!.value).toBe("app_a");
-          expect(results[1]!.value).toBe("__create_new__");
+          expect(results).toHaveLength(2); // create option + 1 match
+          expect(results[0]!.value).toBe("__create_new__");
+          expect(results[1]!.value).toBe("app_a");
 
           const noMatch = config.source("zzz");
           expect(noMatch).toHaveLength(1); // only create option
@@ -508,9 +508,9 @@ describe("link", () => {
           source: (term: string | undefined) => { name: string; value: string }[];
         }) => {
           const results = config.source("abc");
-          expect(results).toHaveLength(2); // 1 match + create option
-          expect(results[0]!.value).toBe("app_abc");
-          expect(results[1]!.value).toBe("__create_new__");
+          expect(results).toHaveLength(2); // create option + 1 match
+          expect(results[0]!.value).toBe("__create_new__");
+          expect(results[1]!.value).toBe("app_abc");
           return "app_abc";
         },
       );

--- a/packages/cli-core/src/commands/link/index.ts
+++ b/packages/cli-core/src/commands/link/index.ts
@@ -227,7 +227,7 @@ async function pickOrCreateApp(apps: Application[], displayPath: string): Promis
       const filtered = term
         ? appChoices.filter((c) => c.name.toLowerCase().includes(term.toLowerCase()))
         : appChoices;
-      return [...filtered, createChoice];
+      return [createChoice, ...filtered];
     },
   });
 


### PR DESCRIPTION
## Summary
- Moves the `+ Create a new application` option to the top of the `clerk link` picker so it's visible without scrolling past the full app list.
- Updates the two tests that asserted index-based ordering and the `link/README.md` note that said the option was "pinned at the bottom".

## Test plan
- [x] `bun run format` / `lint` / `typecheck` / `test` all pass locally (79 files, 53 link tests)
- [x] Run `bun run packages/cli-core/src/cli.ts link` against an account with many apps and confirm the create option shows first both with an empty search and while filtering
- [x] Confirm `--app <id>`, autolink, and existing-profile flows are unaffected (they short-circuit before the picker)