### PR TITLE
docs(skill): teach +clerk_test email + test-phone pattern for agents

### DIFF
--- a/.changeset/aie-897-test-phone-users.md
+++ b/.changeset/aie-897-test-phone-users.md
@@ -1,5 +1,0 @@
----
-"clerk": patch
----
-
-Extend the bundled skill's "Test users" recipe with the US fictional-phone pattern (`+1 (XXX) 555-0100` through `+1 (XXX) 555-0199`) so agents can create test users that verify with OTP `424242` via SMS flows without real phone access.

--- a/.changeset/aie-897-test-phone-users.md
+++ b/.changeset/aie-897-test-phone-users.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Extend the bundled skill's "Test users" recipe with the US fictional-phone pattern (`+1 (XXX) 555-0100` through `+1 (XXX) 555-0199`) so agents can create test users that verify with OTP `424242` via SMS flows without real phone access.

--- a/.changeset/aie-897-test-user-guidance.md
+++ b/.changeset/aie-897-test-user-guidance.md
@@ -2,4 +2,4 @@
 "clerk": patch
 ---
 
-Teach agents the `+clerk_test` email suffix and `424242` OTP pattern for creating test users that bypass client trust in development, both in the bundled skill's recipes and in every `clerk init --prompt` handoff.
+Teach agents the `+clerk_test` email suffix and the US fictional-phone range (`+1 (XXX) 555-0100` through `+1 (XXX) 555-0199`), paired with the fixed `424242` OTP, for creating test users that bypass client trust in development. The pattern is documented in the bundled skill's recipes and every `clerk init --prompt` handoff.

--- a/.changeset/aie-897-test-user-guidance.md
+++ b/.changeset/aie-897-test-user-guidance.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Teach agents the `+clerk_test` email suffix and `424242` OTP pattern for creating test users that bypass client trust in development, both in the bundled skill's recipes and in every `clerk init --prompt` handoff.

