### PR TITLE
fix(cli): show all API errors and surface plain error/message bodies

### DIFF
--- a/.changeset/api-error-formatting.md
+++ b/.changeset/api-error-formatting.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Improve how API error responses are displayed: when a response contains multiple errors they are now all shown instead of just the first, and bodies that carry a plain `error` or `message` field are surfaced directly rather than as raw JSON.

--- a/packages/cli-core/src/cli-program.test.ts
+++ b/packages/cli-core/src/cli-program.test.ts
@@ -169,7 +169,7 @@ describe("formatApiBody", () => {
         },
       ],
     });
-    const result = formatApiBody(new ApiError(400, body), false);
+    const result = formatApiBody(body, false);
     expect(result).toContain("Your plan does not support these features");
     expect(result).toContain("Unsupported features: saml, custom_roles");
   });
@@ -184,7 +184,7 @@ describe("formatApiBody", () => {
         },
       ],
     });
-    const result = formatApiBody(new ApiError(400, body), false);
+    const result = formatApiBody(body, false);
     expect(result).toContain("Unknown config key: sesion");
     expect(result).toContain("Did you mean: session");
     expect(result).toContain("Parameter: sesion");
@@ -200,7 +200,7 @@ describe("formatApiBody", () => {
         },
       ],
     });
-    const result = formatApiBody(new ApiError(400, body), false);
+    const result = formatApiBody(body, false);
     expect(result).toContain("This feature is not enabled on this instance");
     expect(result).toContain("Feature: organizations");
   });
@@ -215,7 +215,7 @@ describe("formatApiBody", () => {
         },
       ],
     });
-    const result = formatApiBody(new ApiError(400, body), false);
+    const result = formatApiBody(body, false);
     expect(result).toContain("Invalid value for session.lifetime");
     expect(result).toContain("Parameter: session.lifetime");
   });
@@ -230,7 +230,7 @@ describe("formatApiBody", () => {
         },
       ],
     });
-    const result = formatApiBody(new ApiError(400, body), false);
+    const result = formatApiBody(body, false);
     expect(result).toContain("Cannot clear this key");
     expect(result).toContain("Parameter: sign_up.mode");
   });
@@ -245,15 +245,14 @@ describe("formatApiBody", () => {
         },
       ],
     });
-    const result = formatApiBody(new ApiError(400, body), false);
+    const result = formatApiBody(body, false);
     expect(result).toContain("Value is not in the allowed set");
     expect(result).toContain("Parameter: branding.logo_url");
   });
 
   // --- Multiple errors ---
-  // The structured path reads from the first parsed error only.
 
