### PR TITLE
fix(link): pin the create-application option to the top of the app picker

### DIFF
--- a/.changeset/commands-update-order-explore.md
+++ b/.changeset/commands-update-order-explore.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Show the "+ Create a new application" option first in the interactive application picker used by `clerk link` and `clerk users`.

--- a/packages/cli-core/src/commands/link/index.test.ts
+++ b/packages/cli-core/src/commands/link/index.test.ts
@@ -434,7 +434,7 @@ describe("link", () => {
       expect(mockFetchApplication).not.toHaveBeenCalled();
     });
 
-    test("source returns all choices plus create option when term is empty", async () => {
+    test("source returns create option first, then all choices, when term is empty", async () => {
       mockIsAgent.mockReturnValue(false);
       mockGetToken.mockResolvedValue("token");
       mockListApplications.mockResolvedValue([
@@ -454,9 +454,14 @@ describe("link", () => {
         },
       ]);
       mockSearch.mockImplementation(
-        async (config: { source: (term: string | undefined) => unknown[] }) => {
+        async (config: {
+          source: (term: string | undefined) => { name: string; value: string }[];
+        }) => {
           const results = config.source(undefined);
-          expect(results).toHaveLength(3); // 2 apps + create option
+          expect(results).toHaveLength(3); // create option + 2 apps
+          expect(results[0]!.value).toBe("__create_new__");
+          expect(results[1]!.value).toBe("app_a");
+          expect(results[2]!.value).toBe("app_b");
           return "app_a";
         },
       );
@@ -489,9 +494,9 @@ describe("link", () => {
           source: (term: string | undefined) => { name: string; value: string }[];
         }) => {
           const results = config.source("my");
-          expect(results).toHaveLength(2); // 1 match + create option
-          expect(results[0]!.value).toBe("app_a");
-          expect(results[1]!.value).toBe("__create_new__");
+          expect(results).toHaveLength(2); // create option + 1 match
+          expect(results[0]!.value).toBe("__create_new__");
+          expect(results[1]!.value).toBe("app_a");
 
           const noMatch = config.source("zzz");
           expect(noMatch).toHaveLength(1); // only create option
@@ -528,9 +533,9 @@ describe("link", () => {
           source: (term: string | undefined) => { name: string; value: string }[];
         }) => {
           const results = config.source("abc");
-          expect(results).toHaveLength(2); // 1 match + create option
-          expect(results[0]!.value).toBe("app_abc");
-          expect(results[1]!.value).toBe("__create_new__");
+          expect(results).toHaveLength(2); // create option + 1 match
+          expect(results[0]!.value).toBe("__create_new__");
+          expect(results[1]!.value).toBe("app_abc");
           return "app_abc";
         },
       );

--- a/packages/cli-core/src/lib/app-picker.ts
+++ b/packages/cli-core/src/lib/app-picker.ts
@@ -57,7 +57,7 @@ export async function pickOrCreateApp(opts: {
       const filtered = term
         ? appChoices.filter((c) => c.name.toLowerCase().includes(term.toLowerCase()))
         : appChoices;
-      return [...filtered, createChoice];
+      return [createChoice, ...filtered];
     },
   });
 


### PR DESCRIPTION
## Summary

- The shared application picker (`lib/app-picker.ts`, used by `clerk link`, `clerk init`, and the `clerk users` fallback) appended the "+ Create a new application" choice **after** all applications. With a long app list the option was hidden below the truncation fold and effectively invisible unless the user scrolled past every app or typed a term with no matches.
- The create choice is now the **first** row, both in the unfiltered list and while a search term is typed.
- The `clerk users` action menu already lists "Create user" first; a sweep of all other interactive list prompts (init, deploy, switch-env, api, skills) found no other selectable "create" options, so this is the only ordering change needed. This also brings the code in line with `commands/link/README.md`, which already documented the option as "pinned at the top".

## Test plan

- [x] Updated the three `clerk link` app-selection tests to assert the create option is index 0 (empty term, name-filtered term, and ID-filtered term), and strengthened the previously length-only unfiltered assertion to pin the full order.
- [x] `bun run format`, `bun run lint`, `bun run typecheck` pass.
- [x] `bun run test` — 2123 tests pass.
- [x] Changeset added (`patch`).