### PR TITLE
fix(telemetry): stop tracking the completion command

### DIFF
--- a/.changeset/remove-completion-telemetry.md
+++ b/.changeset/remove-completion-telemetry.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Stop sending telemetry for `clerk completion`. Shells re-run it on every startup when it is wired into an rc file, so its events measured shell startups rather than CLI usage.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ environment signals (OS, install method, terminal), a random machine identifier 
 your workspace and app IDs when a project is linked. It never collects command
 arguments, option values, file paths, or personal data. The first run only shows a
 disclosure notice and sends nothing (CI environments send from the first run), and
-`clerk --verbose` prints every event before it is sent.
+`clerk --verbose` prints every event before it is sent. Shell completion (`clerk
+completion <shell>` and the `__complete` helper behind Tab) sends nothing at all.
 See https://clerk.com/docs/telemetry for details.
 
 Opt out with `clerk telemetry disable`, or by setting `CLERK_TELEMETRY_DISABLED=1`

--- a/packages/cli-core/src/lib/telemetry.test.ts
+++ b/packages/cli-core/src/lib/telemetry.test.ts
@@ -206,30 +206,6 @@ describe("finalizeAndSendTelemetry", () => {
     expect(Date.now() - started).toBeLessThan(500);
   });
 
-  test("no send for `completion` — shells re-run it, so its events aren't usage", async () => {
-    await markTelemetryNoticeShown();
-    let called = 0;
-    globalThis.fetch = (async () => {
-      called += 1;
-      return new Response("{}");
-    }) as unknown as typeof fetch;
-    process.env.CLERK_TELEMETRY_URL = "https://capture.invalid/v1/event";
-    const root: TelemetryCommand = {
-      name: () => "clerk",
-      options: [],
-      getOptionValueSource: () => undefined,
-      parent: null,
-    };
-    startCommandTelemetry({
-      name: () => "completion",
-      options: [],
-      getOptionValueSource: () => undefined,
-      parent: root,
-    });
-    await finalizeAndSendTelemetry({ outcome: "success", exitCode: 0 });
-    expect(called).toBe(0);
-  });
-
   test("no send when telemetry is disabled via persisted config", async () => {
     let called = 0;
     globalThis.fetch = (async () => {

--- a/packages/cli-core/src/lib/telemetry.test.ts
+++ b/packages/cli-core/src/lib/telemetry.test.ts
@@ -206,6 +206,30 @@ describe("finalizeAndSendTelemetry", () => {
     expect(Date.now() - started).toBeLessThan(500);
   });
 
+  test("no send for `completion` — shells re-run it, so its events aren't usage", async () => {
+    await markTelemetryNoticeShown();
+    let called = 0;
+    globalThis.fetch = (async () => {
+      called += 1;
+      return new Response("{}");
+    }) as unknown as typeof fetch;
+    process.env.CLERK_TELEMETRY_URL = "https://capture.invalid/v1/event";
+    const root: TelemetryCommand = {
+      name: () => "clerk",
+      options: [],
+      getOptionValueSource: () => undefined,
+      parent: null,
+    };
+    startCommandTelemetry({
+      name: () => "completion",
+      options: [],
+      getOptionValueSource: () => undefined,
+      parent: root,
+    });
+    await finalizeAndSendTelemetry({ outcome: "success", exitCode: 0 });
+    expect(called).toBe(0);
+  });
+
   test("no send when telemetry is disabled via persisted config", async () => {
     let called = 0;
     globalThis.fetch = (async () => {

--- a/packages/cli-core/src/lib/telemetry.ts
+++ b/packages/cli-core/src/lib/telemetry.ts
@@ -110,11 +110,25 @@ function collectSetFlagNames(cmd: TelemetryCommand): string[] {
   return names;
 }
 
+/**
+ * Commands that run without a user asking for them, so their events say
+ * nothing about usage. `completion` is re-run by every new shell that has
+ * `eval "$(clerk completion zsh)"` in its rc file — a handful of machines
+ * drowned out the real command mix. (`__complete`, fired on each Tab press,
+ * exits in cli.ts before Commander ever reaches this hook.)
+ */
+const UNTRACKED_COMMANDS = new Set(["completion"]);
+
 /** Pure in-memory; never throws. */
 export function startCommandTelemetry(actionCommand: TelemetryCommand): void {
   try {
+    const command = commandPathOf(actionCommand);
+    if (UNTRACKED_COMMANDS.has(command)) {
+      context = null;
+      return;
+    }
     context = {
-      command: commandPathOf(actionCommand),
+      command,
       flags: collectSetFlagNames(actionCommand).join(","),
       startedAt: Date.now(),
     };

--- a/packages/cli-core/src/lib/telemetry.ts
+++ b/packages/cli-core/src/lib/telemetry.ts
@@ -1,7 +1,8 @@
 /**
  * Per-invocation usage telemetry.
  *
- * One CLI_COMMAND_EXECUTED event per command run, POSTed to the
+ * One CLI_COMMAND_EXECUTED event per command run — except `completion`, which
+ * never emits (see startCommandTelemetry) — POSTed to the
  * telemetry-service worker (BigQuery behind it). Opt out with
  * `clerk telemetry disable` (persisted) or the CLERK_TELEMETRY_DISABLED /
  * DO_NOT_TRACK env vars. Dev builds send nothing unless CLERK_TELEMETRY_URL
@@ -110,20 +111,15 @@ function collectSetFlagNames(cmd: TelemetryCommand): string[] {
   return names;
 }
 
-/**
- * Commands that run without a user asking for them, so their events say
- * nothing about usage. `completion` is re-run by every new shell that has
- * `eval "$(clerk completion zsh)"` in its rc file — a handful of machines
- * drowned out the real command mix. (`__complete`, fired on each Tab press,
- * exits in cli.ts before Commander ever reaches this hook.)
- */
-const UNTRACKED_COMMANDS = new Set(["completion"]);
-
 /** Pure in-memory; never throws. */
 export function startCommandTelemetry(actionCommand: TelemetryCommand): void {
   try {
     const command = commandPathOf(actionCommand);
-    if (UNTRACKED_COMMANDS.has(command)) {
+    // `completion` runs without a user asking for it: every new shell with
+    // `eval "$(clerk completion zsh)"` in its rc file re-runs it, so a handful
+    // of machines drowned out the real command mix. (`__complete`, fired on
+    // each Tab press, exits in cli.ts before Commander reaches this hook.)
+    if (command === "completion") {
       context = null;
       return;
     }

--- a/packages/cli-core/src/test/integration/telemetry.test.ts
+++ b/packages/cli-core/src/test/integration/telemetry.test.ts
@@ -45,7 +45,7 @@ test("sends one event for a successful command", async () => {
   process.env.CLERK_TELEMETRY_URL = TELEMETRY_URL;
   http.mock({ "test-telemetry.clerk.com": {} });
 
-  await clerk("webhooks", "token");
+  await clerk("webhooks", "token", "--json");
 
   const bodies = telemetryEvents();
   expect(bodies).toHaveLength(1);
@@ -77,6 +77,13 @@ test("`completion` sends nothing — not even the first-run notice", async () =>
     expect(result.exitCode).toBe(0);
     expect(result.stderr).not.toContain("Nothing has been sent during this run");
     expect(http.requests).toHaveLength(0);
+
+    // Past the grace run, where every other command starts sending: without
+    // this, the notice alone suppresses the POST and the assertion above
+    // passes even with the `completion` guard removed.
+    await markNoticeAlreadyShown();
+    await clerk("completion", "zsh");
+    expect(http.requests).toHaveLength(0);
   } finally {
     if (originalCi === undefined) delete process.env.CI;
     else process.env.CI = originalCi;
@@ -87,7 +94,7 @@ test("records failures with error code and reuses the machine uuid", async () =>
   await markNoticeAlreadyShown();
   process.env.CLERK_TELEMETRY_URL = TELEMETRY_URL;
   http.mock({ "test-telemetry.clerk.com": {} });
-  const first = await clerk("webhooks", "token");
+  const first = await clerk("webhooks", "token", "--json");
   expect(first.exitCode).toBe(0);
   const firstUuid = telemetryEvents()[0]!.events[0]!.payload.machine_uuid;
 
@@ -117,7 +124,7 @@ test("maps a soft failure (process.exitCode set without throwing) to outcome err
   try {
     // Simulates commands that report failure via process.exitCode instead of throwing.
     process.exitCode = 1;
-    await clerk.raw("webhooks", "token");
+    await clerk.raw("webhooks", "token", "--json");
 
     const bodies = telemetryEvents();
     expect(bodies).toHaveLength(1);
@@ -134,7 +141,7 @@ test("an invalid --mode value still produces an error event", async () => {
   process.env.CLERK_TELEMETRY_URL = TELEMETRY_URL;
   http.mock({ "test-telemetry.clerk.com": {} });
 
-  const result = await clerk.raw("--mode", "banana", "webhooks", "token");
+  const result = await clerk.raw("--mode", "banana", "webhooks", "token", "--json");
   expect(result.exitCode).toBe(2);
 
   const bodies = telemetryEvents();
@@ -143,6 +150,9 @@ test("an invalid --mode value still produces an error event", async () => {
   expect(event.payload.command).toBe("webhooks token");
   expect(event.payload.outcome).toBe("error");
   expect(event.payload.exit_code).toBe(2);
+  // Option values must never reach any event field — fails if the command
+  // path or flags ever start carrying argv values into a sent event.
+  expect(JSON.stringify(event)).not.toContain("banana");
 });
 
 // payload.command comes from the resolved Command objects' registered names,
@@ -167,13 +177,13 @@ test.each([[["users", "sk_test_secret123"]], [["sk_live_pasted"]]])(
 test("command succeeds even when the telemetry endpoint is down", async () => {
   process.env.CLERK_TELEMETRY_URL = TELEMETRY_URL;
   http.mock(); // no routes: every fetch throws, including the telemetry send
-  const result = await clerk.raw("webhooks", "token");
+  const result = await clerk.raw("webhooks", "token", "--json");
   expect(result.exitCode).toBe(0);
 });
 
 test("no telemetry traffic without CLERK_TELEMETRY_URL (dev build guard)", async () => {
   http.mock(); // guard mock: any fetch would throw
-  await clerk("webhooks", "token");
+  await clerk("webhooks", "token", "--json");
   expect(http.requests).toHaveLength(0);
 });
 
@@ -208,12 +218,12 @@ test("the first human run shows the notice and sends nothing; the next run sends
     process.env.CLERK_TELEMETRY_URL = TELEMETRY_URL;
     http.mock({ "test-telemetry.clerk.com": {} });
 
-    const first = await clerk("webhooks", "token");
+    const first = await clerk("webhooks", "token", "--json");
     expect(first.stderr).toContain("Nothing has been sent during this run");
     expect(first.stderr).toContain("clerk telemetry disable");
     expect(telemetryEvents()).toHaveLength(0);
 
-    const second = await clerk("webhooks", "token");
+    const second = await clerk("webhooks", "token", "--json");
     expect(second.stderr).not.toContain("Nothing has been sent during this run");
     expect(telemetryEvents()).toHaveLength(1);
   } finally {
@@ -229,11 +239,11 @@ test("agent-mode first run also gets the notice and sends nothing", async () => 
     process.env.CLERK_TELEMETRY_URL = TELEMETRY_URL;
     http.mock({ "test-telemetry.clerk.com": {} });
 
-    const first = await clerk("--mode", "agent", "webhooks", "token");
+    const first = await clerk("--mode", "agent", "webhooks", "token", "--json");
     expect(first.stderr).toContain("Nothing has been sent during this run");
     expect(telemetryEvents()).toHaveLength(0);
 
-    const second = await clerk("--mode", "agent", "webhooks", "token");
+    const second = await clerk("--mode", "agent", "webhooks", "token", "--json");
     expect(second.stderr).not.toContain("Nothing has been sent during this run");
     expect(telemetryEvents()).toHaveLength(1);
   } finally {
@@ -252,7 +262,7 @@ test("`clerk telemetry disable` itself sends nothing, and the opt-out persists",
   http.mock(); // any fetch would record and throw — none may happen
 
   await clerk("telemetry", "disable");
-  await clerk("webhooks", "token");
+  await clerk("webhooks", "token", "--json");
   expect(http.requests).toHaveLength(0);
 });
 
@@ -263,7 +273,7 @@ test("`clerk telemetry enable` turns events back on", async () => {
 
   await clerk("telemetry", "disable"); // sends nothing: opt-out visible at finalize
   await clerk("telemetry", "enable"); // sends: the user just opted back in
-  await clerk("webhooks", "token");
+  await clerk("webhooks", "token", "--json");
 
   const bodies = telemetryEvents();
   expect(bodies).toHaveLength(2);

--- a/packages/cli-core/src/test/integration/telemetry.test.ts
+++ b/packages/cli-core/src/test/integration/telemetry.test.ts
@@ -45,7 +45,7 @@ test("sends one event for a successful command", async () => {
   process.env.CLERK_TELEMETRY_URL = TELEMETRY_URL;
   http.mock({ "test-telemetry.clerk.com": {} });
 
-  await clerk("completion", "zsh");
+  await clerk("webhooks", "token");
 
   const bodies = telemetryEvents();
   expect(bodies).toHaveLength(1);
@@ -53,9 +53,7 @@ test("sends one event for a successful command", async () => {
   const event = bodies[0]!.events[0]!;
   expect(event.sdk).toBe("clerk-cli");
   expect(event.event).toBe("CLI_COMMAND_EXECUTED");
-  // Command path is subcommand names only — "zsh" is an argument value and
-  // is deliberately excluded.
-  expect(event.payload.command).toBe("completion");
+  expect(event.payload.command).toBe("webhooks token");
   expect(event.payload.outcome).toBe("success");
   expect(event.payload.exit_code).toBe(0);
   expect(event.payload.machine_uuid).toMatch(/^[0-9a-f-]{36}$/);
@@ -63,16 +61,33 @@ test("sends one event for a successful command", async () => {
   // Env-dependent fields are strings, values depend on the host machine.
   expect(typeof event.payload.ai_agent).toBe("string");
   expect(typeof event.payload.install_method).toBe("string");
-  // Never collected: the argument value ("zsh") must not leak into any event
-  // field — fails if command path or flags ever start carrying argv values.
-  expect(JSON.stringify(event)).not.toContain("zsh");
+});
+
+// `eval "$(clerk completion zsh)"` in an rc file re-runs the command on every
+// new shell, so its events measured shell startups, not CLI usage.
+test("`completion` sends nothing — not even the first-run notice", async () => {
+  const originalCi = process.env.CI;
+  delete process.env.CI; // the notice is suppressed in CI environments
+  try {
+    process.env.CLERK_TELEMETRY_URL = TELEMETRY_URL;
+    http.mock(); // any fetch would record and throw
+
+    const result = await clerk("completion", "zsh");
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain("Nothing has been sent during this run");
+    expect(http.requests).toHaveLength(0);
+  } finally {
+    if (originalCi === undefined) delete process.env.CI;
+    else process.env.CI = originalCi;
+  }
 });
 
 test("records failures with error code and reuses the machine uuid", async () => {
   await markNoticeAlreadyShown();
   process.env.CLERK_TELEMETRY_URL = TELEMETRY_URL;
   http.mock({ "test-telemetry.clerk.com": {} });
-  const first = await clerk("completion", "zsh");
+  const first = await clerk("webhooks", "token");
   expect(first.exitCode).toBe(0);
   const firstUuid = telemetryEvents()[0]!.events[0]!.payload.machine_uuid;
 
@@ -102,7 +117,7 @@ test("maps a soft failure (process.exitCode set without throwing) to outcome err
   try {
     // Simulates commands that report failure via process.exitCode instead of throwing.
     process.exitCode = 1;
-    await clerk.raw("completion", "zsh");
+    await clerk.raw("webhooks", "token");
 
     const bodies = telemetryEvents();
     expect(bodies).toHaveLength(1);
@@ -119,13 +134,13 @@ test("an invalid --mode value still produces an error event", async () => {
   process.env.CLERK_TELEMETRY_URL = TELEMETRY_URL;
   http.mock({ "test-telemetry.clerk.com": {} });
 
-  const result = await clerk.raw("--mode", "banana", "completion", "zsh");
+  const result = await clerk.raw("--mode", "banana", "webhooks", "token");
   expect(result.exitCode).toBe(2);
 
   const bodies = telemetryEvents();
   expect(bodies).toHaveLength(1);
   const event = bodies[0]!.events[0]!;
-  expect(event.payload.command).toBe("completion");
+  expect(event.payload.command).toBe("webhooks token");
   expect(event.payload.outcome).toBe("error");
   expect(event.payload.exit_code).toBe(2);
 });
@@ -152,13 +167,13 @@ test.each([[["users", "sk_test_secret123"]], [["sk_live_pasted"]]])(
 test("command succeeds even when the telemetry endpoint is down", async () => {
   process.env.CLERK_TELEMETRY_URL = TELEMETRY_URL;
   http.mock(); // no routes: every fetch throws, including the telemetry send
-  const result = await clerk.raw("completion", "zsh");
+  const result = await clerk.raw("webhooks", "token");
   expect(result.exitCode).toBe(0);
 });
 
 test("no telemetry traffic without CLERK_TELEMETRY_URL (dev build guard)", async () => {
   http.mock(); // guard mock: any fetch would throw
-  await clerk("completion", "zsh");
+  await clerk("webhooks", "token");
   expect(http.requests).toHaveLength(0);
 });
 
@@ -193,12 +208,12 @@ test("the first human run shows the notice and sends nothing; the next run sends
     process.env.CLERK_TELEMETRY_URL = TELEMETRY_URL;
     http.mock({ "test-telemetry.clerk.com": {} });
 
-    const first = await clerk("completion", "zsh");
+    const first = await clerk("webhooks", "token");
     expect(first.stderr).toContain("Nothing has been sent during this run");
     expect(first.stderr).toContain("clerk telemetry disable");
     expect(telemetryEvents()).toHaveLength(0);
 
-    const second = await clerk("completion", "zsh");
+    const second = await clerk("webhooks", "token");
     expect(second.stderr).not.toContain("Nothing has been sent during this run");
     expect(telemetryEvents()).toHaveLength(1);
   } finally {
@@ -214,11 +229,11 @@ test("agent-mode first run also gets the notice and sends nothing", async () => 
     process.env.CLERK_TELEMETRY_URL = TELEMETRY_URL;
     http.mock({ "test-telemetry.clerk.com": {} });
 
-    const first = await clerk("--mode", "agent", "completion", "zsh");
+    const first = await clerk("--mode", "agent", "webhooks", "token");
     expect(first.stderr).toContain("Nothing has been sent during this run");
     expect(telemetryEvents()).toHaveLength(0);
 
-    const second = await clerk("--mode", "agent", "completion", "zsh");
+    const second = await clerk("--mode", "agent", "webhooks", "token");
     expect(second.stderr).not.toContain("Nothing has been sent during this run");
     expect(telemetryEvents()).toHaveLength(1);
   } finally {
@@ -237,7 +252,7 @@ test("`clerk telemetry disable` itself sends nothing, and the opt-out persists",
   http.mock(); // any fetch would record and throw — none may happen
 
   await clerk("telemetry", "disable");
-  await clerk("completion", "zsh");
+  await clerk("webhooks", "token");
   expect(http.requests).toHaveLength(0);
 });
 
@@ -248,12 +263,12 @@ test("`clerk telemetry enable` turns events back on", async () => {
 
   await clerk("telemetry", "disable"); // sends nothing: opt-out visible at finalize
   await clerk("telemetry", "enable"); // sends: the user just opted back in
-  await clerk("completion", "zsh");
+  await clerk("webhooks", "token");
 
   const bodies = telemetryEvents();
   expect(bodies).toHaveLength(2);
   expect(bodies[0]!.events[0]!.payload.command).toBe("telemetry enable");
-  expect(bodies[1]!.events[0]!.payload.command).toBe("completion");
+  expect(bodies[1]!.events[0]!.payload.command).toBe("webhooks token");
 });
 
 test("`clerk telemetry status` reports the state and the winning reason", async () => {


### PR DESCRIPTION
`clerk completion <shell>` is wired into shell rc files with `eval`, so it re-runs on every new shell instead of when a user asks for it. Its events measure shell startups, not CLI usage.

Last 14 days in `clerk_telemetry.events` (test machine excluded):

- `completion` was the #1 command by volume: **19,436 of 55,994 events (34.7%)** — ahead of `api` (25.9%)
- from **9 machines**, one of which (`59a6b836…`) sent **98.2%** of them (12,356 in a single day)
- it was **60.2%** of all CLI events on Aug 14 and 46.8% on Aug 13; drop that one machine and completion is 0.6% of volume

Change: `startCommandTelemetry` skips `completion`, so no event and no first-run disclosure notice on a shell-startup run. `__complete` (each Tab press) already exits in `cli.ts` before Commander, so it never emitted events.

Telemetry integration tests used `clerk completion zsh` as their sample command; they now drive `clerk webhooks token` (also offline and auth-free).

[Data](https://app.hex.tech/f015de3e-633f-45fb-b418-fc14e2123db5/thread/01a01047-6461-73ab-83cd-9bee3505d69b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)