### PR TITLE
fix(update): Do not hang if package manager is not present

### DIFF
--- a/.changeset/clerk-update-yarn-hang.md
+++ b/.changeset/clerk-update-yarn-hang.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Fix `clerk update` hanging when a corepack-shimmed package manager (e.g. yarn) prompts on stdin to download itself on first use. Package-manager probes now run with stdin detached, `COREPACK_ENABLE_DOWNLOAD_PROMPT=0`, and a 1.5s timeout, so a missing or uninitialized PM is treated as not installed instead of blocking the command.

--- a/packages/cli-core/src/lib/installer.ts
+++ b/packages/cli-core/src/lib/installer.ts
@@ -139,27 +139,69 @@ export async function getInstallerPackageDirs(): Promise<Partial<Record<Installe
   return out;
 }
 
+const PM_PROBE_TIMEOUT_MS = 1500;
+
+/**
+ * Run a package-manager probe with stdin detached and a hard timeout, capturing
+ * trimmed stdout on success. Returns null on any failure (spawn error, nonzero
+ * exit, timeout, empty output).
+ *
+ * Why stdin is detached: corepack-shimmed PMs (yarn/pnpm/npm under recent Node
+ * releases) prompt on stdin to download the requested package on first use.
+ * Inheriting the parent's TTY makes that prompt block forever waiting for a
+ * Y/n. `stdin: "ignore"` plus `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` ensures
+ * corepack errors out instead of prompting.
+ *
+ * Why the timeout: defense in depth. Even with stdin handled, slow shims, alias
+ * scripts, or network-bound startup paths can still hang. 1500ms matches the
+ * registry timeout in `fetchLatestVersion`.
+ */
+async function probePmDir(args: string[]): Promise<string | null> {
+  let proc: ReturnType<typeof Bun.spawn> | undefined;
+  try {
+    proc = Bun.spawn(args, {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "ignore",
+      env: { ...process.env, COREPACK_ENABLE_DOWNLOAD_PROMPT: "0" },
+    });
+  } catch {
+    return null;
+  }
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    proc?.kill();
+  }, PM_PROBE_TIMEOUT_MS);
+  try {
+    const exitCode = await proc.exited;
+    if (timedOut || exitCode !== 0) return null;
+    // `stdout: "pipe"` always yields a ReadableStream; the union in the type
+    // covers other stdout modes we don't use here.
+    const stdout = await new Response(proc.stdout as ReadableStream<Uint8Array>).text();
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 async function queryNpmPackageDir(): Promise<string | null> {
   // `npm root -g` reports the actual global node_modules dir on both platforms
   // (POSIX: `<prefix>/lib/node_modules`; Windows: `<prefix>\node_modules`, no
   // `lib` segment). Constructing the path manually breaks on Windows.
-  const result = await Bun.$`npm root -g`.quiet().nothrow();
-  if (result.exitCode !== 0) return null;
-  const dir = result.stdout.toString().trim();
+  const dir = await probePmDir(["npm", "root", "-g"]);
   return dir ? await safeRealpath(dir) : null;
 }
 
 async function queryPnpmPackageDir(): Promise<string | null> {
-  const result = await Bun.$`pnpm root -g`.quiet().nothrow();
-  if (result.exitCode !== 0) return null;
-  const dir = result.stdout.toString().trim();
+  const dir = await probePmDir(["pnpm", "root", "-g"]);
   return dir ? await safeRealpath(dir) : null;
 }
 
 async function queryYarnPackageDir(): Promise<string | null> {
-  const result = await Bun.$`yarn global dir`.quiet().nothrow();
-  if (result.exitCode !== 0) return null;
-  const dir = result.stdout.toString().trim();
+  const dir = await probePmDir(["yarn", "global", "dir"]);
   return dir ? await safeRealpath(join(dir, "node_modules")) : null;
 }
 


### PR DESCRIPTION
I don't have `yarn` installed, and this produced a hang on `clerk update`. The cause of the hang was that it was sitting waiting for user confirmation to download `yarn`, but never surfaced this to the user. Instead, ignore `stdin`, explicitly do not use corepack download prompts, and add a timeout.