### PR TITLE
style: apply oxfmt 0.62 formatting

### DIFF
--- a/packages/cli-core/src/commands/deploy/index.test.ts
+++ b/packages/cli-core/src/commands/deploy/index.test.ts
@@ -238,7 +238,10 @@ describe("deploy", () => {
     // leak an artifact into the repo on every run. Intercept only `.zone` writes
     // so config writes (setProfile) still hit disk in the temp dir.
     const realBunWrite = Bun.write.bind(Bun) as (...args: unknown[]) => Promise<number>;
-    writeSpy = spyOn(Bun, "write").mockImplementation(((destination: unknown, ...rest: unknown[]) =>
+    writeSpy = spyOn(Bun, "write").mockImplementation(((
+      destination: unknown,
+      ...rest: unknown[]
+    ) =>
       String(destination).endsWith(".zone")
         ? Promise.resolve(0)
         : realBunWrite(destination, ...rest)) as typeof Bun.write);

--- a/packages/cli-core/src/commands/users/README.md
+++ b/packages/cli-core/src/commands/users/README.md
@@ -76,9 +76,7 @@ Common list filters:
 
 ```json
 {
-  "data": [
-    /* user objects */
-  ],
+  "data": [/* user objects */],
   "hasMore": true
 }
 ```


### PR DESCRIPTION
## Summary

The oxfmt bump from 0.56.0 to 0.62.0 changed two formatting behaviors — how
arrow-function parameter lists wrap and how arrays containing only an inline
comment collapse. Two files in `packages/cli-core` were merged under the old
version and now fail `format:check`, which has been breaking the Lint job on
every push to `main` since the bump landed. This applies the 0.62 output to
those files. The changes are entirely whitespace; no behavior, no API, and no
test assertions are affected.

Worth flagging for anyone with an older checkout: `bun install` is needed to
pick up oxfmt 0.62, otherwise `format:check` passes locally against the stale
0.56 binary while CI fails.

Note that the E2E job on the same runs failed for an unrelated reason — the
Clerk API returned 502s from Cloudflare during a brief window, which cascaded
into sign-in and cleanup errors. That is not addressed here.

## Test plan

- [x] `bun run format:check` passes
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run test` passes (2608 tests)
- [x] `bun changeset status` passes with no changeset required
