### PR TITLE
fix: handle whitespace in GitHub API JSON when parsing tag_name

### DIFF
--- a/.changeset/fix-install-json-parsing.md
+++ b/.changeset/fix-install-json-parsing.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix curl install script failing with "no stable release found" due to whitespace in GitHub API JSON response

--- a/install.sh
+++ b/install.sh
@@ -209,7 +209,7 @@ else
 
     if [ -z "$TAG" ]; then
       TAG=$(curl -fsSL "${_AUTH[@]}" "https://api.github.com/repos/${REPO}/releases" \
-        | grep -o '"tag_name":"[^"]*canary[^"]*"' \
+        | grep -o '"tag_name": *"[^"]*canary[^"]*"' \
         | head -1 \
         | cut -d'"' -f4 || true)
     fi
@@ -220,7 +220,7 @@ else
     fi
   else
     TAG=$(curl -fsSL "${_AUTH[@]}" "https://api.github.com/repos/${REPO}/releases/latest" \
-      | grep -o '"tag_name":"[^"]*"' \
+      | grep -o '"tag_name": *"[^"]*"' \
       | cut -d'"' -f4 || true)
 
     if [ -z "$TAG" ]; then


### PR DESCRIPTION
The grep patterns assumed no space between JSON keys and values ("tag_name":"v1.0.2"), but the GitHub API returns a space after the colon ("tag_name": "v1.0.2"). This caused the curl install command to always fail with "no stable release found".