### PR TITLE
fix(release): publish native packages before clerk

### DIFF
--- a/scripts/lib/npm.test.ts
+++ b/scripts/lib/npm.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { waitUntilPublished } from "./npm.ts";
+
+describe("waitUntilPublished", () => {
+  test("retries until npm reports the package version is published", async () => {
+    const attempts: string[] = [];
+
+    await waitUntilPublished("@clerk/cli-linux-x64", "1.2.3-canary.0", {
+      intervalMs: 0,
+      timeoutMs: 1_000,
+      isPublished: async (name, version) => {
+        attempts.push(`${name}@${version}`);
+        return attempts.length === 3;
+      },
+    });
+
+    expect(attempts).toEqual([
+      "@clerk/cli-linux-x64@1.2.3-canary.0",
+      "@clerk/cli-linux-x64@1.2.3-canary.0",
+      "@clerk/cli-linux-x64@1.2.3-canary.0",
+    ]);
+  });
+});

--- a/scripts/lib/npm.ts
+++ b/scripts/lib/npm.ts
@@ -41,3 +41,33 @@ export async function publish(dir: string, opts: { dryRun: boolean; tag?: string
   if (opts.dryRun) flags.push("--dry-run");
   await run(flags, { cwd: dir });
 }
+
+/**
+ * Wait until npm reports that a package version has been published.
+ */
+export async function waitUntilPublished(
+  name: string,
+  version: string,
+  opts: {
+    intervalMs: number;
+    timeoutMs: number;
+    isPublished: (name: string, version: string) => Promise<boolean>;
+  },
+): Promise<void> {
+  const startedAt = Date.now();
+
+  while (true) {
+    if (await opts.isPublished(name, version)) {
+      return;
+    }
+
+    const elapsedMs = Date.now() - startedAt;
+    if (elapsedMs >= opts.timeoutMs) {
+      throw new Error(
+        `Timed out waiting for ${name}@${version} to become available on npm after ${opts.timeoutMs}ms`,
+      );
+    }
+
+    await Bun.sleep(Math.min(opts.intervalMs, opts.timeoutMs - elapsedMs));
+  }
+}

--- a/scripts/lib/publish-order.test.ts
+++ b/scripts/lib/publish-order.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { publishDependenciesBeforePackage } from "./publish-order.ts";
+
+describe("publishDependenciesBeforePackage", () => {
+  test("publishes the dependent package only after every dependency is available", async () => {
+    const events: string[] = [];
+    const resolvers: Array<() => void> = [];
+
+    const publish = publishDependenciesBeforePackage(
+      [
+        {
+          publish: async () => {
+            events.push("linux:publish");
+          },
+          waitUntilAvailable: async () => {
+            events.push("linux:wait");
+            await new Promise<void>((resolve) => resolvers.push(resolve));
+            events.push("linux:available");
+          },
+        },
+        {
+          publish: async () => {
+            events.push("darwin:publish");
+          },
+          waitUntilAvailable: async () => {
+            events.push("darwin:wait");
+            await new Promise<void>((resolve) => resolvers.push(resolve));
+            events.push("darwin:available");
+          },
+        },
+      ],
+      {
+        publish: async () => {
+          events.push("clerk:publish");
+        },
+        waitUntilAvailable: undefined,
+      },
+    );
+
+    await Promise.resolve();
+    expect(events).toEqual(["linux:publish", "darwin:publish", "linux:wait", "darwin:wait"]);
+
+    resolvers[0]!();
+    await Promise.resolve();
+    expect(events).not.toContain("clerk:publish");
+
+    resolvers[1]!();
+    await publish;
+    expect(events).toEqual([
+      "linux:publish",
+      "darwin:publish",
+      "linux:wait",
+      "darwin:wait",
+      "linux:available",
+      "darwin:available",
+      "clerk:publish",
+    ]);
+  });
+});

--- a/scripts/lib/publish-order.ts
+++ b/scripts/lib/publish-order.ts
@@ -1,0 +1,25 @@
+/**
+ * A package publish step that may also wait for registry availability.
+ */
+export type PublishStep = {
+  publish: () => Promise<void>;
+  waitUntilAvailable: (() => Promise<void>) | undefined;
+};
+
+/**
+ * Publishes dependency packages before publishing the dependent package.
+ */
+export async function publishDependenciesBeforePackage(
+  dependencies: PublishStep[],
+  dependent: PublishStep,
+): Promise<void> {
+  await Promise.all(
+    dependencies.map(async (dependency) => {
+      await dependency.publish();
+      if (dependency.waitUntilAvailable) {
+        await dependency.waitUntilAvailable();
+      }
+    }),
+  );
+  await dependent.publish();
+}

--- a/scripts/releaser.ts
+++ b/scripts/releaser.ts
@@ -2,7 +2,8 @@ import { mkdir, cp, rm, chmod, copyFile } from "node:fs/promises";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 import { type Target, targets, SCOPE, PKG_PREFIX } from "./lib/targets.ts";
-import { run, isPublished, publish } from "./lib/npm.ts";
+import { run, isPublished, publish, waitUntilPublished } from "./lib/npm.ts";
+import { publishDependenciesBeforePackage } from "./lib/publish-order.ts";
 import { getStableReleaseCreateArgs } from "./lib/release-notes.ts";
 
 const DIST_DIR = join(import.meta.dir, "../dist/platform-packages");
@@ -86,45 +87,63 @@ console.log(
 
 await rm(DIST_DIR, { recursive: true, force: true });
 
-await Promise.all(
-  targets.map(async (target) => {
+await publishDependenciesBeforePackage(
+  targets.map((target) => {
     const name = packageName(target.name);
-    if (await isPublished(name, version)) {
-      console.log(`Skipping ${name}@${version} (already published)`);
-      return;
-    }
-    console.log(`Publishing ${name}@${version}...`);
-    const dir = await generatePlatformPackage(target, version);
-    await publish(dir, { dryRun, tag });
+    return {
+      publish: async () => {
+        if (await isPublished(name, version)) {
+          console.log(`Skipping ${name}@${version} (already published)`);
+          return;
+        }
+        console.log(`Publishing ${name}@${version}...`);
+        const dir = await generatePlatformPackage(target, version);
+        await publish(dir, { dryRun, tag });
+      },
+      waitUntilAvailable: dryRun
+        ? undefined
+        : async () => {
+            console.log(`Waiting for ${name}@${version} to become available on npm...`);
+            await waitUntilPublished(name, version, {
+              intervalMs: 2_000,
+              timeoutMs: 120_000,
+              isPublished,
+            });
+          },
+    };
   }),
+  {
+    publish: async () => {
+      // Build wrapper package.json for publishing: add optionalDependencies from targets and remove private flag.
+      // This mutation is intentional because the repo omits optionalDependencies while the published package includes them.
+      // We restore the original file after publishing (or on failure) so the working tree stays clean.
+      const wrapperRaw = await Bun.file(WRAPPER_PKG_PATH).text();
+      const rootReadmeRaw = await Bun.file(ROOT_README_PATH).text();
+      try {
+        const wrapperPkg = JSON.parse(wrapperRaw);
+        wrapperPkg.version = version;
+        wrapperPkg.optionalDependencies = Object.fromEntries(
+          targets.map((t) => [packageName(t.name), version]),
+        );
+        delete wrapperPkg.private;
+        await Bun.write(WRAPPER_PKG_PATH, JSON.stringify(wrapperPkg, null, 2) + "\n");
+        await Bun.write(WRAPPER_README_PATH, rootReadmeRaw);
+
+        const wrapperName = "clerk";
+        if (await isPublished(wrapperName, version)) {
+          console.log(`Skipping ${wrapperName}@${version} (already published)`);
+        } else {
+          console.log(`Publishing ${wrapperName}@${version}...`);
+          await publish(join(import.meta.dir, "../packages/cli"), { dryRun, tag });
+        }
+      } finally {
+        await Bun.write(WRAPPER_PKG_PATH, wrapperRaw);
+        await rm(WRAPPER_README_PATH, { force: true });
+      }
+    },
+    waitUntilAvailable: undefined,
+  },
 );
-
-// Build wrapper package.json for publishing: add optionalDependencies from targets and remove private flag.
-// This mutation is intentional — the repo omits optionalDependencies while the published package includes them.
-// We restore the original file after publishing (or on failure) so the working tree stays clean.
-const wrapperRaw = await Bun.file(WRAPPER_PKG_PATH).text();
-const rootReadmeRaw = await Bun.file(ROOT_README_PATH).text();
-try {
-  const wrapperPkg = JSON.parse(wrapperRaw);
-  wrapperPkg.version = version;
-  wrapperPkg.optionalDependencies = Object.fromEntries(
-    targets.map((t) => [packageName(t.name), version]),
-  );
-  delete wrapperPkg.private;
-  await Bun.write(WRAPPER_PKG_PATH, JSON.stringify(wrapperPkg, null, 2) + "\n");
-  await Bun.write(WRAPPER_README_PATH, rootReadmeRaw);
-
-  const wrapperName = "clerk";
-  if (await isPublished(wrapperName, version)) {
-    console.log(`Skipping ${wrapperName}@${version} (already published)`);
-  } else {
-    console.log(`Publishing ${wrapperName}@${version}...`);
-    await publish(join(import.meta.dir, "../packages/cli"), { dryRun, tag });
-  }
-} finally {
-  await Bun.write(WRAPPER_PKG_PATH, wrapperRaw);
-  await rm(WRAPPER_README_PATH, { force: true });
-}
 
 // Create git tag and GitHub Release for stable releases (no --tag flag).
 // Canary (--tag canary) and snapshot (--tag snapshot) skip this.


### PR DESCRIPTION
## What

- Publish native CLI packages before publishing the top-level `clerk` wrapper.
- Wait for each native package version to become visible on npm before publishing `clerk`.
- Add focused tests for publish ordering and npm availability polling.

## Why

The wrapper declares native packages as optional dependencies, so canary installs can fail if `clerk` is published before npm has the native versions available.

## Testing

- `bun run format`
- `bun test scripts/lib/publish-order.test.ts scripts/lib/npm.test.ts --isolate`
- `bun run lint`
- `bun run typecheck`
- `bun run test`