### PR TITLE
fix(api): keep separator between path and summary in `clerk api ls`

### DIFF
--- a/.changeset/api-ls-path-separator.md
+++ b/.changeset/api-ls-path-separator.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Keep a separator between the path and description in `clerk api ls` so long endpoint paths no longer run straight into their summaries.

--- a/packages/cli-core/src/commands/api/ls.test.ts
+++ b/packages/cli-core/src/commands/api/ls.test.ts
@@ -6,6 +6,19 @@ import { parseSpec, _setCacheDir } from "./catalog.ts";
 import { useCaptureLog, stubFetch } from "../../test/lib/stubs.ts";
 import { apiLs } from "./ls.ts";
 
+const LONG_PATH_SPEC = `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: "1.0"
+paths:
+  /organizations/{organization_id}/memberships/{user_id}:
+    get:
+      tags: [Organizations]
+      summary: Get organization membership
+      operationId: GetOrganizationMembership
+`;
+
 const MINIMAL_SPEC = `
 openapi: "3.0.0"
 info:
@@ -111,5 +124,16 @@ describe("apiLs", () => {
 
     await runApiLs(undefined, { platform: true });
     expect(captured.out).not.toBe("");
+  });
+
+  test("long path (>=50 chars) is separated from summary by at least two spaces", async () => {
+    const longPath = "/organizations/{organization_id}/memberships/{user_id}";
+    const cached = parseSpec(LONG_PATH_SPEC);
+    cached.fetchedAt = Date.now();
+    await Bun.write(join(tempDir, "bapi-catalog.json"), JSON.stringify(cached));
+
+    await runApiLs(undefined, {});
+
+    expect(captured.out).toContain(`${longPath}  Get organization membership`);
   });
 });

--- a/packages/cli-core/src/commands/api/ls.ts
+++ b/packages/cli-core/src/commands/api/ls.ts
@@ -35,7 +35,9 @@ function printTable(endpoints: EndpointInfo[]): void {
 
   for (const ep of endpoints) {
     const method = ep.method.padEnd(methodWidth);
-    const path = ep.path.padEnd(pathWidth);
+    // padEnd is a no-op once the path meets/exceeds pathWidth, so guarantee a
+    // separator for over-long paths instead of gluing the summary onto them.
+    const path = ep.path.length >= pathWidth ? `${ep.path}  ` : ep.path.padEnd(pathWidth);
     log.data(`${method}${path}${ep.summary}`);
   }
 }


### PR DESCRIPTION
## Summary

`clerk api ls` rendered long endpoint paths with the summary glued directly onto the path, e.g.:

```
GET     /platform/applications/{applicationID}/instances/{envOrInsID}/configGet instance config
```

`pathWidth` is capped at 50, and `String.prototype.padEnd` is a no-op once the path already meets/exceeds that width, so no separator was emitted. This guarantees a two-space separator for over-long paths while leaving normal-width alignment untouched.

## Test plan
- `bun test src/commands/api/ls.test.ts` passes
- Existing `ls` tests are spacing-agnostic (substring assertions); no snapshot to update

Fixes #330