### PR TITLE
feat(api): add `clerk api --fapi` for the public Frontend API

### DIFF
--- a/.changeset/api-fapi-passthrough.md
+++ b/.changeset/api-fapi-passthrough.md
@@ -1,0 +1,5 @@
+---
+"clerk": minor
+---
+
+Add `clerk api --fapi` to call an instance's public Frontend API (e.g. `clerk api --fapi /environment --app <id>`). The FAPI host is resolved from the instance's publishable key, and the request is unauthenticated since these endpoints are public, which closes the loop on verifying config changes end to end with the CLI alone.

--- a/packages/cli-core/src/commands/api/README.md
+++ b/packages/cli-core/src/commands/api/README.md
@@ -55,22 +55,26 @@ clerk api /users --instance prod
 
 # Platform API mode
 clerk api /v1/platform/applications --platform
+
+# Frontend API mode — fetch the public environment payload to verify config
+clerk api --fapi /environment --app app_123 --instance dev
 ```
 
 ## Options
 
-| Flag                    | Description                                                       |
-| ----------------------- | ----------------------------------------------------------------- |
-| `-X, --method <method>` | HTTP method. Defaults to GET, or POST if body is provided.        |
-| `-d, --data <json>`     | JSON request body (inline)                                        |
-| `--file <path>`         | Read request body from a file                                     |
-| `--include`             | Show response status and headers                                  |
-| `--app <id>`            | Application ID to target when resolving keys                      |
-| `--secret-key <key>`    | Override the secret key                                           |
-| `--instance <id>`       | Instance to target for key resolution (`dev`, `prod`, or full ID) |
-| `--platform`            | Use Platform API instead of Backend API                           |
-| `--dry-run`             | Show request without executing                                    |
-| `--yes`                 | Skip confirmation for mutating requests                           |
+| Flag                    | Description                                                                     |
+| ----------------------- | ------------------------------------------------------------------------------- |
+| `-X, --method <method>` | HTTP method. Defaults to GET, or POST if body is provided.                      |
+| `-d, --data <json>`     | JSON request body (inline)                                                      |
+| `--file <path>`         | Read request body from a file                                                   |
+| `--include`             | Show response status and headers                                                |
+| `--app <id>`            | Application ID to target when resolving keys                                    |
+| `--secret-key <key>`    | Override the secret key                                                         |
+| `--instance <id>`       | Instance to target for key resolution (`dev`, `prod`, or full ID)               |
+| `--platform`            | Use Platform API instead of Backend API                                         |
+| `--fapi`                | Use the instance's public Frontend API (no auth; host from the publishable key) |
+| `--dry-run`             | Show request without executing                                                  |
+| `--yes`                 | Skip confirmation for mutating requests                                         |
 
 ## Authentication
 
@@ -93,6 +97,17 @@ Platform API auth (used by `--platform` mode, and by steps 3 and 4 above):
 3. Interactive human-mode prompt for a Platform API key
 
 The CLI validates key prefixes and will warn if you pass an `ak_` key where an `sk_` key is expected, or vice versa.
+
+### Frontend API (`--fapi`)
+
+`--fapi` targets the instance's public Frontend API — the same surface clerk-js
+consumes — which is useful for verifying that a config change took effect (e.g.
+`clerk api --fapi /environment`). The FAPI host is resolved from the instance's
+publishable key, looked up via the Platform API from `--app`/`--instance` or the
+linked project, so resolving the host needs Platform API auth, but the request
+itself is unauthenticated (these endpoints are public). `--fapi` and `--platform`
+cannot be combined. Paths are `/v1`-normalized like the other modes, so both
+`/environment` and `/v1/environment` work.
 
 ## API Endpoints
 

--- a/packages/cli-core/src/commands/api/bapi.ts
+++ b/packages/cli-core/src/commands/api/bapi.ts
@@ -6,14 +6,7 @@
 import { getBapiBaseUrl } from "../../lib/environment.ts";
 import { normalizeBapiPath } from "../../lib/bapi-command.ts";
 import { BapiError } from "../../lib/errors.ts";
-import { loggedFetch } from "../../lib/fetch.ts";
-
-export interface BapiResponse {
-  status: number;
-  headers: Headers;
-  body: unknown;
-  rawBody: string;
-}
+import { loggedFetch, type ApiResponse } from "../../lib/fetch.ts";
 
 export async function bapiRequest(options: {
   method: string;
@@ -21,7 +14,7 @@ export async function bapiRequest(options: {
   secretKey: string;
   body?: string;
   baseUrl?: string;
-}): Promise<BapiResponse> {
+}): Promise<ApiResponse> {
   const base = options.baseUrl ?? getBapiBaseUrl();
   const path = normalizeBapiPath(options.path);
 

--- a/packages/cli-core/src/commands/api/fapi.ts
+++ b/packages/cli-core/src/commands/api/fapi.ts
@@ -15,13 +15,10 @@ import {
   throwUsageError,
   withApiContext,
 } from "../../lib/errors.ts";
-import { decodePublishableKey } from "../../lib/fapi.ts";
+import { decodePublishableKey, CLERK_JS_API_VERSION } from "../../lib/fapi.ts";
 import { loggedFetch } from "../../lib/fetch.ts";
 import { fetchApplication, type ApplicationInstance } from "../../lib/plapi.ts";
 import type { BapiResponse } from "./bapi.ts";
-
-/** clerk-js API version FAPI shapes its `/v1/environment` payload for. */
-const CLERK_JS_API_VERSION = "5";
 
 interface ResolveOptions {
   app?: string;

--- a/packages/cli-core/src/commands/api/fapi.ts
+++ b/packages/cli-core/src/commands/api/fapi.ts
@@ -53,14 +53,14 @@ async function resolveInstance(options: ResolveOptions): Promise<ApplicationInst
   }
 
   const app = await withApiContext(fetchApplication(ctx.appId), "Failed to resolve instance");
-  const instance = app.instances.find((entry) => entry.instance_id === ctx.instanceId);
-  if (!instance) {
+  const resolved = resolveFetchedApplicationInstance(ctx.appId, app, ctx.instanceId);
+  if (!resolved.found) {
     throw new CliError(`Instance ${ctx.instanceId} not found in application.`, {
       code: ERROR_CODE.INSTANCE_NOT_FOUND,
       docsUrl: "https://clerk.com/docs/guides/development/managing-environments",
     });
   }
-  return instance;
+  return resolved.instance;
 }
 
 /** Resolve the instance's FAPI host from its publishable key. */

--- a/packages/cli-core/src/commands/api/fapi.ts
+++ b/packages/cli-core/src/commands/api/fapi.ts
@@ -1,0 +1,109 @@
+/**
+ * Frontend API (FAPI) passthrough for `clerk api --fapi`.
+ *
+ * FAPI is the public API that clerk-js consumes. Its host is per-instance and
+ * derived from the instance's publishable key, and the endpoints exposed here
+ * (e.g. `/v1/environment`) are public, so no auth header is sent.
+ */
+
+import { resolveAppContext, resolveFetchedApplicationInstance } from "../../lib/config.ts";
+import { normalizeBapiPath } from "../../lib/bapi-command.ts";
+import {
+  CliError,
+  ERROR_CODE,
+  FapiError,
+  throwUsageError,
+  withApiContext,
+} from "../../lib/errors.ts";
+import { decodePublishableKey } from "../../lib/fapi.ts";
+import { loggedFetch } from "../../lib/fetch.ts";
+import { fetchApplication, type ApplicationInstance } from "../../lib/plapi.ts";
+import type { BapiResponse } from "./bapi.ts";
+
+/** clerk-js API version FAPI shapes its `/v1/environment` payload for. */
+const CLERK_JS_API_VERSION = "5";
+
+interface ResolveOptions {
+  app?: string;
+  instance?: string;
+}
+
+async function resolveInstance(options: ResolveOptions): Promise<ApplicationInstance> {
+  if (options.app) {
+    const app = await withApiContext(fetchApplication(options.app), "Failed to resolve instance");
+    const resolved = resolveFetchedApplicationInstance(options.app, app, options.instance);
+    if (!resolved.found) {
+      throw new CliError(`Instance ${resolved.instanceId} not found in application.`, {
+        code: ERROR_CODE.INSTANCE_NOT_FOUND,
+        docsUrl: "https://clerk.com/docs/guides/development/managing-environments",
+      });
+    }
+    return resolved.instance;
+  }
+
+  let ctx: Awaited<ReturnType<typeof resolveAppContext>>;
+  try {
+    ctx = await resolveAppContext({ app: options.app, instance: options.instance });
+  } catch (error) {
+    if (error instanceof CliError && error.code === ERROR_CODE.NOT_LINKED) {
+      throwUsageError(
+        "No instance found. Link a project with `clerk link`, or pass --app <app_id>.",
+        "https://clerk.com/docs/guides/development/managing-environments",
+        ERROR_CODE.NOT_LINKED,
+      );
+    }
+    throw error;
+  }
+
+  const app = await withApiContext(fetchApplication(ctx.appId), "Failed to resolve instance");
+  const instance = app.instances.find((entry) => entry.instance_id === ctx.instanceId);
+  if (!instance) {
+    throw new CliError(`Instance ${ctx.instanceId} not found in application.`, {
+      code: ERROR_CODE.INSTANCE_NOT_FOUND,
+      docsUrl: "https://clerk.com/docs/guides/development/managing-environments",
+    });
+  }
+  return instance;
+}
+
+/** Resolve the instance's FAPI host from its publishable key. */
+export async function resolveFapiHost(options: ResolveOptions): Promise<string> {
+  const instance = await resolveInstance(options);
+  return decodePublishableKey(instance.publishable_key).fapiHost;
+}
+
+export async function fapiRequest(options: {
+  method: string;
+  path: string;
+  fapiHost: string;
+  body?: string;
+}): Promise<BapiResponse> {
+  const url = new URL(`https://${options.fapiHost}${normalizeBapiPath(options.path)}`);
+  if (!url.searchParams.has("_clerk_js_version")) {
+    url.searchParams.set("_clerk_js_version", CLERK_JS_API_VERSION);
+  }
+
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (options.body) headers["Content-Type"] = "application/json";
+
+  const response = await loggedFetch(url, {
+    tag: "fapi",
+    method: options.method,
+    headers,
+    body: options.body,
+  });
+
+  if (!response.ok) {
+    throw await FapiError.fromResponse(response);
+  }
+
+  const rawBody = await response.text();
+  let body: unknown;
+  try {
+    body = JSON.parse(rawBody);
+  } catch {
+    body = rawBody;
+  }
+
+  return { status: response.status, headers: response.headers, body, rawBody };
+}

