### PR TITLE
docs(skill): add test-phone pattern for agent test users

### DIFF
--- a/.changeset/aie-897-test-phone-users.md
+++ b/.changeset/aie-897-test-phone-users.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Extend the bundled skill's "Test users" recipe with the US fictional-phone pattern (`+1 (XXX) 555-0100` through `+1 (XXX) 555-0199`) so agents can create test users that verify with OTP `424242` via SMS flows without real phone access.

--- a/skills/clerk/references/recipes.md
+++ b/skills/clerk/references/recipes.md
@@ -54,10 +54,12 @@ clerk api /users/user_abc123 -X DELETE --yes
 
 ### Test users (development only)
 
-For test accounts you need to sign into without real email access, use the `+clerk_test` email suffix. Clerk recognizes these as test emails: no message is sent, and the verification code is a fixed `424242`. The domain portion is arbitrary.
+For test accounts you need to sign into without real email or SMS delivery, Clerk provides two magic patterns that both verify with the fixed OTP `424242`. Use them on development instances; production rejects them.
+
+**By email.** Any address with the `+clerk_test` subaddress is recognized as a test email. The domain portion is arbitrary.
 
 ```sh
-# Create a test user (dev instance)
+# Create a test user with a test email (dev instance)
 clerk api /users -d '{
   "email_address": ["demo+clerk_test@example.com"],
   "password": "TestPass123!",
@@ -65,9 +67,20 @@ clerk api /users -d '{
 }'
 ```
 
-When signing in as this user in a browser or Playwright, enter `424242` at the OTP prompt.
+**By phone.** Any US fictional phone number in the `+1 (XXX) 555-0100` through `+1 (XXX) 555-0199` range is recognized as a test phone. Pass the E.164 form.
 
-This pattern only applies to development instances. In production, client trust blocks sign-in regardless of the suffix. See [Clerk's test emails and phones reference](https://clerk.com/docs/testing/test-emails-and-phones) for the complete list of magic values (OTPs, phone numbers, test cards).
+```sh
+# Create a test user with a test phone (dev instance)
+clerk api /users -d '{
+  "phone_number": ["+12015550100"],
+  "password": "TestPass123!",
+  "skip_password_checks": true
+}'
+```
+
+When signing in as either user in a browser or Playwright, enter `424242` at the OTP prompt.
+
+These patterns only apply to development instances. In production, client trust blocks sign-in regardless of suffix or number, and using real-looking test addresses is highly discouraged. Test addresses and numbers do not count against the dev-instance monthly caps (20 SMS, 100 emails). See [Clerk's test emails and phones reference](https://clerk.com/docs/guides/development/testing/test-emails-and-phones) for the full contract.
 
 ## Organizations
 


### PR DESCRIPTION
## Summary

The parent PR taught agents how to create test users with `+clerk_test` email addresses that bypass client trust via the fixed `424242` OTP. This PR completes the pattern by adding the companion phone guidance: Clerk also treats US fictional phone numbers in the `+1 (XXX) 555-0100` through `+1 (XXX) 555-0199` range as test phones that verify with the same OTP. Agents building SMS-first or multi-factor flows now have a documented, deterministic way to exercise them in development without real phone access.

## What changed

- **Restructured the "Test users (development only)" recipe in `skills/clerk/references/recipes.md`** so the email and phone patterns sit side by side under a shared intro, rather than treating the email pattern as the only option and mentioning phones only in a trailing footnote. Each pattern gets its own `clerk api /users` example using the exact body shape the Backend API expects.
- **Updated the canonical docs link** to `https://clerk.com/docs/guides/development/testing/test-emails-and-phones` to match Clerk's current site layout.
- **Called out the dev-instance monthly caps** (20 SMS, 100 emails) and the fact that test addresses and numbers do not count against them, because that is the first question an agent asks when seeing the recipe for the first time.
- **Patch changeset for `clerk`.** Bundled skill content change, same rationale as the parent PR.

## Test plan

- [x] `bun run format:check`, `bun run lint`, `bun run typecheck`, `bun run test` (79 passed)
- [x] `bun changeset status` reports `clerk` at `patch` (both PRs in the stack contribute)
- [ ] CI on this PR (stacked on top of #227, so CI here includes both changes)
- [ ] Reviewer: confirm the phone-range bullet is accurate and the Clerk docs link still resolves

Refs AIE-897.