### PR TITLE
fix(e2e): add rsbuild peer for tanstack fixture

### DIFF
--- a/scripts/refresh-e2e-fixtures.ts
+++ b/scripts/refresh-e2e-fixtures.ts
@@ -86,10 +86,17 @@ for (const testFile of testFiles) {
     const pkg = JSON.parse(await Bun.file(pkgPath).text()) as {
       name?: string;
       dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
     };
     pkg.name = `clerk-fixture-${name}`;
     pkg.dependencies ??= {};
     pkg.dependencies[config.clerkSdk] = "latest";
+    if (name === "tanstack-start") {
+      pkg.devDependencies ??= {};
+      // TanStack Start's current scaffold omits this peer dependency even
+      // though the Vite plugin imports it during config evaluation.
+      pkg.devDependencies["@rsbuild/core"] = "^2.0.0";
+    }
     await Bun.write(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
 
     // Strip generated artifacts that shouldn't be committed

--- a/test/e2e/fixtures/tanstack-start/package.json
+++ b/test/e2e/fixtures/tanstack-start/package.json
@@ -26,6 +26,7 @@
     "tailwindcss": "^4.1.18"
   },
   "devDependencies": {
+    "@rsbuild/core": "^2.0.0",
     "@tanstack/devtools-vite": "latest",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.0",


### PR DESCRIPTION
## What

- add `@rsbuild/core` to the committed `tanstack-start` e2e fixture so the generated Vite config can resolve its current TanStack Start peer dependency
- update the fixture refresh script to preserve that dependency on future refreshes

## Why

TanStack Start's current scaffold omits `@rsbuild/core`, but the generated Vite config now pulls in code that requires it during config evaluation. That causes the TanStack Start e2e fixture to fail before the app can build or start.

## How

- patch the fixture's `package.json` to declare the missing peer
- special-case `tanstack-start` in the refresh script so refreshed fixtures keep the same dependency instead of reintroducing the failure
