### PR TITLE
Stop emitting explicit version in Homebrew formulae

### DIFF
--- a/scripts/lib/homebrew.test.ts
+++ b/scripts/lib/homebrew.test.ts
@@ -16,7 +16,10 @@ describe("renderFormula", () => {
       },
     });
 
-    expect(result).toContain('version "1.2.3"');
+    // Homebrew scans the version from the /releases/download/vX.Y.Z/ URL
+    // (Homebrew/brew#23338); an explicit `version` line fails `brew audit`
+    // as redundant in the homebrew-stable tap's CI.
+    expect(result).not.toContain('version "');
     expect(result).toContain(
       "https://github.com/clerk/cli/releases/download/v1.2.3/homebrew-clerk-darwin-arm64.tar.gz",
     );

--- a/scripts/lib/homebrew.ts
+++ b/scripts/lib/homebrew.ts
@@ -33,7 +33,6 @@ export function renderFormula(input: FormulaInput): string {
   return `class ${className} < Formula
   desc "Command-line interface for Clerk"
   homepage "https://clerk.com"
-  version "${version}"
   license "MIT"${kegOnly}
 
   on_macos do


### PR DESCRIPTION
## Summary

The homebrew-stable tap's CI went red on [this run](https://github.com/clerk/homebrew-stable/actions/runs/30558414457): `brew audit` now fails every formula with `version X.Y.Z is redundant with version scanned from URL`.

Root cause is [Homebrew/brew#23338](https://github.com/Homebrew/brew/pull/23338) (merged Jul 28): brew now prefers the numeric release tag (`v2.3.1`) in `/releases/download/vX.Y.Z/…` URLs over the asset filename when scanning versions, so it derives the version on its own and treats our explicit `version` line as a redundancy error.

clerk/homebrew-stable#3 fixes the four already-published formulae; this PR fixes the generator (`renderFormula` in `scripts/lib/homebrew.ts`) so the next release doesn't reintroduce the line.

The formula's `test do` block keeps working: `version.to_s` resolves from the URL-scanned version.

## Validation

- `bun test scripts/lib/homebrew.test.ts` — 11 pass
- `bun run format` / `bun run lint` — clean
- `bun run typecheck` — clean (an earlier failure in `cli-core`'s integration harness test was stale local `node_modules`; passes after `bun install --frozen-lockfile`)
- The equivalent formula change (version line removed) passes `brew audit --except=installed --tap=clerk/stable`, `brew style`, and `brew readall` locally on brew `ed35dbcb2e` — the exact commit the failing CI run used — and versions scan correctly (`2.3.1 / 0.8.4 / 1.5.0 / 2.3.1`)

No changeset: release tooling only, no user-facing CLI behavior change.