--- a/packages/cli-core/src/commands/api/fapi.ts
+++ b/packages/cli-core/src/commands/api/fapi.ts
@@ -1,24 +1,15 @@
 /**
- * Frontend API (FAPI) passthrough for `clerk api --fapi`.
+ * Instance + FAPI host resolution for `clerk api --fapi`.
  *
  * FAPI is the public API that clerk-js consumes. Its host is per-instance and
- * derived from the instance's publishable key, and the endpoints exposed here
- * (e.g. `/v1/environment`) are public, so no auth header is sent.
+ * derived from the instance's publishable key. The passthrough request itself
+ * lives in `lib/fapi.ts` (`fapiRequest`) alongside the other FAPI helpers.
  */
 
 import { resolveAppContext, resolveFetchedApplicationInstance } from "../../lib/config.ts";
-import { normalizeBapiPath } from "../../lib/bapi-command.ts";
-import {
-  CliError,
-  ERROR_CODE,
-  FapiError,
-  throwUsageError,
-  withApiContext,
-} from "../../lib/errors.ts";
-import { decodePublishableKey, CLERK_JS_API_VERSION } from "../../lib/fapi.ts";
-import { loggedFetch } from "../../lib/fetch.ts";
+import { CliError, ERROR_CODE, throwUsageError, withApiContext } from "../../lib/errors.ts";
+import { decodePublishableKey } from "../../lib/fapi.ts";
 import { fetchApplication, type ApplicationInstance } from "../../lib/plapi.ts";
