### PR TITLE
fix(update): target the running binary instead of the first PATH hit

### DIFF
--- a/.changeset/auto-update-fixes.md
+++ b/.changeset/auto-update-fixes.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Fix `clerk update` to upgrade the binary that is actually running. With multiple installs on the same machine (e.g. bun and asdf-npm), the command now picks the install that owns the currently-running `clerk` as the primary target instead of the first `PATH` match, so `clerk -v` reflects the upgrade without needing `--all`.

--- a/packages/cli-core/src/commands/update/README.md
+++ b/packages/cli-core/src/commands/update/README.md
@@ -19,7 +19,7 @@ clerk update [options]
 ## Behavior
 
 1. Fetches the latest version for the given channel from the npm registry
-2. Walks `PATH` to find every `clerk` binary. For asdf shims (bash scripts, not symlinks), resolves through `asdf which <name>` so the underlying installer is visible. Picks the first one as the **primary target**
+2. Walks `PATH` to find every `clerk` binary. For asdf shims (bash scripts, not symlinks), resolves through `asdf which <name>` so the underlying installer is visible. The **primary target** is the install that owns `process.execPath` (the binary the user just invoked). If the running binary can't be matched against any enumerated install, falls back to the first PATH entry.
 3. Determines which installer owns the primary target via `ownerOfBinary()`:
    - Known installer (npm/bun/pnpm/yarn) → installs via that PM
    - Homebrew → runs `brew upgrade clerk` after confirmation (stable channel only; refuses on `canary` since there is no canary tap). After the brew command succeeds, verifies the installed version matches the npm registry's `latest`; fails loudly if the tap is stale.
@@ -30,9 +30,13 @@ clerk update [options]
 7. With `--all`, updates every on-PATH `clerk` install whose owner the CLI can drive. If the primary itself is blocked (e.g. Homebrew on `canary`, or `null` owner), the primary is skipped with a warning and the remaining installs still run; the run only refuses when every target is blocked. Failures on individual installs are recorded in the summary but don't short-circuit the rest.
 8. After a successful install, prints a shell-specific `hash -r` / `rehash` hint when applicable
 
-## Why PATH-walking matters
+## Primary target selection
 
-A machine can host multiple `clerk` installs (bun + asdf-npm + Homebrew is common). `process.execPath` tells you what is running right now, but the binary the user's shell will resolve next may be a different one (e.g. `~/.bun/bin/clerk` shadowing `~/.asdf/shims/clerk`). To ensure the update actually affects the user's next `clerk` invocation, the command resolves the target from `PATH` order, not from `process.execPath`.
+A machine can host multiple `clerk` installs (bun + asdf-npm + Homebrew is common). The command walks `PATH` to enumerate every install, then picks the one that owns `process.execPath` as the primary. This is the binary the user just invoked — updating any other install would leave `clerk -v` unchanged and silently diverge what the user sees from what the command reported as "updated".
+
+PATH order alone is insufficient because a fresh `PATH` walk can disagree with what actually ran: zsh and bash cache resolved command paths in a hash table, and `PATH` ordering under asdf + bun can place the asdf shim before `~/.bun/bin` even though the user's shell hash still points at bun's install. The running install is authoritative in every case.
+
+Remaining installs are reported as "others" and updated only with `--all`. If the running binary can't be classified (standalone `install.sh` binary, or `process.execPath` outside any known installer dir), the command falls back to PATH-first order.
 
 ## Version managers (asdf, nvm)
 

--- a/packages/cli-core/src/commands/update/index.ts
+++ b/packages/cli-core/src/commands/update/index.ts
@@ -5,10 +5,12 @@ import {
   asdfPluginFromPath,
   asdfReshim,
   findClerkOnPath,
+  findRunningInstallIndex,
   getInstallerPackageDirs,
   globalInstallCommand,
   ownerOfBinary,
   resolveAsdfShim,
+  safeRealpath,
   type Installer,
 } from "../../lib/installer.ts";
 import { log } from "../../lib/log.ts";
@@ -61,9 +63,29 @@ async function resolveTargets(
     unique.push(c);
   }
 
