### PR TITLE
docs(e2e): align fixture-authoring docs with the #280 manifest harness

### DIFF
--- a/.claude/rules/e2e.md
+++ b/.claude/rules/e2e.md
@@ -56,9 +56,8 @@ bun run test:e2e                             # Same flags as above
 Fixture maintenance:
 
 ```sh
-bun run e2e:refresh-fixtures                 # Re-scaffold all non-pinned fixtures
-bun run e2e:refresh-fixtures -- --force      # Include pinned fixtures
-bun run e2e:refresh-fixtures -- --only nextjs-app-router  # Refresh one fixture
+bun run e2e:refresh-fixtures                             # Re-scaffold every fixture (pinned included)
+bun run e2e:refresh-fixtures -- --only nextjs-app-router # Refresh one fixture
 ```
 
 ## Test runner (`scripts/run-tests.ts`)
@@ -79,28 +78,33 @@ A single test runner used by both `bun run test` and `bun run test:e2e`. Each te
 Each fixture directory contains:
 
 - Framework source files (scaffolded by `config.scaffoldCmd`)
-- A `.test.ts` file that exports a `config: FixtureConfig` and calls `runFixtureTests()` and `runBrowserTests()`
+- A checked-in `package-lock.json` (fixtures use npm; the refresh script generates the lockfile so setup can run `npm ci`)
+- A `.test.ts` file that calls `createFixtureHarness("<name>")` and passes the returned harness to `runFixtureTests()` and `runBrowserTests()`
+
+Fixture config is no longer exported from each test file. It lives in a single manifest keyed by fixture name (`test/e2e/fixtures.manifest.ts`), which is the source of truth shared by both the test files and `scripts/refresh-e2e-fixtures.ts`. The manifest keys double as the fixture directory names (`test/e2e/fixtures/<name>/`) and as the typed argument to `createFixtureHarness()`. `createFixtureHarness(name)` looks up the entry and threads the resolved `config` and `fixtureDir` through to the setup and test helpers.
 
 ### FixtureConfig
 
-Defined in `test/e2e/lib/types.ts`:
+The manifest entries satisfy `FixtureConfig`, defined in `test/e2e/lib/types.ts`:
 
-- `description` - human-readable name
 - `scaffoldCmd` - command the refresh script uses to scaffold the project
 - `clerkSdk` - Clerk SDK package name (e.g. `@clerk/nextjs`)
 - `buildCmd` - build command (e.g. `["next", "build"]`)
 - `devCmd` - dev server command; port flag appended automatically (`-p` for Next.js, `--port` for others)
-- `pinned` - when true, refresh script skips unless `--force` is passed
-- `notes` - required when pinned, explains why this variant exists
+- `notes` - explains why a pinned variant exists (required when `pinnedDependencyRanges` is set)
+- `pinnedDependencyRanges` - allowed generated dependency ranges enforced when the refresh script regenerates a pinned fixture
+- `packageJsonOverrides` - `package.json` `dependencies` / `devDependencies` merged in after scaffolding and before the fixture is copied
 
 ### Setup flow (`fixture-setup.ts`)
+
+`setupFixture(name)` looks up the manifest entry, then:
 
 1. Copy fixture to a temp directory
 2. Git init and commit (so the CLI profile key is stable)
 3. `clerk link --app $CLERK_CLI_TEST_APP_ID` with an isolated `CLERK_CONFIG_DIR`
-4. `clerk init --yes`
+4. `clerk init --yes --no-skills` (skills install is skipped so skill template files don't break framework typecheck)
 5. Parse `.env` / `.env.local` for publishable and secret keys (uses `detectPublishableKeyName` / `detectSecretKeyName` from CLI source)
-6. `bun install`
+6. `npm ci --ignore-scripts --legacy-peer-deps` (installs from the fixture's checked-in `package-lock.json`)
 
 ### Build + typecheck test (`runFixtureTests`)
 
@@ -135,9 +139,9 @@ Within each test file, `createFixtureHarness()` runs `setupFixture()` once in `b
 
 ## Adding a new fixture
 
-1. Create `test/e2e/fixtures/<name>/`
-2. Scaffold the framework manually or via `bun run e2e:refresh-fixtures`
-3. Add a `<name>.test.ts` exporting `config: FixtureConfig` and calling `runFixtureTests()` and `runBrowserTests()`
+1. Add an entry to `test/e2e/fixtures.manifest.ts` keyed by `<name>` (this drives both scaffolding and the tests)
+2. Scaffold the framework via `bun run e2e:refresh-fixtures -- --only <name>` (generates `test/e2e/fixtures/<name>/`, including its `package-lock.json`)
+3. Add a `<name>.test.ts` that calls `createFixtureHarness("<name>")` and passes the harness to `runFixtureTests()` and `runBrowserTests()`
 4. Add a `README.md` in the fixture directory describing the project
 
 Helper functions are in `test/e2e/lib/`:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ If you already have the required env vars exported (e.g. in CI, or you don't hav
 bun run test:e2e -- --filter react
 ```
 
-E2E test files live in `test/e2e/`, with fixture projects in `test/e2e/fixtures/`. Each test file exports a `FixtureConfig` and calls `runFixtureTest()` and `runBrowserTest()` from `test/e2e/lib/`. See `.claude/rules/e2e.md` for full details on adding fixtures and required env vars.
+E2E test files live in `test/e2e/`, with fixture projects in `test/e2e/fixtures/`. Fixture config lives in `test/e2e/fixtures.manifest.ts`, keyed by fixture name; each test file calls `createFixtureHarness("<name>")` and passes the returned harness to `runFixtureTests()` and `runBrowserTests()` from `test/e2e/lib/`. See `.claude/rules/e2e.md` for full details on adding fixtures and required env vars.
 
 ## Opening a pull request
 


### PR DESCRIPTION
## Summary

The E2E fixture-authoring docs still described the pre-#280 harness, so they pointed contributors — and agents, since `.claude/rules/e2e.md` loads as instructions — at helpers and a setup flow that no longer exist. This realigns them with the manifest-driven harness #280 introduced. Docs only; every claim was checked against the current source under `test/e2e/`.

## Changes

- `.claude/rules/e2e.md` — "How fixtures work", "Setup flow", and "Adding a new fixture" now describe the manifest. Config lives in `test/e2e/fixtures.manifest.ts` keyed by fixture name, and tests call `createFixtureHarness(name)` instead of exporting `config` from each test file.
- Setup installs with `npm ci` (fixtures moved from bun to npm with a checked-in `package-lock.json`), not `bun install`.
- Rewrote the `FixtureConfig` field list to match `test/e2e/lib/types.ts`: dropped the removed `description` and `pinned`, added `pinnedDependencyRanges` and `packageJsonOverrides`.
- Dropped the stale `--force` / non-pinned refresh flags — `scripts/refresh-e2e-fixtures.ts` only accepts `--only`.
- `CONTRIBUTING.md` — the E2E paragraph now points at the manifest and uses the plural `runFixtureTests()` / `runBrowserTests()`, correcting the singular `runFixtureTest()` / `runBrowserTest()`.

## Not planned

- The test-runner / `--parallel` doc fixes, plus the patch-filename and single-fixture-command corrections in `e2e.md` — handled in #392.
- No changeset. Docs only, no `packages/**` source touched.

## References

- #392 — deliberately scoped this fixture-doc rewrite out; this is the follow-up.
- #280 — introduced the manifest-driven harness these docs now match.
