### PR TITLE
ci: pin Node.js 22 in release and e2e workflows

### DIFF
--- a/.github/workflows/refresh-fixtures.yml
+++ b/.github/workflows/refresh-fixtures.yml
@@ -31,6 +31,10 @@ jobs:
           # unrelated changes from a feature branch into the refresh PR.
           ref: main
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
       - uses: oven-sh/setup-bun@v2
 
       - run: bun install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v6
         with:
-          node-version: "lts/*"
+          node-version: 22
           registry-url: "https://registry.npmjs.org"
       - run: bun install --frozen-lockfile
 
@@ -293,7 +293,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v6
         with:
-          node-version: "lts/*"
+          node-version: 22
           registry-url: "https://registry.npmjs.org"
       - run: bun install --frozen-lockfile
 
@@ -461,7 +461,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v6
         with:
-          node-version: "lts/*"
+          node-version: 22
           registry-url: "https://registry.npmjs.org"
       - run: bun install --frozen-lockfile
 


### PR DESCRIPTION
## What

- Pin release npm publishing jobs to Node.js 22 instead of the floating `lts/*` value.
- Add an explicit Node.js 22 setup to the E2E fixture refresh workflow.

## Why

The release and fixture-refresh workflows should use the same explicit Node.js major as CI so npm publishing and E2E fixture generation do not fall back to Node.js 20.

## Testing

- `bun run format`
- `bun run format:check`
- `git diff --check`