--- a/packages/cli-core/src/commands/init/prompts/astro.md
+++ b/packages/cli-core/src/commands/init/prompts/astro.md
@@ -109,3 +109,5 @@ If any fails, revise.
 ## After Setup
 
 Have the user sign up as their first test user. After signup succeeds and a profile icon appears, congratulate them. Then recommend exploring: Components (https://clerk.com/docs/reference/components/overview), Dashboard (https://dashboard.clerk.com/).
+
+If you (the agent) need to create test users programmatically to exercise auth-gated code, use a `+clerk_test` email suffix. Clerk accepts `424242` as the OTP for these addresses, so you don't need inbox access. Development instances only.

--- a/packages/cli-core/src/commands/init/prompts/expo.md
+++ b/packages/cli-core/src/commands/init/prompts/expo.md
@@ -115,3 +115,5 @@ If any fails, revise.
 ## After Setup
 
 Have the user sign up as their first test user. After signup succeeds, congratulate them. Then recommend exploring: Components (https://clerk.com/docs/reference/components/overview), Dashboard (https://dashboard.clerk.com/).
+
+If you (the agent) need to create test users programmatically to exercise auth-gated code, use a `+clerk_test` email suffix. Clerk accepts `424242` as the OTP for these addresses, so you don't need inbox access. Development instances only.

--- a/packages/cli-core/src/commands/init/prompts/express.md
+++ b/packages/cli-core/src/commands/init/prompts/express.md
@@ -74,3 +74,5 @@ If any fails, revise.
 ## After Setup
 
 Have the user test the protected route by sending a request without authentication (should get 401) and with a valid session token (should succeed). Then recommend exploring: Dashboard (https://dashboard.clerk.com/).
+
+If you (the agent) need to create test users programmatically to exercise auth-gated code, use a `+clerk_test` email suffix. Clerk accepts `424242` as the OTP for these addresses, so you don't need inbox access. Development instances only.

--- a/packages/cli-core/src/commands/init/prompts/fastify.md
+++ b/packages/cli-core/src/commands/init/prompts/fastify.md
@@ -74,3 +74,5 @@ If any fails, revise.
 ## After Setup
 
 Have the user test the protected route by sending a request without authentication (should get 401) and with a valid session token (should succeed). Then recommend exploring: Dashboard (https://dashboard.clerk.com/).
+
+If you (the agent) need to create test users programmatically to exercise auth-gated code, use a `+clerk_test` email suffix. Clerk accepts `424242` as the OTP for these addresses, so you don't need inbox access. Development instances only.

--- a/packages/cli-core/src/commands/init/prompts/generic-fallback.md
+++ b/packages/cli-core/src/commands/init/prompts/generic-fallback.md
@@ -45,3 +45,5 @@ If any fails, revise.
 ## After Setup
 
 Have the user sign up as their first test user. After signup succeeds and a profile icon appears, congratulate them. Then recommend exploring: Components (https://clerk.com/docs/reference/components/overview), Dashboard (https://dashboard.clerk.com/).
+
+If you (the agent) need to create test users programmatically to exercise auth-gated code, use a `+clerk_test` email suffix. Clerk accepts `424242` as the OTP for these addresses, so you don't need inbox access. Development instances only.

--- a/packages/cli-core/src/commands/init/prompts/generic.md
+++ b/packages/cli-core/src/commands/init/prompts/generic.md
@@ -40,3 +40,5 @@ If any fails, revise.
 ## After Setup
 
 Have the user sign up as their first test user. After signup succeeds and a profile icon appears, congratulate them. Then recommend exploring: Components (https://clerk.com/docs/reference/components/overview), Dashboard (https://dashboard.clerk.com/).
+
+If you (the agent) need to create test users programmatically to exercise auth-gated code, use a `+clerk_test` email suffix. Clerk accepts `424242` as the OTP for these addresses, so you don't need inbox access. Development instances only.

--- a/packages/cli-core/src/commands/init/prompts/nextjs-app-router.md
+++ b/packages/cli-core/src/commands/init/prompts/nextjs-app-router.md
@@ -125,3 +125,5 @@ If any fails, revise.
 ## After Setup
 
 Have the user sign up as their first test user in the nav. After signup succeeds and a profile icon appears, congratulate them. If a "Configure your application" callout appears, tell them to click it. Then recommend exploring: Organizations (https://clerk.com/docs/guides/organizations/overview), Components (https://clerk.com/docs/reference/components/overview), Dashboard (https://dashboard.clerk.com/).
+
+If you (the agent) need to create test users programmatically to exercise auth-gated code, use a `+clerk_test` email suffix. Clerk accepts `424242` as the OTP for these addresses, so you don't need inbox access. Development instances only.

--- a/packages/cli-core/src/commands/init/prompts/nextjs-pages-router.md
+++ b/packages/cli-core/src/commands/init/prompts/nextjs-pages-router.md
@@ -108,3 +108,5 @@ If any fails, revise.
 ## After Setup
 
 Have the user sign up as their first test user in the nav. After signup succeeds and a profile icon appears, congratulate them. If a "Configure your application" callout appears, tell them to click it. Then recommend exploring: Organizations (https://clerk.com/docs/guides/organizations/overview), Components (https://clerk.com/docs/reference/components/overview), Dashboard (https://dashboard.clerk.com/).
+
+If you (the agent) need to create test users programmatically to exercise auth-gated code, use a `+clerk_test` email suffix. Clerk accepts `424242` as the OTP for these addresses, so you don't need inbox access. Development instances only.

--- a/packages/cli-core/src/commands/init/prompts/nuxt.md
+++ b/packages/cli-core/src/commands/init/prompts/nuxt.md
@@ -90,3 +90,5 @@ If any fails, revise.
 ## After Setup
 
 Have the user sign up as their first test user. After signup succeeds and a profile icon appears, congratulate them. Then recommend exploring: Components (https://clerk.com/docs/reference/components/overview), Dashboard (https://dashboard.clerk.com/).
+
+If you (the agent) need to create test users programmatically to exercise auth-gated code, use a `+clerk_test` email suffix. Clerk accepts `424242` as the OTP for these addresses, so you don't need inbox access. Development instances only.

--- a/packages/cli-core/src/commands/init/prompts/react-router.md
+++ b/packages/cli-core/src/commands/init/prompts/react-router.md
@@ -111,3 +111,5 @@ If any fails, revise.
 ## After Setup
 
 Have the user sign up as their first test user. After signup succeeds and a profile icon appears, congratulate them. Then recommend exploring: Components (https://clerk.com/docs/reference/components/overview), Dashboard (https://dashboard.clerk.com/).
+
+If you (the agent) need to create test users programmatically to exercise auth-gated code, use a `+clerk_test` email suffix. Clerk accepts `424242` as the OTP for these addresses, so you don't need inbox access. Development instances only.

--- a/packages/cli-core/src/commands/init/prompts/react.md
+++ b/packages/cli-core/src/commands/init/prompts/react.md
@@ -90,3 +90,5 @@ If any fails, revise.
 ## After Setup
 
 Have the user sign up as their first test user. After signup succeeds and a profile icon appears, congratulate them. Then recommend exploring: Components (https://clerk.com/docs/reference/components/overview), Dashboard (https://dashboard.clerk.com/).
+
+If you (the agent) need to create test users programmatically to exercise auth-gated code, use a `+clerk_test` email suffix. Clerk accepts `424242` as the OTP for these addresses, so you don't need inbox access. Development instances only.

--- a/packages/cli-core/src/commands/init/prompts/tanstack-start.md
+++ b/packages/cli-core/src/commands/init/prompts/tanstack-start.md
@@ -104,3 +104,5 @@ If any fails, revise.
 ## After Setup
 
 Have the user sign up as their first test user. After signup succeeds and a profile icon appears, congratulate them. Then recommend exploring: Components (https://clerk.com/docs/reference/components/overview), Dashboard (https://dashboard.clerk.com/).
+
+If you (the agent) need to create test users programmatically to exercise auth-gated code, use a `+clerk_test` email suffix. Clerk accepts `424242` as the OTP for these addresses, so you don't need inbox access. Development instances only.

--- a/packages/cli-core/src/commands/init/prompts/vue.md
+++ b/packages/cli-core/src/commands/init/prompts/vue.md
@@ -81,3 +81,5 @@ If any fails, revise.
 ## After Setup
 
 Have the user sign up as their first test user. After signup succeeds and a profile icon appears, congratulate them. Then recommend exploring: Components (https://clerk.com/docs/reference/components/overview), Dashboard (https://dashboard.clerk.com/).
+
+If you (the agent) need to create test users programmatically to exercise auth-gated code, use a `+clerk_test` email suffix. Clerk accepts `424242` as the OTP for these addresses, so you don't need inbox access. Development instances only.

--- a/skills/clerk/references/recipes.md
+++ b/skills/clerk/references/recipes.md
@@ -54,10 +54,12 @@ clerk api /users/user_abc123 -X DELETE --yes
 
 ### Test users (development only)
 
-For test accounts you need to sign into without real email access, use the `+clerk_test` email suffix. Clerk recognizes these as test emails: no message is sent, and the verification code is a fixed `424242`. The domain portion is arbitrary.
+For test accounts you need to sign into without real email or SMS delivery, Clerk provides two magic patterns that both verify with the fixed OTP `424242`. Use them on development instances; production rejects them.
+
+**By email.** Any address with the `+clerk_test` subaddress is recognized as a test email. The domain portion is arbitrary.
 
 ```sh
-# Create a test user (dev instance)
+# Create a test user with a test email (dev instance)
 clerk api /users -d '{
   "email_address": ["demo+clerk_test@example.com"],
   "password": "TestPass123!",
@@ -65,9 +67,20 @@ clerk api /users -d '{
 }'
 ```
 
-When signing in as this user in a browser or Playwright, enter `424242` at the OTP prompt.
+**By phone.** Any US fictional phone number in the `+1 (XXX) 555-0100` through `+1 (XXX) 555-0199` range is recognized as a test phone. Pass the E.164 form.
 
-This pattern only applies to development instances. In production, client trust blocks sign-in regardless of the suffix. See [Clerk's test emails and phones reference](https://clerk.com/docs/testing/test-emails-and-phones) for the complete list of magic values (OTPs, phone numbers, test cards).
+```sh
+# Create a test user with a test phone (dev instance)
+clerk api /users -d '{
+  "phone_number": ["+12015550100"],
+  "password": "TestPass123!",
+  "skip_password_checks": true
+}'
+```
+
+When signing in as either user in a browser or Playwright, enter `424242` at the OTP prompt.
+
+These patterns only apply to development instances. In production, client trust blocks sign-in regardless of suffix or number, and using real-looking test addresses is highly discouraged. Test addresses and numbers do not count against the dev-instance monthly caps (20 SMS, 100 emails). See [Clerk's test emails and phones reference](https://clerk.com/docs/guides/development/testing/test-emails-and-phones) for the full contract.
 
 ## Organizations
 

--- a/skills/clerk/references/recipes.md
+++ b/skills/clerk/references/recipes.md
@@ -52,6 +52,23 @@ clerk api /users/user_abc123 -X DELETE --dry-run
 clerk api /users/user_abc123 -X DELETE --yes
 ```
 
+### Test users (development only)
+
+For test accounts you need to sign into without real email access, use the `+clerk_test` email suffix. Clerk recognizes these as test emails: no message is sent, and the verification code is a fixed `424242`. The domain portion is arbitrary.
+
+```sh
+# Create a test user (dev instance)
+clerk api /users -d '{
+  "email_address": ["demo+clerk_test@example.com"],
+  "password": "TestPass123!",
+  "skip_password_checks": true
+}'
+```
+
+When signing in as this user in a browser or Playwright, enter `424242` at the OTP prompt.
+
+This pattern only applies to development instances. In production, client trust blocks sign-in regardless of the suffix. See [Clerk's test emails and phones reference](https://clerk.com/docs/testing/test-emails-and-phones) for the complete list of magic values (OTPs, phone numbers, test cards).
+
 ## Organizations
 
 ```sh


### PR DESCRIPTION
## Summary

When an AI agent creates a test user via `clerk api /users` and tries to sign in as that user, Clerk's default-on client trust blocks the flow: the OTP email or SMS goes to an address the agent cannot read. The bundled `clerk` skill teaches user creation with plain `alice@example.com` style addresses and says nothing about either of Clerk's test-account patterns, so agents hit a dead end during demos and automated sign-in flows.

This PR teaches both agent-facing surfaces (the bundled Clerk skill and the `clerk init --prompt` framework handoffs) the full test-account contract that our own E2E helper already relies on:

- **Email:** `+clerk_test` subaddress, fixed OTP `424242`.
- **Phone:** US fictional numbers `+1 (XXX) 555-0100` through `+1 (XXX) 555-0199`, same `424242` OTP.

Both patterns are dev-instance-only and test addresses and numbers do not count against Clerk's monthly caps.

## What changed

- **New "Test users (development only)" subsection in `skills/clerk/references/recipes.md`.** Placed directly after the existing "Create a user" block under `## Users`, so agents browsing user-management recipes find the test variants in the same scroll. The section opens with a shared intro, then presents email and phone patterns side by side, each with its own `clerk api /users` example using the exact body shape the Backend API expects. Uses `skip_password_checks: true` to mirror the flag we set in `test/e2e/lib/test-user.ts`.
- **One-sentence pointer appended to every `clerk init --prompt` handoff.** All 13 framework prompts under `packages/cli-core/src/commands/init/prompts/*.md` now carry a uniform sentence in their `## After Setup` section so agents learn the pattern at scaffold time, when they are most likely to exercise auth-gated code. The existing human-signup instruction is left intact because it targets a different flow that does not hit client trust.
- **Docs link points at the canonical Clerk page** (`https://clerk.com/docs/guides/development/testing/test-emails-and-phones`) for the full magic-values contract and production warnings.
- **Patch changeset for `clerk`.** Skill content and init prompts ship inside the compiled `clerk` binary via `{ type: "text" }` imports in `packages/cli-core/src/commands/init/prompts/index.ts`, so a content change is user-facing and belongs in the changelog.

## Test plan

- [x] `bun run format:check`, `bun run lint`, `bun run typecheck`, `bun run test` (79 passed)
- [x] `bun changeset status` reports `clerk` at `patch`
- [ ] CI E2E suite on this PR (the fixture helper already uses `+clerk_test`, so any regression in the underlying Clerk behavior shows up there)
- [ ] Reviewer: skim the new "Test users" subsection and confirm the email range, phone range, OTP, and Clerk docs link are all correct

## History

Originally shipped as two stacked PRs (#227 email, #229 phone) and folded into this single PR after review feedback noted the phone addition did not conceptually depend on the email one. #229 is marked MERGED in the GitHub UI only because the force-push that carried the fold made the phone commit reachable from this branch's history; the phone content reaches main through this PR.

Refs AIE-897.