### PR TITLE
feat: accept plural `orgs`/`users` as canonical `--for` values

### DIFF
--- a/.changeset/accept-orgs-flag-alias.md
+++ b/.changeset/accept-orgs-flag-alias.md
@@ -1,0 +1,5 @@
+---
+"clerk": minor
+---
+
+Accept plural `orgs` and `users` as the canonical values for `--for` on `clerk enable billing` and `clerk disable billing`. The singular `org` and `user` continue to work as aliases.

--- a/packages/cli-core/src/cli-program.ts
+++ b/packages/cli-core/src/cli-program.ts
@@ -626,10 +626,10 @@ Give AI agents better Clerk context: install the Clerk skills
       { command: "clerk enable orgs", description: "Enable organizations" },
       {
         command: "clerk enable orgs --force-selection --max-members 10",
-        description: "Enable organizations with options",
+        description: "Enable orgs with options",
       },
       {
-        command: "clerk enable billing --for org",
+        command: "clerk enable billing --for orgs",
         description: "Enable billing for organizations only",
       },
       {
@@ -672,7 +672,7 @@ Give AI agents better Clerk context: install the Clerk skills
     .description("Enable billing for organizations and/or users")
     .option(
       "--for <targets...>",
-      "Billing targets (org and/or user), separated by spaces or commas (e.g. org user). Defaults to both when omitted.",
+      "Billing targets (orgs and/or users), separated by spaces or commas (e.g. orgs users). Defaults to both when omitted.",
     )
     .option("--app <id>", "Application ID to target")
     .option("--instance <id>", "Instance to target (dev, prod, or instance ID)")
@@ -685,15 +685,15 @@ Give AI agents better Clerk context: install the Clerk skills
         description: "Enable billing for organizations and users",
       },
       {
-        command: "clerk enable billing --for org",
+        command: "clerk enable billing --for orgs",
         description: "Enable billing for organizations only",
       },
       {
-        command: "clerk enable billing --for user",
+        command: "clerk enable billing --for users",
         description: "Enable billing for users only",
       },
       {
-        command: "clerk enable billing --for org user",
+        command: "clerk enable billing --for orgs users",
         description: "Enable billing for both targets",
       },
       {
@@ -709,7 +709,7 @@ Give AI agents better Clerk context: install the Clerk skills
     .setExamples([
       { command: "clerk disable orgs", description: "Disable organizations" },
       {
-        command: "clerk disable billing --for org",
+        command: "clerk disable billing --for orgs",
         description: "Disable billing for organizations only (leaves organizations enabled)",
       },
       {
@@ -742,7 +742,7 @@ Give AI agents better Clerk context: install the Clerk skills
     )
     .option(
       "--for <targets...>",
-      "Billing targets (org and/or user), separated by spaces or commas (e.g. org user). Defaults to both when omitted.",
+      "Billing targets (orgs and/or users), separated by spaces or commas (e.g. orgs users). Defaults to both when omitted.",
     )
     .option("--app <id>", "Application ID to target")
     .option("--instance <id>", "Instance to target (dev, prod, or instance ID)")
@@ -754,11 +754,11 @@ Give AI agents better Clerk context: install the Clerk skills
         description: "Disable billing for organizations and users",
       },
       {
-        command: "clerk disable billing --for org",
+        command: "clerk disable billing --for orgs",
         description: "Disable billing for organizations only",
       },
       {
-        command: "clerk disable billing --for user",
+        command: "clerk disable billing --for users",
         description: "Disable billing for users only",
       },
     ])