-import type { BapiResponse } from "./bapi.ts";
 
 interface ResolveOptions {
   app?: string;
@@ -67,40 +58,4 @@ async function resolveInstance(options: ResolveOptions): Promise<ApplicationInst
 export async function resolveFapiHost(options: ResolveOptions): Promise<string> {
   const instance = await resolveInstance(options);
   return decodePublishableKey(instance.publishable_key).fapiHost;
-}
-
-export async function fapiRequest(options: {
-  method: string;
-  path: string;
-  fapiHost: string;
-  body?: string;
-}): Promise<BapiResponse> {
-  const url = new URL(`https://${options.fapiHost}${normalizeBapiPath(options.path)}`);
-  if (!url.searchParams.has("_clerk_js_version")) {
-    url.searchParams.set("_clerk_js_version", CLERK_JS_API_VERSION);
-  }
-
-  const headers: Record<string, string> = { Accept: "application/json" };
-  if (options.body) headers["Content-Type"] = "application/json";
-
-  const response = await loggedFetch(url, {
-    tag: "fapi",
-    method: options.method,
-    headers,
-    body: options.body,
-  });
-
-  if (!response.ok) {
-    throw await FapiError.fromResponse(response);
-  }
-
-  const rawBody = await response.text();
-  let body: unknown;
-  try {
-    body = JSON.parse(rawBody);
-  } catch {
-    body = rawBody;
-  }
-
-  return { status: response.status, headers: response.headers, body, rawBody };
 }

--- a/packages/cli-core/src/commands/api/index.test.ts
+++ b/packages/cli-core/src/commands/api/index.test.ts
@@ -542,6 +542,77 @@ describe("api command", () => {
     expect(captured.out).toContain(JSON.stringify(errorBody, null, 2));
   });
 
+  test("--fapi without --app and no linked project errors with NOT_LINKED guidance", async () => {
+    delete process.env.CLERK_SECRET_KEY;
+
+    await expect(runApi("/environment", { fapi: true })).rejects.toThrow(/clerk link|--app/);
+  });
+
+  test.each([
+    ["/environment", "/v1/environment"],
+    ["/v1/environment", "/v1/environment"],
+  ])("--fapi: %s resolves to the same FAPI path %s", async (input, expectedPath) => {
+    process.env.CLERK_PLATFORM_API_KEY = "ak_test_platform";
+    const pk = `pk_test_${btoa("clerk.example.com$")}`;
+    let capturedPath = "";
+
+    stubFetch(async (input) => {
+      const url = input.toString();
+      if (url.includes("/v1/platform/applications/app_1")) {
+        return new Response(
+          JSON.stringify({
+            application_id: "app_1",
+            instances: [
+              { instance_id: "ins_dev", environment_type: "development", publishable_key: pk },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      capturedPath = new URL(url).pathname;
+      return new Response(JSON.stringify({}), { status: 200 });
+    });
+
+    await runApi(input, { fapi: true, app: "app_1" });
+    expect(capturedPath).toBe(expectedPath);
+  });
+
+  test("--fapi + --secret-key emits a warning that --secret-key is ignored", async () => {
+    process.env.CLERK_PLATFORM_API_KEY = "ak_test_platform";
+    const pk = `pk_test_${btoa("clerk.example.com$")}`;
+
+    stubFetch(async (input) => {
+      const url = input.toString();
+      if (url.includes("/v1/platform/applications/app_1")) {
+        return new Response(
+          JSON.stringify({
+            application_id: "app_1",
+            instances: [
+              { instance_id: "ins_dev", environment_type: "development", publishable_key: pk },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({}), { status: 200 });
+    });
+
+    await runApi("/environment", { fapi: true, app: "app_1", secretKey: "sk_test_ignored" });
+    expect(captured.err).toMatch(/--secret-key is ignored/);
+  });
+
+  test("--fapi + --dry-run does not make any network request", async () => {
+    let fetchCalled = false;
+    stubFetch(async () => {
+      fetchCalled = true;
+      return new Response(JSON.stringify({}), { status: 200 });
+    });
+
+    await runApi("/environment", { fapi: true, app: "app_1", dryRun: true });
+    expect(fetchCalled).toBe(false);
+    expect(captured.err).toContain("[dry-run] GET <fapi-host>");
+  });
+
   // --- Error handling ---
 
   test("errors when no secret key available", async () => {

--- a/packages/cli-core/src/commands/api/index.test.ts
+++ b/packages/cli-core/src/commands/api/index.test.ts
@@ -476,6 +476,72 @@ describe("api command", () => {
     );
   });
 
+  // --- --fapi mode ---
+
+  test("--fapi resolves the FAPI host from the publishable key and sends no auth header", async () => {
+    delete process.env.CLERK_SECRET_KEY;
+    process.env.CLERK_PLATFORM_API_KEY = "ak_test_platform";
+    const pk = `pk_test_${btoa("clerk.example.com$")}`;
+    let fapiUrl = "";
+    let fapiAuth: string | null = "unset";
+
+    stubFetch(async (input, init) => {
+      const url = input.toString();
+      if (url.includes("/v1/platform/applications/app_1")) {
+        return new Response(
+          JSON.stringify({
+            application_id: "app_1",
+            instances: [
+              { instance_id: "ins_dev", environment_type: "development", publishable_key: pk },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      fapiUrl = url;
+      fapiAuth = new Headers(init?.headers).get("Authorization");
+      return new Response(JSON.stringify({ environment: "ok" }), { status: 200 });
+    });
+
+    await runApi("/environment", { fapi: true, app: "app_1", instance: "dev" });
+    expect(fapiUrl).toContain("https://clerk.example.com/v1/environment");
+    expect(fapiUrl).toContain("_clerk_js_version=");
+    expect(fapiAuth).toBeNull();
+  });
+
+  test("--fapi cannot be combined with --platform", async () => {
+    await expect(runApi("/environment", { fapi: true, platform: true })).rejects.toThrow(
+      "cannot be combined",
+    );
+  });
+
+  test("--fapi prints API error response body to stdout and exits 1", async () => {
+    setMode("human");
+    process.env.CLERK_PLATFORM_API_KEY = "ak_test_platform";
+    const pk = `pk_test_${btoa("clerk.example.com$")}`;
+    const errorBody = { errors: [{ message: "no environment", code: "not_found" }] };
+
+    stubFetch(async (input) => {
+      const url = input.toString();
+      if (url.includes("/v1/platform/applications/app_1")) {
+        return new Response(
+          JSON.stringify({
+            application_id: "app_1",
+            instances: [
+              { instance_id: "ins_dev", environment_type: "development", publishable_key: pk },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify(errorBody), { status: 404 });
+    });
+
+    await runApi("/environment", { fapi: true, app: "app_1" });
+    expect(process.exitCode).toBe(1);
+    expect(captured.out).toContain(JSON.stringify(errorBody, null, 2));
+  });
+
   // --- Error handling ---
 
   test("errors when no secret key available", async () => {

--- a/packages/cli-core/src/commands/api/index.ts
+++ b/packages/cli-core/src/commands/api/index.ts
@@ -2,9 +2,10 @@ import type { Program } from "../../cli-program.ts";
 import { getAuthToken } from "../../lib/plapi.ts";
 import { getBapiBaseUrl, getPlapiBaseUrl } from "../../lib/environment.ts";
 import { normalizeBapiPath, resolveBapiSecretKey } from "../../lib/bapi-command.ts";
-import { bapiRequest } from "./bapi.ts";
+import { bapiRequest, type BapiResponse } from "./bapi.ts";
+import { fapiRequest, resolveFapiHost } from "./fapi.ts";
 import {
-  BapiError,
+  ApiError,
   ERROR_CODE,
   UserAbortError,
   isPromptExitError,
@@ -25,11 +26,42 @@ export interface ApiOptions {
   secretKey?: string;
   instance?: string;
   platform?: boolean;
+  fapi?: boolean;
   dryRun?: boolean;
   yes?: boolean;
 }
 
 const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+type RunRequest = (req: { method: string; path: string; body?: string }) => Promise<BapiResponse>;
+
+/** Resolve the API surface (base URL + request executor) from the flags. */
+async function resolveApiTarget(
+  options: ApiOptions,
+): Promise<{ baseUrl: string; runRequest: RunRequest }> {
+  if (options.fapi) {
+    if (options.platform) {
+      throwUsageError(
+        "--fapi and --platform cannot be combined.",
+        undefined,
+        ERROR_CODE.USAGE_ERROR,
+      );
+    }
+    const fapiHost = await resolveFapiHost(options);
+    const baseUrl = `https://${fapiHost}`;
+    return { baseUrl, runRequest: (req) => fapiRequest({ ...req, fapiHost }) };
+  }
+
+  if (options.platform) {
+    const secretKey = await getAuthToken();
+    const baseUrl = getPlapiBaseUrl();
+    return { baseUrl, runRequest: (req) => bapiRequest({ ...req, secretKey, baseUrl }) };
+  }
+
+  const secretKey = await resolveBapiSecretKey(options);
+  const baseUrl = getBapiBaseUrl();
+  return { baseUrl, runRequest: (req) => bapiRequest({ ...req, secretKey, baseUrl }) };
+}
 
 export async function api(
   endpoint: string | undefined,
@@ -61,17 +93,8 @@ export async function api(
     // 2. Determine HTTP method
     const method = (options.method ?? (body ? "POST" : "GET")).toUpperCase();
 
-    // 3. Resolve authentication
-    let secretKey: string;
-    let baseUrl: string;
-
-    if (options.platform) {
-      secretKey = await getAuthToken();
-      baseUrl = getPlapiBaseUrl();
-    } else {
-      secretKey = await resolveBapiSecretKey(options);
-      baseUrl = getBapiBaseUrl();
-    }
+    // 3. Resolve the request target (base URL + executor)
+    const { baseUrl, runRequest } = await resolveApiTarget(options);
 
     // 4. Dry run
     if (options.dryRun) {
@@ -97,13 +120,7 @@ export async function api(
     // 6. Execute request
     try {
       const response = await withSpinner("Executing request...", () =>
-        bapiRequest({
-          method,
-          path: endpoint,
-          secretKey,
-          body: body ?? undefined,
-          baseUrl,
-        }),
+        runRequest({ method, path: endpoint, body: body ?? undefined }),
       );
 
       if (options.include) {
@@ -112,10 +129,10 @@ export async function api(
       printBody(response.body);
       closeStatus = "success";
     } catch (error) {
-      // Handle BapiError locally to print the raw API response body to stdout
+      // Handle API errors locally to print the raw response body to stdout
       // (for piping), rather than propagating to the global error handler.
-      if (error instanceof BapiError) {
-        if (options.include) {
+      if (error instanceof ApiError) {
+        if (options.include && error.headers) {
           printHeaders(error.status, error.headers);
         }
         prettyPrint(error.body);
@@ -216,6 +233,10 @@ export function registerApi(program: Program): void {
     .option("--secret-key <key>", "Override the secret key")
     .option("--instance <id>", "Instance to target (dev, prod, or instance ID)")
     .option("--platform", "Use Platform API instead of Backend API")
+    .option(
+      "--fapi",
+      "Use the instance's public Frontend API (no auth; host resolved from the publishable key)",
+    )
     .option("--dry-run", "Show the request without executing it")
     .option("--yes", "Skip confirmation for mutating requests")
     .setExamples([
@@ -225,6 +246,10 @@ export function registerApi(program: Program): void {
       {
         command: 'clerk api /users -d \'{"first_name":"Alice"}\'',
         description: "POST with a JSON body",
+      },
+      {
+        command: "clerk api --fapi /environment --app <id> --instance dev",
+        description: "GET the public FAPI environment payload",
       },
     ])
     .action(api);

--- a/packages/cli-core/src/commands/api/index.ts
+++ b/packages/cli-core/src/commands/api/index.ts
@@ -247,7 +247,7 @@ export function registerApi(program: Program): void {
     .option("--platform", "Use Platform API instead of Backend API")
     .option(
       "--fapi",
-      "Use the instance's public Frontend API (no auth; host resolved from the publishable key)",
+      "Use the instance's public Frontend API (unauthenticated endpoints only; host derived from the publishable key)",
     )
     .option("--dry-run", "Show the request without executing it")
     .option("--yes", "Skip confirmation for mutating requests")

--- a/packages/cli-core/src/commands/api/index.ts
+++ b/packages/cli-core/src/commands/api/index.ts
@@ -2,8 +2,10 @@ import type { Program } from "../../cli-program.ts";
 import { getAuthToken } from "../../lib/plapi.ts";
 import { getBapiBaseUrl, getPlapiBaseUrl } from "../../lib/environment.ts";
 import { normalizeBapiPath, resolveBapiSecretKey } from "../../lib/bapi-command.ts";
-import { bapiRequest, type BapiResponse } from "./bapi.ts";
-import { fapiRequest, resolveFapiHost } from "./fapi.ts";
+import { type ApiResponse } from "../../lib/fetch.ts";
+import { bapiRequest } from "./bapi.ts";
+import { fapiRequest } from "../../lib/fapi.ts";
+import { resolveFapiHost } from "./fapi.ts";
 import {
   ApiError,
   ERROR_CODE,
@@ -33,7 +35,7 @@ export interface ApiOptions {
 
 const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
-type RunRequest = (req: { method: string; path: string; body?: string }) => Promise<BapiResponse>;
+type RunRequest = (req: { method: string; path: string; body?: string }) => Promise<ApiResponse>;
 
 /** Validate fapi flag combinations and emit warnings for ignored flags. */
 function validateFapiOptions(options: ApiOptions): void {

--- a/packages/cli-core/src/commands/api/index.ts
+++ b/packages/cli-core/src/commands/api/index.ts
@@ -35,18 +35,21 @@ const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 type RunRequest = (req: { method: string; path: string; body?: string }) => Promise<BapiResponse>;
 
+/** Validate fapi flag combinations and emit warnings for ignored flags. */
+function validateFapiOptions(options: ApiOptions): void {
+  if (options.platform) {
+    throwUsageError("--fapi and --platform cannot be combined.", undefined, ERROR_CODE.USAGE_ERROR);
+  }
+  if (options.secretKey) {
+    log.warn("--secret-key is ignored when --fapi is set.");
+  }
+}
+
 /** Resolve the API surface (base URL + request executor) from the flags. */
 async function resolveApiTarget(
   options: ApiOptions,
 ): Promise<{ baseUrl: string; runRequest: RunRequest }> {
   if (options.fapi) {
-    if (options.platform) {
-      throwUsageError(
-        "--fapi and --platform cannot be combined.",
-        undefined,
-        ERROR_CODE.USAGE_ERROR,
-      );
-    }
     const fapiHost = await resolveFapiHost(options);
     const baseUrl = `https://${fapiHost}`;
     return { baseUrl, runRequest: (req) => fapiRequest({ ...req, fapiHost }) };
@@ -93,17 +96,26 @@ export async function api(
     // 2. Determine HTTP method
     const method = (options.method ?? (body ? "POST" : "GET")).toUpperCase();
 
-    // 3. Resolve the request target (base URL + executor)
-    const { baseUrl, runRequest } = await resolveApiTarget(options);
-
-    // 4. Dry run
+    // 3. Dry run — for --fapi, skip host resolution to avoid a real Platform API round-trip
     if (options.dryRun) {
-      log.info(`[dry-run] ${method} ${baseUrl}${normalizeBapiPath(endpoint)}`);
+      if (options.fapi) {
+        validateFapiOptions(options);
+        log.info(`[dry-run] ${method} <fapi-host>${normalizeBapiPath(endpoint)}`);
+      } else {
+        const { baseUrl } = await resolveApiTarget(options);
+        log.info(`[dry-run] ${method} ${baseUrl}${normalizeBapiPath(endpoint)}`);
+      }
       if (body) {
         prettyPrint(body);
       }
       return;
     }
+
+    // 4. Resolve the request target (base URL + executor)
+    if (options.fapi) {
+      validateFapiOptions(options);
+    }
+    const { runRequest } = await resolveApiTarget(options);
 
     // 5. Confirmation for mutating methods
     if (MUTATING_METHODS.has(method) && isHuman() && !options.yes) {

--- a/packages/cli-core/src/lib/fapi.test.ts
+++ b/packages/cli-core/src/lib/fapi.test.ts
@@ -102,7 +102,7 @@ describe("fetchUserSettings", () => {
     expect(settings.attributes.email_address?.enabled).toBe(true);
     expect(capturedUrl).toContain("https://foo.example.com/v1/environment");
     expect(capturedUrl).toContain("__clerk_db_jwt=jwt-abc");
-    expect(capturedUrl).toContain("_clerk_js_version=5");
+    expect(capturedUrl).toContain("_clerk_js_version=6");
   });
 
   test("omits __clerk_db_jwt when no jwt is provided", async () => {

--- a/packages/cli-core/src/lib/fapi.ts
+++ b/packages/cli-core/src/lib/fapi.ts
@@ -15,7 +15,7 @@ const PK_LIVE_PREFIX = "pk_live_";
  * The clerk-js client version FAPI's `/v1/environment` payload is shaped for.
  * Bump when consuming response fields introduced in a later major version.
  */
-export const CLERK_JS_API_VERSION = "5";
+export const CLERK_JS_API_VERSION = "6";
 
 export type InstanceType = "development" | "production";
 

--- a/packages/cli-core/src/lib/fapi.ts
+++ b/packages/cli-core/src/lib/fapi.ts
@@ -5,8 +5,9 @@
  */
 
 import type { UserSettingsJSON } from "@clerk/shared/types";
+import { normalizeBapiPath } from "./bapi-command.ts";
 import { CliError, FapiError, ERROR_CODE } from "./errors.ts";
-import { loggedFetch } from "./fetch.ts";
+import { loggedFetch, type ApiResponse } from "./fetch.ts";
 
 const PK_TEST_PREFIX = "pk_test_";
 const PK_LIVE_PREFIX = "pk_live_";
@@ -119,4 +120,46 @@ export async function fetchUserSettings(
     });
   }
   return body.user_settings;
+}
+
+/**
+ * Passthrough request used by `clerk api --fapi`. Unlike the typed helpers
+ * above, this issues an arbitrary request against the instance's FAPI host and
+ * returns the normalized response untouched. FAPI endpoints exposed here are
+ * public, so no auth header is sent.
+ */
+export async function fapiRequest(options: {
+  method: string;
+  path: string;
+  fapiHost: string;
+  body?: string;
+}): Promise<ApiResponse> {
+  const url = new URL(`https://${options.fapiHost}${normalizeBapiPath(options.path)}`);
+  if (!url.searchParams.has("_clerk_js_version")) {
+    url.searchParams.set("_clerk_js_version", CLERK_JS_API_VERSION);
+  }
+
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (options.body) headers["Content-Type"] = "application/json";
+
+  const response = await loggedFetch(url, {
+    tag: "fapi",
+    method: options.method,
+    headers,
+    body: options.body,
+  });
+
+  if (!response.ok) {
+    throw await FapiError.fromResponse(response);
+  }
+
+  const rawBody = await response.text();
+  let body: unknown;
+  try {
+    body = JSON.parse(rawBody);
+  } catch {
+    body = rawBody;
+  }
+
+  return { status: response.status, headers: response.headers, body, rawBody };
 }

--- a/packages/cli-core/src/lib/fapi.ts
+++ b/packages/cli-core/src/lib/fapi.ts
@@ -15,7 +15,7 @@ const PK_LIVE_PREFIX = "pk_live_";
  * The clerk-js client version FAPI's `/v1/environment` payload is shaped for.
  * Bump when consuming response fields introduced in a later major version.
  */
-const CLERK_JS_API_VERSION = "5";
+export const CLERK_JS_API_VERSION = "5";
 
 export type InstanceType = "development" | "production";
 

--- a/packages/cli-core/src/lib/fetch.ts
+++ b/packages/cli-core/src/lib/fetch.ts
@@ -16,6 +16,18 @@ const USER_AGENT = buildUserAgent();
 
 export type LoggedFetchInit = RequestInit & { tag: string };
 
+/**
+ * Normalized response shape returned by the higher-level API request wrappers
+ * (`bapiRequest`, `fapiRequest`). `body` is the parsed JSON when the payload is
+ * valid JSON, otherwise the raw string; `rawBody` is always the unparsed text.
+ */
+export interface ApiResponse {
+  status: number;
+  headers: Headers;
+  body: unknown;
+  rawBody: string;
+}
+
 export async function loggedFetch(url: URL | string, options: LoggedFetchInit): Promise<Response> {
   const { tag, ...init } = options;
   const method = init.method ?? "GET";


### PR DESCRIPTION
## Summary

`clerk api` spoke only BAPI (default) and PLAPI (`--platform`). After a config change, the natural way to verify it took effect is the instance's public FAPI `/v1/environment` payload (what clerk-js actually consumes) — but that meant dropping to `curl` plus decoding the FAPI domain out of the publishable key by hand.

This adds `--fapi`:

```sh
clerk api --fapi /environment --app <id> --instance dev
```

- Resolves the FAPI host from the instance's publishable key (looked up via `--app`/`--instance` or the linked project through the Platform API), reusing the existing `lib/fapi.ts` client and `decodePublishableKey`.
- The request itself is **unauthenticated** — these endpoints are public.
- Paths are `/v1`-normalized like the other modes, so both `/environment` and `/v1/environment` work.
- `--fapi` and `--platform` are mutually exclusive.

Implementation reuses the request-target resolution: `api()` now builds a `{ baseUrl, runRequest }` pair, which also de-duplicates the BAPI/PLAPI branches. The local error handler was broadened from `BapiError` to `ApiError` so FAPI error bodies still print to stdout for piping.

## Test plan
- New tests in `src/commands/api/index.test.ts`: host resolution + no auth header; `--fapi`/`--platform` conflict; FAPI error body printed to stdout with exit 1
- Full api + completion + api-queries integration suites pass

Closes #332