### PR TITLE
perf(build): minify bundle and compiled binary

### DIFF
--- a/.changeset/bundle-size.md
+++ b/.changeset/bundle-size.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Reduce the size of the published `clerk` binary and JS bundle by enabling minification during the build. The compiled binary shrinks by ~1 MB across all platforms, and the bundled `cli.js` artifact shrinks by ~41% (2.37 MB → 1.40 MB), with no change to behavior.

--- a/packages/cli-core/package.json
+++ b/packages/cli-core/package.json
@@ -7,8 +7,8 @@
   },
   "type": "module",
   "scripts": {
-    "build": "bun build ./src/cli.ts --outfile ./dist/cli.js --target node --external @napi-rs/keyring",
-    "build:compile": "bun build --compile --no-compile-autoload-dotenv ./src/cli.ts --outfile ./dist/clerk",
+    "build": "bun build ./src/cli.ts --outfile ./dist/cli.js --target node --external @napi-rs/keyring --minify",
+    "build:compile": "bun build --compile --minify --no-compile-autoload-dotenv ./src/cli.ts --outfile ./dist/clerk",
     "dev": "bun run ./src/cli.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "lint": "oxlint src/",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -90,6 +90,7 @@ for (const target of selectedTargets) {
     "bun",
     "build",
     "--compile",
+    "--minify",
     "--no-compile-autoload-dotenv",
     `--target=${target.bunTarget}`,
     `--define`,


### PR DESCRIPTION
## Summary

- Adds `--minify` to all `bun build` invocations: the `cli.js` bundle, the local `--compile` binary, and the cross-platform release build in `scripts/build.ts`.
- Reduces the shipped `clerk` binary by ~1 MB on every target (63.38 MB → 62.39 MB on darwin-arm64 measured locally).
- Reduces the bundled `cli.js` artifact by ~41% (2.37 MB → 1.40 MB).
- No behavior change. `--define`-injected values (`CLI_VERSION`, `CLI_ENV_PROFILES`) are unaffected because Bun substitutes defines before minification.

## Why minify only

Reduction beyond `--minify` requires changing the deploy model (the embedded Bun runtime is ~60 MB of the binary and is fixed). I evaluated and rejected:

- `--target=bun` (the default) — *grew* the bundle: 1.40 MB → 1.63 MB.
- `--sourcemap=none` on `--compile` — *grew* the binary by 1.85 MB (Bun quirk; default behavior is smaller).
- `--bytecode` — fails on `cli.ts`'s top-level `await import()` for the completion fast path; bytecode also typically increases output size.
- Switching `@inquirer/prompts` to per-package imports — tree-shaking already eliminates unused prompts (verified: 360 KB used vs 420 KB if `import * as`).

## Test plan

- [x] `bun run build` produces `cli.js` of 1,400,498 B (down from 2,372,203 B)
- [x] `bun run build:compile` produces `dist/clerk` of 62,388,832 B (down from 63,379,552 B)
- [x] `bun run scripts/build.ts --target darwin-arm64 --version 0.0.0-test` succeeds and the binary reports the injected version
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun run format:check` passes
- [x] `bun run test` — all 82 unit + integration tests pass
- [x] Manual smoke on the minified compiled binary: `--version`, `--help`, `apps --help`, `init --help`, `completion bash` all behave correctly
- [ ] CI runs `bun changeset status --since=origin/main` (verified locally with staged changeset: exits 0, "clerk: patch")
- [ ] CI runs `bun run test:e2e` against the source (not the compiled binary), so minify is not exercised but also not broken