### PR TITLE
fix(auth): print the sign-in URL always and launch the host browser from WSL

### DIFF
--- a/.changeset/cli-issue-411-context-fix.md
+++ b/.changeset/cli-issue-411-context-fix.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Fix `clerk auth login` in WSL2, SSH, and headless environments: the sign-in URL is now always printed as a copy-friendly manual fallback, WSL launches the Windows host browser via PowerShell interop when `wslview` is not installed, and the authentication timeout error now explains how to recover.

--- a/packages/cli-core/src/commands/auth/README.md
+++ b/packages/cli-core/src/commands/auth/README.md
@@ -11,7 +11,7 @@ Authenticates the user via an OAuth 2.0 PKCE flow. After a successful login (or 
 1. Checks for an existing valid token — if found, prompts to re-authenticate (in agent mode, skips and runs autoclaim immediately)
 2. Generates PKCE parameters (code verifier, challenge, state)
 3. Starts a local HTTP callback server on `127.0.0.1`
-4. Opens the browser to the Clerk OAuth authorization URL
+4. Prints the Clerk OAuth authorization URL and opens the browser to it. The URL is always printed as a manual fallback for environments where browser launch is unreliable (WSL2, SSH, headless shells). In WSL, the Windows host browser is reached via `wslview` or, when that is not installed, the always-present `powershell.exe` interop binary (`Start-Process`).
 5. Waits for the redirect callback with an authorization code
 6. Exchanges the code for an access token
 7. Stores the token and user info in local config

--- a/packages/cli-core/src/commands/auth/login.test.ts
+++ b/packages/cli-core/src/commands/auth/login.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe, afterEach, mock, spyOn } from "bun:test";
+import { test, expect, describe, afterEach, beforeEach, mock, spyOn } from "bun:test";
 import { AuthError } from "../../lib/errors.ts";
 import { useCaptureLog, credentialStoreStubs, configStubs } from "../../test/lib/stubs.ts";
 
