### PR TITLE
fix(agent): warn on sandboxed Clerk runs

### DIFF
--- a/.changeset/agent-sandbox-warning.md
+++ b/.changeset/agent-sandbox-warning.md
@@ -1,0 +1,15 @@
+---
+"clerk": patch
+---
+
+Improve Clerk CLI behavior for sandboxed agent runs.
+
+The CLI now warns once per invocation when host-only Clerk state or system
+capabilities are unavailable in agent mode, which helps distinguish real auth
+and linking failures from sandbox-induced ones. `clerk doctor` also includes a
+`Host execution` check in agent mode so the sandbox condition is visible in
+structured diagnostics.
+
+This release also updates the bundled Clerk skill docs to explain the warning,
+when to rerun commands on the host, and how sandboxed agent runs can misreport
+auth, linking, env, and API failures.

--- a/.changeset/clerk-skill-sandbox-guidance.md
+++ b/.changeset/clerk-skill-sandbox-guidance.md
@@ -1,5 +1,0 @@
----
-"clerk": patch
----
-
-Document the sandbox limitation in the bundled Clerk skill. AI coding agents that run CLI commands inside a sandbox see false "not signed in" / "no app linked" failures because the OS credential store, `~/.clerk`, linked project metadata, local `.env*` files, and outbound network are unavailable. The skill now tells agents to run Clerk CLI commands on the user's host shell and to discount sandbox-caused auth/linking/env/network failures.

--- a/.changeset/clerk-skill-sandbox-guidance.md
+++ b/.changeset/clerk-skill-sandbox-guidance.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Document the sandbox limitation in the bundled Clerk skill. AI coding agents that run CLI commands inside a sandbox see false "not signed in" / "no app linked" failures because the OS credential store, `~/.clerk`, linked project metadata, local `.env*` files, and outbound network are unavailable. The skill now tells agents to run Clerk CLI commands on the user's host shell and to discount sandbox-caused auth/linking/env/network failures.

--- a/packages/cli-core/src/commands/api/catalog.ts
+++ b/packages/cli-core/src/commands/api/catalog.ts
@@ -8,6 +8,7 @@ import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { CLERK_CACHE_DIR, CACHE_TTL_MS, OPENAPI_SPEC_URLS } from "../../lib/constants.ts";
 import { CliError, ERROR_CODE } from "../../lib/errors.ts";
+import { withHomeFsAccess, withNetworkAccess } from "../../lib/host-execution.ts";
 import { withSpinner } from "../../lib/spinner.ts";
 import { log } from "../../lib/log.ts";
 