+  // Promote the install that owns the currently-running binary to primary.
+  // The binary the user just invoked is the authoritative update target:
+  // shell hash caches (zsh/bash) and PATH ordering quirks (asdf shims before
+  // `~/.bun/bin`) can make a fresh PATH walk disagree with what actually ran,
+  // leaving `clerk -v` unchanged after an "Updated" message because a
+  // different install got the upgrade. When the running binary isn't on PATH
+  // (invoked by absolute path, PATH mutated mid-session), fall through to
+  // PATH order.
+  const runningResolved = await safeRealpath(runningPath);
+  const runningIdx = findRunningInstallIndex(unique, runningResolved, installDirs);
+  const reordered =
+    runningIdx > 0
+      ? [unique[runningIdx]!, ...unique.slice(0, runningIdx), ...unique.slice(runningIdx + 1)]
+      : unique;
+
   // Fallback when PATH discovery yields nothing: use the running binary.
+  // `resolvedPath` gets the realpath'd variant so ownerOfBinary sees the
+  // same form (e.g. `/private/var/...` on macOS) that PM install dirs use —
+  // otherwise an unresolved `/var/...` execPath would fail owner matching.
   const effective =
-    unique.length > 0 ? unique : [{ displayPath: runningPath, resolvedPath: runningPath }];
+    reordered.length > 0
+      ? reordered
+      : [{ displayPath: runningPath, resolvedPath: runningResolved }];
 
   const toTarget = (c: { displayPath: string; resolvedPath: string }): Target => ({
     displayPath: c.displayPath,

--- a/packages/cli-core/src/commands/update/index.ts
+++ b/packages/cli-core/src/commands/update/index.ts
@@ -46,7 +46,10 @@ async function resolveTargets(
   runningPath: string,
   installDirs: Awaited<ReturnType<typeof getInstallerPackageDirs>>,
 ): Promise<{ primary: Target; others: Target[] }> {
-  const onPath = await findClerkOnPath();
+  const [onPath, runningResolved] = await Promise.all([
+    findClerkOnPath(),
+    safeRealpath(runningPath),
+  ]);
 
   const resolved = await Promise.all(onPath.map((p) => resolveAsdfShim(p)));
   const candidates = onPath.map((displayPath, i) => ({
@@ -71,7 +74,6 @@ async function resolveTargets(
   // different install got the upgrade. When the running binary isn't on PATH
   // (invoked by absolute path, PATH mutated mid-session), fall through to
   // PATH order.
-  const runningResolved = await safeRealpath(runningPath);
   const runningIdx = findRunningInstallIndex(unique, runningResolved, installDirs);
   const reordered =
     runningIdx > 0
@@ -86,6 +88,10 @@ async function resolveTargets(
     reordered.length > 0
       ? reordered
       : [{ displayPath: runningPath, resolvedPath: runningResolved }];
+
+  log.debug(
+    `update: primary=${effective[0]!.resolvedPath} (runningIdx=${runningIdx}, execPath=${runningResolved})`,
+  );
 
   const toTarget = (c: { displayPath: string; resolvedPath: string }): Target => ({
     displayPath: c.displayPath,

--- a/packages/cli-core/src/lib/installer.test.ts
+++ b/packages/cli-core/src/lib/installer.test.ts
@@ -6,6 +6,7 @@ import {
   isHomebrewPath,
   globalInstallCommand,
   findClerkOnPath,
+  findRunningInstallIndex,
   ownerOfBinary,
   isAsdfShimPath,
   asdfPluginFromPath,
@@ -179,6 +180,89 @@ describe("ownerOfBinary", () => {
         win,
       ),
     ).toBe("npm");
+  });
+});
+
+// ── findRunningInstallIndex ─────────────────────────────────────────────────
+
+describe("findRunningInstallIndex", () => {
+  const dirs = {
+    npm: "/home/u/.asdf/installs/nodejs/22.16.0/lib/node_modules",
+    bun: "/home/u/.bun/install/global/node_modules",
+  } as const;
+
+  // Platform binaries the Node shim spawns (what process.execPath resolves to
+  // inside the compiled CLI).
+  const bunPlatformBin = "/home/u/.bun/install/global/node_modules/@clerk/cli-linux-x64/bin/clerk";
+  const npmPlatformBin =
+    "/home/u/.asdf/installs/nodejs/22.16.0/lib/node_modules/@clerk/cli-linux-x64/bin/clerk";
+
+  // PATH candidates after realpath + asdf resolution (sibling shims in the
+  // same install tree as the platform binary).
+  const bunCandidate = {
+    resolvedPath: "/home/u/.bun/install/global/node_modules/clerk/bin/clerk",
+  };
+  const npmCandidate = {
+    resolvedPath: "/home/u/.asdf/installs/nodejs/22.16.0/lib/node_modules/clerk/bin/clerk",
+  };
+
+  test("returns index of candidate owned by same installer as execPath", () => {
+    // Reproduces the reported bug: asdf-npm first on PATH, user ran bun's
+    // install. The running install must win over PATH order.
+    const candidates = [npmCandidate, bunCandidate];
+    expect(findRunningInstallIndex(candidates, bunPlatformBin, dirs)).toBe(1);
+  });
+
+  test("picks the right install when running is npm and PATH puts bun first", () => {
+    // Mirror case of the above, covering the other direction.
+    const candidates = [bunCandidate, npmCandidate];
+    expect(findRunningInstallIndex(candidates, npmPlatformBin, dirs)).toBe(1);
+  });
+
+  test("returns 0 when the running install is already first on PATH", () => {
+    const candidates = [bunCandidate, npmCandidate];
+    expect(findRunningInstallIndex(candidates, bunPlatformBin, dirs)).toBe(0);
+  });
+
+  test("returns -1 when execPath is outside every known installer dir", () => {
+    // install.sh-style standalone binary: not owned by any PM, so there is
+    // no "running install" to match against — caller falls back to PATH order.
+    const candidates = [bunCandidate, npmCandidate];
+    expect(findRunningInstallIndex(candidates, "/usr/local/bin/clerk", dirs)).toBe(-1);
+  });
+
+  test("returns -1 when candidates is empty", () => {
+    expect(findRunningInstallIndex([], bunPlatformBin, dirs)).toBe(-1);
+  });
+
+  test("returns -1 when the running installer is not among candidates", () => {
+    // Running install has owner, but none of the PATH candidates share it.
+    // Caller should fall through to PATH-first order rather than misfire.
+    const candidates = [npmCandidate];
+    expect(findRunningInstallIndex(candidates, bunPlatformBin, dirs)).toBe(-1);
+  });
+
+  test("matches Homebrew execPath against a Homebrew candidate", () => {
+    const candidates = [
+      { resolvedPath: "/opt/homebrew/Cellar/clerk/1.0.0/bin/clerk" },
+      npmCandidate,
+    ];
+    expect(
+      findRunningInstallIndex(candidates, "/opt/homebrew/Cellar/clerk/1.0.0/bin/clerk", dirs),
+    ).toBe(0);
+  });
+
+  test("returns -1 when execPath is under an inactive asdf-nodejs version", () => {
+    // installDirs.npm points at the currently-active nodejs version (from
+    // `npm root -g`). A binary under a *different* asdf-nodejs install (e.g.
+    // the user invoked clerk from a shell that had v20 active, while the
+    // current shell has v22 active) doesn't start with the active dir, so
+    // ownerOfBinary returns null and the helper safely falls back to PATH
+    // order rather than mismatching against the active version's clerk.
+    const candidates = [bunCandidate, npmCandidate];
+    const inactiveNodeExec =
+      "/home/u/.asdf/installs/nodejs/20.0.0/lib/node_modules/@clerk/cli-linux-x64/bin/clerk";
+    expect(findRunningInstallIndex(candidates, inactiveNodeExec, dirs)).toBe(-1);
   });
 });
 

--- a/packages/cli-core/src/lib/installer.ts
+++ b/packages/cli-core/src/lib/installer.ts
@@ -31,10 +31,10 @@ export function isHomebrewPath(execPath: string): boolean {
 // ── PATH discovery ───────────────────────────────────────────────────────────
 
 // On a machine with more than one global install (bun + asdf-npm + Homebrew
-// is a common combo), runtime-based detection isn't enough: `npm install -g`
-// can land in the wrong prefix while the shell still resolves `clerk` to a
-// different binary. findClerkOnPath walks PATH so the caller can target the
-// first-on-PATH install, i.e. what the user's shell will actually execute.
+// is a common combo), the caller needs to enumerate every install so it can
+// report "other" installs and honor `--all`. Primary selection happens above
+// this layer: the update command uses `findRunningInstallIndex` to pick the
+// install that owns `process.execPath` rather than the first PATH hit.
 
 /**
  * Returns symlink-resolved absolute paths to every `clerk` binary on PATH, in
@@ -96,7 +96,14 @@ async function isExecutableFile(path: string): Promise<boolean> {
   }
 }
 
-async function safeRealpath(p: string): Promise<string> {
+/**
+ * `realpath` that returns the input path unchanged on any error (missing file,
+ * permission denied, etc.) instead of throwing. Used wherever a best-effort
+ * symlink resolution is good enough — matching against installer dirs still
+ * works if both sides stay unresolved, and callers can't meaningfully recover
+ * from a failed realpath on a path the user asked about.
+ */
+export async function safeRealpath(p: string): Promise<string> {
   try {
     return await realpath(p);
   } catch {
@@ -253,6 +260,40 @@ export function ownerOfBinary(
     }
   }
   return best?.installer ?? null;
+}
+
+/**
+ * Index of the candidate install that owns `execPath` (the currently-running
+ * binary), or `-1` if none matches.
+ *
+ * Matching is by owning installer, not path equality: `PATH` exposes a
+ * symlink/shim (e.g. `~/.bun/bin/clerk`) while `process.execPath` lands on the
+ * platform binary beneath it (e.g.
+ * `~/.bun/install/global/node_modules/@clerk/cli-<arch>/bin/clerk`). Both
+ * resolve to the same owner under `installDirs`, which uniquely identifies
+ * the install (each installer tracks one active dir).
+ *
+ * Callers use this to promote the running install to "primary" regardless of
+ * `PATH` order — the binary the user just invoked is the authoritative
+ * update target. Shell hash caches (zsh/bash) and asdf-vs-bun `PATH` ordering
+ * can make a fresh `PATH` walk pick a different install than the one that
+ * actually ran.
+ *
+ * Inactive asdf-nodejs versions: when the running binary sits under an asdf
+ * nodejs install that is NOT the shell's currently-active one,
+ * `installDirs.npm` (from `npm root -g`) points at a sibling version, so
+ * `ownerOfBinary(execPath, installDirs)` returns `null` and this helper
+ * returns `-1`. Callers fall back to PATH order rather than mismatching
+ * against the active version.
+ */
+export function findRunningInstallIndex(
+  candidates: ReadonlyArray<{ resolvedPath: string }>,
+  execPath: string,
+  installDirs: Partial<Record<Installer, string>>,
+): number {
+  const execOwner = ownerOfBinary(execPath, installDirs);
+  if (execOwner === null) return -1;
+  return candidates.findIndex((c) => ownerOfBinary(c.resolvedPath, installDirs) === execOwner);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fix `clerk update` picking the wrong install when multiple `clerk` binaries coexist on the same machine (e.g. bun + asdf-npm). The primary update target is now the install that owns `process.execPath` — the binary the user just invoked — instead of the first `PATH` hit. PATH-first remains the fallback when the running binary isn't on PATH or has no known owner.
- Extract the match logic to a pure helper `findRunningInstallIndex` in `lib/installer.ts`, export the previously-private `safeRealpath` (it's now needed from the command), and fix a latent bug where the PATH-empty fallback stored the un-realpath'd `process.execPath` as `resolvedPath` (breaks owner matching on macOS `/var` → `/private/var` paths).
- Rewrite the update command's `README.md` "Primary target selection" section; the old "Why PATH-walking matters" text documented the buggy design as intentional.

### Repro (from the bug report)

```
$ clerk update
◇  Checking for updates
│    Current: 1.0.0
│    Latest:  1.0.2
│    Target:  /Users/.../.asdf/installs/nodejs/22.16.0/lib/node_modules/clerk/bin/clerk (npm)
✔ Update clerk 1.0.0 → 1.0.2? Yes
◇  Updated npm
│  Also found 1 other clerk install:
│    /Users/.../.bun/install/global/node_modules/clerk/bin/clerk (bun)
│
└  Successfully updated to 1.0.2

$ clerk -v
1.0.0                      # ← bun's install (what the shell actually runs) is unchanged
$ which clerk
/Users/.../.bun/bin/clerk  # ← bun, not npm
```

After this fix the bun install is picked as primary and gets upgraded, so `clerk -v` reflects the new version.

### Why owner-matching, not path-equality

`process.execPath` inside the compiled CLI lands on the platform binary at `@clerk/cli-<arch>/bin/clerk`, while PATH candidates resolve to the shim at `clerk/bin/clerk`. Both sit under the same installer's `node_modules`, so `ownerOfBinary()` returns the same installer for both. `installDirs[installer]` tracks exactly one active dir per installer, so "same owner" uniquely identifies "same install" — no cross-install false matches. Binaries under *inactive* asdf-nodejs versions return `owner=null` and safely fall back to PATH order.

## Test plan

- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` (79 passed; 8 new unit tests for `findRunningInstallIndex` covering: bug-case reproduction, reverse-case, already-first, empty-candidates, unowned execPath, no-matching-candidate, Homebrew, and inactive-asdf-nodejs fallback)
- [x] Local `clerk update` smoke test on a machine with both bun and asdf-npm installs (pending CI)