### PR TITLE
ci(release): notify Slack on successful stable releases

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -1,0 +1,28 @@
+name: Notify Release
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+        description: Released version (without the leading "v")
+    secrets:
+      SLACK_RELEASE_WEBHOOK_URL:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-bun
+      - name: Notify Slack
+        run: bun scripts/slack-release.ts --version "$VERSION"
+        env:
+          SLACK_RELEASE_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
+          VERSION: ${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,6 +174,15 @@ jobs:
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
+  notify-stable-success:
+    needs: [versioning, publish-npm, publish-github, homebrew]
+    if: needs.versioning.outputs.release_created == 'true'
+    uses: ./.github/workflows/notify-release.yml
+    with:
+      version: ${{ needs.versioning.outputs.version }}
+    secrets:
+      SLACK_RELEASE_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
+
   # ─── Canary release ────────────────────────────────────────────────
 
   canary-version:

--- a/scripts/slack-release.ts
+++ b/scripts/slack-release.ts
@@ -1,0 +1,65 @@
+/**
+ * Post a stable-release notification to Slack via an incoming webhook.
+ *
+ * Usage:
+ *   bun scripts/slack-release.ts --version <version>
+ *
+ * Required env vars:
+ *   SLACK_RELEASE_WEBHOOK_URL - Slack incoming webhook URL for release announcements
+ *   GITHUB_REPOSITORY         - e.g. "clerk/cli"
+ *   GITHUB_SERVER_URL         - e.g. "https://github.com"
+ */
+
+import { parseArgs } from "node:util";
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    version: { type: "string" },
+  },
+  strict: true,
+});
+
+if (!values.version) {
+  console.error("Usage: bun scripts/slack-release.ts --version <version>");
+  process.exit(1);
+}
+
+const webhookUrl = process.env.SLACK_RELEASE_WEBHOOK_URL;
+if (!webhookUrl) {
+  throw new Error("SLACK_RELEASE_WEBHOOK_URL is required");
+}
+
+const repo = process.env.GITHUB_REPOSITORY ?? "clerk/cli";
+const serverUrl = process.env.GITHUB_SERVER_URL ?? "https://github.com";
+const tag = `v${values.version}`;
+const releaseUrl = `${serverUrl}/${repo}/releases/tag/${tag}`;
+
+const payload = {
+  blocks: [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: [
+          `*:tada: clerk ${tag} released*`,
+          `*Repo:* \`${repo}\``,
+          `*Release:* <${releaseUrl}|View on GitHub>`,
+        ].join("\n"),
+      },
+    },
+  ],
+};
+
+const res = await fetch(webhookUrl, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(payload),
+});
+
+if (!res.ok) {
+  const body = await res.text();
+  throw new Error(`Slack webhook failed (${res.status}): ${body}`);
+}
+
+console.log("Slack release notification sent.");


### PR DESCRIPTION
## Summary
Adds a success-side Slack notification for stable releases. A new `scripts/slack-release.ts` posts the released version and a link to the GitHub release page to `SLACK_RELEASE_WEBHOOK_URL`, wrapped by a reusable `notify-release.yml` workflow. The `release.yml` workflow now runs a `notify-stable-success` job after `publish-npm`, `publish-github`, and `homebrew` all succeed on a stable release.

The existing failure notifications (`SLACK_WEBHOOK_URL`) are unchanged, and canary and snapshot channels are not wired up to the new webhook.

## Test plan
- [ ] Merge a changeset-bearing PR and confirm the `notify-stable-success` job fires after all stable jobs succeed and posts to the new Slack channel.
- [ ] Confirm non-release pushes (no changeset) do not trigger the job.