### PR TITLE
ci: pin GitHub workflows to Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
           ref: ${{ inputs.ref }}
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
       - name: Mark workspace as safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/refresh-fixtures.yml
+++ b/.github/workflows/refresh-fixtures.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - uses: oven-sh/setup-bun@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
       - run: bun install --frozen-lockfile
 
@@ -293,7 +293,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
       - run: bun install --frozen-lockfile
 
@@ -461,7 +461,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
       - run: bun install --frozen-lockfile
 


### PR DESCRIPTION
## What

- Pin every GitHub Actions `actions/setup-node` step to Node.js 24.

## Why

This keeps CI, release publishing, snapshot publishing, and fixture refresh jobs on the requested Node.js major version.
