### PR TITLE
fix(security): harden clerk init dependency-install spawn

### DIFF
--- a/.changeset/fix-pnpmfile-autoload.md
+++ b/.changeset/fix-pnpmfile-autoload.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Harden the dependency-install step of `clerk init`. Previously, the package-manager spawn in attacker-controlled cwd could execute arbitrary JavaScript via pnpm's `.pnpmfile.cjs` autoload or via lifecycle scripts (`preinstall`/`install`/`postinstall`) in the project's `package.json`. The install command now passes `--ignore-pnpmfile` (pnpm) and `--ignore-scripts` (all package managers).

--- a/packages/cli-core/src/commands/init/bootstrap-registry.ts
+++ b/packages/cli-core/src/commands/init/bootstrap-registry.ts
@@ -1,4 +1,4 @@
-import type { PackageManager } from "../../lib/package-manager.ts";
+import { PM_INSTALL_HARDENING_FLAGS, type PackageManager } from "../../lib/package-manager.ts";
 
 export type BootstrapEntry = {
   label: string;
@@ -147,9 +147,15 @@ export const BOOTSTRAP_REGISTRY: BootstrapEntry[] = [
   ...BOOTSTRAP_AUTHENTICATED_REGISTRY,
 ];
 
+// Hardening flags come from PM_INSTALL_HARDENING_FLAGS (see package-manager.ts
+// for the threat model). `clerk init --starter` runs this in projectDir,
+// which is freshly scaffolded from an official template but lives inside the
+// user's cwd — defense-in-depth covers a hypothetical attacker-planted
+// `.pnpmfile.cjs` or lifecycle script in the template, and keeps both install
+// surfaces (this one and the SDK install in heuristics.ts) symmetric.
 export const PM_INSTALL_COMMANDS: Record<PackageManager, string[]> = {
-  npm: ["npm", "install"],
-  yarn: ["yarn", "install"],
-  pnpm: ["pnpm", "install"],
-  bun: ["bun", "install"],
+  npm: ["npm", "install", ...PM_INSTALL_HARDENING_FLAGS.npm],
+  yarn: ["yarn", "install", ...PM_INSTALL_HARDENING_FLAGS.yarn],
+  pnpm: ["pnpm", "install", ...PM_INSTALL_HARDENING_FLAGS.pnpm],
+  bun: ["bun", "install", ...PM_INSTALL_HARDENING_FLAGS.bun],
 };

--- a/packages/cli-core/src/lib/installer.ts
+++ b/packages/cli-core/src/lib/installer.ts
@@ -12,7 +12,7 @@ import { access, realpath, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { delimiter, join, sep } from "node:path";
 import { UPDATE_PACKAGE_NAME } from "./constants.ts";
-import { pmInstallCommand, type PackageManager } from "./package-manager.ts";
+import type { PackageManager } from "./package-manager.ts";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -353,12 +353,21 @@ function normalizeWindowsPath(p: string): string {
 
 // ── Install command strings ─────────────────────────────────────────────────
 
+// Human-facing upgrade-Clerk commands. Intentionally NOT built from
+// `pmInstallCommand`: that helper adds `--ignore-pnpmfile` / `--ignore-scripts`
+// to defend `clerk init`'s spawn in attacker-controlled cwd. Those flags
+// don't belong in an upgrade hint a user copy-pastes to install the trusted
+// `clerk` package globally — postinstall scripts are how some PMs link the
+// binary into PATH.
+const GLOBAL_UPDATE_COMMANDS = {
+  bun: "bun add -g",
+  pnpm: "pnpm add -g",
+  npm: "npm install -g",
+} satisfies Record<Exclude<PackageManager, "yarn">, string>;
+
 /** Human-readable install/update command for the given installer. */
 export function globalInstallCommand(installer: Installer, packageSpec: string): string {
   if (installer === "homebrew") return `brew upgrade ${UPDATE_PACKAGE_NAME}`;
   if (installer === "yarn") return `yarn global add ${packageSpec}`;
-
-  // For bun, pnpm, and npm the global form is the local `<pm> add` command
-  // with a `-g` flag appended — reuse `pmInstallCommand` as the base.
-  return `${pmInstallCommand(installer as PackageManager)} -g ${packageSpec}`;
+  return `${GLOBAL_UPDATE_COMMANDS[installer]} ${packageSpec}`;
 }

--- a/packages/cli-core/src/lib/installer.ts
+++ b/packages/cli-core/src/lib/installer.ts
@@ -12,7 +12,6 @@ import { access, realpath, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { delimiter, join, sep } from "node:path";
 import { UPDATE_PACKAGE_NAME } from "./constants.ts";
-import type { PackageManager } from "./package-manager.ts";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -363,7 +362,7 @@ const GLOBAL_UPDATE_COMMANDS = {
   bun: "bun add -g",
   pnpm: "pnpm add -g",
   npm: "npm install -g",
-} satisfies Record<Exclude<PackageManager, "yarn">, string>;
+} satisfies Record<Exclude<Installer, "homebrew" | "yarn">, string>;
 
 /** Human-readable install/update command for the given installer. */
 export function globalInstallCommand(installer: Installer, packageSpec: string): string {

--- a/packages/cli-core/src/lib/package-manager.test.ts
+++ b/packages/cli-core/src/lib/package-manager.test.ts
@@ -2,28 +2,23 @@ import { test, expect, describe } from "bun:test";
 import { pmInstallCommand, PACKAGE_MANAGERS } from "./package-manager.ts";
 
 describe("pmInstallCommand hardening flags", () => {
-  // AIE-969: `clerk init` spawns the project package manager in attacker-
-  // controlled cwd. These flags are load-bearing — `--ignore-pnpmfile` blocks
-  // pnpm's `.pnpmfile.cjs` autoload code-exec, `--ignore-scripts` blocks
+  // `clerk init` spawns the project package manager in attacker-controlled
+  // cwd. These flags are load-bearing — `--ignore-pnpmfile` blocks pnpm's
+  // `.pnpmfile.cjs` autoload code-exec, `--ignore-scripts` blocks
   // lifecycle-script code-exec from the attacker's package.json. If any of
   // these drop, the install spawn regains its arbitrary-code-exec primitive.
 
-  test("every package manager emits --ignore-scripts", () => {
-    for (const pm of PACKAGE_MANAGERS) {
-      expect(pmInstallCommand(pm)).toContain("--ignore-scripts");
-    }
+  test.each([...PACKAGE_MANAGERS])("%s emits --ignore-scripts", (pm) => {
+    expect(pmInstallCommand(pm)).toContain("--ignore-scripts");
   });
 
   test("pnpm additionally emits --ignore-pnpmfile", () => {
     expect(pmInstallCommand("pnpm")).toContain("--ignore-pnpmfile");
   });
 
-  test("first token is the bare binary name (spawn tokenization)", () => {
-    // heuristics.runPmInstall splits addCmd by " " and uses [0] as the binary
-    // it probes via Bun.which(). A flag-prefixed binary would break that.
-    expect(pmInstallCommand("bun").split(" ")[0]).toBe("bun");
-    expect(pmInstallCommand("pnpm").split(" ")[0]).toBe("pnpm");
-    expect(pmInstallCommand("yarn").split(" ")[0]).toBe("yarn");
-    expect(pmInstallCommand("npm").split(" ")[0]).toBe("npm");
+  // heuristics.runPmInstall splits addCmd by " " and uses [0] as the binary
+  // it probes via Bun.which(). A flag-prefixed binary would break that.
+  test.each([...PACKAGE_MANAGERS])("%s install command starts with the bare binary", (pm) => {
+    expect(pmInstallCommand(pm).split(" ")[0]).toBe(pm);
   });
 });

--- a/packages/cli-core/src/lib/package-manager.test.ts
+++ b/packages/cli-core/src/lib/package-manager.test.ts
@@ -1,0 +1,29 @@
+import { test, expect, describe } from "bun:test";
+import { pmInstallCommand, PACKAGE_MANAGERS } from "./package-manager.ts";
+
+describe("pmInstallCommand hardening flags", () => {
+  // AIE-969: `clerk init` spawns the project package manager in attacker-
+  // controlled cwd. These flags are load-bearing — `--ignore-pnpmfile` blocks
+  // pnpm's `.pnpmfile.cjs` autoload code-exec, `--ignore-scripts` blocks
+  // lifecycle-script code-exec from the attacker's package.json. If any of
+  // these drop, the install spawn regains its arbitrary-code-exec primitive.
+
+  test("every package manager emits --ignore-scripts", () => {
+    for (const pm of PACKAGE_MANAGERS) {
+      expect(pmInstallCommand(pm)).toContain("--ignore-scripts");
+    }
+  });
+
+  test("pnpm additionally emits --ignore-pnpmfile", () => {
+    expect(pmInstallCommand("pnpm")).toContain("--ignore-pnpmfile");
+  });
+
+  test("first token is the bare binary name (spawn tokenization)", () => {
+    // heuristics.runPmInstall splits addCmd by " " and uses [0] as the binary
+    // it probes via Bun.which(). A flag-prefixed binary would break that.
+    expect(pmInstallCommand("bun").split(" ")[0]).toBe("bun");
+    expect(pmInstallCommand("pnpm").split(" ")[0]).toBe("pnpm");
+    expect(pmInstallCommand("yarn").split(" ")[0]).toBe("yarn");
+    expect(pmInstallCommand("npm").split(" ")[0]).toBe("npm");
+  });
+});

--- a/packages/cli-core/src/lib/package-manager.ts
+++ b/packages/cli-core/src/lib/package-manager.ts
@@ -8,11 +8,20 @@ export const PACKAGE_MANAGERS = ["bun", "pnpm", "yarn", "npm"] as const;
 
 export type PackageManager = (typeof PACKAGE_MANAGERS)[number];
 
+// Security: `clerk init` runs the user's package manager in attacker-controlled
+// cwd to install the framework SDK. Two cwd-reachable code-exec primitives
+// exist on a vanilla `<pm> add`:
+//   1. pnpm autoloads `.pnpmfile.cjs` at install startup (top-level code runs
+//      via `require()` before any package resolves). `--ignore-pnpmfile`
+//      disables that loader.
+//   2. Every PM runs lifecycle scripts (preinstall/install/postinstall) from
+//      the project's package.json on every install. `--ignore-scripts` skips
+//      them; the legitimate user re-runs install later for native modules.
 const PM_INSTALL_COMMANDS = {
-  bun: "bun add",
-  yarn: "yarn add",
-  pnpm: "pnpm add",
-  npm: "npm install",
+  bun: "bun add --ignore-scripts",
+  yarn: "yarn add --ignore-scripts",
+  pnpm: "pnpm add --ignore-pnpmfile --ignore-scripts",
+  npm: "npm install --ignore-scripts",
 } satisfies Record<PackageManager, string>;
 
 /** Returns the `<pm> add`-style command for installing dependencies. */

--- a/packages/cli-core/src/lib/package-manager.ts
+++ b/packages/cli-core/src/lib/package-manager.ts
@@ -10,18 +10,28 @@ export type PackageManager = (typeof PACKAGE_MANAGERS)[number];
 
 // Security: `clerk init` runs the user's package manager in attacker-controlled
 // cwd to install the framework SDK. Two cwd-reachable code-exec primitives
-// exist on a vanilla `<pm> add`:
+// exist on a vanilla `<pm> add`/`<pm> install`:
 //   1. pnpm autoloads `.pnpmfile.cjs` at install startup (top-level code runs
 //      via `require()` before any package resolves). `--ignore-pnpmfile`
 //      disables that loader.
 //   2. Every PM runs lifecycle scripts (preinstall/install/postinstall) from
 //      the project's package.json on every install. `--ignore-scripts` skips
 //      them; the legitimate user re-runs install later for native modules.
+//
+// Single source of truth — `PM_INSTALL_COMMANDS` below and the `--starter`
+// bootstrap install in `commands/init/bootstrap-registry.ts` both consume it.
+export const PM_INSTALL_HARDENING_FLAGS = {
+  bun: ["--ignore-scripts"],
+  yarn: ["--ignore-scripts"],
+  pnpm: ["--ignore-pnpmfile", "--ignore-scripts"],
+  npm: ["--ignore-scripts"],
+} as const satisfies Record<PackageManager, readonly string[]>;
+
 const PM_INSTALL_COMMANDS = {
-  bun: "bun add --ignore-scripts",
-  yarn: "yarn add --ignore-scripts",
-  pnpm: "pnpm add --ignore-pnpmfile --ignore-scripts",
-  npm: "npm install --ignore-scripts",
+  bun: ["bun", "add", ...PM_INSTALL_HARDENING_FLAGS.bun].join(" "),
+  yarn: ["yarn", "add", ...PM_INSTALL_HARDENING_FLAGS.yarn].join(" "),
+  pnpm: ["pnpm", "add", ...PM_INSTALL_HARDENING_FLAGS.pnpm].join(" "),
+  npm: ["npm", "install", ...PM_INSTALL_HARDENING_FLAGS.npm].join(" "),
 } satisfies Record<PackageManager, string>;
 
 /** Returns the `<pm> add`-style command for installing dependencies. */


### PR DESCRIPTION
## Summary

`clerk init` spawns the user's package manager in attacker-controlled `cwd` to install the framework SDK. Two cwd-reachable code-exec primitives were live on that spawn:

1. **pnpm `.pnpmfile.cjs` autoload** — pnpm `require()`s `.pnpmfile.cjs` from cwd at startup before resolving any package. Top-level statements execute at full user privilege. Verified live: a sentinel `.pnpmfile.cjs` writes `/tmp/PWNED` while `clerk init` reports a normal install. This is AIE-969.
2. **Lifecycle scripts** — every PM (`npm`/`yarn`/`pnpm`/`bun`) runs `preinstall`/`install`/`postinstall` from the project's `package.json` on every install, which the attacker controls in the cloned repo.

The fix passes `--ignore-pnpmfile` (pnpm) and `--ignore-scripts` (all package managers) to the install spawn, closing both primitives. `PM_INSTALL_HARDENING_FLAGS` is the single source of truth — both the SDK install (`heuristics.installSdk`/`installDeps`) and the `clerk init --starter` bootstrap install (`bootstrap.installDependencies`) consume it, so the two install surfaces can't drift.

`globalInstallCommand` (the `clerk update` upgrade-hint message) is intentionally decoupled — that string is copy-pasted by users to install the trusted `clerk` package globally, and lifecycle scripts are how some PMs link the binary into PATH.

## Test plan

- [x] Empirical exploit reproduction: baseline `pnpm add` in attacker cwd fires the sentinel `.pnpmfile.cjs`; with the flags applied, the same install succeeds without the sentinel firing.
- [x] `bun run format` / `lint` / `typecheck` clean
- [x] `bun run test` for the affected files (`package-manager.test.ts`, `installer.test.ts`, `bootstrap.test.ts`): 77/77 pass
- [x] Full `bun run test`: no new failures (pre-existing env-related failures unchanged at 122)
- [x] CI runs all unit + e2e suites on push

Fixes AIE-969.