### PR TITLE
fix(test): pass --no-gitInit to nuxt fixture scaffold

### DIFF
--- a/test/e2e/fixtures.manifest.ts
+++ b/test/e2e/fixtures.manifest.ts
@@ -96,6 +96,7 @@ export const fixtures = {
       "--template",
       "minimal",
       "--no-install",
+      "--no-gitInit",
       "--packageManager",
       "npm",
       "--force",


### PR DESCRIPTION
## Summary

The scheduled Refresh E2E Fixtures workflow was failing on the `nuxt` fixture. A newer `nuxi init` refuses to assume a git-init default in a non-interactive terminal and now requires the `--gitInit`/`--no-gitInit` flag to be set explicitly, so the scaffold aborted with `Non-interactive terminal detected. Missing required argument: --gitInit` and the refresh script exited non-zero. This adds `--no-gitInit` to the nuxt `scaffoldCmd`, matching what the CLI's own bootstrap already passes to `create-nuxt`.

## Test plan

- [x] Reproduced the original failure, then confirmed `npx nuxi@latest init … --no-gitInit` exits 0
- [x] `bun run e2e:refresh-fixtures -- --only nuxt` now succeeds end to end