-  test("formats multiple errors: surfaces first error with its meta", () => {
+  test("formats multiple errors joined by newlines", () => {
     const body = JSON.stringify({
       errors: [
         {
@@ -268,9 +267,13 @@ describe("formatApiBody", () => {
         },
       ],
     });
-    const result = formatApiBody(new ApiError(400, body), false);
+    const result = formatApiBody(body, false);
     expect(result).toContain("Invalid session lifetime");
-    expect(result).toContain("Parameter: session.lifetime");
+    expect(result).toContain("Unknown key: bogus");
+    expect(result).toContain("Did you mean: session");
+    // Two errors separated by newline
+    const lines = result.split("\n");
+    expect(lines.length).toBeGreaterThanOrEqual(2);
   });
 
   // --- Error without meta ---
@@ -279,34 +282,32 @@ describe("formatApiBody", () => {
     const body = JSON.stringify({
       errors: [{ code: "resource_not_found", message: "Instance not found" }],
     });
-    const result = formatApiBody(new ApiError(400, body), false);
+    const result = formatApiBody(body, false);
     expect(result).toBe("Instance not found");
   });
 
-  // --- Bodies without a Clerk errors array ---
-  // parseApiBody falls back to truncateBody(body) as the message when there
-  // is no errors[0], so formatStructuredError returns the truncated body string.
+  // --- Fallback paths ---
 
-  test("returns truncated body when no errors array (error field only)", () => {
+  test("falls back to parsed.error when no errors array", () => {
     const body = JSON.stringify({ error: "Something went wrong" });
-    const result = formatApiBody(new ApiError(400, body), false);
-    expect(result).toBe(body);
+    const result = formatApiBody(body, false);
+    expect(result).toBe("Something went wrong");
   });
 
-  test("returns truncated body when no errors array (message field only)", () => {
+  test("falls back to parsed.message when no errors array or error field", () => {
     const body = JSON.stringify({ message: "Bad request" });
-    const result = formatApiBody(new ApiError(400, body), false);
-    expect(result).toBe(body);
+    const result = formatApiBody(body, false);
+    expect(result).toBe("Bad request");
   });
 
   test("truncates non-JSON body over 200 chars", () => {
     const body = "x".repeat(300);
-    const result = formatApiBody(new ApiError(400, body), false);
+    const result = formatApiBody(body, false);
     expect(result).toBe("x".repeat(200) + "...");
   });
 
   test("returns short non-JSON body as-is", () => {
-    const result = formatApiBody(new ApiError(400, "Bad Request"), false);
+    const result = formatApiBody("Bad Request", false);
     expect(result).toBe("Bad Request");
   });
 
@@ -315,29 +316,28 @@ describe("formatApiBody", () => {
   test("verbose mode returns full pretty-printed JSON", () => {
     const obj = { errors: [{ code: "test", message: "test msg" }] };
     const body = JSON.stringify(obj);
-    const result = formatApiBody(new ApiError(400, body), true);
+    const result = formatApiBody(body, true);
     expect(result).toBe("\n" + JSON.stringify(obj, null, 2));
   });
 
   test("verbose mode returns raw body for non-JSON", () => {
-    const result = formatApiBody(new ApiError(400, "not json"), true);
+    const result = formatApiBody("not json", true);
     expect(result).toBe("\nnot json");
   });
 
   // --- Edge cases ---
 
-  test("handles empty errors array by returning truncated body", () => {
+  test("handles empty errors array by falling through to message", () => {
     const body = JSON.stringify({ errors: [], message: "fallback" });
-    const result = formatApiBody(new ApiError(400, body), false);
-    // No errors[0] so parseApiBody falls back to truncateBody(body)
-    expect(result).toBe(body);
+    const result = formatApiBody(body, false);
+    expect(result).toBe("fallback");
   });
 
   test("handles error with empty meta", () => {
     const body = JSON.stringify({
       errors: [{ code: "config_validation_error", message: "Bad value", meta: {} }],
     });
-    const result = formatApiBody(new ApiError(400, body), false);
+    const result = formatApiBody(body, false);
     expect(result).toBe("Bad value");
   });
 
@@ -351,7 +351,7 @@ describe("formatApiBody", () => {
         },
       ],
     });
-    const result = formatApiBody(new ApiError(400, body), false);
+    const result = formatApiBody(body, false);
     expect(result).toBe("Plan limitation");
   });
 });
@@ -472,7 +472,7 @@ describe("reportError", () => {
     });
 
     // Only the prefix + status wiring is asserted here; the detail string is
-    // `formatStructuredError`'s job and is covered by the `formatApiBody` block.
+    // `formatSingleError`'s job and is covered by the `formatApiBody` block.
     test("human mode prefixes with the status", () => {
       reportError(new ApiError(400, body), false);
       expect(captured.err).toContain("Request failed (400): Missing param");

--- a/packages/cli-core/src/cli-program.ts
+++ b/packages/cli-core/src/cli-program.ts
@@ -162,23 +162,40 @@ export function createProgram(): Program {
   return program;
 }
 
-export function formatApiBody(error: ApiError, verbose: boolean): string {
+export function formatApiBody(body: string, verbose: boolean): string {
   if (verbose) {
     try {
-      return "\n" + JSON.stringify(JSON.parse(error.body), null, 2);
+      return "\n" + JSON.stringify(JSON.parse(body), null, 2);
     } catch {
-      return "\n" + error.body;
+      return "\n" + body;
     }
   }
-  return formatStructuredError(error);
+
+  try {
+    const parsed = JSON.parse(body);
+    if (Array.isArray(parsed.errors) && parsed.errors.length > 0) {
+      return parsed.errors.map(formatSingleError).join("\n");
+    }
+    if (parsed.error) return parsed.error;
+    if (parsed.message) return parsed.message;
+  } catch {
+    // not JSON
+  }
+
+  if (body.length > 200) return body.slice(0, 200) + "...";
+  return body;
 }
 
-function formatStructuredError(error: ApiError): string {
-  let msg = error.message;
-  const { meta, code } = error;
+function formatSingleError(err: {
+  message?: string;
+  code?: string;
+  meta?: Record<string, unknown>;
+}): string {
+  let msg = err.message ?? "Unknown error";
+  const meta = err.meta;
   if (!meta) return msg;
 
-  switch (code) {
+  switch (err.code) {
     case "unsupported_subscription_plan_features": {
       const features = meta.unsupported_features;
       if (Array.isArray(features) && features.length > 0) {
@@ -303,7 +320,7 @@ export function reportError(error: unknown, verbose: boolean): number {
   }
 
   if (error instanceof ApiError) {
-    const detail = formatApiBody(error, verbose);
+    const detail = formatApiBody(error.body, verbose);
     const prefix = error.context ?? "Request failed";
     if (isAgent()) {
       const apiErrors: ApiErrorEntry[] | undefined =


### PR DESCRIPTION
## Summary

When an API request fails, the CLI now parses the response body so every error in a multi-error response is shown, joined by newlines, instead of only the first one. Response bodies that carry a plain `error` or `message` field instead of a Clerk `errors` array are surfaced directly rather than printed as raw JSON. The error classes and their structured fields are unchanged, so existing consumers that read `code` and `meta` (such as the deploy command) keep working.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run test` (1679 pass)