### PR TITLE
fix(skills): hide internal Claude Code skills from public skills CLI

### DIFF
--- a/.claude/skills/audit-clerk-skill/SKILL.md
+++ b/.claude/skills/audit-clerk-skill/SKILL.md
@@ -5,6 +5,8 @@ effort: high
 user-invocable: true
 disable-model-invocation: true
 argument-hint: "[--apply]"
+metadata:
+  internal: true
 ---
 
 # Audit the clerk Skill

--- a/.claude/skills/changesets/SKILL.md
+++ b/.claude/skills/changesets/SKILL.md
@@ -6,6 +6,8 @@ user-invocable: true
 disable-model-invocation: false
 effort: high
 allowed-tools: Bash(git:*), Bash(gh pr view:*), Bash(gh pr list:*), Bash(bun changeset status:*), Bash(bun changeset --empty:*), Bash(git add:*), Bash(git commit:*), Read, Write, Edit, Glob
+metadata:
+  internal: true
 ---
 
 # /changesets create


### PR DESCRIPTION
## Summary

- The vercel-labs [`skills`](https://github.com/vercel-labs/skills) CLI scans `.claude/skills/` as a default discovery path, so `bunx skills@latest add clerk/cli` was surfacing the project-internal `audit-clerk-skill` and `changesets` skills alongside the public `clerk` skill.
- Adds `metadata.internal: true` to both internal SKILL.md frontmatters. Per the `skills` CLI docs, this hides them from default discovery while leaving them installable behind `INSTALL_INTERNAL_SKILLS=1` for maintainers.
- Claude Code itself ignores the `metadata` block, so local invocation of these skills is unaffected.

## Before

```
Found 3 skills
Select skills to install (space to toggle)
☐ audit-clerk-skill
☐ changesets
☐ clerk
```

## After

```
Found 1 skill
Select skills to install (space to toggle)
☐ clerk
```

## Test plan

- [ ] After merge, run `bunx skills@latest add clerk/cli` and confirm only `clerk` appears in the picker.
- [ ] Run `INSTALL_INTERNAL_SKILLS=1 bunx skills@latest add clerk/cli` and confirm all three skills are listed.
- [ ] Confirm Claude Code still loads `audit-clerk-skill` and `changesets` from `.claude/skills/` locally.