### PR TITLE
fix(auth): revoke OAuth sessions on logout

### DIFF
--- a/.changeset/oauth-revoke-on-logout.md
+++ b/.changeset/oauth-revoke-on-logout.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Revoke the OAuth session with Clerk when signing out, so `clerk auth logout` ends the session everywhere instead of only deleting the local credentials. Re-authenticating over an existing session now revokes the previous one as well.

--- a/packages/cli-core/src/commands/auth/README.md
+++ b/packages/cli-core/src/commands/auth/README.md
@@ -15,7 +15,8 @@ Authenticates the user via an OAuth 2.0 PKCE flow. After a successful login (or 
 5. Waits for the redirect callback with an authorization code
 6. Exchanges the code for an access token
 7. Stores the token and user info in local config
-8. **Autoclaim**: if `.clerk/keyless.json` exists in the current directory, claims the temporary application, links it to the project, and pulls environment variables
+8. If this was a re-authentication over an existing session, revokes the previous grant. This happens only after the replacement is stored, so an abandoned browser flow leaves the original session intact
+9. **Autoclaim**: if `.clerk/keyless.json` exists in the current directory, claims the temporary application, links it to the project, and pulls environment variables
 
 #### Keyless autoclaim breadcrumb lifecycle
 
@@ -35,8 +36,17 @@ OAuth requests are made against the Clerk OAuth system instance (default `https:
 | Authorize      | `GET`  | `/oauth/authorize`                            | Browser redirect with PKCE `code_challenge`, `state`, `client_id`, `redirect_uri` |
 | Token exchange | `POST` | `/oauth/token`                                | Exchanges authorization code + `code_verifier` for an access token                |
 | User info      | `GET`  | `/oauth/userinfo`                             | Fetches `sub` (user ID) and `email` using the access token                        |
+| Revoke         | `POST` | `/oauth/token/revoke`                         | Revokes the superseded refresh token on re-authentication (RFC 7009)              |
 | Autoclaim      | `POST` | `/v1/platform/accountless_applications/claim` | Claims a keyless application by token; returns the full `Application` object      |
 
 ### `clerk auth logout` (aliases: `signout`, `sign-out`)
 
-Removes the stored authentication token and clears auth info from local config. No API calls are made.
+Revokes the stored OAuth grant server-side, removes the stored authentication token, and clears auth info from local config.
+
+Revocation is best-effort: a network failure or a server error is logged under `--verbose` and never blocks logout, and the local credentials are deleted either way. Per RFC 7009 §2.2 the endpoint answers `200` even for a token it does not recognise, so an already-expired session is indistinguishable from a successful revocation.
+
+#### API Endpoints
+
+| Step   | Method | Endpoint              | Description                                                    |
+| ------ | ------ | --------------------- | -------------------------------------------------------------- |
+| Revoke | `POST` | `/oauth/token/revoke` | Revokes the stored refresh token, invalidating the whole grant |

--- a/packages/cli-core/src/commands/auth/login.test.ts
+++ b/packages/cli-core/src/commands/auth/login.test.ts
@@ -13,6 +13,8 @@ const mockSetAuth = mock();
 const mockResolveProfile = mock();
 const mockExchangeCodeForToken = mock();
 const mockFetchUserInfo = mock();
+const mockRevokeToken = mock();
+const mockGetStoredSession = mock();
 const mockStartAuthServer = mock();
 const mockIsHuman = mock();
 const mockConfirm = mock();
@@ -24,6 +26,7 @@ mock.module("../../lib/credential-store.ts", () => ({
   getValidToken: (...args: unknown[]) => mockGetValidToken(...args),
   storeToken: (...args: unknown[]) => mockStoreToken(...args),
   createOAuthSession: (...args: unknown[]) => mockCreateOAuthSession(...args),
+  getStoredSession: (...args: unknown[]) => mockGetStoredSession(...args),
 }));
 
 mock.module("../../lib/config.ts", () => ({
@@ -36,6 +39,7 @@ mock.module("../../lib/config.ts", () => ({
 mock.module("../../lib/token-exchange.ts", () => ({
   exchangeCodeForToken: (...args: unknown[]) => mockExchangeCodeForToken(...args),
   fetchUserInfo: (...args: unknown[]) => mockFetchUserInfo(...args),
+  revokeToken: (...args: unknown[]) => mockRevokeToken(...args),
 }));
 
 mock.module("../../lib/environment.ts", () => ({
@@ -114,6 +118,8 @@ describe("login", () => {
     mockResolveProfile.mockReset();
     mockExchangeCodeForToken.mockReset();
     mockFetchUserInfo.mockReset();
+    mockRevokeToken.mockReset();
+    mockGetStoredSession.mockReset();
     mockStartAuthServer.mockReset();
     mockIsHuman.mockReset();
     mockConfirm.mockReset();
@@ -340,6 +346,65 @@ describe("login", () => {
     expect(mockConfirm).not.toHaveBeenCalled();
     expect(mockStartAuthServer).toHaveBeenCalled();
     expect(result).toEqual({ userId: "user_new", email: "new@example.com" });
+  });
+
+  test("revokes the superseded grant after re-authenticating", async () => {
+    mockIsHuman.mockReturnValue(true);
+    mockGetValidToken.mockResolvedValue("existing-token");
+    mockGetAuth.mockResolvedValue({ userId: "user_123" });
+    mockGetStoredSession.mockResolvedValue({
+      accessToken: "old-access-token",
+      refreshToken: "old-refresh-token",
+      expiresAt: Date.now() + 60_000,
+      tokenType: "Bearer",
+    });
+    mockFetchUserInfo
+      .mockResolvedValueOnce({ userId: "user_123", email: "old@example.com" })
+      .mockResolvedValueOnce({ userId: "user_new", email: "new@example.com" });
+    mockConfirm.mockResolvedValue(true);
+    mockOAuthSuccess({ code: "reauth-code", user: null });
+
+    await runLogin();
+
+    expect(mockRevokeToken).toHaveBeenCalledWith("old-refresh-token", "refresh_token");
+    // The replacement must be stored before the old grant is torn down.
+    expect(mockStoreToken.mock.invocationCallOrder[0]!).toBeLessThan(
+      mockRevokeToken.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  test("does not revoke anything when logging in without an existing session", async () => {
+    mockIsHuman.mockReturnValue(true);
+    mockGetValidToken.mockResolvedValue(null);
+    mockGetAuth.mockResolvedValue(null);
+    mockFetchUserInfo.mockResolvedValue({ userId: "user_123", email: "new@example.com" });
+    mockOAuthSuccess({ code: "fresh-code", user: null });
+
+    await runLogin();
+
+    expect(mockRevokeToken).not.toHaveBeenCalled();
+  });
+
+  test("leaves the existing session intact when the browser flow fails", async () => {
+    mockIsHuman.mockReturnValue(true);
+    mockGetValidToken.mockResolvedValue("existing-token");
+    mockGetAuth.mockResolvedValue({ userId: "user_123" });
+    mockGetStoredSession.mockResolvedValue({
+      accessToken: "old-access-token",
+      refreshToken: "old-refresh-token",
+      expiresAt: Date.now() + 60_000,
+      tokenType: "Bearer",
+    });
+    mockFetchUserInfo.mockResolvedValueOnce({ userId: "user_123", email: "old@example.com" });
+    mockConfirm.mockResolvedValue(true);
+    mockStartAuthServer.mockReturnValue({
+      port: 3000,
+      waitForCallback: () => Promise.reject(new Error("Authentication timed out.")),
+      stop: () => {},
+    });
+
+    await expect(runLogin()).rejects.toThrow("Authentication timed out.");
+    expect(mockRevokeToken).not.toHaveBeenCalled();
   });
 
   test("in human mode, throws UserAbortError when user declines re-auth", async () => {

--- a/packages/cli-core/src/commands/auth/login.ts
+++ b/packages/cli-core/src/commands/auth/login.ts
@@ -1,8 +1,18 @@
 import { generateCodeVerifier, generateCodeChallenge, generateState } from "../../lib/pkce.ts";
 import { startAuthServer } from "../../lib/auth-server.ts";
-import { exchangeCodeForToken, fetchUserInfo, type UserInfo } from "../../lib/token-exchange.ts";
+import {
+  exchangeCodeForToken,
+  fetchUserInfo,
+  revokeToken,
+  type UserInfo,
+} from "../../lib/token-exchange.ts";
 import { getOAuthConfig } from "../../lib/environment.ts";
-import { createOAuthSession, getValidToken, storeToken } from "../../lib/credential-store.ts";
+import {
+  createOAuthSession,
+  getStoredSession,
+  getValidToken,
+  storeToken,
+} from "../../lib/credential-store.ts";
 import { getAuth, setAuth, resolveProfile } from "../../lib/config.ts";
 import { AUTH_TIMEOUT_MS, CALLBACK_PATH, CLERK_CLIENT_CLI } from "../../lib/constants.ts";
 import { confirm } from "../../lib/prompts.ts";
@@ -122,7 +132,21 @@ export async function login(options: LoginOptions = {}): Promise<UserInfo> {
     }
   }
 
+  // Captured before the new flow so the outgoing grant can be revoked once the
+  // replacement is stored. Read from the credential store rather than reused
+  // from `existingSession` because the session check above may have refreshed
+  // it, and the server rotates the refresh token on every exchange.
+  const previousSession = existingSession ? await getStoredSession() : null;
+
   const userInfo = await performOAuthFlow();
+
+  // Only after the replacement is safely stored: revoking up front would leave
+  // the user with no session at all if the browser flow were abandoned.
+  if (previousSession) {
+    await withSpinner("Revoking previous session...", () =>
+      revokeToken(previousSession.refreshToken, "refresh_token"),
+    );
+  }
 
   // Best-effort: ensure the user has at least one application so downstream
   // commands (clerk link, clerk init) have something to operate on.

--- a/packages/cli-core/src/commands/auth/logout.test.ts
+++ b/packages/cli-core/src/commands/auth/logout.test.ts
@@ -1,12 +1,12 @@
 import { test, expect, describe, afterEach, mock, spyOn } from "bun:test";
 import { useCaptureLog, credentialStoreStubs, configStubs } from "../../test/lib/stubs.ts";
 
-const mockDeleteToken = mock();
+const mockRevokeAndDeleteToken = mock();
 const mockClearAuth = mock();
 
 mock.module("../../lib/credential-store.ts", () => ({
   ...credentialStoreStubs,
-  deleteToken: (...args: unknown[]) => mockDeleteToken(...args),
+  revokeAndDeleteToken: (...args: unknown[]) => mockRevokeAndDeleteToken(...args),
 }));
 
 mock.module("../../lib/config.ts", () => ({
@@ -21,7 +21,7 @@ describe("logout", () => {
   const captured = useCaptureLog();
 
   afterEach(() => {
-    mockDeleteToken.mockReset();
+    mockRevokeAndDeleteToken.mockReset();
     mockClearAuth.mockReset();
     consoleSpy?.mockRestore();
   });
@@ -30,19 +30,19 @@ describe("logout", () => {
     return logout();
   }
 
-  test("deletes token and clears auth config", async () => {
-    mockDeleteToken.mockResolvedValue(undefined);
+  test("revokes the session, deletes the token, and clears auth config", async () => {
+    mockRevokeAndDeleteToken.mockResolvedValue(undefined);
     mockClearAuth.mockResolvedValue(undefined);
 
     consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     await runLogout();
 
-    expect(mockDeleteToken).toHaveBeenCalledTimes(1);
+    expect(mockRevokeAndDeleteToken).toHaveBeenCalledTimes(1);
     expect(mockClearAuth).toHaveBeenCalledTimes(1);
   });
 
   test("prints success message", async () => {
-    mockDeleteToken.mockResolvedValue(undefined);
+    mockRevokeAndDeleteToken.mockResolvedValue(undefined);
     mockClearAuth.mockResolvedValue(undefined);
 
     consoleSpy = spyOn(console, "log").mockImplementation(() => {});

--- a/packages/cli-core/src/commands/auth/logout.ts
+++ b/packages/cli-core/src/commands/auth/logout.ts
@@ -1,12 +1,12 @@
-import { deleteToken } from "../../lib/credential-store.ts";
+import { revokeAndDeleteToken } from "../../lib/credential-store.ts";
 import { clearAuth } from "../../lib/config.ts";
 import { log } from "../../lib/log.ts";
-import { intro, outro } from "../../lib/spinner.ts";
+import { intro, outro, withSpinner } from "../../lib/spinner.ts";
 import { NEXT_STEPS } from "../../lib/next-steps.ts";
 
 export async function logout(): Promise<void> {
   intro("Signing out");
-  await deleteToken();
+  await withSpinner("Revoking session...", () => revokeAndDeleteToken());
   await clearAuth();
   log.success("Logged out successfully");
   outro(NEXT_STEPS.LOGOUT);

--- a/packages/cli-core/src/lib/credential-store.test.ts
+++ b/packages/cli-core/src/lib/credential-store.test.ts
@@ -11,6 +11,7 @@ const tempDir = await mkdtemp(join(tmpdir(), "clerk-cred-test-"));
 process.env.CLERK_CONFIG_DIR = tempDir;
 
 const mockRefreshAccessToken = mock();
+const mockRevokeToken = mock();
 
 mock.module("@napi-rs/keyring", () => ({
   Entry: class {
@@ -27,10 +28,18 @@ mock.module("./version.ts", () => ({
 
 mock.module("./token-exchange.ts", () => ({
   refreshAccessToken: (...args: unknown[]) => mockRefreshAccessToken(...args),
+  revokeToken: (...args: unknown[]) => mockRevokeToken(...args),
 }));
 
-const { createOAuthSession, deleteToken, getStoredSession, getToken, getValidToken, storeToken } =
-  await import("./credential-store.ts");
+const {
+  createOAuthSession,
+  deleteToken,
+  getStoredSession,
+  getToken,
+  getValidToken,
+  revokeAndDeleteToken,
+  storeToken,
+} = await import("./credential-store.ts");
 
 async function writeLegacyToken(value: string): Promise<void> {
   await writeFile(join(tempDir, "credentials"), value, { mode: 0o600 });
@@ -44,7 +53,41 @@ afterAll(async () => {
 describe("credential-store", () => {
   beforeEach(async () => {
     mockRefreshAccessToken.mockReset();
+    mockRevokeToken.mockReset();
     await deleteToken();
+  });
+
+  test("revokeAndDeleteToken revokes the stored refresh token before deleting it", async () => {
+    await storeToken({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      expiresAt: Date.now() + 60_000,
+      tokenType: "Bearer",
+    });
+
+    await revokeAndDeleteToken();
+
+    expect(mockRevokeToken).toHaveBeenCalledWith("refresh-token", "refresh_token");
+    expect(await getStoredSession()).toBeNull();
+  });
+
+  test("revokeAndDeleteToken skips revocation when nothing is stored", async () => {
+    await revokeAndDeleteToken();
+
+    expect(mockRevokeToken).not.toHaveBeenCalled();
+  });
+
+  test("revokeAndDeleteToken deletes local credentials even if revocation throws", async () => {
+    await storeToken({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      expiresAt: Date.now() + 60_000,
+      tokenType: "Bearer",
+    });
+    mockRevokeToken.mockRejectedValue(new Error("network unreachable"));
+
+    await expect(revokeAndDeleteToken()).rejects.toThrow("network unreachable");
+    expect(await getStoredSession()).toBeNull();
   });
 
   test("getToken returns null when no token is stored", async () => {

--- a/packages/cli-core/src/lib/credential-store.ts
+++ b/packages/cli-core/src/lib/credential-store.ts
@@ -19,7 +19,7 @@ import {
   withKeychainAccess,
 } from "./host-execution.ts";
 import { log } from "./log.ts";
-import { refreshAccessToken, type TokenResponse } from "./token-exchange.ts";
+import { refreshAccessToken, revokeToken, type TokenResponse } from "./token-exchange.ts";
 import { CURRENT_VERSION, IS_DEV_BUILD } from "./version.ts";
 
 export const KEYCHAIN_SERVICE = "clerk-cli";
@@ -489,4 +489,31 @@ export async function getValidToken(): Promise<string | null> {
 export async function deleteToken(): Promise<void> {
   await keyringDelete();
   await fileDelete();
+}
+
+/**
+ * Revoke the stored OAuth grant server-side, then delete it locally.
+ *
+ * Use this for deliberate session teardown — `clerk auth logout`, and
+ * re-authenticating over a live session — where leaving the old refresh token
+ * redeemable would make the local delete a false reassurance.
+ *
+ * Not used by the refresh path: a session that failed with `invalid_grant` has
+ * already been spent server-side, so there is nothing left to revoke and the
+ * extra round trip would only slow down the re-auth prompt.
+ */
+export async function revokeAndDeleteToken(): Promise<void> {
+  const session = await getStoredSession().catch(() => null);
+
+  try {
+    if (session) {
+      log.debug("credentials: revoking stored OAuth session");
+      await revokeToken(session.refreshToken, "refresh_token");
+    }
+  } finally {
+    // Deleting locally is the part the user asked for and the part that must
+    // not be skippable. `revokeToken` already swallows its own failures, so
+    // this only guards against an unexpected throw further up.
+    await deleteToken();
+  }
 }

--- a/packages/cli-core/src/lib/environment.ts
+++ b/packages/cli-core/src/lib/environment.ts
@@ -133,6 +133,7 @@ export function getOAuthConfig() {
     scopes: process.env.CLERK_OAUTH_SCOPES ?? "",
     authorizeUrl: new URL("/oauth/authorize", baseUrl).href,
     tokenUrl: new URL("/oauth/token", baseUrl).href,
+    revokeUrl: new URL("/oauth/token/revoke", baseUrl).href,
     userinfoUrl: new URL("/oauth/userinfo", baseUrl).href,
   };
 }

--- a/packages/cli-core/src/lib/token-exchange.test.ts
+++ b/packages/cli-core/src/lib/token-exchange.test.ts
@@ -1,5 +1,10 @@
 import { test, expect, describe, afterEach, mock } from "bun:test";
-import { exchangeCodeForToken, refreshAccessToken, fetchUserInfo } from "./token-exchange.ts";
+import {
+  exchangeCodeForToken,
+  refreshAccessToken,
+  revokeToken,
+  fetchUserInfo,
+} from "./token-exchange.ts";
 
 const originalFetch = globalThis.fetch;
 
@@ -170,5 +175,48 @@ describe("refreshAccessToken", () => {
     const body = new URLSearchParams(calledInit.body);
     expect(body.get("grant_type")).toBe("refresh_token");
     expect(body.get("refresh_token")).toBe("refresh-token-123");
+  });
+});
+
+describe("revokeToken", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("posts the token, hint, and client_id to the revocation endpoint", async () => {
+    globalThis.fetch = mock(
+      async () => new Response("", { status: 200 }),
+    ) as unknown as typeof fetch;
+
+    await revokeToken("refresh-token-123", "refresh_token");
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+    const [calledUrl, calledInit] = (globalThis.fetch as unknown as ReturnType<typeof mock>).mock
+      .calls[0]!;
+    expect(String(calledUrl)).toContain("/oauth/token/revoke");
+    expect(calledInit.method).toBe("POST");
+    expect(calledInit.headers.get("Content-Type")).toBe("application/x-www-form-urlencoded");
+
+    const body = new URLSearchParams(calledInit.body);
+    expect(body.get("token")).toBe("refresh-token-123");
+    expect(body.get("token_type_hint")).toBe("refresh_token");
+    expect(body.get("client_id")).toBeTruthy();
+  });
+
+  test("resolves without throwing when the endpoint returns an error status", async () => {
+    globalThis.fetch = mock(
+      async () => new Response(JSON.stringify({ error: "invalid_request" }), { status: 400 }),
+    ) as unknown as typeof fetch;
+
+    expect(await revokeToken("spent-token", "refresh_token")).toBeUndefined();
+  });
+
+  test("resolves without throwing when the request fails outright", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("network unreachable");
+    }) as unknown as typeof fetch;
+
+    expect(await revokeToken("refresh-token-123", "refresh_token")).toBeUndefined();
   });
 });

--- a/packages/cli-core/src/lib/token-exchange.ts
+++ b/packages/cli-core/src/lib/token-exchange.ts
@@ -10,8 +10,9 @@
  */
 
 import { getOAuthConfig } from "./environment.ts";
-import { ApiError, withApiContext } from "./errors.ts";
+import { ApiError, errorMessage, withApiContext } from "./errors.ts";
 import { loggedFetch } from "./fetch.ts";
+import { log } from "./log.ts";
 
 export interface TokenResponse {
   access_token: string;
@@ -19,6 +20,9 @@ export interface TokenResponse {
   expires_in: number;
   refresh_token: string;
 }
+
+/** `token_type_hint` values the revocation endpoint accepts (RFC 7009 §2.1). */
+export type TokenTypeHint = "access_token" | "refresh_token";
 
 export interface UserInfo {
   userId: string;
@@ -85,6 +89,41 @@ export async function refreshAccessToken(refreshToken: string): Promise<TokenRes
     })(),
     "Token refresh failed",
   );
+}
+
+/**
+ * Revoke a token at the OAuth revocation endpoint (RFC 7009).
+ *
+ * Revoking the refresh token invalidates the whole grant server-side, so a
+ * stored session that has been discarded locally cannot be replayed by anyone
+ * who recovered it from a backup, a shared machine, or a CI cache.
+ *
+ * Best-effort by contract: the caller is already discarding the credentials,
+ * and a network blip or a server error must not leave the user unable to log
+ * out. Failures are logged under `--verbose` and swallowed. Per RFC 7009 §2.2
+ * the endpoint also answers 200 for a token it does not recognise, so an
+ * already-expired session is indistinguishable from a successful revocation —
+ * which is exactly the outcome we want either way.
+ */
+export async function revokeToken(token: string, tokenTypeHint: TokenTypeHint): Promise<void> {
+  const oauth = getOAuthConfig();
+  const body = new URLSearchParams({
+    token,
+    token_type_hint: tokenTypeHint,
+    client_id: oauth.clientId,
+  });
+
+  try {
+    await loggedFetch(oauth.revokeUrl, {
+      tag: "oauth",
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+      bestEffort: true,
+    });
+  } catch (error) {
+    log.debug(`oauth: token revocation failed — ${errorMessage(error)}`);
+  }
 }
 
 export async function fetchUserInfo(accessToken: string): Promise<UserInfo> {

--- a/packages/cli-core/src/test/integration/lib/harness.ts
+++ b/packages/cli-core/src/test/integration/lib/harness.ts
@@ -75,6 +75,9 @@ mock.module(
         expiresAt: Date.now() + tokenResponse.expires_in * 1000,
         tokenType: tokenResponse.token_type,
       }),
+      revokeAndDeleteToken: async () => {
+        mockState.storedToken = null;
+      },
       _setTokenOverride: () => {},
       KEYCHAIN_SERVICE: "clerk-cli",
       LOCAL_DEV_KEYCHAIN_SERVICE: "clerk-cli-dev",
@@ -221,6 +224,7 @@ mock.module(
         expires_in: 3600,
         refresh_token: "mock_refresh_token",
       }),
+      revokeToken: async () => {},
       fetchUserInfo: async (token: string) => {
         if (!token || token === "expired_token") throw new Error("Unauthorized");
         return { userId: "user_123", email: "test@example.com" };

--- a/packages/cli-core/src/test/lib/stubs.ts
+++ b/packages/cli-core/src/test/lib/stubs.ts
@@ -194,6 +194,7 @@ export const credentialStoreStubs = {
   hasAccountCredentials: async () => Boolean(process.env.CLERK_PLATFORM_API_KEY),
   storeToken: async () => {},
   deleteToken: async () => {},
+  revokeAndDeleteToken: async () => {},
   createOAuthSession: (tokenResponse: {
     access_token: string;
     refresh_token: string;
@@ -233,6 +234,7 @@ export { listageStubs } from "./listage-stubs.ts";
 export const tokenExchangeStubs = {
   exchangeCodeForToken: async () => ({}),
   refreshAccessToken: async () => ({}),
+  revokeToken: async () => {},
   fetchUserInfo: async () => ({}),
 };
 


### PR DESCRIPTION
## Summary

`clerk auth logout` previously deleted the stored OAuth session locally and never told the authorization server, so the refresh token stayed redeemable until its natural expiry — the local delete was a false reassurance on shared machines, CI runners, and any host the user no longer trusts. The same gap applied to `clerk auth login` when re-authenticating over a live session: a new grant was minted while the old one stayed valid.

Both paths now call the OAuth 2.0 Token Revocation endpoint (RFC 7009) at `/oauth/token/revoke`, which the instance advertises as `revocation_endpoint` in its discovery document and which accepts a public client presenting only its `client_id`. Logout revokes the stored refresh token and then deletes locally in a `finally`, so the local delete is never skippable. Re-authentication captures the outgoing refresh token before the browser flow and revokes it only after the replacement is stored, so an abandoned or failed flow leaves the original session intact rather than stranding the user with no credentials.

Revocation is best-effort throughout: the caller is already discarding the credentials, so a network failure or a server error is logged under `--verbose` and never blocks logout or re-authentication. Per RFC 7009 §2.2 the endpoint also answers `200` for a token it does not recognise, so an already-expired session is indistinguishable from a successful revocation. A refresh that has already failed with `invalid_grant` skips revocation entirely, since that grant is spent server-side and there is nothing left to revoke.

## Test plan

- [x] `bun run format:check`, `bun run lint`, `bun run typecheck`
- [x] `bun run test` — 2607 pass, 0 fail
- [x] Verified against the live endpoint that a public client sending only `token` + `client_id` receives `200`, and that omitting `client_id` receives `400 invalid_request`
- [x] Manual, logout: captured a freshly issued refresh token without redeeming it, ran `auth logout --verbose`, confirmed the `POST /oauth/token/revoke` request, then confirmed the captured token was rejected with `invalid_grant`
- [x] Manual, re-authentication: captured the outgoing refresh token without redeeming it, completed `auth login -y`, confirmed a different session was stored, that the old grant was rejected with `invalid_grant`, and that the revoke request was issued only after the replacement was written to the keyring