### PR TITLE
fix(security): disable bunfig.toml autoload in compiled CLI binary

### DIFF
--- a/.changeset/fix-bunfig-autoload.md
+++ b/.changeset/fix-bunfig-autoload.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Disable `bunfig.toml` autoload in the compiled CLI binary. Previously, an attacker-supplied `bunfig.toml` in the current working directory could execute arbitrary JavaScript (via `preload`) before argv parsing on any `clerk` invocation — including `clerk --version` and unknown subcommands. The release and local compile scripts now pass `--no-compile-autoload-bunfig` to `bun build --compile`, mirroring the existing `--no-compile-autoload-dotenv` hardening.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -109,7 +109,7 @@ The release workflow (`.github/workflows/release.yml`) runs on every push to `ma
 
 Defined in [`.github/workflows/build-binaries.yml`](../.github/workflows/build-binaries.yml) and called by the release, canary, and snapshot pipelines. Runs as a **single sequential job** on a Blacksmith runner that cross-compiles all 8 targets in ~5.5 seconds total using `scripts/build.ts`. For each target, the script:
 
-1. Cross-compiles the CLI using `bun build --compile --no-compile-autoload-dotenv --target=<bun_target>`
+1. Cross-compiles the CLI using `bun build --compile --no-compile-autoload-dotenv --no-compile-autoload-bunfig --target=<bun_target>`
 2. Injects the version via `--define "CLI_VERSION=\"$CLI_VERSION\""`
 3. Verifies the binary format using `file` output
 4. The workflow then uploads each binary as a separate GitHub Actions artifact

--- a/packages/cli-core/package.json
+++ b/packages/cli-core/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "scripts": {
     "build": "bun build ./src/cli.ts --outfile ./dist/cli.js --target node --external @napi-rs/keyring --minify",
-    "build:compile": "bun build --compile --minify --no-compile-autoload-dotenv ./src/cli.ts --outfile ./dist/clerk",
+    "build:compile": "bun build --compile --minify --no-compile-autoload-dotenv --no-compile-autoload-bunfig ./src/cli.ts --outfile ./dist/clerk",
     "dev": "bun run ./src/cli.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "lint": "oxlint src/",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -92,6 +92,7 @@ for (const target of selectedTargets) {
     "--compile",
     "--minify",
     "--no-compile-autoload-dotenv",
+    "--no-compile-autoload-bunfig",
     `--target=${target.bunTarget}`,
     `--define`,
     `CLI_VERSION="${version}"`,


### PR DESCRIPTION
## Summary

Fixes [AIE-965](https://linear.app/clerk/issue/AIE-965/clerk-cli-code-exec-via-bunfigtoml-in-cwd) — arbitrary code execution via attacker-supplied `bunfig.toml` in the working directory.

### The vulnerability

Bun's `--compile` standalone executables autoload `bunfig.toml` from the **runtime cwd** by default. An attacker who can drop a `bunfig.toml` into a directory the user later `cd`s into can execute arbitrary JavaScript on **any** `clerk` invocation, before argv parsing — including `clerk --version` and unknown subcommands.

Repro (pre-fix):

```sh
mkdir /tmp/c && cd /tmp/c
echo 'preload = ["data:text/javascript,require(\"fs\").writeFileSync(\"/tmp/PWNED\",\"x\")"]' > bunfig.toml
clerk --version && ls /tmp/PWNED
```

### The fix

Pass `--no-compile-autoload-bunfig` to `bun build --compile` in both build paths:

- `packages/cli-core/package.json` — `build:compile` script (local builds)
- `scripts/build.ts` — release pipeline (called from `.github/workflows/build-binaries.yml`)

This mirrors the existing `--no-compile-autoload-dotenv` hardening already in place. The flag was introduced in Bun 1.2.x and is documented at https://bun.com/reference/bun/CompileBuildOptions/autoloadBunfig.

Also bumps the release docs that quote the compile command line.

## Verification

Reproduced the exploit against an **unpatched** local binary and confirmed:
- Unpatched: `/tmp/PWNED` is written. Exploit succeeds.
- Patched: `/tmp/PWNED` is **not** written. `clerk --version` prints normally.

Tested three variants — `data:` URL preload, local `./evil.js` preload, and invalid subcommand. All blocked.

Audited the repo for any other `bun build --compile` invocations (`grep -rn "bun build --compile"`) — the only two compile sites are both patched; remaining matches are documentation comments.

## Test plan

- [x] `bun run format` — passes
- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun run typecheck` — passes across all packages
- [x] Local compile (`bun run build:compile`) succeeds with new flag
- [x] Exploit no longer works against patched binary
- [x] Exploit confirmed working against unpatched binary (sanity check)
- [x] CI green on this PR