### PR TITLE
fix(orgs): enable organization creation defaults with `--auto-create`

### DIFF
--- a/.changeset/orgs-auto-create-creation-defaults.md
+++ b/.changeset/orgs-auto-create-creation-defaults.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Fix `clerk enable orgs --auto-create` so organizations are actually auto-created for new users. The flag now also enables organization creation defaults, which the API requires before honoring the automatic creation setting.

--- a/packages/cli-core/src/commands/orgs/README.md
+++ b/packages/cli-core/src/commands/orgs/README.md
@@ -29,6 +29,13 @@ clerk disable orgs [options]
 The boolean flags above are one-way: they set the field to `true` only. To
 clear a field, use `clerk config patch --json '{"organization_settings":{...}}'`.
 
+`--auto-create` patches both `organization_creation_defaults.enabled` and
+`organization_creation_defaults.automatic_organization_creation.enabled` — the
+API only auto-creates organizations when both are true. When this enables
+creation defaults for the first time, the API seeds the remaining sub-settings
+(name template, fallback name, email-domain detection) with its standard
+defaults.
+
 ### `disable`
 
 | Flag              | Description                            |

--- a/packages/cli-core/src/commands/orgs/index.test.ts
+++ b/packages/cli-core/src/commands/orgs/index.test.ts
@@ -150,7 +150,7 @@ describe("clerk enable/disable orgs", () => {
     expect(parsed.organization_settings.domains_enabled).toBe(true);
   });
 
-  test("enable passes --auto-create flag", async () => {
+  test("enable --auto-create enables both organization_creation_defaults.enabled and the nested auto-creation flag", async () => {
     let capturedBody = "";
     stubFetch(async (_input, init) => {
       if (init?.method === "PATCH") capturedBody = init.body as string;
@@ -162,10 +162,13 @@ describe("clerk enable/disable orgs", () => {
     await orgsEnable({ autoCreate: true });
 
     const parsed = JSON.parse(capturedBody);
-    expect(
-      parsed.organization_settings.organization_creation_defaults.automatic_organization_creation
-        .enabled,
-    ).toBe(true);
+    const defaults = parsed.organization_settings.organization_creation_defaults;
+    // FAPI only auto-creates organizations when BOTH the umbrella
+    // organization_creation_defaults.enabled and the nested flag are true —
+    // patching only the nested flag silently does nothing on instances where
+    // the umbrella was never enabled.
+    expect(defaults.enabled).toBe(true);
+    expect(defaults.automatic_organization_creation.enabled).toBe(true);
   });
 
   test("enable --dry-run plumbs dry_run=true to the API and prints dry-run output", async () => {

--- a/packages/cli-core/src/commands/orgs/index.ts
+++ b/packages/cli-core/src/commands/orgs/index.ts
@@ -37,7 +37,13 @@ export async function orgsEnable(options: OrgsOptions): Promise<void> {
   if (options.forceSelection) orgSettings.force_organization_selection = true;
   if (options.domains) orgSettings.domains_enabled = true;
   if (options.autoCreate) {
+    // The API only auto-creates organizations when BOTH the umbrella
+    // organization_creation_defaults.enabled and the nested flag are true.
+    // Sending both in one patch is safe: the backend's enable transition seeds
+    // defaults only for sub-settings not explicitly provided, and re-sending
+    // enabled=true on an already-enabled instance is a no-op.
     orgSettings.organization_creation_defaults = {
+      enabled: true,
       automatic_organization_creation: { enabled: true },
     };
   }


### PR DESCRIPTION
## Summary

Found while reviewing clerk/clerk#2961, where the docs work around it by telling agents to patch the parent flag manually.

`clerk enable orgs --auto-create` patched only `organization_creation_defaults.automatic_organization_creation.enabled`. The API gates auto-creation on the umbrella `organization_creation_defaults.enabled` too, so on instances where creation defaults were never enabled the command succeeded — and no organization was ever auto-created. 

Perhaps it's this way for some reason, but it tripped me up when verifying the docs contribution.

## Changes

- `--auto-create` now sends both flags in one patch.
- Sending both together is safe: the API's enable transition seeds defaults only for sub-settings not in the request, so the explicit auto-create value wins and the remaining sub-settings get the same seeds the Dashboard flow produces. Re-sending `enabled: true` on an already-enabled instance is a no-op, so the command stays idempotent.
- Payload test now asserts both flags, and the command README documents the behavior.

## References

- clerk/clerk#2961

🤖 Generated with [Claude Code](https://claude.com/claude-code)