--- a/packages/cli-core/src/cli-program.ts
+++ b/packages/cli-core/src/cli-program.ts
@@ -626,7 +626,7 @@ Give AI agents better Clerk context: install the Clerk skills
       { command: "clerk enable orgs", description: "Enable organizations" },
       {
         command: "clerk enable orgs --force-selection --max-members 10",
-        description: "Enable orgs with options",
+        description: "Enable organizations with options",
       },
       {
         command: "clerk enable billing --for orgs",

--- a/packages/cli-core/src/commands/billing/README.md
+++ b/packages/cli-core/src/commands/billing/README.md
@@ -15,27 +15,28 @@ clerk enable billing [--for <targets>] [options]
 clerk disable billing [--for <targets>] [options]
 ```
 
-`<targets>` is `org` and/or `user`, accepted as space-separated, comma-separated,
-or repeated `--for` flags (matching `clerk config pull --keys`). When omitted,
-the command targets both:
+`<targets>` is `orgs` and/or `users`, accepted as space-separated, comma-separated,
+or repeated `--for` flags (matching `clerk config pull --keys`). The singular
+forms `org` and `user` are still accepted as aliases for backward compatibility.
+When omitted, the command targets both:
 
 ```sh
-clerk enable billing --for org user
-clerk enable billing --for org,user
-clerk enable billing --for org --for user
-clerk enable billing                   # defaults to both
+clerk enable billing --for orgs users
+clerk enable billing --for orgs,users
+clerk enable billing --for orgs --for users
+clerk enable billing                     # defaults to both
 ```
 
 ## Options
 
-| Flag              | Description                                                                     |
-| ----------------- | ------------------------------------------------------------------------------- |
-| `--for <targets>` | Targets (`org` and/or `user`), separated by spaces or commas. Defaults to both. |
-| `--app <id>`      | Target a specific application                                                   |
-| `--instance <id>` | Target a specific instance (dev, prod)                                          |
-| `--yes`           | Skip the confirmation prompt                                                    |
-| `--dry-run`       | Preview the patch without applying it                                           |
-| `--no-skills`     | Skip the post-enable `clerk-billing` agent skill install (enable only)          |
+| Flag              | Description                                                                       |
+| ----------------- | --------------------------------------------------------------------------------- |
+| `--for <targets>` | Targets (`orgs` and/or `users`), separated by spaces or commas. Defaults to both. |
+| `--app <id>`      | Target a specific application                                                     |
+| `--instance <id>` | Target a specific instance (dev, prod)                                            |
+| `--yes`           | Skip the confirmation prompt                                                      |
+| `--dry-run`       | Preview the patch without applying it                                             |
+| `--no-skills`     | Skip the post-enable `clerk-billing` agent skill install (enable only)            |
 
 ## Agent skill
 
@@ -50,7 +51,7 @@ The install runs via the user's package runner (`bunx`, `pnpm dlx`, `yarn dlx`, 
 
 ## Cascade behavior
 
-- `enable billing --for org` (or `org,user`, or no `--for`) **also** sets
+- `enable billing --for orgs` (or `orgs,users`, or no `--for`) **also** sets
   `organization_settings.enabled = true`. Billing for organizations requires
   organizations enabled, so this saves a separate command. The cascade is
   idempotent — if organizations are already on, the diff is empty for that

--- a/packages/cli-core/src/commands/billing/index.test.ts
+++ b/packages/cli-core/src/commands/billing/index.test.ts
@@ -88,7 +88,7 @@ describe("clerk enable/disable billing", () => {
 
   // --- enable ---
 
-  test("enable --for org sends organization_enabled = true and cascades organization_settings.enabled", async () => {
+  test("enable --for orgs sends organization_enabled = true and cascades organization_settings.enabled", async () => {
     let capturedBody = "";
     stubFetch(async (_input, init) => {
       if (init?.method === "PATCH") capturedBody = init.body as string;
@@ -97,7 +97,7 @@ describe("clerk enable/disable billing", () => {
 
     await setupProfile();
     const { billingEnable } = await import("./index.ts");
-    await captured.run(() => billingEnable({ for: ["org"] }));
+    await captured.run(() => billingEnable({ for: ["orgs"] }));
 
     const parsed = JSON.parse(capturedBody);
     expect(parsed.billing.organization_enabled).toBe(true);
@@ -105,7 +105,7 @@ describe("clerk enable/disable billing", () => {
     expect(parsed.organization_settings.enabled).toBe(true);
   });
 
-  test("enable --for user sends user_enabled = true and does NOT cascade orgs", async () => {
+  test("enable --for users sends user_enabled = true and does NOT cascade orgs", async () => {
     let capturedBody = "";
     stubFetch(async (_input, init) => {
       if (init?.method === "PATCH") capturedBody = init.body as string;
@@ -114,7 +114,7 @@ describe("clerk enable/disable billing", () => {
 
     await setupProfile();
     const { billingEnable } = await import("./index.ts");
-    await captured.run(() => billingEnable({ for: ["user"] }));
+    await captured.run(() => billingEnable({ for: ["users"] }));
 
     const parsed = JSON.parse(capturedBody);
     expect(parsed.billing.user_enabled).toBe(true);
@@ -122,7 +122,7 @@ describe("clerk enable/disable billing", () => {
     expect(parsed.organization_settings).toBeUndefined();
   });
 
-  test("enable --for org,user (CSV form) sets both billing fields and cascades orgs", async () => {
+  test("enable --for orgs,users (CSV form) sets both billing fields and cascades orgs", async () => {
     let capturedBody = "";
     stubFetch(async (_input, init) => {
       if (init?.method === "PATCH") capturedBody = init.body as string;
@@ -131,7 +131,7 @@ describe("clerk enable/disable billing", () => {
 
     await setupProfile();
     const { billingEnable } = await import("./index.ts");
-    await captured.run(() => billingEnable({ for: ["org,user"] }));
+    await captured.run(() => billingEnable({ for: ["orgs,users"] }));
 
     const parsed = JSON.parse(capturedBody);
     expect(parsed.billing.organization_enabled).toBe(true);
@@ -139,7 +139,7 @@ describe("clerk enable/disable billing", () => {
     expect(parsed.organization_settings.enabled).toBe(true);
   });
 
-  test("enable --for org user (variadic form) sets both billing fields and cascades orgs", async () => {
+  test("enable --for orgs users (variadic form) sets both billing fields and cascades orgs", async () => {
     let capturedBody = "";
     stubFetch(async (_input, init) => {
       if (init?.method === "PATCH") capturedBody = init.body as string;
@@ -149,7 +149,24 @@ describe("clerk enable/disable billing", () => {
     await setupProfile();
     const { billingEnable } = await import("./index.ts");
     // Commander variadic produces a string[] when the user writes
-    // `--for org user` or `--for org --for user`.
+    // `--for orgs users` or `--for orgs --for users`.
+    await captured.run(() => billingEnable({ for: ["orgs", "users"] }));
+
+    const parsed = JSON.parse(capturedBody);
+    expect(parsed.billing.organization_enabled).toBe(true);
+    expect(parsed.billing.user_enabled).toBe(true);
+    expect(parsed.organization_settings.enabled).toBe(true);
+  });
+
+  test("enable --for org/user (singular aliases) still works for backward compatibility", async () => {
+    let capturedBody = "";
+    stubFetch(async (_input, init) => {
+      if (init?.method === "PATCH") capturedBody = init.body as string;
+      return new Response(JSON.stringify({}), { status: 200 });
+    });
+
+    await setupProfile();
+    const { billingEnable } = await import("./index.ts");
     await captured.run(() => billingEnable({ for: ["org", "user"] }));
 
     const parsed = JSON.parse(capturedBody);
@@ -200,7 +217,7 @@ describe("clerk enable/disable billing", () => {
 
     await setupProfile();
     const { billingEnable } = await import("./index.ts");
-    await captured.run(() => billingEnable({ for: [" org , org , user "] }));
+    await captured.run(() => billingEnable({ for: [" orgs , orgs , users "] }));
 
     const parsed = JSON.parse(capturedBody);
     expect(parsed.billing.organization_enabled).toBe(true);
@@ -210,7 +227,7 @@ describe("clerk enable/disable billing", () => {
   test("enable shows success message", async () => {
     await setupProfile();
     const { billingEnable } = await import("./index.ts");
-    await captured.run(() => billingEnable({ for: ["org"] }));
+    await captured.run(() => billingEnable({ for: ["orgs"] }));
 
     expect(captured.err).toContain("Billing enabled for organizations");
   });
@@ -224,7 +241,7 @@ describe("clerk enable/disable billing", () => {
 
     await setupProfile();
     const { billingEnable } = await import("./index.ts");
-    await captured.run(() => billingEnable({ for: ["org"], dryRun: true }));
+    await captured.run(() => billingEnable({ for: ["orgs"], dryRun: true }));
 
     expect(capturedUrl).toContain("dry_run=true");
     expect(captured.err).toContain("[dry-run]");
@@ -232,7 +249,7 @@ describe("clerk enable/disable billing", () => {
 
   // --- disable ---
 
-  test("disable --for org sets organization_enabled = false and never touches organization_settings", async () => {
+  test("disable --for orgs sets organization_enabled = false and never touches organization_settings", async () => {
     let capturedBody = "";
     stubFetch(async (_input, init) => {
       if (init?.method === "PATCH") capturedBody = init.body as string;
@@ -241,7 +258,7 @@ describe("clerk enable/disable billing", () => {
 
     await setupProfile();
     const { billingDisable } = await import("./index.ts");
-    await captured.run(() => billingDisable({ for: ["org"] }));
+    await captured.run(() => billingDisable({ for: ["orgs"] }));
 
     const parsed = JSON.parse(capturedBody);
     expect(parsed.billing.organization_enabled).toBe(false);
@@ -249,7 +266,7 @@ describe("clerk enable/disable billing", () => {
     expect(parsed.organization_settings).toBeUndefined();
   });
 
-  test("disable --for user sets user_enabled = false and never touches organization_settings", async () => {
+  test("disable --for users sets user_enabled = false and never touches organization_settings", async () => {
     let capturedBody = "";
     stubFetch(async (_input, init) => {
       if (init?.method === "PATCH") capturedBody = init.body as string;
@@ -258,7 +275,7 @@ describe("clerk enable/disable billing", () => {
 
     await setupProfile();
     const { billingDisable } = await import("./index.ts");
-    await captured.run(() => billingDisable({ for: ["user"] }));
+    await captured.run(() => billingDisable({ for: ["users"] }));
 
     const parsed = JSON.parse(capturedBody);
     expect(parsed.billing.user_enabled).toBe(false);
@@ -292,7 +309,7 @@ describe("clerk enable/disable billing", () => {
   test("disable shows success message", async () => {
     await setupProfile();
     const { billingDisable } = await import("./index.ts");
-    await captured.run(() => billingDisable({ for: ["org"] }));
+    await captured.run(() => billingDisable({ for: ["orgs"] }));
 
     expect(captured.err).toContain("Billing disabled for organizations");
   });
@@ -320,7 +337,7 @@ describe("clerk enable/disable billing", () => {
   test("enable installs the clerk-billing agent skill in agent mode", async () => {
     await setupProfile();
     const { billingEnable } = await import("./index.ts");
-    await captured.run(() => billingEnable({ for: ["org"] }));
+    await captured.run(() => billingEnable({ for: ["orgs"] }));
 
     expect(skillCalls).toEqual([{ source: "clerk/skills", skillNames: ["clerk-billing"] }]);
   });
@@ -328,7 +345,7 @@ describe("clerk enable/disable billing", () => {
   test("enable --no-skills suppresses the skill install", async () => {
     await setupProfile();
     const { billingEnable } = await import("./index.ts");
-    await captured.run(() => billingEnable({ for: ["org"], skills: false }));
+    await captured.run(() => billingEnable({ for: ["orgs"], skills: false }));
 
     expect(skillCalls).toHaveLength(0);
   });
@@ -336,7 +353,7 @@ describe("clerk enable/disable billing", () => {
   test("enable --dry-run does not install the skill", async () => {
     await setupProfile();
     const { billingEnable } = await import("./index.ts");
-    await captured.run(() => billingEnable({ for: ["org"], dryRun: true }));
+    await captured.run(() => billingEnable({ for: ["orgs"], dryRun: true }));
 
     expect(skillCalls).toHaveLength(0);
   });
@@ -346,7 +363,7 @@ describe("clerk enable/disable billing", () => {
 
     await setupProfile();
     const { billingEnable } = await import("./index.ts");
-    await captured.run(() => billingEnable({ for: ["org"] }));
+    await captured.run(() => billingEnable({ for: ["orgs"] }));
 
     expect(skillCalls).toHaveLength(0);
   });
@@ -354,7 +371,7 @@ describe("clerk enable/disable billing", () => {
   test("disable does not trigger the skill install", async () => {
     await setupProfile();
     const { billingDisable } = await import("./index.ts");
-    await captured.run(() => billingDisable({ for: ["org"] }));
+    await captured.run(() => billingDisable({ for: ["orgs"] }));
 
     expect(skillCalls).toHaveLength(0);
   });

--- a/packages/cli-core/src/commands/billing/index.ts
+++ b/packages/cli-core/src/commands/billing/index.ts
@@ -17,31 +17,41 @@ interface BillingOptions {
   skills?: boolean;
 }
 
-type Target = "org" | "user";
+type Target = "orgs" | "users";
 
-// Accepts variadic (`--for org user`), CSV (`--for org,user`), or repeated
-// (`--for org --for user`) — mirrors `--keys` on `clerk config pull`.
+// `org`/`user` are accepted as aliases for backward compatibility with the
+// initial release that used singular tokens.
+const TARGET_ALIASES: Record<string, Target> = {
+  org: "orgs",
+  orgs: "orgs",
+  user: "users",
+  users: "users",
+};
+
+// Accepts variadic (`--for orgs users`), CSV (`--for orgs,users`), or repeated
+// (`--for orgs --for users`) — mirrors `--keys` on `clerk config pull`.
 function parseForTargets(values: string[] | undefined): Target[] {
-  if (!values?.length) return ["org", "user"];
+  if (!values?.length) return ["orgs", "users"];
   const seen = new Set<Target>();
   for (const value of values) {
     for (const part of value.split(",")) {
       const trimmed = part.trim();
       if (!trimmed) continue;
-      if (trimmed !== "org" && trimmed !== "user") {
-        throwUsageError(`Invalid --for value: "${trimmed}". Expected "org" and/or "user".`);
+      const canonical = TARGET_ALIASES[trimmed];
+      if (!canonical) {
+        throwUsageError(`Invalid --for value: "${trimmed}". Expected "orgs" and/or "users".`);
       }
-      seen.add(trimmed);
+      seen.add(canonical);
     }
   }
   if (seen.size === 0) {
-    throwUsageError('--for must include at least one of: "org", "user".');
+    throwUsageError('--for must include at least one of: "orgs", "users".');
   }
   return [...seen];
 }
 
 function describeTargets(targets: Target[]): string {
-  const parts = targets.map((t) => (t === "org" ? "organizations" : "users"));
+  const parts = targets.map((t) => (t === "orgs" ? "organizations" : "users"));
   return parts.length === 2 ? `${parts[0]} and ${parts[1]}` : parts[0]!;
 }
 
@@ -51,12 +61,12 @@ export async function billingEnable(options: BillingOptions): Promise<void> {
 
   const billing: Record<string, unknown> = {};
   const payload: Record<string, unknown> = { billing };
-  if (targets.includes("org")) {
+  if (targets.includes("orgs")) {
     billing.organization_enabled = true;
     // Org billing requires orgs enabled; cascade is idempotent.
     payload.organization_settings = { enabled: true };
   }
-  if (targets.includes("user")) {
+  if (targets.includes("users")) {
     billing.user_enabled = true;
   }
 
@@ -114,8 +124,8 @@ export async function billingDisable(options: BillingOptions): Promise<void> {
 
   // No cascade: leave organization_settings untouched.
   const billing: Record<string, unknown> = {};
-  if (targets.includes("org")) billing.organization_enabled = false;
-  if (targets.includes("user")) billing.user_enabled = false;
+  if (targets.includes("orgs")) billing.organization_enabled = false;
+  if (targets.includes("users")) billing.user_enabled = false;
 
   await applyConfigPatch({
     ctx,

--- a/packages/cli-core/src/commands/completion/__complete.ts
+++ b/packages/cli-core/src/commands/completion/__complete.ts
@@ -53,9 +53,9 @@ const KNOWN_OPTION_VALUES: Record<string, Completion[]> = {
     { name: "canary", description: "Latest canary (pre-release) build" },
   ],
   "--for": [
-    { name: "org", description: "Organizations only" },
-    { name: "user", description: "Users only" },
-    { name: "org,user", description: "Both organizations and users" },
+    { name: "orgs", description: "Organizations only" },
+    { name: "users", description: "Users only" },
+    { name: "orgs,users", description: "Both organizations and users" },
   ],
 };
 

--- a/packages/cli-core/src/commands/orgs/README.md
+++ b/packages/cli-core/src/commands/orgs/README.md
@@ -42,7 +42,7 @@ When `billing.organization_enabled` is currently true, `disable` warns and asks
 for confirmation in human mode. In agent mode (no TTY), the command refuses
 unless `--yes` is passed — this avoids stranding org billing in a stale state.
 Disabling organizations never disables organization billing automatically; run
-`clerk disable billing --for org` first if that's what you intend.
+`clerk disable billing --for orgs` first if that's what you intend.
 
 ## Clerk API endpoints
 

--- a/packages/cli-core/src/commands/orgs/index.ts
+++ b/packages/cli-core/src/commands/orgs/index.ts
@@ -76,7 +76,7 @@ export async function orgsDisable(options: OrgsOptions): Promise<void> {
   if (orgBillingOn && !isHuman() && !options.yes) {
     throwUsageError(
       "Organization billing is enabled. Disabling organizations would leave `billing.organization_enabled` stranded. " +
-        "Run `clerk disable billing --for org` first, or pass --yes to override.",
+        "Run `clerk disable billing --for orgs` first, or pass --yes to override.",
     );
   }
 
@@ -89,7 +89,7 @@ export async function orgsDisable(options: OrgsOptions): Promise<void> {
     yes: options.yes,
     dryRun: options.dryRun,
     warning: orgBillingOn
-      ? "Organization billing is currently enabled. Disabling organizations will leave `billing.organization_enabled` stranded — consider running `clerk disable billing --for org` separately."
+      ? "Organization billing is currently enabled. Disabling organizations will leave `billing.organization_enabled` stranded — consider running `clerk disable billing --for orgs` separately."
       : undefined,
     currentConfig: current,
   });


### PR DESCRIPTION
## Summary

- Switches the canonical `--for` values on `clerk enable billing` and `clerk disable billing` from singular (`org`/`user`) to plural (`orgs`/`users`), since the plural forms read more naturally.
- Keeps the singular forms accepted as backward-compatible aliases so existing scripts and docs keep working.
- Updates help text, examples, error messages, tab-completion hints, READMEs, and the cross-reference in `clerk disable orgs` warnings, plus tests that cover both canonical and alias inputs.

## Test plan

- [ ] `bun run test packages/cli-core/src/commands/billing/index.test.ts`
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] Manually verify `clerk enable billing --for orgs` and `--for org` both still work