@@ -101,6 +101,10 @@ describe("login", () => {
   const captured = useCaptureLog();
   const origSpawn = Bun.spawn;
 
+  beforeEach(() => {
+    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+  });
+
   afterEach(() => {
     mockGetValidToken.mockReset();
     mockStoreToken.mockReset();
@@ -140,6 +144,50 @@ describe("login", () => {
     }
   }
 
+  interface OAuthFlowOverrides {
+    code?: string;
+    tokens?: { accessToken: string; refreshToken: string; expiresAt: number };
+    /** Pass null when the test wires mockFetchUserInfo itself (e.g. resolveOnce chains). */
+    user?: { userId: string; email: string } | null;
+  }
+
+  /** Arrange every mock a successful OAuth flow needs; returns the auth server stub. */
+  function mockOAuthSuccess(overrides: OAuthFlowOverrides = {}) {
+    const {
+      code = "fresh-auth-code",
+      tokens = {
+        accessToken: "new-access-token",
+        refreshToken: "new-refresh-token",
+        expiresAt: 123,
+      },
+      user = { userId: "user_new", email: "new@example.com" },
+    } = overrides;
+
+    mockBunSpawn();
+    const server = {
+      port: 54321,
+      waitForCallback: mock().mockResolvedValue({ code }),
+      stop: mock(),
+    };
+    mockStartAuthServer.mockReturnValue(server);
+    mockExchangeCodeForToken.mockResolvedValue({
+      access_token: tokens.accessToken,
+      token_type: "Bearer",
+      expires_in: 3600,
+      refresh_token: tokens.refreshToken,
+    });
+    mockCreateOAuthSession.mockReturnValue({
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+      expiresAt: tokens.expiresAt,
+      tokenType: "Bearer",
+    });
+    mockStoreToken.mockResolvedValue(undefined);
+    mockSetAuth.mockResolvedValue(undefined);
+    if (user) mockFetchUserInfo.mockResolvedValue(user);
+    return server;
+  }
+
   test("returns early when already authenticated with valid token", async () => {
     mockGetValidToken.mockResolvedValue("existing-token");
     mockGetAuth.mockResolvedValue({ userId: "user_123" });
@@ -148,7 +196,6 @@ describe("login", () => {
       email: "existing@example.com",
     });
 
-    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     const result = await runLogin();
 
     expect(result).toEqual({ userId: "user_123", email: "existing@example.com" });
@@ -158,35 +205,8 @@ describe("login", () => {
 
   test("performs fresh login when no token exists", async () => {
     mockGetValidToken.mockResolvedValue(null);
-    mockBunSpawn();
+    mockOAuthSuccess();
 
-    const mockServer = {
-      port: 54321,
-      waitForCallback: mock().mockResolvedValue({ code: "fresh-auth-code" }),
-      stop: mock(),
-    };
-    mockStartAuthServer.mockReturnValue(mockServer);
-
-    mockExchangeCodeForToken.mockResolvedValue({
-      access_token: "new-access-token",
-      token_type: "Bearer",
-      expires_in: 3600,
-      refresh_token: "new-refresh-token",
-    });
-    mockCreateOAuthSession.mockReturnValue({
-      accessToken: "new-access-token",
-      refreshToken: "new-refresh-token",
-      expiresAt: 123,
-      tokenType: "Bearer",
-    });
-    mockStoreToken.mockResolvedValue(undefined);
-    mockFetchUserInfo.mockResolvedValue({
-      userId: "user_new",
-      email: "new@example.com",
-    });
-    mockSetAuth.mockResolvedValue(undefined);
-
-    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     const result = await runLogin();
 
     expect(result).toEqual({ userId: "user_new", email: "new@example.com" });
@@ -219,31 +239,16 @@ describe("login", () => {
       userId: "user_refreshed",
       email: "refreshed@example.com",
     });
-    mockBunSpawn();
-
-    const mockServer = {
-      port: 54321,
-      waitForCallback: mock().mockResolvedValue({ code: "refresh-code" }),
-      stop: mock(),
-    };
-    mockStartAuthServer.mockReturnValue(mockServer);
-
-    mockExchangeCodeForToken.mockResolvedValue({
-      access_token: "refreshed-token",
-      token_type: "Bearer",
-      expires_in: 3600,
-      refresh_token: "refreshed-refresh-token",
+    mockOAuthSuccess({
+      code: "refresh-code",
+      tokens: {
+        accessToken: "refreshed-token",
+        refreshToken: "refreshed-refresh-token",
+        expiresAt: 456,
+      },
+      user: null,
     });
-    mockCreateOAuthSession.mockReturnValue({
-      accessToken: "refreshed-token",
-      refreshToken: "refreshed-refresh-token",
-      expiresAt: 456,
-      tokenType: "Bearer",
-    });
-    mockStoreToken.mockResolvedValue(undefined);
-    mockSetAuth.mockResolvedValue(undefined);
 
-    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     const result = await runLogin();
 
     expect(result).toEqual({ userId: "user_refreshed", email: "refreshed@example.com" });
@@ -269,8 +274,6 @@ describe("login", () => {
     };
     mockStartAuthServer.mockReturnValue(mockServer);
 
-    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
-
     await expect(runLogin()).rejects.toThrow("Authentication timed out");
     expect(mockServer.stop).toHaveBeenCalled();
   });
@@ -278,35 +281,8 @@ describe("login", () => {
   test("proceeds with login when token exists but no auth config", async () => {
     mockGetValidToken.mockResolvedValue("orphan-token");
     mockGetAuth.mockResolvedValue(undefined);
-    mockBunSpawn();
+    mockOAuthSuccess({ user: { userId: "user_brand_new", email: "brandnew@example.com" } });
 
-    const mockServer = {
-      port: 54321,
-      waitForCallback: mock().mockResolvedValue({ code: "new-code" }),
-      stop: mock(),
-    };
-    mockStartAuthServer.mockReturnValue(mockServer);
-
-    mockExchangeCodeForToken.mockResolvedValue({
-      access_token: "brand-new-token",
-      token_type: "Bearer",
-      expires_in: 3600,
-      refresh_token: "brand-new-refresh-token",
-    });
-    mockCreateOAuthSession.mockReturnValue({
-      accessToken: "brand-new-token",
-      refreshToken: "brand-new-refresh-token",
-      expiresAt: 789,
-      tokenType: "Bearer",
-    });
-    mockStoreToken.mockResolvedValue(undefined);
-    mockFetchUserInfo.mockResolvedValue({
-      userId: "user_brand_new",
-      email: "brandnew@example.com",
-    });
-    mockSetAuth.mockResolvedValue(undefined);
-
-    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     const result = await runLogin();
 
     expect(result).toEqual({ userId: "user_brand_new", email: "brandnew@example.com" });
@@ -322,7 +298,6 @@ describe("login", () => {
       email: "agent@example.com",
     });
 
-    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     const result = await runLogin();
 
     expect(result).toEqual({ userId: "user_123", email: "agent@example.com" });
@@ -339,31 +314,8 @@ describe("login", () => {
       .mockResolvedValueOnce({ userId: "user_123", email: "old@example.com" })
       .mockResolvedValueOnce({ userId: "user_new", email: "new@example.com" });
     mockConfirm.mockResolvedValue(true);
-    mockBunSpawn();
+    mockOAuthSuccess({ code: "reauth-code", user: null });
 
-    const mockServer = {
-      port: 54321,
-      waitForCallback: mock().mockResolvedValue({ code: "reauth-code" }),
-      stop: mock(),
-    };
-    mockStartAuthServer.mockReturnValue(mockServer);
-
-    mockExchangeCodeForToken.mockResolvedValue({
-      access_token: "new-token",
-      token_type: "Bearer",
-      expires_in: 3600,
-      refresh_token: "new-refresh-token",
-    });
-    mockCreateOAuthSession.mockReturnValue({
-      accessToken: "new-token",
-      refreshToken: "new-refresh-token",
-      expiresAt: 999,
-      tokenType: "Bearer",
-    });
-    mockStoreToken.mockResolvedValue(undefined);
-    mockSetAuth.mockResolvedValue(undefined);
-
-    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     const result = await runLogin();
 
     expect(mockConfirm).toHaveBeenCalledWith({
@@ -381,31 +333,8 @@ describe("login", () => {
     mockFetchUserInfo
       .mockResolvedValueOnce({ userId: "user_123", email: "old@example.com" })
       .mockResolvedValueOnce({ userId: "user_new", email: "new@example.com" });
-    mockBunSpawn();
+    mockOAuthSuccess({ code: "reauth-code", user: null });
 
-    const mockServer = {
-      port: 54321,
-      waitForCallback: mock().mockResolvedValue({ code: "reauth-code" }),
-      stop: mock(),
-    };
-    mockStartAuthServer.mockReturnValue(mockServer);
-
-    mockExchangeCodeForToken.mockResolvedValue({
-      access_token: "new-token",
-      token_type: "Bearer",
-      expires_in: 3600,
-      refresh_token: "new-refresh-token",
-    });
-    mockCreateOAuthSession.mockReturnValue({
-      accessToken: "new-token",
-      refreshToken: "new-refresh-token",
-      expiresAt: 999,
-      tokenType: "Bearer",
-    });
-    mockStoreToken.mockResolvedValue(undefined);
-    mockSetAuth.mockResolvedValue(undefined);
-
-    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     const result = await runLogin({ yes: true });
 
     expect(mockConfirm).not.toHaveBeenCalled();
@@ -423,8 +352,6 @@ describe("login", () => {
     });
     mockConfirm.mockResolvedValue(false);
 
-    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
-
     await expect(runLogin()).rejects.toThrow("User aborted");
     expect(mockConfirm).toHaveBeenCalled();
     expect(mockStartAuthServer).not.toHaveBeenCalled();
@@ -432,33 +359,7 @@ describe("login", () => {
 
   test("shows linked app with name and id in next steps when linked", async () => {
     mockGetValidToken.mockResolvedValue(null);
-    mockBunSpawn();
-
-    const mockServer = {
-      port: 54321,
-      waitForCallback: mock().mockResolvedValue({ code: "fresh-auth-code" }),
-      stop: mock(),
-    };
-    mockStartAuthServer.mockReturnValue(mockServer);
-
-    mockExchangeCodeForToken.mockResolvedValue({
-      access_token: "new-access-token",
-      token_type: "Bearer",
-      expires_in: 3600,
-      refresh_token: "new-refresh-token",
-    });
-    mockCreateOAuthSession.mockReturnValue({
-      accessToken: "new-access-token",
-      refreshToken: "new-refresh-token",
-      expiresAt: 123,
-      tokenType: "Bearer",
-    });
-    mockStoreToken.mockResolvedValue(undefined);
-    mockFetchUserInfo.mockResolvedValue({
-      userId: "user_new",
-      email: "new@example.com",
-    });
-    mockSetAuth.mockResolvedValue(undefined);
+    mockOAuthSuccess();
     mockResolveProfile.mockResolvedValue({
       path: "/some/path",
       profile: {
@@ -470,7 +371,6 @@ describe("login", () => {
       resolvedVia: "remote",
     });
 
-    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     await runLogin();
 
     expect(captured.err).toContain("Linked to `My App` (app_abc123)");
@@ -478,33 +378,7 @@ describe("login", () => {
 
   test("shows linked app with only id when appName is missing", async () => {
     mockGetValidToken.mockResolvedValue(null);
-    mockBunSpawn();
-
-    const mockServer = {
-      port: 54321,
-      waitForCallback: mock().mockResolvedValue({ code: "fresh-auth-code" }),
-      stop: mock(),
-    };
-    mockStartAuthServer.mockReturnValue(mockServer);
-
-    mockExchangeCodeForToken.mockResolvedValue({
-      access_token: "new-access-token",
-      token_type: "Bearer",
-      expires_in: 3600,
-      refresh_token: "new-refresh-token",
-    });
-    mockCreateOAuthSession.mockReturnValue({
-      accessToken: "new-access-token",
-      refreshToken: "new-refresh-token",
-      expiresAt: 123,
-      tokenType: "Bearer",
-    });
-    mockStoreToken.mockResolvedValue(undefined);
-    mockFetchUserInfo.mockResolvedValue({
-      userId: "user_new",
-      email: "new@example.com",
-    });
-    mockSetAuth.mockResolvedValue(undefined);
+    mockOAuthSuccess();
     mockResolveProfile.mockResolvedValue({
       path: "/some/path",
       profile: {
@@ -515,7 +389,6 @@ describe("login", () => {
       resolvedVia: "remote",
     });
 
-    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     await runLogin();
 
     expect(captured.err).toContain("Linked to `app_abc123`");
@@ -523,36 +396,9 @@ describe("login", () => {
 
   test("shows default next steps when not linked", async () => {
     mockGetValidToken.mockResolvedValue(null);
-    mockBunSpawn();
-
-    const mockServer = {
-      port: 54321,
-      waitForCallback: mock().mockResolvedValue({ code: "fresh-auth-code" }),
-      stop: mock(),
-    };
-    mockStartAuthServer.mockReturnValue(mockServer);
-
-    mockExchangeCodeForToken.mockResolvedValue({
-      access_token: "new-access-token",
-      token_type: "Bearer",
-      expires_in: 3600,
-      refresh_token: "new-refresh-token",
-    });
-    mockCreateOAuthSession.mockReturnValue({
-      accessToken: "new-access-token",
-      refreshToken: "new-refresh-token",
-      expiresAt: 123,
-      tokenType: "Bearer",
-    });
-    mockStoreToken.mockResolvedValue(undefined);
-    mockFetchUserInfo.mockResolvedValue({
-      userId: "user_new",
-      email: "new@example.com",
-    });
-    mockSetAuth.mockResolvedValue(undefined);
+    mockOAuthSuccess();
     mockResolveProfile.mockResolvedValue(undefined);
 
-    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     await runLogin();
 
     expect(captured.err).not.toContain("Linked to");
@@ -560,35 +406,8 @@ describe("login", () => {
 
   test("authorize URL includes clerk_client=cli so dashboard recognizes CLI sign-up", async () => {
     mockGetValidToken.mockResolvedValue(null);
-    mockBunSpawn();
+    mockOAuthSuccess();
 
-    const mockServer = {
-      port: 54321,
-      waitForCallback: mock().mockResolvedValue({ code: "fresh-auth-code" }),
-      stop: mock(),
-    };
-    mockStartAuthServer.mockReturnValue(mockServer);
-
-    mockExchangeCodeForToken.mockResolvedValue({
-      access_token: "new-access-token",
-      token_type: "Bearer",
-      expires_in: 3600,
-      refresh_token: "new-refresh-token",
-    });
-    mockCreateOAuthSession.mockReturnValue({
-      accessToken: "new-access-token",
-      refreshToken: "new-refresh-token",
-      expiresAt: 123,
-      tokenType: "Bearer",
-    });
-    mockStoreToken.mockResolvedValue(undefined);
-    mockFetchUserInfo.mockResolvedValue({
-      userId: "user_new",
-      email: "new@example.com",
-    });
-    mockSetAuth.mockResolvedValue(undefined);
-
-    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     await runLogin({ showNextSteps: false });
 
     expect(mockOpenBrowser).toHaveBeenCalledTimes(1);
@@ -597,76 +416,46 @@ describe("login", () => {
     expect(parsed.searchParams.get("clerk_client")).toBe("cli");
   });
 
-  test("does not emit the OAuth authorize URL through debug logging", async () => {
-    setLogLevel("debug");
+  test("always prints the authorize URL as a manual fallback, even when the browser opens", async () => {
     mockGetValidToken.mockResolvedValue(null);
-    mockBunSpawn();
+    mockOAuthSuccess();
+    mockOpenBrowser.mockResolvedValue({ ok: true, launcher: "open" });
 
-    const mockServer = {
-      port: 54321,
-      waitForCallback: mock().mockResolvedValue({ code: "fresh-auth-code" }),
-      stop: mock(),
-    };
-    mockStartAuthServer.mockReturnValue(mockServer);
-
-    mockExchangeCodeForToken.mockResolvedValue({
-      access_token: "new-access-token",
-      token_type: "Bearer",
-      expires_in: 3600,
-      refresh_token: "new-refresh-token",
-    });
-    mockCreateOAuthSession.mockReturnValue({
-      accessToken: "new-access-token",
-      refreshToken: "new-refresh-token",
-      expiresAt: 123,
-      tokenType: "Bearer",
-    });
-    mockStoreToken.mockResolvedValue(undefined);
-    mockFetchUserInfo.mockResolvedValue({
-      userId: "user_new",
-      email: "new@example.com",
-    });
-    mockSetAuth.mockResolvedValue(undefined);
-
-    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     await runLogin({ showNextSteps: false });
 
-    expect(captured.err).not.toContain("https://test.example.com/oauth/authorize");
-    expect(captured.err).not.toContain("test-state-value");
-    expect(captured.err).not.toContain("test-code-challenge");
+    expect(captured.err).toContain("https://test.example.com/oauth/authorize");
+    expect(captured.err).toContain("If it doesn't open, use this URL");
+  });
+
+  test("warns when the browser cannot be opened, pointing at the printed URL", async () => {
+    mockGetValidToken.mockResolvedValue(null);
+    mockOAuthSuccess();
+    mockOpenBrowser.mockResolvedValue({ ok: false, reason: "no-launcher" });
+
+    await runLogin({ showNextSteps: false });
+
+    expect(captured.err).toContain("https://test.example.com/oauth/authorize");
+    expect(captured.err).toContain("Could not open your browser automatically");
+  });
+
+  test("does not emit the PKCE code verifier through debug logging", async () => {
+    setLogLevel("debug");
+    mockGetValidToken.mockResolvedValue(null);
+    mockOAuthSuccess();
+
+    await runLogin({ showNextSteps: false });
+
+    // The authorize URL (containing state + code_challenge) is printed on
+    // purpose as the manual fallback. The code verifier is the secret that
+    // makes possession of that URL useless to an attacker — it must never
+    // appear in any output.
+    expect(captured.err).not.toContain("test-code-verifier");
   });
 
   test("calls ensureFirstApplication after a successful OAuth flow", async () => {
     mockGetValidToken.mockResolvedValue(null);
-    mockBunSpawn();
+    mockOAuthSuccess();
 
-    const mockServer = {
-      port: 54321,
-      waitForCallback: mock().mockResolvedValue({ code: "fresh-auth-code" }),
-      stop: mock(),
-    };
-    mockStartAuthServer.mockReturnValue(mockServer);
-
-    mockExchangeCodeForToken.mockResolvedValue({
-      access_token: "new-access-token",
-      token_type: "Bearer",
-      expires_in: 3600,
-      refresh_token: "new-refresh-token",
-    });
-    mockCreateOAuthSession.mockReturnValue({
-      accessToken: "new-access-token",
-      refreshToken: "new-refresh-token",
-      expiresAt: 123,
-      tokenType: "Bearer",
-    });
-    mockStoreToken.mockResolvedValue(undefined);
-    mockFetchUserInfo.mockResolvedValue({
-      userId: "user_new",
-      email: "new@example.com",
-    });
-    mockSetAuth.mockResolvedValue(undefined);
-
-    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     await runLogin({ showNextSteps: false });
 
     expect(mockEnsureFirstApplication).toHaveBeenCalledTimes(1);
@@ -680,7 +469,6 @@ describe("login", () => {
       email: "existing@example.com",
     });
 
-    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     await runLogin();
 
     expect(mockEnsureFirstApplication).not.toHaveBeenCalled();
@@ -688,35 +476,7 @@ describe("login", () => {
 
   test("suppresses auth next-steps when requested", async () => {
     mockGetValidToken.mockResolvedValue(null);
-    mockBunSpawn();
-
-    const mockServer = {
-      port: 54321,
-      waitForCallback: mock().mockResolvedValue({ code: "fresh-auth-code" }),
-      stop: mock(),
-    };
-    mockStartAuthServer.mockReturnValue(mockServer);
-
-    mockExchangeCodeForToken.mockResolvedValue({
-      access_token: "new-access-token",
-      token_type: "Bearer",
-      expires_in: 3600,
-      refresh_token: "new-refresh-token",
-    });
-    mockCreateOAuthSession.mockReturnValue({
-      accessToken: "new-access-token",
-      refreshToken: "new-refresh-token",
-      expiresAt: 123,
-      tokenType: "Bearer",
-    });
-    mockStoreToken.mockResolvedValue(undefined);
-    mockFetchUserInfo.mockResolvedValue({
-      userId: "user_new",
-      email: "new@example.com",
-    });
-    mockSetAuth.mockResolvedValue(undefined);
-
-    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+    mockOAuthSuccess();
     consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
 
     await runLogin({ showNextSteps: false });

--- a/packages/cli-core/src/commands/auth/login.ts
+++ b/packages/cli-core/src/commands/auth/login.ts
@@ -54,13 +54,18 @@ async function performOAuthFlow(): Promise<UserInfo> {
   authorizeUrl.searchParams.set("code_challenge_method", "S256");
   authorizeUrl.searchParams.set("clerk_client", CLERK_CLIENT_CLI);
 
-  // Critical fallback: the OAuth callback can't complete unless the user
-  // reaches the authorize URL somehow.
+  // Printed unconditionally: a launcher can exit 0 without anything visibly
+  // opening (WSL, headless shells), and the flow can't complete unless the
+  // user reaches this URL. Safe to display — the token exchange also requires
+  // the PKCE code verifier, which never leaves this process.
   const urlString = authorizeUrl.toString();
+  log.info(
+    `Opening your browser to sign in. If it doesn't open, use this URL:\n  ${cyan(urlString)}`,
+  );
   const result = await openBrowser(urlString);
   if (!result.ok) {
     log.warn(
-      `\nCould not open your browser automatically. Open this URL to continue:\n  ${cyan(urlString)}\n${dim("(Reason: " + result.reason + ")")}\n`,
+      `Could not open your browser automatically ${dim(`(${result.reason})`)}. Open the URL above to continue.`,
     );
   }
 

--- a/packages/cli-core/src/lib/auth-server.ts
+++ b/packages/cli-core/src/lib/auth-server.ts
@@ -186,7 +186,11 @@ export function startAuthServer(expectedState: string): AuthServerResult {
 
   const timeout = setTimeout(() => {
     log.debug(`auth-server: timed out after ${AUTH_TIMEOUT_MS}ms`);
-    rejectCallback(new Error("Authentication timed out. Please try again."));
+    rejectCallback(
+      new Error(
+        "Authentication timed out. Run `clerk auth login` to try again — if your browser did not open, copy the printed URL into any browser on this machine.",
+      ),
+    );
     server?.stop();
   }, AUTH_TIMEOUT_MS);
 

--- a/packages/cli-core/src/lib/open.test.ts
+++ b/packages/cli-core/src/lib/open.test.ts
@@ -10,49 +10,116 @@ const bunOverrides = Bun as unknown as {
   spawn: (cmd: string[], opts?: unknown) => { exited: Promise<number> };
 };
 
+function stubPlatform(platform: NodeJS.Platform) {
+  Object.defineProperty(process, "platform", { value: platform, writable: true });
+}
+
+/** Only the given binaries resolve on PATH. */
+function stubWhich(available: Record<string, string>) {
+  bunOverrides.which = (bin) => available[bin] ?? null;
+}
+
+function stubWsl() {
+  stubPlatform("linux");
+  process.env.WSL_DISTRO_NAME = "Ubuntu";
+}
+
+/** Record spawned commands; every spawn exits 0 immediately. */
+function captureSpawn(): string[][] {
+  const commands: string[][] = [];
+  bunOverrides.spawn = (cmd) => {
+    commands.push(cmd);
+    return { exited: Promise.resolve(0) };
+  };
+  return commands;
+}
+
 afterEach(() => {
   bunOverrides.which = origWhich as typeof bunOverrides.which;
   bunOverrides.spawn = origSpawn as typeof bunOverrides.spawn;
   Object.defineProperty(process, "platform", { value: origPlatform, writable: true });
+  delete process.env.WSL_DISTRO_NAME;
+  delete process.env.WSL_INTEROP;
 });
+
+const OAUTH_URL = "https://example.com/oauth?client_id=abc&response_type=code&state=xyz";
 
 describe("openBrowser", () => {
   test("win32: quotes URL so ampersands are not treated as cmd.exe separators", async () => {
-    Object.defineProperty(process, "platform", { value: "win32", writable: true });
+    stubPlatform("win32");
+    const spawned = captureSpawn();
 
-    let capturedCmd: string[] | undefined;
-    bunOverrides.spawn = (cmd: string[], _opts?: unknown) => {
-      capturedCmd = cmd;
-      return { exited: Promise.resolve(0) };
-    };
-
-    const url = "https://example.com/oauth?client_id=abc&response_type=code&state=xyz";
-    const result = await openBrowser(url);
+    const result = await openBrowser(OAUTH_URL);
 
     expect(result.ok).toBe(true);
-    expect(capturedCmd).toBeDefined();
     // cmd.exe /c 'start "" "<url>"' — passed as a single string so cmd.exe
     // parses it as a shell command line, preserving the quotes around the URL.
-    expect(capturedCmd![0]).toBe("cmd.exe");
-    expect(capturedCmd![1]).toBe("/c");
-    expect(capturedCmd![2]).toBe(`start "" "${url}"`);
+    expect(spawned).toEqual([["cmd.exe", "/c", `start "" "${OAUTH_URL}"`]]);
   });
 
   test("non-win32: passes URL without extra quoting", async () => {
-    Object.defineProperty(process, "platform", { value: "linux", writable: true });
+    stubPlatform("linux");
+    stubWhich({ "xdg-open": "/usr/bin/xdg-open" });
+    const spawned = captureSpawn();
 
-    bunOverrides.which = (bin: string) => (bin === "xdg-open" ? "/usr/bin/xdg-open" : null);
-
-    let capturedCmd: string[] | undefined;
-    bunOverrides.spawn = (cmd: string[], _opts?: unknown) => {
-      capturedCmd = cmd;
-      return { exited: Promise.resolve(0) };
-    };
-
-    const url = "https://example.com/oauth?client_id=abc&response_type=code&state=xyz";
-    const result = await openBrowser(url);
+    const result = await openBrowser(OAUTH_URL);
 
     expect(result.ok).toBe(true);
-    expect(capturedCmd).toEqual(["xdg-open", url]);
+    expect(spawned).toEqual([["xdg-open", OAUTH_URL]]);
+  });
+
+  test("WSL: prefers wslview when installed", async () => {
+    stubWsl();
+    stubWhich({ wslview: "/usr/bin/wslview", "powershell.exe": "/mnt/c/powershell.exe" });
+    const spawned = captureSpawn();
+
+    const result = await openBrowser(OAUTH_URL);
+
+    expect(result.ok).toBe(true);
+    expect(spawned).toEqual([["wslview", OAUTH_URL]]);
+  });
+
+  test("WSL: falls back to powershell.exe interop when wslview is missing", async () => {
+    stubWsl();
+    // Typical WSL without wslu: only Windows interop binaries resolve; xdg-open
+    // is absent (no Linux desktop environment).
+    stubWhich({
+      "powershell.exe": "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe",
+    });
+    const spawned = captureSpawn();
+
+    const result = await openBrowser(OAUTH_URL);
+
+    expect(result.ok).toBe(true);
+    // Single-quoted so `&` in the query string is not a PowerShell operator.
+    expect(spawned).toEqual([
+      [
+        "powershell.exe",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `Start-Process '${OAUTH_URL}'`,
+      ],
+    ]);
+  });
+
+  test("WSL: escapes single quotes in the URL for PowerShell", async () => {
+    stubPlatform("linux");
+    process.env.WSL_INTEROP = "/run/WSL/1_interop";
+    stubWhich({ "powershell.exe": "/mnt/c/powershell.exe" });
+    const spawned = captureSpawn();
+
+    await openBrowser("https://example.com/path?q=it's");
+
+    expect(spawned[0]?.[4]).toBe("Start-Process 'https://example.com/path?q=it''s'");
+  });
+
+  test("WSL: reports no-launcher when neither wslview nor interop binaries resolve", async () => {
+    stubWsl();
+    stubWhich({});
+
+    const result = await openBrowser("https://example.com");
+
+    expect(result).toEqual({ ok: false, reason: "no-launcher" });
   });
 });

--- a/packages/cli-core/src/lib/open.ts
+++ b/packages/cli-core/src/lib/open.ts
@@ -31,16 +31,11 @@ export type OpenResult =
 /**
  * Candidate browser-launcher binaries per platform, in preference order.
  * The first one that exists on PATH wins.
- *
- * Linux ordering rationale: `wslview` first because it correctly hands the
- * URL to the Windows host browser inside WSL (xdg-open inside WSL usually
- * fails or opens nothing). `xdg-open` is the standard Linux tool. The other
- * entries are direct browser binaries as last-ditch fallbacks.
  */
 const LAUNCHERS: Record<NodeJS.Platform, readonly string[]> = {
   darwin: ["open"],
   win32: ["start"],
-  linux: ["wslview", "xdg-open", "gnome-open", "kde-open", "sensible-browser"],
+  linux: ["xdg-open", "gnome-open", "kde-open", "sensible-browser"],
   // Other platforms (freebsd, openbsd, sunos, aix, android) get xdg-open as
   // a best guess.
   aix: ["xdg-open"],
@@ -52,6 +47,65 @@ const LAUNCHERS: Record<NodeJS.Platform, readonly string[]> = {
   sunos: ["xdg-open"],
   cygwin: ["start"],
 };
+
+/**
+ * Launcher chain for WSL (Windows Subsystem for Linux), where the goal is to
+ * reach the *Windows host's* browser, not a Linux one:
+ *
+ *  1. `wslview` (from wslu) — purpose-built for this, but not always installed
+ *  2. `powershell.exe` — present on PATH in every default WSL install via
+ *     Windows interop (/mnt/c/...); `Start-Process <url>` opens the host's
+ *     default browser
+ *  3. `xdg-open` and friends — last resort, useful under WSLg with a Linux
+ *     browser installed
+ *
+ * `explorer.exe` is deliberately absent: it opens URLs fine but always exits
+ * with code 1, which our fast-non-zero-exit failure detection would misread
+ * as a launch failure.
+ */
+const WSL_LAUNCHERS = ["wslview", "powershell.exe", ...LAUNCHERS.linux] as const;
+
+/**
+ * WSL2 sets `WSL_DISTRO_NAME` and `WSL_INTEROP`; as a fallback (older WSL1,
+ * sanitized environments) the kernel version string in /proc/version
+ * contains "microsoft".
+ */
+async function isWsl(): Promise<boolean> {
+  if (process.platform !== "linux") return false;
+  if (process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP) return true;
+  try {
+    return /microsoft/i.test(await Bun.file("/proc/version").text());
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Build the spawn command for a given launcher.
+ *
+ * - `start` (Windows): invoked via cmd.exe. The entire command is passed as a
+ *   single string after `/c` so that cmd.exe parses it exactly as if typed at
+ *   the prompt: `start "" "https://..."`. The empty `""` is the window title
+ *   (otherwise `start` interprets a quoted URL as the title), and the URL is
+ *   quoted so `&` in OAuth query strings is not treated as a cmd.exe command
+ *   separator.
+ * - `powershell.exe` (WSL interop): `Start-Process '<url>'` with the URL in
+ *   single quotes so `&` is not treated as a PowerShell operator; embedded
+ *   single quotes are doubled per PowerShell quoting rules.
+ */
+function launchCommand(launcher: string, url: string): string[] {
+  if (launcher === "start") return ["cmd.exe", "/c", `start "" "${url}"`];
+  if (launcher === "powershell.exe") {
+    return [
+      "powershell.exe",
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      `Start-Process '${url.replace(/'/g, "''")}'`,
+    ];
+  }
+  return [launcher, url];
+}
 
 /**
  * Try to open `url` in the user's default browser.
@@ -68,7 +122,9 @@ const LAUNCHERS: Record<NodeJS.Platform, readonly string[]> = {
  * ```
  */
 export async function openBrowser(url: string): Promise<OpenResult> {
-  const candidates = LAUNCHERS[process.platform] ?? ["xdg-open"];
+  const candidates = (await isWsl())
+    ? WSL_LAUNCHERS
+    : (LAUNCHERS[process.platform] ?? ["xdg-open"]);
 
   // Pick the first launcher that's actually installed. `start` is a cmd.exe
   // builtin (not a real binary on PATH), so we treat it as always-available
@@ -79,13 +135,7 @@ export async function openBrowser(url: string): Promise<OpenResult> {
     return { ok: false, reason: "no-launcher" };
   }
 
-  // On Windows, invoke `start` via cmd.exe. The entire command is passed as a
-  // single string after `/c` so that cmd.exe parses it exactly as if typed at
-  // the prompt: `start "" "https://..."`.  The empty `""` is the window title
-  // (otherwise `start` interprets a quoted URL as the title), and the URL is
-  // quoted so `&` in OAuth query strings is not treated as a cmd.exe command
-  // separator.
-  const command = launcher === "start" ? ["cmd.exe", "/c", `start "" "${url}"`] : [launcher, url];
+  const command = launchCommand(launcher, url);
 
   try {
     const result = await withBrowserLaunch(


### PR DESCRIPTION
## Summary

Fixes #411 — `clerk auth login` was unusable in WSL2 (and SSH/headless shells): the CLI depended on a browser launch that silently fails there, printed no URL, and hung until a generic timeout.

Three layers of fallback, so login always has a path forward:

- **The authorize URL is always printed** before the launch attempt — a launcher can exit 0 without anything visibly opening (WSL's `xdg-open`), so failure detection alone can't cover it. Printing is safe: completing the token exchange requires the PKCE `code_verifier`, which never leaves the CLI process. When no launcher works, a warning points back at the printed URL.
- **WSL now reaches the Windows host browser without extra setup.** WSL is detected via `WSL_DISTRO_NAME`/`WSL_INTEROP` (fallback: `/proc/version` containing "microsoft") and the launcher chain becomes `wslview → powershell.exe → xdg-open…`. `powershell.exe -NoProfile -NonInteractive -Command Start-Process '<url>'` is on PATH in every default WSL install via Windows interop; the URL is single-quoted (embedded `'` doubled) so `&` in OAuth query strings isn't parsed as a PowerShell operator. `explorer.exe` is deliberately excluded: it opens URLs but always exits 1, which the fast-failure grace race would misread as a failed launch.
- **The auth timeout error is actionable**: re-run `clerk auth login` and copy the printed URL into any browser on the machine.

The full round trip works in WSL2 because it forwards `127.0.0.1` between Windows and the VM in both directions, so the host browser still reaches the CLI's OAuth callback server.

Also in this diff: `login.test.ts` had its ~25-line OAuth-success mock block repeated 14 times (my new tests initially added 3 more) — extracted a `mockOAuthSuccess(overrides)` helper, shrinking the file 804 → 486 lines with coverage unchanged.

Out of scope, possible follow-up: the issue's option 1 (RFC 8628 device authorization flow) needs a server-side endpoint on the Clerk OAuth instance; it's the right answer for SSH-to-remote-box sessions where the callback server lives on the far end.

## Test plan

- [x] 4 new `openBrowser` unit tests: wslview preference, PowerShell fallback, single-quote escaping, no-launcher; login tests assert the URL always prints and the PKCE `code_verifier` never appears in output
- [x] Full suite: 2460 pass / 0 fail; `lint`, `typecheck`, `format:check` clean
- [x] Real unmocked runs: macOS CLI with a lying exit-0 launcher (URL still printed), with no launcher (warning + actionable timeout), Docker Linux with `WSL_DISTRO_NAME` set (real spawn of `powershell.exe Start-Process '<url>'` captured), and `curl` playing the browser against the callback server (CLI advanced to token exchange)
- [ ] Confirm on a physical WSL2 machine that `Start-Process` renders the host browser (the one hop not provable from macOS/Docker)