### PR TITLE
fix(test/e2e): make users-list importable by refresh-fixtures script

### DIFF
--- a/scripts/refresh-e2e-fixtures.ts
+++ b/scripts/refresh-e2e-fixtures.ts
@@ -54,8 +54,18 @@ for (const testFile of testFiles) {
   matchedOnly = true;
 
   const { config } = (await import(testFile)) as {
-    config: import("../test/e2e/lib/types.ts").FixtureConfig;
+    config?: import("../test/e2e/lib/types.ts").FixtureConfig;
   };
+
+  // Skip non-fixture e2e tests (e.g. live-API roundtrip tests that don't
+  // scaffold a project and therefore don't export a FixtureConfig).
+  if (!config) {
+    if (onlyName) {
+      console.error(`❌ ${name} is not a fixture (no config export).`);
+      process.exit(1);
+    }
+    continue;
+  }
 
   if (config.pinned && !force) {
     console.log(`⏭  Skipping pinned fixture: ${name} (use --force to refresh)`);

--- a/test/e2e/users-list.test.ts
+++ b/test/e2e/users-list.test.ts
@@ -16,57 +16,61 @@ import { tmpdir } from "node:os";
 import { createTestUser, deleteTestUser } from "./lib/test-user.ts";
 
 const FIXTURE_NAME = "users-list";
-const APP_ID = process.env.CLERK_CLI_TEST_APP_ID;
-const PLATFORM_KEY = process.env.CLERK_PLATFORM_API_KEY;
-
-if (!APP_ID || !PLATFORM_KEY) {
-  throw new Error(
-    "CLERK_CLI_TEST_APP_ID and CLERK_PLATFORM_API_KEY are required. " +
-      "Run via `bun run test:e2e:op` for local 1Password injection.",
-  );
-}
-
 const CLI_PATH = join(import.meta.dir, "../../packages/cli-core/src/cli.ts");
 
-let configDir: string;
-const createdIds: string[] = [];
+// Skip when imported by scripts/refresh-e2e-fixtures.ts; the env-var check
+// and bun:test hooks below would otherwise throw on a metadata-only import.
+if (!process.env.CLERK_REFRESH_FIXTURES) {
+  let APP_ID!: string;
+  let configDir: string;
+  const createdIds: string[] = [];
 
-beforeAll(() => {
-  configDir = mkdtempSync(join(tmpdir(), "clerk-cli-e2e-users-list-"));
-});
+  beforeAll(() => {
+    const appId = process.env.CLERK_CLI_TEST_APP_ID;
+    const platformKey = process.env.CLERK_PLATFORM_API_KEY;
+    if (!appId || !platformKey) {
+      throw new Error(
+        "CLERK_CLI_TEST_APP_ID and CLERK_PLATFORM_API_KEY are required. " +
+          "Run via `bun run test:e2e:op` for local 1Password injection.",
+      );
+    }
+    APP_ID = appId;
+    configDir = mkdtempSync(join(tmpdir(), "clerk-cli-e2e-users-list-"));
+  });
 
-afterAll(async () => {
-  for (const id of createdIds) {
-    await deleteTestUser(id, configDir, { appId: APP_ID }, FIXTURE_NAME);
-  }
-  rmSync(configDir, { recursive: true, force: true });
-});
+  afterAll(async () => {
+    for (const id of createdIds) {
+      await deleteTestUser(id, configDir, { appId: APP_ID }, FIXTURE_NAME);
+    }
+    rmSync(configDir, { recursive: true, force: true });
+  });
 
-test("users list --json returns a { data, hasMore } envelope around the BAPI users", async () => {
-  const users = await Promise.all(
-    [1, 2, 3].map(async () => {
-      const u = await createTestUser(configDir, { appId: APP_ID }, FIXTURE_NAME);
-      createdIds.push(u.id);
-      return u;
-    }),
-  );
+  test("users list --json returns a { data, hasMore } envelope around the BAPI users", async () => {
+    const users = await Promise.all(
+      [1, 2, 3].map(async () => {
+        const u = await createTestUser(configDir, { appId: APP_ID }, FIXTURE_NAME);
+        createdIds.push(u.id);
+        return u;
+      }),
+    );
 
-  const result = await Bun.$`bun ${CLI_PATH} users list --json --app ${APP_ID} \
-    --user-id ${users[0].id} --user-id ${users[1].id} --user-id ${users[2].id}`
-    .env({ ...process.env, CLERK_CONFIG_DIR: configDir })
-    .quiet();
+    const result = await Bun.$`bun ${CLI_PATH} users list --json --app ${APP_ID} \
+      --user-id ${users[0].id} --user-id ${users[1].id} --user-id ${users[2].id}`
+      .env({ ...process.env, CLERK_CONFIG_DIR: configDir })
+      .quiet();
 
-  const body = JSON.parse(result.stdout.toString()) as {
-    data: Array<{ id: unknown }>;
-    hasMore: boolean;
-  };
+    const body = JSON.parse(result.stdout.toString()) as {
+      data: Array<{ id: unknown }>;
+      hasMore: boolean;
+    };
 
-  expect(Array.isArray(body.data)).toBe(true);
-  expect(typeof body.hasMore).toBe("boolean");
-  // Three explicit user_id filters and a 100-row default page size, so the
-  // page can never overflow.
-  expect(body.hasMore).toBe(false);
-  expect(body.data.every((u) => typeof u.id === "string")).toBe(true);
-  const returned = body.data.map((u) => u.id as string).sort();
-  expect(returned).toEqual(users.map((u) => u.id).sort());
-});
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(typeof body.hasMore).toBe("boolean");
+    // Three explicit user_id filters and a 100-row default page size, so the
+    // page can never overflow.
+    expect(body.hasMore).toBe(false);
+    expect(body.data.every((u) => typeof u.id === "string")).toBe(true);
+    const returned = body.data.map((u) => u.id as string).sort();
+    expect(returned).toEqual(users.map((u) => u.id).sort());
+  });
+}


### PR DESCRIPTION
## Summary

The biweekly Refresh E2E Fixtures workflow has been failing on `main` since #237 landed `test/e2e/users-list.test.ts`. The refresh script imports every `test/e2e/*.test.ts` file to read each one's `FixtureConfig`, but `users-list.test.ts` threw at module top-level when `CLERK_CLI_TEST_APP_ID` and `CLERK_PLATFORM_API_KEY` were unset, which they are in that workflow because the script does not actually need them.

This change moves the env-var requirement into `beforeAll`, wraps the `bun:test` hook registrations in a `CLERK_REFRESH_FIXTURES` guard (matching the convention in `test/e2e/lib/fixture-test.ts`), and teaches the refresh script to skip imported files that do not export a `FixtureConfig`. Either fix on its own is insufficient: `bun:test`'s `beforeAll` itself throws when called outside the runner, and even with the file made import-safe, the script still crashes on `config.pinned` for non-fixture files. The combination also future-proofs the refresh against the next non-fixture e2e test that lands.

## Test plan

- [x] `bun run format` / `lint` / `typecheck` / `test` clean locally
- [x] `CLERK_REFRESH_FIXTURES=1 bun -e "import('./test/e2e/users-list.test.ts')"` succeeds
- [x] `bun run e2e:refresh-fixtures -- --only nextjs-pages-router` runs end-to-end
- [ ] Manually trigger the Refresh E2E Fixtures workflow on `main` after merge to verify