@@ -54,19 +55,31 @@ function cacheFilePath(platform: boolean): string {
 // ── Cache I/O ──────────────────────────────────────────────────────────────
 
 async function readCache(platform: boolean): Promise<Catalog | null> {
-  try {
-    const file = Bun.file(cacheFilePath(platform));
-    if (!(await file.exists())) return null;
-    const data = await file.json();
-    return data as Catalog;
-  } catch {
-    return null;
-  }
+  const path = cacheFilePath(platform);
+  return withHomeFsAccess(
+    { operation: "read", target: path, label: "CLI cache directory" },
+    async () => {
+      try {
+        const file = Bun.file(path);
+        if (!(await file.exists())) return null;
+        const data = await file.json();
+        return data as Catalog;
+      } catch {
+        return null;
+      }
+    },
+  );
 }
 
 async function writeCache(platform: boolean, catalog: Catalog): Promise<void> {
-  await mkdir(cacheDir(), { recursive: true });
-  await Bun.write(cacheFilePath(platform), JSON.stringify(catalog));
+  const path = cacheFilePath(platform);
+  await withHomeFsAccess(
+    { operation: "write", target: path, label: "CLI cache directory" },
+    async () => {
+      await mkdir(cacheDir(), { recursive: true });
+      await Bun.write(path, JSON.stringify(catalog));
+    },
+  );
 }
 
 // ── Spec parsing ───────────────────────────────────────────────────────────
@@ -128,7 +141,10 @@ export async function loadCatalog(options: { platform?: boolean } = {}): Promise
   const url = platform ? OPENAPI_SPEC_URLS.platform : OPENAPI_SPEC_URLS.bapi;
   try {
     const catalog = await withSpinner("Fetching API catalog...", async () => {
-      const response = await fetch(url);
+      const response = await withNetworkAccess(
+        { operation: "connect", target: url, label: "api-catalog" },
+        async () => fetch(url),
+      );
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}`);
       }

--- a/packages/cli-core/src/commands/doctor/checks.ts
+++ b/packages/cli-core/src/commands/doctor/checks.ts
@@ -15,6 +15,8 @@ import {
   formatChannelFlag,
   formatChannelLabel,
 } from "../../lib/update-check.ts";
+import { formatHostStateProbeFailures, getAgentHostStateProbe } from "../../lib/host-execution.ts";
+import { isAgent } from "../../mode.ts";
 import type { CheckResult, DoctorContext, FixAction } from "./types.ts";
 
 interface CheckOptions {
@@ -73,6 +75,25 @@ export async function checkLoggedIn(ctx: DoctorContext): Promise<CheckResult> {
     });
   }
   return check.pass("Logged in (token found in credential store)");
+}
+
+export async function checkHostExecution(): Promise<CheckResult> {
+  const check = defineCheck("Host execution");
+  if (!isAgent()) {
+    return check.pass("Skipped (human mode)");
+  }
+
+  const probe = await getAgentHostStateProbe();
+  if (probe.ok) {
+    return check.pass("Host-only Clerk state is writable in agent mode");
+  }
+
+  return check.warn("Host-only Clerk state is not writable in agent mode", {
+    detail: formatHostStateProbeFailures(probe.failures),
+    remedy:
+      "This may be a sandboxed run. Re-run the command on the host shell before trusting auth, link, env, or API failures.",
+    fixable: false,
+  });
 }
 
 export async function checkTokenValid(ctx: DoctorContext): Promise<CheckResult> {

--- a/packages/cli-core/src/commands/doctor/doctor.test.ts
+++ b/packages/cli-core/src/commands/doctor/doctor.test.ts
@@ -10,6 +10,10 @@ import type { Application } from "../../lib/plapi.ts";
 
 let mockUserInfo: { userId: string; email: string } | null = null;
 let mockUserInfoError: Error | null = null;
+let mockHostStateProbe = {
+  ok: true,
+  failures: [] as Array<{ label: string; path: string; error: string }>,
+};
 
 mock.module("../../lib/token-exchange.ts", () => ({
   ...tokenExchangeStubs,
@@ -20,8 +24,14 @@ mock.module("../../lib/token-exchange.ts", () => ({
 }));
 
 mock.module("../../lib/git.ts", () => gitStubs);
+mock.module("../../lib/host-execution.ts", () => ({
+  getAgentHostStateProbe: async () => mockHostStateProbe,
+  formatHostStateProbeFailures: (failures: Array<{ label: string; path: string; error: string }>) =>
+    failures.map((failure) => `${failure.label}: ${failure.error} (${failure.path})`).join("\n"),
+}));
 
 const {
+  checkHostExecution,
   checkLoggedIn,
   checkTokenValid,
   checkProjectLinked,
@@ -150,6 +160,7 @@ beforeEach(async () => {
 
   mockUserInfo = null;
   mockUserInfoError = null;
+  mockHostStateProbe = { ok: true, failures: [] };
 
   stubFetch(async () => new Response(JSON.stringify(mockApplication), { status: 200 }));
 });
@@ -177,6 +188,54 @@ describe("checkLoggedIn", () => {
       status: "fail",
       remedy: "clerk auth login",
       fix: true,
+    });
+  });
+});
+
+describe("checkHostExecution", () => {
+  test("pass when not in agent mode", async () => {
+    process.env.CLERK_MODE = "human";
+    const result = await checkHostExecution();
+    expectCheck(result, {
+      name: "Host execution",
+      status: "pass",
+      message: "Skipped (human mode)",
+    });
+  });
+
+  test("pass when agent mode has writable host state", async () => {
+    process.env.CLERK_MODE = "agent";
+    mockHostStateProbe = { ok: true, failures: [] };
+
+    const result = await checkHostExecution();
+    expectCheck(result, {
+      name: "Host execution",
+      status: "pass",
+      message: "writable in agent mode",
+    });
+  });
+
+  test("warn when agent mode cannot write host state", async () => {
+    process.env.CLERK_MODE = "agent";
+    mockHostStateProbe = {
+      ok: false,
+      failures: [
+        {
+          label: "CLI config directory",
+          path: "/Users/test/Library/Preferences/clerk-cli/.clerk-write-probe-1",
+          error: "EPERM: operation not permitted",
+        },
+      ],
+    };
+
+    const result = await checkHostExecution();
+    expectCheck(result, {
+      name: "Host execution",
+      status: "warn",
+      message: "not writable in agent mode",
+      remedy: "Re-run the command on the host shell",
+      detail: "EPERM: operation not permitted",
+      fix: false,
     });
   });
 });

--- a/packages/cli-core/src/commands/doctor/index.ts
+++ b/packages/cli-core/src/commands/doctor/index.ts
@@ -1,4 +1,4 @@
-import { isHuman } from "../../mode.ts";
+import { isAgent, isHuman } from "../../mode.ts";
 import { bold, green, red } from "../../lib/color.ts";
 import { log } from "../../lib/log.ts";
 import { CliError, ERROR_CODE, errorMessage } from "../../lib/errors.ts";
@@ -6,6 +6,7 @@ import { intro, outro, bar, withSpinner } from "../../lib/spinner.ts";
 import { createDoctorContext } from "./context.ts";
 import {
   checkLoggedIn,
+  checkHostExecution,
   checkTokenValid,
   checkProjectLinked,
   checkLinkedAppExists,
@@ -18,7 +19,7 @@ import {
 import { formatCheckResult, formatJson } from "./format.ts";
 import type { CheckFn, CheckResult, DoctorContext, DoctorOptions } from "./types.ts";
 
-const CHECKS: CheckFn[] = [
+const BASE_CHECKS: CheckFn[] = [
   checkCliVersion,
   checkLoggedIn,
   checkTokenValid,
@@ -30,9 +31,13 @@ const CHECKS: CheckFn[] = [
   checkShellCompletion,
 ];
 
+function getChecks(): CheckFn[] {
+  return isAgent() ? [checkHostExecution, ...BASE_CHECKS] : BASE_CHECKS;
+}
+
 async function runChecks(ctx: DoctorContext): Promise<CheckResult[]> {
   return Promise.all(
-    CHECKS.map(async (check) => {
+    getChecks().map(async (check) => {
       try {
         return await check(ctx);
       } catch (error) {

--- a/packages/cli-core/src/lib/auth-server.test.ts
+++ b/packages/cli-core/src/lib/auth-server.test.ts
@@ -1,11 +1,32 @@
-import { test, expect, describe } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { startAuthServer } from "./auth-server.ts";
 
 describe("auth-server", () => {
+  let serveSpy: ReturnType<typeof spyOn> | undefined;
+  let clearTimeoutSpy: ReturnType<typeof spyOn> | undefined;
+
+  afterEach(() => {
+    serveSpy?.mockRestore();
+    clearTimeoutSpy?.mockRestore();
+    serveSpy = undefined;
+    clearTimeoutSpy = undefined;
+  });
+
   test("starts on a random port", () => {
     const server = startAuthServer("test-state");
     expect(server.port).toBeGreaterThan(0);
     server.stop();
+  });
+
+  test("clears the timeout when Bun.serve throws", () => {
+    serveSpy = spyOn(Bun, "serve").mockImplementation(() => {
+      throw new Error("listen failed");
+    });
+    clearTimeoutSpy = spyOn(globalThis, "clearTimeout");
+
+    expect(() => startAuthServer("test-state")).toThrow("listen failed");
+    expect(serveSpy).toHaveBeenCalled();
+    expect(clearTimeoutSpy).toHaveBeenCalled();
   });
 
   test("callback resolves with code on valid request", async () => {

--- a/packages/cli-core/src/lib/auth-server.ts
+++ b/packages/cli-core/src/lib/auth-server.ts
@@ -155,6 +155,7 @@ export function startAuthServer(expectedState: string): AuthServerResult {
       },
     });
   } catch (error) {
+    clearTimeout(timeout);
     observeHostCapabilityFailure("localhost-bind", error, {
       operation: "listen",
       target: "127.0.0.1:0",

--- a/packages/cli-core/src/lib/auth-server.ts
+++ b/packages/cli-core/src/lib/auth-server.ts
@@ -4,6 +4,7 @@
  */
 
 import { AUTH_TIMEOUT_MS, CALLBACK_PATH } from "./constants.ts";
+import { observeHostCapabilityFailure } from "./host-execution.ts";
 import { log } from "./log.ts";
 
 function escapeHtml(str: string): string {
@@ -79,6 +80,7 @@ interface AuthServerResult {
 export function startAuthServer(expectedState: string): AuthServerResult {
   let resolveCallback: (value: { code: string }) => void;
   let rejectCallback: (reason: Error) => void;
+  let server: ReturnType<typeof Bun.serve> | undefined;
 
   const callbackPromise = new Promise<{ code: string }>((resolve, reject) => {
     resolveCallback = resolve;
@@ -88,78 +90,88 @@ export function startAuthServer(expectedState: string): AuthServerResult {
   const timeout = setTimeout(() => {
     log.debug(`auth-server: timed out after ${AUTH_TIMEOUT_MS}ms`);
     rejectCallback(new Error("Authentication timed out. Please try again."));
-    server.stop();
+    server?.stop();
   }, AUTH_TIMEOUT_MS);
 
-  const server = Bun.serve({
-    hostname: "127.0.0.1",
-    port: 0,
-    routes: {
-      [CALLBACK_PATH]: {
-        GET: (req) => {
-          const url = new URL(req.url);
-          const code = url.searchParams.get("code");
-          const state = url.searchParams.get("state");
-          const error = url.searchParams.get("error");
+  try {
+    server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      routes: {
+        [CALLBACK_PATH]: {
+          GET: (req) => {
+            const url = new URL(req.url);
+            const code = url.searchParams.get("code");
+            const state = url.searchParams.get("state");
+            const error = url.searchParams.get("error");
 
-          if (error) {
-            const description = url.searchParams.get("error_description") || error;
-            log.debug(`auth-server: OAuth error in callback — ${error}: ${description}`);
-            rejectCallback(new Error(`OAuth error: ${description}`));
+            if (error) {
+              const description = url.searchParams.get("error_description") || error;
+              log.debug(`auth-server: OAuth error in callback — ${error}: ${description}`);
+              rejectCallback(new Error(`OAuth error: ${description}`));
+              clearTimeout(timeout);
+              setTimeout(() => server?.stop(), 100);
+              return new Response(ERROR_HTML(description), {
+                headers: { "Content-Type": "text/html" },
+              });
+            }
+
+            if (state !== expectedState) {
+              log.debug(`auth-server: state mismatch (expected=${expectedState}, got=${state})`);
+              rejectCallback(new Error("Invalid state parameter. Possible CSRF attack."));
+              clearTimeout(timeout);
+              setTimeout(() => server?.stop(), 100);
+              return new Response(ERROR_HTML("Invalid state parameter."), {
+                status: 400,
+                headers: { "Content-Type": "text/html" },
+              });
+            }
+
+            if (!code) {
+              log.debug("auth-server: callback received with no authorization code");
+              rejectCallback(new Error("No authorization code received."));
+              clearTimeout(timeout);
+              setTimeout(() => server?.stop(), 100);
+              return new Response(ERROR_HTML("No authorization code received."), {
+                status: 400,
+                headers: { "Content-Type": "text/html" },
+              });
+            }
+
+            log.debug("auth-server: callback received with valid code and state");
+            resolveCallback({ code });
             clearTimeout(timeout);
-            setTimeout(() => server.stop(), 100);
-            return new Response(ERROR_HTML(description), {
+            setTimeout(() => server?.stop(), 100);
+            return new Response(SUCCESS_HTML, {
               headers: { "Content-Type": "text/html" },
             });
-          }
-
-          if (state !== expectedState) {
-            log.debug(`auth-server: state mismatch (expected=${expectedState}, got=${state})`);
-            rejectCallback(new Error("Invalid state parameter. Possible CSRF attack."));
-            clearTimeout(timeout);
-            setTimeout(() => server.stop(), 100);
-            return new Response(ERROR_HTML("Invalid state parameter."), {
-              status: 400,
-              headers: { "Content-Type": "text/html" },
-            });
-          }
-
-          if (!code) {
-            log.debug("auth-server: callback received with no authorization code");
-            rejectCallback(new Error("No authorization code received."));
-            clearTimeout(timeout);
-            setTimeout(() => server.stop(), 100);
-            return new Response(ERROR_HTML("No authorization code received."), {
-              status: 400,
-              headers: { "Content-Type": "text/html" },
-            });
-          }
-
-          log.debug("auth-server: callback received with valid code and state");
-          resolveCallback({ code });
-          clearTimeout(timeout);
-          setTimeout(() => server.stop(), 100);
-          return new Response(SUCCESS_HTML, {
-            headers: { "Content-Type": "text/html" },
-          });
+          },
         },
       },
-    },
-    fetch() {
-      return new Response("Clerk CLI is waiting for authentication...", {
-        headers: { "Content-Type": "text/plain" },
-      });
-    },
-  });
+      fetch() {
+        return new Response("Clerk CLI is waiting for authentication...", {
+          headers: { "Content-Type": "text/plain" },
+        });
+      },
+    });
+  } catch (error) {
+    observeHostCapabilityFailure("localhost-bind", error, {
+      operation: "listen",
+      target: "127.0.0.1:0",
+      label: CALLBACK_PATH,
+    });
+    throw error;
+  }
 
-  log.debug(`auth-server: listening on 127.0.0.1:${server.port} for ${CALLBACK_PATH}`);
+  const activeServer = server;
+  log.debug(`auth-server: listening on 127.0.0.1:${activeServer.port} for ${CALLBACK_PATH}`);
 
   return {
-    port: server.port!,
+    port: activeServer.port!,
     waitForCallback: () => callbackPromise,
     stop: () => {
       clearTimeout(timeout);
-      server.stop();
+      activeServer.stop();
     },
   };
 }

--- a/packages/cli-core/src/lib/config.ts
+++ b/packages/cli-core/src/lib/config.ts
@@ -9,6 +9,7 @@ import { CONFIG_FILE } from "./constants.ts";
 import { getCurrentEnvName } from "./environment.ts";
 import { getGitRepoIdentifier, getGitNormalizedRemote } from "./git.ts";
 import { CliError, ERROR_CODE } from "./errors.ts";
+import { withHomeFsAccess } from "./host-execution.ts";
 import { log } from "./log.ts";
 
 let overrideConfigFile: string | undefined;
@@ -19,7 +20,10 @@ export function _setConfigDir(dir: string | undefined): void {
 }
 
 export function getConfigFile(): string {
-  return overrideConfigFile ?? CONFIG_FILE;
+  return (
+    overrideConfigFile ??
+    (process.env.CLERK_CONFIG_DIR ? join(process.env.CLERK_CONFIG_DIR, "config.json") : CONFIG_FILE)
+  );
 }
 
 interface Auth {
@@ -72,21 +76,31 @@ function migrateRawConfig(raw: Record<string, unknown>): ClerkConfig {
 export async function readConfig(): Promise<ClerkConfig> {
   const path = getConfigFile();
   log.debug(`config: reading ${path}`);
-  const file = Bun.file(path);
-  if (!(await file.exists())) return defaultConfig();
-  try {
-    const raw = (await file.json()) as Record<string, unknown>;
-    return migrateRawConfig(raw);
-  } catch {
-    return defaultConfig();
-  }
+  return withHomeFsAccess(
+    { operation: "read", target: path, label: "CLI config directory" },
+    async () => {
+      const file = Bun.file(path);
+      if (!(await file.exists())) return defaultConfig();
+      try {
+        const raw = (await file.json()) as Record<string, unknown>;
+        return migrateRawConfig(raw);
+      } catch {
+        return defaultConfig();
+      }
+    },
+  );
 }
 
 export async function writeConfig(config: ClerkConfig): Promise<void> {
   const path = getConfigFile();
   log.debug(`config: writing ${path}`);
-  await mkdir(dirname(path), { recursive: true });
-  await Bun.write(path, JSON.stringify(config, null, 2) + "\n");
+  await withHomeFsAccess(
+    { operation: "write", target: path, label: "CLI config directory" },
+    async () => {
+      await mkdir(dirname(path), { recursive: true });
+      await Bun.write(path, JSON.stringify(config, null, 2) + "\n");
+    },
+  );
 }
 
 export async function getAuth(): Promise<Auth | undefined> {

--- a/packages/cli-core/src/lib/credential-store.ts
+++ b/packages/cli-core/src/lib/credential-store.ts
@@ -7,11 +7,16 @@
  * File fallback: "credentials.<envName>"
  */
 
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
 import { mkdir, chmod, writeFile, unlink } from "node:fs/promises";
 import { CREDENTIALS_FILE } from "./constants.ts";
 import { getCurrentEnvName } from "./environment.ts";
 import { ApiError, AuthError, CliError, ERROR_CODE, errorMessage } from "./errors.ts";
+import {
+  observeHostCapabilityFailure,
+  withHomeFsAccess,
+  withKeychainAccess,
+} from "./host-execution.ts";
 import { log } from "./log.ts";
 import { refreshAccessToken, type TokenResponse } from "./token-exchange.ts";
 import { resolveCliVersion } from "./version.ts";
@@ -37,9 +42,12 @@ function keychainAccount(): string {
 }
 
 function credentialsFile(): string {
+  const basePath = process.env.CLERK_CONFIG_DIR
+    ? join(process.env.CLERK_CONFIG_DIR, "credentials")
+    : CREDENTIALS_FILE;
   const envName = getCurrentEnvName();
-  if (envName === "production") return CREDENTIALS_FILE;
-  return `${CREDENTIALS_FILE}.${envName}`;
+  if (envName === "production") return basePath;
+  return `${basePath}.${envName}`;
 }
 
 let keyringModule: typeof import("@napi-rs/keyring") | null | undefined;
@@ -104,14 +112,24 @@ async function keyringStore(value: string): Promise<boolean> {
   const service = await resolveKeychainService();
   const account = keychainAccount();
   log.debug(`credentials: storing session in keyring (service=${service}, account=${account})`);
-  try {
-    const entry = new mod.Entry(service, account);
-    entry.setPassword(value);
-    return true;
-  } catch (error) {
-    log.debug(`credentials: failed to store session in keyring: ${errorMessage(error)}`);
-    return false;
-  }
+  return withKeychainAccess(
+    { operation: "write", target: `${service}/${account}`, label: "credential keychain entry" },
+    async () => {
+      try {
+        const entry = new mod.Entry(service, account);
+        entry.setPassword(value);
+        return true;
+      } catch (error) {
+        observeHostCapabilityFailure("keychain", error, {
+          operation: "write",
+          target: `${service}/${account}`,
+          label: "credential keychain entry",
+        });
+        log.debug(`credentials: failed to store session in keyring: ${errorMessage(error)}`);
+        return false;
+      }
+    },
+  );
 }
 
 async function keyringGet(): Promise<string | null> {
@@ -123,15 +141,25 @@ async function keyringGet(): Promise<string | null> {
   const service = await resolveKeychainService();
   const account = keychainAccount();
   log.debug(`credentials: checking keyring (service=${service}, account=${account})`);
-  try {
-    const entry = new mod.Entry(service, account);
-    const value = entry.getPassword();
-    log.debug(`credentials: ${value ? "found session in keyring" : "no session in keyring"}`);
-    return value;
-  } catch (error) {
-    log.debug(`credentials: keyring lookup failed: ${errorMessage(error)}`);
-    return null;
-  }
+  return withKeychainAccess(
+    { operation: "read", target: `${service}/${account}`, label: "credential keychain entry" },
+    async () => {
+      try {
+        const entry = new mod.Entry(service, account);
+        const value = entry.getPassword();
+        log.debug(`credentials: ${value ? "found session in keyring" : "no session in keyring"}`);
+        return value;
+      } catch (error) {
+        observeHostCapabilityFailure("keychain", error, {
+          operation: "read",
+          target: `${service}/${account}`,
+          label: "credential keychain entry",
+        });
+        log.debug(`credentials: keyring lookup failed: ${errorMessage(error)}`);
+        return null;
+      }
+    },
+  );
 }
 
 async function keyringDelete(): Promise<boolean> {
@@ -140,46 +168,71 @@ async function keyringDelete(): Promise<boolean> {
   const service = await resolveKeychainService();
   const account = keychainAccount();
   log.debug(`credentials: deleting session from keyring (service=${service}, account=${account})`);
-  try {
-    const entry = new mod.Entry(service, account);
-    entry.deletePassword();
-    return true;
-  } catch {
-    return false;
-  }
+  return withKeychainAccess(
+    { operation: "delete", target: `${service}/${account}`, label: "credential keychain entry" },
+    async () => {
+      try {
+        const entry = new mod.Entry(service, account);
+        entry.deletePassword();
+        return true;
+      } catch (error) {
+        observeHostCapabilityFailure("keychain", error, {
+          operation: "delete",
+          target: `${service}/${account}`,
+          label: "credential keychain entry",
+        });
+        return false;
+      }
+    },
+  );
 }
 
 async function fileStore(value: string): Promise<void> {
   const path = credentialsFile();
   log.debug(`credentials: storing session in file ${path}`);
-  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
-  await writeFile(path, value, { mode: 0o600 });
-  // We keep the chmod because if the file permission had changed
-  // `writeFile` wouldn't set it back to 0o600
-  await chmod(path, 0o600);
+  await withHomeFsAccess(
+    { operation: "write", target: path, label: "credential fallback directory" },
+    async () => {
+      await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+      await writeFile(path, value, { mode: 0o600 });
+      // We keep the chmod because if the file permission had changed
+      // `writeFile` wouldn't set it back to 0o600
+      await chmod(path, 0o600);
+    },
+  );
 }
 
 async function fileGet(): Promise<string | null> {
   const path = credentialsFile();
   log.debug(`credentials: checking file ${path}`);
-  const file = Bun.file(path);
-  if (!(await file.exists())) {
-    log.debug("credentials: credentials file not found");
-    return null;
-  }
-  const value = (await file.text()).trim() || null;
-  log.debug(`credentials: ${value ? "found session in file" : "credentials file is empty"}`);
-  return value;
+  return withHomeFsAccess(
+    { operation: "read", target: path, label: "credential fallback directory" },
+    async () => {
+      const file = Bun.file(path);
+      if (!(await file.exists())) {
+        log.debug("credentials: credentials file not found");
+        return null;
+      }
+      const value = (await file.text()).trim() || null;
+      log.debug(`credentials: ${value ? "found session in file" : "credentials file is empty"}`);
+      return value;
+    },
+  );
 }
 
 async function fileDelete(): Promise<void> {
   const path = credentialsFile();
-  try {
-    log.debug(`credentials: deleting credentials file ${path}`);
-    await unlink(path);
-  } catch {
-    // File doesn't exist, nothing to delete
-  }
+  await withHomeFsAccess(
+    { operation: "delete", target: path, label: "credential fallback directory" },
+    async () => {
+      try {
+        log.debug(`credentials: deleting credentials file ${path}`);
+        await unlink(path);
+      } catch {
+        // File doesn't exist, nothing to delete
+      }
+    },
+  );
 }
 
 function isOAuthSession(value: unknown): value is OAuthSession {

--- a/packages/cli-core/src/lib/fetch.ts
+++ b/packages/cli-core/src/lib/fetch.ts
@@ -9,6 +9,7 @@
  */
 
 import { log } from "./log.ts";
+import { withNetworkAccess } from "./host-execution.ts";
 
 export type LoggedFetchInit = RequestInit & { tag: string };
 
@@ -17,7 +18,10 @@ export async function loggedFetch(url: URL | string, options: LoggedFetchInit): 
   const method = init.method ?? "GET";
   const urlStr = url.toString();
   log.debug(`${tag}: ${method} ${urlStr}`);
-  const response = await fetch(url, init);
+  const response = await withNetworkAccess(
+    { operation: "connect", target: urlStr, label: tag },
+    async () => fetch(url, init),
+  );
   if (!response.ok) {
     // Clone so the caller can still consume the body for error construction.
     const body = await response.clone().text();

--- a/packages/cli-core/src/lib/host-execution.ts
+++ b/packages/cli-core/src/lib/host-execution.ts
@@ -1,0 +1,232 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, unlink, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { isAgent } from "../mode.ts";
+import { CONFIG_FILE, CREDENTIALS_FILE } from "./constants.ts";
+import { errorMessage } from "./errors.ts";
+import { log } from "./log.ts";
+
+export type HostCapability =
+  | "home-fs"
+  | "keychain"
+  | "network"
+  | "browser-launch"
+  | "localhost-bind";
+
+export type HostOperation = "read" | "write" | "delete" | "connect" | "open" | "listen";
+
+export interface HostCapabilityDetails {
+  operation?: HostOperation;
+  target?: string;
+  label?: string;
+}
+
+export interface HostStateProbeFailure {
+  label: string;
+  path: string;
+  error: string;
+}
+
+export interface HostStateProbeResult {
+  ok: boolean;
+  failures: HostStateProbeFailure[];
+}
+
+let cachedAgentHostStateProbe: Promise<HostStateProbeResult> | undefined;
+let warnedAboutSandbox = false;
+
+function getProbeTargets(): Array<{ label: string; dir: string }> {
+  const clerkConfigDir = process.env.CLERK_CONFIG_DIR;
+  const configFile = clerkConfigDir ? join(clerkConfigDir, "config.json") : CONFIG_FILE;
+  const credentialsFile = clerkConfigDir ? join(clerkConfigDir, "credentials") : CREDENTIALS_FILE;
+
+  return [
+    { label: "CLI config directory", dir: dirname(configFile) },
+    { label: "credential fallback directory", dir: dirname(credentialsFile) },
+  ];
+}
+
+async function probeDirectoryWrite(
+  label: string,
+  dir: string,
+): Promise<HostStateProbeFailure | null> {
+  const probePath = join(dir, `.clerk-write-probe-${process.pid}-${randomUUID()}`);
+
+  try {
+    await mkdir(dir, { recursive: true });
+    await writeFile(probePath, `${new Date().toISOString()}\n`);
+    await unlink(probePath);
+    return null;
+  } catch (error) {
+    return {
+      label,
+      path: probePath,
+      error: errorMessage(error),
+    };
+  }
+}
+
+async function probeHomeFsAccess(details: HostCapabilityDetails): Promise<HostStateProbeResult> {
+  const target = details.target;
+  if (!target) {
+    return { ok: true, failures: [] };
+  }
+
+  const failure = await probeDirectoryWrite(details.label ?? "host directory", dirname(target));
+  return { ok: failure === null, failures: failure ? [failure] : [] };
+}
+
+function formatCapabilityContext(
+  capability: HostCapability,
+  details: HostCapabilityDetails,
+  error?: unknown,
+): string {
+  const parts = [`capability=${capability}`];
+  if (details.operation) parts.push(`operation=${details.operation}`);
+  if (details.target) parts.push(`target=${details.target}`);
+  if (error !== undefined) parts.push(`error=${errorMessage(error)}`);
+  return parts.join(", ");
+}
+
+function warnAboutSandbox(detail?: string): void {
+  if (warnedAboutSandbox) return;
+  warnedAboutSandbox = true;
+
+  log.warn(
+    "Host-only Clerk state or system capabilities may be unavailable in agent mode. This may be a sandboxed run.",
+  );
+  log.warn(
+    "Re-run this command on the host shell before trusting auth, link, env, or API failures.",
+  );
+
+  if (detail) {
+    log.debug(detail);
+  }
+}
+
+function isPermissionLikeFailure(error: unknown): boolean {
+  const message = errorMessage(error);
+  return [
+    /\bEPERM\b/i,
+    /\bEACCES\b/i,
+    /operation not permitted/i,
+    /permission denied/i,
+    /sandbox/i,
+    /interaction is not allowed/i,
+    /access denied/i,
+  ].some((pattern) => pattern.test(message));
+}
+
+function isLikelySandboxFailure(capability: HostCapability, error: unknown): boolean {
+  if (
+    capability === "network" ||
+    capability === "browser-launch" ||
+    capability === "localhost-bind"
+  ) {
+    return true;
+  }
+
+  return isPermissionLikeFailure(error);
+}
+
+async function maybeWarnForCapability(
+  capability: HostCapability,
+  details: HostCapabilityDetails,
+): Promise<void> {
+  if (!isAgent() || warnedAboutSandbox) return;
+  if (capability !== "home-fs") return;
+
+  const probe = await probeHomeFsAccess(details);
+  if (!probe.ok) {
+    warnAboutSandbox(`sandbox probe failures:\n${formatHostStateProbeFailures(probe.failures)}`);
+  }
+}
+
+export async function withHostCapability<T>(
+  capability: HostCapability,
+  details: HostCapabilityDetails,
+  fn: () => Promise<T>,
+): Promise<T> {
+  await maybeWarnForCapability(capability, details);
+
+  try {
+    return await fn();
+  } catch (error) {
+    observeHostCapabilityFailure(capability, error, details);
+    throw error;
+  }
+}
+
+export async function withHomeFsAccess<T>(
+  details: HostCapabilityDetails,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return withHostCapability("home-fs", details, fn);
+}
+
+export async function withKeychainAccess<T>(
+  details: HostCapabilityDetails,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return withHostCapability("keychain", details, fn);
+}
+
+export async function withNetworkAccess<T>(
+  details: HostCapabilityDetails,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return withHostCapability("network", details, fn);
+}
+
+export async function withBrowserLaunch<T>(
+  details: HostCapabilityDetails,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return withHostCapability("browser-launch", details, fn);
+}
+
+export function observeHostCapabilityFailure(
+  capability: HostCapability,
+  error: unknown,
+  details: HostCapabilityDetails = {},
+): void {
+  if (!isAgent() || warnedAboutSandbox) return;
+  if (!isLikelySandboxFailure(capability, error)) return;
+
+  warnAboutSandbox(
+    `sandbox capability failure: ${formatCapabilityContext(capability, details, error)}`,
+  );
+}
+
+export async function probeHostStateAccess(): Promise<HostStateProbeResult> {
+  const failures = (
+    await Promise.all(
+      getProbeTargets().map((target) => probeDirectoryWrite(target.label, target.dir)),
+    )
+  ).filter((failure): failure is HostStateProbeFailure => failure !== null);
+
+  return { ok: failures.length === 0, failures };
+}
+
+export async function getAgentHostStateProbe(): Promise<HostStateProbeResult> {
+  if (!isAgent()) {
+    return { ok: true, failures: [] };
+  }
+
+  if (!cachedAgentHostStateProbe) {
+    cachedAgentHostStateProbe = probeHostStateAccess();
+  }
+
+  return cachedAgentHostStateProbe;
+}
+
+export function formatHostStateProbeFailures(failures: HostStateProbeFailure[]): string {
+  return failures
+    .map((failure) => `${failure.label}: ${failure.error} (${failure.path})`)
+    .join("\n");
+}
+
+export function _resetAgentHostStateProbe(): void {
+  cachedAgentHostStateProbe = undefined;
+  warnedAboutSandbox = false;
+}

--- a/packages/cli-core/src/lib/open.ts
+++ b/packages/cli-core/src/lib/open.ts
@@ -21,6 +21,8 @@
  * cannot complete without the user reaching the URL.
  */
 
+import { observeHostCapabilityFailure, withBrowserLaunch } from "./host-execution.ts";
+
 /** Outcome of an `openBrowser` call. */
 export type OpenResult =
   | { ok: true; launcher: string }
@@ -82,43 +84,55 @@ export async function openBrowser(url: string): Promise<OpenResult> {
   const command = launcher === "start" ? ["cmd.exe", "/c", "start", "", url] : [launcher, url];
 
   try {
-    const proc = Bun.spawn(command, {
-      // Detach so the parent process (clerk CLI) can exit without waiting
-      // for the browser to close.
-      stdout: "ignore",
-      stderr: "ignore",
-      stdin: "ignore",
-    });
+    const result = await withBrowserLaunch(
+      { operation: "open", target: url, label: launcher },
+      async () => {
+        const proc = Bun.spawn(command, {
+          // Detach so the parent process (clerk CLI) can exit without waiting
+          // for the browser to close.
+          stdout: "ignore",
+          stderr: "ignore",
+          stdin: "ignore",
+        });
 
-    // Race the launcher's exit against a short grace period. Real launchers
-    // (open, xdg-open, wslview, cmd start) hand off to the OS and exit within
-    // a few ms, so the common case is either:
-    //   - exit code 0 before the timer fires -> clear success
-    //   - still running after 150ms -> effectively success, fire-and-forget
-    // The case we care about catching is a fast non-zero exit, which happens
-    // in headless/misconfigured environments (e.g. xdg-open with no DISPLAY).
-    // Without this we'd return ok:true and the caller would skip printing the
-    // fallback URL, leaving auth login to hang on the OAuth callback.
-    const GRACE_MS = 150;
-    const outcome = await Promise.race([
-      proc.exited.then(
-        (code) => ({ kind: "exited" as const, code }),
-        () => ({ kind: "failed" as const }),
-      ),
-      new Promise<{ kind: "running" }>((resolve) =>
-        setTimeout(() => resolve({ kind: "running" }), GRACE_MS),
-      ),
-    ]);
+        // Race the launcher's exit against a short grace period. Real launchers
+        // (open, xdg-open, wslview, cmd start) hand off to the OS and exit within
+        // a few ms, so the common case is either:
+        //   - exit code 0 before the timer fires -> clear success
+        //   - still running after 150ms -> effectively success, fire-and-forget
+        // The case we care about catching is a fast non-zero exit, which happens
+        // in headless/misconfigured environments (e.g. xdg-open with no DISPLAY).
+        // Without this we'd return ok:true and the caller would skip printing the
+        // fallback URL, leaving auth login to hang on the OAuth callback.
+        const GRACE_MS = 150;
+        const outcome = await Promise.race([
+          proc.exited.then(
+            (code) => ({ kind: "exited" as const, code }),
+            () => ({ kind: "failed" as const }),
+          ),
+          new Promise<{ kind: "running" }>((resolve) =>
+            setTimeout(() => resolve({ kind: "running" }), GRACE_MS),
+          ),
+        ]);
 
-    if (outcome.kind === "failed" || (outcome.kind === "exited" && outcome.code !== 0)) {
-      return { ok: false, reason: "spawn-failed" };
-    }
+        if (outcome.kind === "failed" || (outcome.kind === "exited" && outcome.code !== 0)) {
+          observeHostCapabilityFailure("browser-launch", new Error("spawn-failed"), {
+            operation: "open",
+            target: url,
+            label: launcher,
+          });
+          return { ok: false as const, reason: "spawn-failed" as const };
+        }
 
-    // Still running (or exited cleanly). Swallow any later rejection so it
-    // doesn't surface as an unhandled promise rejection after the CLI moves on.
-    proc.exited.catch(() => {});
-    return { ok: true, launcher };
+        // Still running (or exited cleanly). Swallow any later rejection so it
+        // doesn't surface as an unhandled promise rejection after the CLI moves on.
+        proc.exited.catch(() => {});
+        return { ok: true as const, launcher };
+      },
+    );
+
+    return result;
   } catch {
-    return { ok: false, reason: "spawn-failed" };
+    return { ok: false as const, reason: "spawn-failed" };
   }
 }

--- a/skills/clerk/SKILL.md
+++ b/skills/clerk/SKILL.md
@@ -15,6 +15,32 @@ The `clerk` binary is a pre-authenticated gateway to Clerk's Backend API and Pla
 
 > This skill was installed by `clerk init` (or `clerk skill install`) and is pinned to clerk `{{CLI_VERSION}}`. If `clerk --version` disagrees, refresh it with `clerk skill install` (or `bunx clerk@{{CLI_VERSION}} skill install`). The binary is always the source of truth, so run `clerk <command> --help` to verify anything this skill claims.
 
+## Execution environment (run on the host, not a sandbox)
+
+Most AI coding agents default to running shell commands in a sandbox where
+network access, credential stores, and the user's home directory are
+unavailable. The Clerk CLI cannot work there. It depends on host-local state:
+
+- **OS credential store**: `clerk auth login` stores the OAuth token in the
+  system keychain. A sandbox without keychain access reports "not logged in"
+  even when the host is authenticated.
+- **`~/.clerk`**: saved profile, selected app/instance, and cached metadata.
+- **Linked project metadata**: resolved from the repo's git remote plus
+  local config. Sandboxes with a read-only or stripped repo see no link.
+- **Local `.env*` files**: publishable and secret keys materialized by
+  `clerk env pull`.
+- **Outbound network access to Clerk**: every Backend and Platform API call.
+
+**Run these commands on the user's host shell, not in a sandbox:**
+
+`clerk doctor`, `clerk whoami`, `clerk auth login`, `clerk link`, `clerk env pull`,
+`clerk apps ...`, `clerk config ...`, `clerk api ...`.
+
+If a command was accidentally run in a sandbox and it reports "not signed in",
+"no app linked", missing env, credential-store errors, or network failures,
+**do not treat the result as authoritative**. Rerun it on the host before
+acting on it or reporting it to the user.
+
 ## Invoking the CLI
 
 Before running any `clerk` command, figure out which binary to invoke and bind that choice for the rest of the session:

--- a/skills/clerk/SKILL.md
+++ b/skills/clerk/SKILL.md
@@ -15,31 +15,48 @@ The `clerk` binary is a pre-authenticated gateway to Clerk's Backend API and Pla
 
 > This skill was installed by `clerk init` (or `clerk skill install`) and is pinned to clerk `{{CLI_VERSION}}`. If `clerk --version` disagrees, refresh it with `clerk skill install` (or `bunx clerk@{{CLI_VERSION}} skill install`). The binary is always the source of truth, so run `clerk <command> --help` to verify anything this skill claims.
 
-## Execution environment (run on the host, not a sandbox)
+## Execution environment (prefer the host, understand the sandbox warning)
 
-Most AI coding agents default to running shell commands in a sandbox where
-network access, credential stores, and the user's home directory are
-unavailable. The Clerk CLI cannot work there. It depends on host-local state:
+Most AI coding agents default to running shell commands in a sandbox where the
+user's home directory, OS keychain, browser launch, localhost callback
+binding, or network access may be blocked. The Clerk CLI depends on all of
+those host capabilities:
 
 - **OS credential store**: `clerk auth login` stores the OAuth token in the
   system keychain. A sandbox without keychain access reports "not logged in"
   even when the host is authenticated.
-- **`~/.clerk`**: saved profile, selected app/instance, and cached metadata.
-- **Linked project metadata**: resolved from the repo's git remote plus
-  local config. Sandboxes with a read-only or stripped repo see no link.
+- **Home-directory Clerk state**: saved config, cached metadata, and fallback
+  credentials live under the user's Clerk config/data directories.
+- **Linked project metadata**: resolved from the repo's git remote plus Clerk
+  config. Sandboxes with stripped repo state or blocked home-dir reads can
+  misreport "not linked".
 - **Local `.env*` files**: publishable and secret keys materialized by
   `clerk env pull`.
 - **Outbound network access to Clerk**: every Backend and Platform API call.
+- **Browser + localhost OAuth callback**: `clerk auth login` needs both.
 
-**Run these commands on the user's host shell, not in a sandbox:**
+In agent mode, the CLI now does a **best-effort warn-once check** at the
+host-sensitive library boundaries. When it detects that host-only Clerk state
+or system capabilities are unavailable, it emits:
+
+```text
+Host-only Clerk state or system capabilities may be unavailable in agent mode. This may be a sandboxed run.
+Re-run this command on the host shell before trusting auth, link, env, or API failures.
+```
+
+Treat that warning as authoritative. The command may continue, but any auth,
+link, env, config, API, browser, or OAuth callback failure from that
+invocation is untrusted until you rerun the same command on the host.
+
+**Prefer these commands on the user's host shell, not in a sandbox:**
 
 `clerk doctor`, `clerk whoami`, `clerk auth login`, `clerk link`, `clerk env pull`,
 `clerk apps ...`, `clerk config ...`, `clerk api ...`.
 
-If a command was accidentally run in a sandbox and it reports "not signed in",
-"no app linked", missing env, credential-store errors, or network failures,
-**do not treat the result as authoritative**. Rerun it on the host before
-acting on it or reporting it to the user.
+If a command was accidentally run in a sandbox and it reports `Not logged in`,
+`auth_required`, `not linked`, missing env, keychain/file permission errors,
+or network failures, **do not treat the result as authoritative**. Rerun it on
+the host before acting on it or reporting it to the user.
 
 ## Invoking the CLI
 
@@ -74,7 +91,9 @@ clerk --version               # confirm the binary is on PATH
 clerk doctor --json           # structured health check; exit 1 if anything failed
 ```
 
-**Always run `clerk doctor --json` first.** It catches the common setup failures (not logged in, project not linked, missing keys, outdated bundled skill) up front, so later commands don't fail with confusing errors. Each result has `name`, `status` (`pass`/`warn`/`fail`), `message`, optional `detail`, optional `remedy` (how to fix it), and optional `fix` (label for auto-fixable issues). Parse that and act on it, or surface it to the user. Rerun `clerk doctor --json` whenever a later command starts misbehaving.
+**Always run `clerk doctor --json` first.** It catches the common setup failures (not logged in, project not linked, missing keys, outdated bundled skill) up front, so later commands don't fail with confusing errors. In agent mode it also includes a `Host execution` check that warns when Clerk's host-side config / credential directories are not writable, which is the canonical signal that the current invocation is likely sandboxed.
+
+Each result has `name`, `status` (`pass`/`warn`/`fail`), `message`, optional `detail`, optional `remedy` (how to fix it), and optional `fix` (label for auto-fixable issues). Parse that and act on it, or surface it to the user. If `Host execution` warns, rerun the command on the host before trusting any auth/link/env/API failures from the same sandboxed run. Rerun `clerk doctor --json` whenever a later command starts misbehaving.
 
 If `clerk skill --help` reports a newer CLI than the skill you're reading, run `clerk skill install` to refresh the bundled skill. The CLI binary is always the source of truth.
 
@@ -176,6 +195,8 @@ See [references/recipes.md](references/recipes.md) for concrete patterns: listin
 The CLI auto-detects agent mode when stdout is not a TTY, or when `--mode agent` / `CLERK_MODE=agent` is set. In agent mode:
 
 - **Interactive prompts are disabled.** Commands that would normally show pickers (`link` without `--app`, interactive `api`, `unlink` without `--yes`) either auto-resolve or exit with a usage error. Always pass explicit flags (`--app`, `--yes`) in scripted calls.
+- **Host-sensitive operations emit a sandbox warning once per invocation.** Home-directory Clerk state, keychain access, networked Clerk calls, browser launch, and localhost OAuth callback setup can trigger the warning shown above. If it appears, rerun the same command on the host before trusting the result.
+- **If your harness does not clearly present as agent mode, force it.** Use `--mode agent` or `CLERK_MODE=agent` when you want the CLI's non-interactive behavior and sandbox warning path to apply deterministically.
 - **`link` supports deterministic agent flows.** In agent mode, `clerk link --app <id>` links directly. Without `--app`, the CLI will try silent key-based autolink first; if it cannot determine the app unambiguously, it exits and tells you to pass `--app`.
 - **`unlink` requires `--yes` in agent mode.** This preserves the same safety bar as other destructive commands while still letting an agent complete the unlink non-interactively.
 - **Mutations still require `--yes`** unless you accept per-call confirmation is impossible.
@@ -183,7 +204,7 @@ The CLI auto-detects agent mode when stdout is not a TTY, or when `--mode agent`
 - **`apps list` and `apps create` default to JSON** when piped.
 - **`clerk init --prompt`** prints a short agent-oriented handoff telling the agent to run `clerk init -y` (it is NOT a framework-specific integration guide; use the runtime `clerk init` output itself for that).
 
-Full matrix in [references/agent-mode.md](references/agent-mode.md).
+Full matrix and sandbox details in [references/agent-mode.md](references/agent-mode.md).
 
 ## Output format and errors
 
@@ -201,6 +222,6 @@ Full matrix in [references/agent-mode.md](references/agent-mode.md).
 
 ## References
 
-- [references/auth.md](references/auth.md) — auth flow, key resolution order, `--app`/`--instance` targeting, Backend vs Platform API.
+- [references/auth.md](references/auth.md) — auth flow, key resolution order, host-vs-sandbox behavior, `--app`/`--instance` targeting, Backend vs Platform API.
 - [references/recipes.md](references/recipes.md) — copy-pasteable recipes for common Clerk tasks.
-- [references/agent-mode.md](references/agent-mode.md) — agent-mode behavior matrix, exit codes, error format.
+- [references/agent-mode.md](references/agent-mode.md) — agent-mode behavior matrix, sandbox warning semantics, exit codes, error format.

--- a/skills/clerk/references/agent-mode.md
+++ b/skills/clerk/references/agent-mode.md
@@ -134,6 +134,7 @@ All three remediation commands are themselves interactive by default: `auth logi
 
 ## What NOT to do in agent mode
 
+- **Don't trust sandboxed output.** AI agent sandboxes hide the credential store, `~/.clerk`, the linked project metadata, local `.env*` files, and outbound network. `clerk doctor`, `whoami`, `auth login`, `link`, `env pull`, `apps`, `config`, and `api` all need host execution. See "Execution environment" in the skill's main `SKILL.md`. If a sandboxed run reports an auth/link/env/credential/network failure, rerun it on the host before acting on the result.
 - **Don't call `clerk auth login` from an agent and expect it to work** — it opens a browser and waits for a callback. Instead, export `CLERK_PLATFORM_API_KEY`.
 - **Don't call `clerk link` without `--app` and assume the agent can pick for you** — it only succeeds when silent autolink can determine the app from detected keys.
 - **Don't run `clerk unlink` in agent mode without `--yes`** — it exits with a usage error instead of prompting.

--- a/skills/clerk/references/agent-mode.md
+++ b/skills/clerk/references/agent-mode.md
@@ -2,6 +2,40 @@
 
 The Clerk CLI has a first-class "agent" mode that's designed for non-interactive and AI-driven use. Read this before writing scripts or letting an LLM drive the CLI.
 
+## Sandbox warning semantics
+
+Agent mode and sandboxing are related but not identical:
+
+- **Agent mode** controls non-interactive behavior.
+- **Sandboxing** controls whether the CLI can actually reach host-only Clerk
+  state and host system capabilities.
+
+In agent mode, the CLI now performs a **best-effort warn-once check** at the
+host-sensitive integration boundaries. The first time an invocation hits a
+blocked host capability, it emits:
+
+```text
+Host-only Clerk state or system capabilities may be unavailable in agent mode. This may be a sandboxed run.
+Re-run this command on the host shell before trusting auth, link, env, or API failures.
+```
+
+Treat that warning as authoritative. The command may still continue and return
+an ordinary Clerk error, but any auth/link/env/config/API/browser/OAuth
+failure from that invocation should be treated as suspect until rerun on the
+host.
+
+The warning can be triggered by:
+
+- home-directory Clerk config / credential file access
+- OS keychain access
+- outbound Clerk network requests
+- browser launch
+- localhost callback server binding for OAuth
+
+If your harness does not obviously look non-interactive, force agent behavior
+with `--mode agent` or `CLERK_MODE=agent` so the CLI's non-interactive and
+sandbox-warning paths apply deterministically.
+
 ## How agent mode is detected
 
 Priority (first match wins):
@@ -27,6 +61,9 @@ Force human mode with `--mode human` or `CLERK_MODE=human`. Typical AI-agent inv
 | `clerk auth login` when already authenticated                    | Prompt to re-auth              | Silent no-op                                                                                                                                                          |
 | `clerk init`                                                     | Full interactive scaffold flow | Skips the interactive scaffold and either runs non-interactively with `--yes` or, with `--prompt`, emits a short agent handoff pointing the agent at `clerk init -y`. |
 | Color / spinners                                                 | Enabled                        | Disabled                                                                                                                                                              |
+
+In addition, sandboxed agent-mode invocations may emit the warning above once
+per CLI invocation when a host-sensitive operation is blocked.
 
 **Rule of thumb:** always pass `--yes` for mutations, `--json` for structured output where available, and `--app` / `--instance` explicitly instead of relying on pickers.
 
@@ -87,6 +124,11 @@ clerk doctor --json --spotlight
 
 Parse the output, then for each failing check read `remedy` and act. Never call `--fix` from an agent — it's interactive.
 
+In agent mode, `doctor` also includes a **`Host execution`** check when it can
+detect that Clerk's host-side state is not writable. If that check warns, stop
+trusting auth/link/env/API failures from the same sandboxed run and rerun the
+relevant command on the host.
+
 ### Preview every mutation
 
 ```sh
@@ -134,7 +176,7 @@ All three remediation commands are themselves interactive by default: `auth logi
 
 ## What NOT to do in agent mode
 
-- **Don't trust sandboxed output.** AI agent sandboxes hide the credential store, `~/.clerk`, the linked project metadata, local `.env*` files, and outbound network. `clerk doctor`, `whoami`, `auth login`, `link`, `env pull`, `apps`, `config`, and `api` all need host execution. See "Execution environment" in the skill's main `SKILL.md`. If a sandboxed run reports an auth/link/env/credential/network failure, rerun it on the host before acting on the result.
+- **Don't ignore the sandbox warning.** If the CLI says host-only Clerk state or system capabilities may be unavailable, rerun the same command on the host before trusting the result.
 - **Don't call `clerk auth login` from an agent and expect it to work** — it opens a browser and waits for a callback. Instead, export `CLERK_PLATFORM_API_KEY`.
 - **Don't call `clerk link` without `--app` and assume the agent can pick for you** — it only succeeds when silent autolink can determine the app from detected keys.
 - **Don't run `clerk unlink` in agent mode without `--yes`** — it exits with a usage error instead of prompting.

--- a/skills/clerk/references/auth.md
+++ b/skills/clerk/references/auth.md
@@ -34,6 +34,37 @@ When you run `clerk api --platform ...`, or any command that already uses PLAPI 
 
 Set `CLERK_PLATFORM_API_KEY` for CI and scripted agent usage. Use `clerk auth login` for local interactive development.
 
+## Host vs sandbox behavior
+
+These auth and targeting rules only produce trustworthy results when the CLI
+can actually reach the user's host state.
+
+In agent mode, the CLI now emits a best-effort warning once per invocation
+when it detects that host-only Clerk state or system capabilities are
+unavailable:
+
+```text
+Host-only Clerk state or system capabilities may be unavailable in agent mode. This may be a sandboxed run.
+Re-run this command on the host shell before trusting auth, link, env, or API failures.
+```
+
+That warning usually means one of the following is blocked:
+
+- Clerk home-directory config or fallback credential files
+- OS keychain access
+- outbound Clerk network access
+- browser launch or localhost OAuth callback setup
+
+When that warning appears, stop trusting the current invocation's auth or
+targeting result. A sandboxed run can misreport:
+
+- `Not logged in` / `auth_required`
+- `Not authenticated. Run clerk auth login or set CLERK_PLATFORM_API_KEY`
+- `No Clerk project linked`
+- missing env or missing linked profile state
+
+Rerun the same command on the host before acting on it.
+
 > **`config` commands do not accept `--secret-key`.** They target the Platform API and authenticate via the PLAPI chain above (`CLERK_PLATFORM_API_KEY` or the stored OAuth token). If you need to script `config pull/schema/patch/put` in CI, export `CLERK_PLATFORM_API_KEY`; a Backend API `sk_...` key will not work.
 
 ## Project linking
@@ -85,6 +116,9 @@ OAuth 2.0 PKCE flow against the Clerk OAuth system instance (`https://clerk.cler
 6. Stores the token in the OS credential store.
 
 In agent mode, if already authenticated, it's a no-op. If not, it prints guidance rather than opening a browser.
+In a sandbox, even the "already authenticated" check can be false if the
+keychain or fallback credential file is blocked, so rerun on the host before
+trusting a sandboxed auth failure.
 
 ### `clerk auth logout`
 
@@ -110,11 +144,12 @@ Hits `GET /oauth/userinfo` with the stored token and prints the email. Exits wit
 
 ## Common auth failure modes
 
-| Symptom                     | Likely cause                                                  | Fix                                                          |
-| --------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------ |
-| `Not authenticated`         | No token stored, no `CLERK_PLATFORM_API_KEY`                  | `clerk auth login` or export `CLERK_PLATFORM_API_KEY`        |
-| `No Clerk project linked`   | Running a command that needs a linked profile with no `--app` | `clerk link` or pass `--app <id>`                            |
-| `Invalid secret key prefix` | Passed `ak_...` where `sk_...` expected (or vice versa)       | Check which API the command hits; pass the matching key type |
-| `Unauthorized` from API     | Key belongs to a different instance                           | Verify `--instance` and ensure the key matches               |
+| Symptom                             | Likely cause                                                  | Fix                                                          |
+| ----------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------ |
+| `Not authenticated`                 | No token stored, no `CLERK_PLATFORM_API_KEY`                  | `clerk auth login` or export `CLERK_PLATFORM_API_KEY`        |
+| `No Clerk project linked`           | Running a command that needs a linked profile with no `--app` | `clerk link` or pass `--app <id>`                            |
+| `Invalid secret key prefix`         | Passed `ak_...` where `sk_...` expected (or vice versa)       | Check which API the command hits; pass the matching key type |
+| `Unauthorized` from API             | Key belongs to a different instance                           | Verify `--instance` and ensure the key matches               |
+| Sandbox warning + auth/link failure | Host-only Clerk state or system capabilities are blocked      | Rerun the same command on the host before trusting the error |
 
 When in doubt: `clerk doctor --json` walks through all of this and tells you exactly what's wrong.


### PR DESCRIPTION
## Summary

This PR teaches the Clerk CLI to detect likely sandboxed agent runs at the actual host-integration boundaries and warn once per invocation before agents trust auth, link, env, config, or API failures.

It also adds a dedicated `Host execution` check to `clerk doctor` in agent mode, and updates the bundled Clerk skill so agents know how to recognize the warning, when to rerun on the host, and how sandboxed runs can misreport auth and targeting state.

## What changed

- Added `packages/cli-core/src/lib/host-execution.ts` as the shared host-capability warning layer.
- Moved sandbox detection to the real host-sensitive library boundaries instead of command wrappers:
  - config file access
  - credential store and keychain access
  - outbound network requests
  - browser launch
  - localhost OAuth callback binding
  - API catalog cache/network access
- Added a `Host execution` diagnostic to `clerk doctor` in agent mode, with structured detail and remedy output.
- Updated doctor tests to cover the new host-execution check.
- Updated the bundled `skills/clerk` docs and references to explain the sandbox warning semantics, host rerun guidance, and explicit `agent` mode behavior.
- Consolidated the changeset into a single patch release note covering the CLI warning, doctor check, and skill guidance.

## Test plan

- [x] `bun test packages/cli-core/src/lib/config.test.ts`
- [x] `bun test packages/cli-core/src/lib/credential-store.test.ts`
- [x] `bun test packages/cli-core/src/commands/whoami/index.test.ts`
- [x] `bun test packages/cli-core/src/commands/doctor/doctor.test.ts`
- [x] `bun test packages/cli-core/src/cli-program.test.ts`
- [x] `bun test packages/cli-core/src/lib/auth-server.test.ts` on the host
- [x] `bun run --filter @clerk/cli-core typecheck`
- [x] `bun run --filter @clerk/cli-core lint`
- [x] `bun run --filter @clerk/cli-core format:check`
- [x] Verified `CLERK_MODE=agent bun run packages/cli-core/src/cli.ts whoami --verbose`, `apps list --json --verbose`, and `doctor --json --spotlight` warn in the sandbox
- [x] Verified the same commands do not emit the warning on the host

Refs AIE-896.
