### PR TITLE
fix(init): use @clerk/nuxt@latest now that keyless ships in stable

### DIFF
--- a/.changeset/nuxt-sdk-latest.md
+++ b/.changeset/nuxt-sdk-latest.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+`clerk init --starter` now installs `@clerk/nuxt@latest` for new Nuxt projects instead of the pinned `@clerk/nuxt@2.2.0-snapshot.v20260413174426`. Keyless support shipped in stable `@clerk/nuxt@2.2.0`, so the snapshot pin (originally a workaround) is no longer needed.

--- a/packages/cli-core/src/lib/framework.ts
+++ b/packages/cli-core/src/lib/framework.ts
@@ -47,8 +47,6 @@ export const FRAMEWORK_MAP: FrameworkInfo[] = [
     dep: "nuxt",
     name: "Nuxt",
     sdk: "@clerk/nuxt",
-    // TODO: Remove sdkInstall once @clerk/nuxt stable (>=2.2.0) ships with keyless support
-    sdkInstall: "@clerk/nuxt@2.2.0-snapshot.v20260413174426",
     envVar: "NUXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
     secretKeyEnvVar: "NUXT_CLERK_SECRET_KEY",
     envFile: ".env",


### PR DESCRIPTION
## Summary

- Drop the `sdkInstall: "@clerk/nuxt@2.2.0-snapshot.v20260413174426"` override on the Nuxt entry in `FRAMEWORK_MAP`. The pin was a temporary bridge until keyless support landed in stable; the changelog confirms it shipped in `@clerk/nuxt@2.2.0` ("Introduce Keyless quickstart for Nuxt"), and stable is now at `2.3.0`.
- `clerk init --starter` for Nuxt now installs `@clerk/nuxt@latest`, matching every other framework in the registry.
- The generic `sdkInstall` field on `FrameworkInfo` stays as an escape hatch for future pinning.

## Test plan

- [x] `bun run format` / `bun run lint` / `bun run typecheck`
- [x] `bun test` for `framework.test.ts` and `commands/init/` (281 pass)
- [x] Manual: run `clerk init --starter` against a fresh Nuxt project, confirm dev server boots and the keyless flow renders sign-in/sign-up