### PR TITLE
fix(auth): report OAuth revocation failures

### DIFF
--- a/.changeset/oauth-revoke-hardening.md
+++ b/.changeset/oauth-revoke-hardening.md
@@ -1,0 +1,7 @@
+---
+"clerk": patch
+---
+
+Report when signing out cannot revoke the session with Clerk, instead of always printing a clean sign-out. Local credentials are still removed either way, and `clerk auth logout` now also warns when `CLERK_PLATFORM_API_KEY` is set, since that key keeps authenticating requests.
+
+Revoke the superseded session more reliably when re-authenticating: a transient error while checking the existing session no longer leaves the old session un-revoked, and a malformed `CLERK_OAUTH_BASE_URL` no longer aborts sign-out partway through.

--- a/packages/cli-core/src/commands/auth/README.md
+++ b/packages/cli-core/src/commands/auth/README.md
@@ -15,7 +15,7 @@ Authenticates the user via an OAuth 2.0 PKCE flow. After a successful login (or 
 5. Waits for the redirect callback with an authorization code
 6. Exchanges the code for an access token
 7. Stores the token and user info in local config
-8. If this was a re-authentication over an existing session, revokes the previous grant. This happens only after the replacement is stored, so an abandoned browser flow leaves the original session intact
+8. If this was a re-authentication over an existing session, revokes the previous grant. The outgoing session is read once the authorization code arrives and just before the token exchange replaces it, and revoked only after the replacement is stored — so an abandoned browser flow leaves the original session intact, and a concurrent refresh has the smallest possible window to rotate the token out from under the revocation. A failure here warns rather than failing the login
 9. **Autoclaim**: if `.clerk/keyless.json` exists in the current directory, claims the temporary application, links it to the project, and pulls environment variables
 
 #### Keyless autoclaim breadcrumb lifecycle
@@ -41,12 +41,20 @@ OAuth requests are made against the Clerk OAuth system instance (default `https:
 
 ### `clerk auth logout` (aliases: `signout`, `sign-out`)
 
-Revokes the stored OAuth grant server-side, removes the stored authentication token, and clears auth info from local config.
+Revokes the **current environment's** OAuth grant server-side, removes the stored authentication token, and clears auth info from local config.
 
-Revocation is best-effort: a network failure or a server error is logged under `--verbose` and never blocks logout, and the local credentials are deleted either way. Per RFC 7009 §2.2 the endpoint answers `200` even for a token it does not recognise, so an already-expired session is indistinguishable from a successful revocation.
+#### What revocation does and does not cover
+
+- **Does**: invalidates the refresh token for the active environment's session, so it can no longer be redeemed.
+- **Does not**: invalidate an outstanding JWT access token. The server refuses to revoke those (`JWT access tokens cannot be revoked`) because a JWT is verified by signature, not by a lookup — it stays usable until it expires.
+- **Does not**: touch sessions stored for other environments, the user's dashboard/browser session, or `CLERK_PLATFORM_API_KEY`. Logout warns when that variable is set, since it continues to authenticate requests.
+
+Revocation never blocks logout: the local credentials are deleted whether or not the server was reached. When revocation fails, the command says so and points at the dashboard rather than reporting a clean sign-out. Details are logged under `--verbose`.
+
+Two cases report success without anything actually being revoked server-side, both inherent to RFC 7009 §2.2, which specifies `200` for an unrecognised token: an already-expired session, and a token another process rotated away while the flow was in progress.
 
 #### API Endpoints
 
-| Step   | Method | Endpoint              | Description                                                    |
-| ------ | ------ | --------------------- | -------------------------------------------------------------- |
-| Revoke | `POST` | `/oauth/token/revoke` | Revokes the stored refresh token, invalidating the whole grant |
+| Step   | Method | Endpoint              | Description                                                  |
+| ------ | ------ | --------------------- | ------------------------------------------------------------ |
+| Revoke | `POST` | `/oauth/token/revoke` | Revokes the stored refresh token for the current environment |

--- a/packages/cli-core/src/commands/auth/login.test.ts
+++ b/packages/cli-core/src/commands/auth/login.test.ts
@@ -128,6 +128,8 @@ describe("login", () => {
     mockEnsureFirstApplication.mockResolvedValue(undefined);
     mockIsHuman.mockReturnValue(false);
     mockOpenBrowser.mockResolvedValue({ ok: true, launcher: "test" });
+    mockRevokeToken.mockResolvedValue("revoked");
+    mockGetStoredSession.mockResolvedValue(null);
     setLogLevel("info");
     consoleSpy?.mockRestore();
     consoleErrorSpy?.mockRestore();
@@ -348,16 +350,35 @@ describe("login", () => {
     expect(result).toEqual({ userId: "user_new", email: "new@example.com" });
   });
 
+  /**
+   * Wires getStoredSession/storeToken as a single stateful store, so that
+   * storing the new session changes what a subsequent read returns. A stateless
+   * mock cannot distinguish "captured the outgoing session" from "captured the
+   * one we just created", which is the refactor these tests exist to catch.
+   */
+  function useStatefulCredentialStore(initial: Record<string, unknown> | null) {
+    let stored = initial;
+    mockGetStoredSession.mockImplementation(async () => stored);
+    mockStoreToken.mockImplementation(async (session: unknown) => {
+      stored = session as Record<string, unknown>;
+    });
+    return {
+      current: () => stored,
+    };
+  }
+
+  const OLD_SESSION = {
+    accessToken: "old-access-token",
+    refreshToken: "old-refresh-token",
+    expiresAt: Date.now() + 60_000,
+    tokenType: "Bearer",
+  };
+
   test("revokes the superseded grant after re-authenticating", async () => {
     mockIsHuman.mockReturnValue(true);
     mockGetValidToken.mockResolvedValue("existing-token");
     mockGetAuth.mockResolvedValue({ userId: "user_123" });
-    mockGetStoredSession.mockResolvedValue({
-      accessToken: "old-access-token",
-      refreshToken: "old-refresh-token",
-      expiresAt: Date.now() + 60_000,
-      tokenType: "Bearer",
-    });
+    useStatefulCredentialStore(OLD_SESSION);
     mockFetchUserInfo
       .mockResolvedValueOnce({ userId: "user_123", email: "old@example.com" })
       .mockResolvedValueOnce({ userId: "user_new", email: "new@example.com" });
@@ -366,17 +387,57 @@ describe("login", () => {
 
     await runLogin();
 
+    // The OLD refresh token, not the newly minted one. With a stateful store
+    // this fails if the capture moves below the token exchange.
     expect(mockRevokeToken).toHaveBeenCalledWith("old-refresh-token", "refresh_token");
     // The replacement must be stored before the old grant is torn down.
     expect(mockStoreToken.mock.invocationCallOrder[0]!).toBeLessThan(
       mockRevokeToken.mock.invocationCallOrder[0]!,
     );
+    // …and the capture must happen before the store, or it reads the new one.
+    expect(mockGetStoredSession.mock.invocationCallOrder.at(-1)!).toBeLessThan(
+      mockStoreToken.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  test("revokes the outgoing grant even when the session pre-check fails", async () => {
+    mockIsHuman.mockReturnValue(true);
+    // A live session exists in the store, but the pre-flight probe blows up.
+    // getExistingSession swallows it, so `existingSession` is null — the old
+    // grant must still be revoked rather than orphaned.
+    mockGetValidToken.mockRejectedValue(new Error("network unreachable"));
+    mockGetAuth.mockResolvedValue({ userId: "user_123" });
+    useStatefulCredentialStore(OLD_SESSION);
+    mockFetchUserInfo.mockResolvedValue({ userId: "user_new", email: "new@example.com" });
+    mockOAuthSuccess({ code: "reauth-code", user: null });
+
+    await runLogin();
+
+    expect(mockRevokeToken).toHaveBeenCalledWith("old-refresh-token", "refresh_token");
+  });
+
+  test("warns when the superseded grant could not be revoked", async () => {
+    mockIsHuman.mockReturnValue(true);
+    mockGetValidToken.mockResolvedValue("existing-token");
+    mockGetAuth.mockResolvedValue({ userId: "user_123" });
+    useStatefulCredentialStore(OLD_SESSION);
+    mockFetchUserInfo
+      .mockResolvedValueOnce({ userId: "user_123", email: "old@example.com" })
+      .mockResolvedValueOnce({ userId: "user_new", email: "new@example.com" });
+    mockConfirm.mockResolvedValue(true);
+    mockRevokeToken.mockResolvedValue("failed");
+    mockOAuthSuccess({ code: "reauth-code", user: null });
+
+    await runLogin();
+
+    expect(captured.err).toContain("could not be revoked");
   });
 
   test("does not revoke anything when logging in without an existing session", async () => {
     mockIsHuman.mockReturnValue(true);
     mockGetValidToken.mockResolvedValue(null);
     mockGetAuth.mockResolvedValue(null);
+    useStatefulCredentialStore(null);
     mockFetchUserInfo.mockResolvedValue({ userId: "user_123", email: "new@example.com" });
     mockOAuthSuccess({ code: "fresh-code", user: null });
 

--- a/packages/cli-core/src/commands/auth/login.ts
+++ b/packages/cli-core/src/commands/auth/login.ts
@@ -12,12 +12,13 @@ import {
   getStoredSession,
   getValidToken,
   storeToken,
+  type OAuthSession,
 } from "../../lib/credential-store.ts";
 import { getAuth, setAuth, resolveProfile } from "../../lib/config.ts";
 import { AUTH_TIMEOUT_MS, CALLBACK_PATH, CLERK_CLIENT_CLI } from "../../lib/constants.ts";
 import { confirm } from "../../lib/prompts.ts";
 import { isHuman } from "../../mode.ts";
-import { throwUserAbort } from "../../lib/errors.ts";
+import { errorMessage, throwUserAbort } from "../../lib/errors.ts";
 import { intro, outro, bar, withSpinner } from "../../lib/spinner.ts";
 import { NEXT_STEPS } from "../../lib/next-steps.ts";
 import { attemptAutoclaim, type AutoclaimResult } from "../../lib/autoclaim.ts";
@@ -44,7 +45,16 @@ async function getExistingSession(): Promise<UserInfo | null> {
   }
 }
 
-async function performOAuthFlow(): Promise<UserInfo> {
+interface OAuthFlowResult {
+  userInfo: UserInfo;
+  /**
+   * The session that was current immediately before the token exchange
+   * replaced it, or null if there was none. The caller revokes it.
+   */
+  previousSession: OAuthSession | null;
+}
+
+async function performOAuthFlow(): Promise<OAuthFlowResult> {
   const codeVerifier = generateCodeVerifier();
   const codeChallenge = await generateCodeChallenge(codeVerifier);
   const state = generateState();
@@ -89,6 +99,20 @@ async function performOAuthFlow(): Promise<UserInfo> {
     }),
   );
 
+  // Snapshotted here: the authorization code has arrived, so the store still
+  // holds the outgoing session and is about to be overwritten. Reading any
+  // earlier widens the window for another process to rotate the refresh token
+  // out from under the revocation; reading any later returns the session we
+  // just created and would revoke the grant we are in the middle of minting.
+  let previousSession: OAuthSession | null = null;
+  try {
+    previousSession = await getStoredSession();
+  } catch (error) {
+    // An unreadable store must not fail an otherwise successful login; we just
+    // lose the ability to revoke whatever was there.
+    log.debug(`credentials: could not read outgoing session — ${errorMessage(error)}`);
+  }
+
   const tokenResponse = await withSpinner("Completing authentication...", () =>
     exchangeCodeForToken({
       code,
@@ -102,7 +126,7 @@ async function performOAuthFlow(): Promise<UserInfo> {
   const userInfo = await fetchUserInfo(tokenResponse.access_token);
   await setAuth({ userId: userInfo.userId });
 
-  return userInfo;
+  return { userInfo, previousSession };
 }
 
 export async function login(options: LoginOptions = {}): Promise<UserInfo> {
@@ -132,20 +156,24 @@ export async function login(options: LoginOptions = {}): Promise<UserInfo> {
     }
   }
 
-  // Captured before the new flow so the outgoing grant can be revoked once the
-  // replacement is stored. Read from the credential store rather than reused
-  // from `existingSession` because the session check above may have refreshed
-  // it, and the server rotates the refresh token on every exchange.
-  const previousSession = existingSession ? await getStoredSession() : null;
+  // `previousSession` comes from the credential store, not from
+  // `existingSession`: the latter is the result of a network round trip whose
+  // errors are all swallowed, so a transient failure there would silently
+  // orphan a live grant instead of revoking it. The store is the authority on
+  // whether there is anything to revoke.
+  const { userInfo, previousSession } = await performOAuthFlow();
 
-  const userInfo = await performOAuthFlow();
-
-  // Only after the replacement is safely stored: revoking up front would leave
-  // the user with no session at all if the browser flow were abandoned.
+  // Revoked only after the replacement is safely stored: doing it up front
+  // would leave the user with no session at all if the flow were abandoned.
   if (previousSession) {
-    await withSpinner("Revoking previous session...", () =>
+    const outcome = await withSpinner("Revoking previous session...", () =>
       revokeToken(previousSession.refreshToken, "refresh_token"),
     );
+    if (outcome === "failed") {
+      log.warn(
+        "Signed in, but the previous session could not be revoked with Clerk. Revoke it from the dashboard if it may have been exposed.",
+      );
+    }
   }
 
   // Best-effort: ensure the user has at least one application so downstream

--- a/packages/cli-core/src/commands/auth/logout.test.ts
+++ b/packages/cli-core/src/commands/auth/logout.test.ts
@@ -31,7 +31,7 @@ describe("logout", () => {
   }
 
   test("revokes the session, deletes the token, and clears auth config", async () => {
-    mockRevokeAndDeleteToken.mockResolvedValue(undefined);
+    mockRevokeAndDeleteToken.mockResolvedValue("revoked");
     mockClearAuth.mockResolvedValue(undefined);
 
     consoleSpy = spyOn(console, "log").mockImplementation(() => {});
@@ -42,12 +42,61 @@ describe("logout", () => {
   });
 
   test("prints success message", async () => {
-    mockRevokeAndDeleteToken.mockResolvedValue(undefined);
+    mockRevokeAndDeleteToken.mockResolvedValue("revoked");
     mockClearAuth.mockResolvedValue(undefined);
 
     consoleSpy = spyOn(console, "log").mockImplementation(() => {});
     await runLogout();
 
     expect(captured.err).toContain("Logged out successfully");
+  });
+
+  test("reports success when there was no session to revoke", async () => {
+    mockRevokeAndDeleteToken.mockResolvedValue("nothing_to_revoke");
+    mockClearAuth.mockResolvedValue(undefined);
+
+    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+    await runLogout();
+
+    expect(captured.err).toContain("Logged out successfully");
+    expect(captured.err).not.toContain("could not be revoked");
+  });
+
+  test("warns instead of claiming success when revocation fails", async () => {
+    mockRevokeAndDeleteToken.mockResolvedValue("failed");
+    mockClearAuth.mockResolvedValue(undefined);
+
+    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+    await runLogout();
+
+    expect(captured.err).toContain("could not be revoked with Clerk");
+    expect(captured.err).not.toContain("Logged out successfully");
+  });
+
+  test("still clears auth config when revocation fails", async () => {
+    mockRevokeAndDeleteToken.mockResolvedValue("failed");
+    mockClearAuth.mockResolvedValue(undefined);
+
+    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+    await runLogout();
+
+    expect(mockClearAuth).toHaveBeenCalledTimes(1);
+  });
+
+  test("warns that a platform API key still authenticates", async () => {
+    const previous = process.env.CLERK_PLATFORM_API_KEY;
+    process.env.CLERK_PLATFORM_API_KEY = "sk_test_platform";
+    mockRevokeAndDeleteToken.mockResolvedValue("revoked");
+    mockClearAuth.mockResolvedValue(undefined);
+
+    consoleSpy = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await runLogout();
+    } finally {
+      if (previous === undefined) delete process.env.CLERK_PLATFORM_API_KEY;
+      else process.env.CLERK_PLATFORM_API_KEY = previous;
+    }
+
+    expect(captured.err).toContain("CLERK_PLATFORM_API_KEY");
   });
 });

--- a/packages/cli-core/src/commands/auth/logout.ts
+++ b/packages/cli-core/src/commands/auth/logout.ts
@@ -6,8 +6,25 @@ import { NEXT_STEPS } from "../../lib/next-steps.ts";
 
 export async function logout(): Promise<void> {
   intro("Signing out");
-  await withSpinner("Revoking session...", () => revokeAndDeleteToken());
+  const outcome = await withSpinner("Revoking session...", () => revokeAndDeleteToken());
   await clearAuth();
-  log.success("Logged out successfully");
+
+  if (outcome === "failed") {
+    // The local credentials are gone either way, but the grant may still be
+    // redeemable by anyone holding a copy. Saying "logged out" here would be
+    // the false assurance this whole path exists to avoid.
+    log.warn(
+      "Signed out locally, but the session could not be revoked with Clerk. If the credentials may have been exposed, revoke the session from the dashboard.",
+    );
+  } else {
+    log.success("Logged out successfully");
+  }
+
+  if (process.env.CLERK_PLATFORM_API_KEY) {
+    log.warn(
+      "`CLERK_PLATFORM_API_KEY` is set and still authenticates requests. Unset it to fully sign out.",
+    );
+  }
+
   outro(NEXT_STEPS.LOGOUT);
 }

--- a/packages/cli-core/src/lib/credential-store.test.ts
+++ b/packages/cli-core/src/lib/credential-store.test.ts
@@ -64,17 +64,54 @@ describe("credential-store", () => {
       expiresAt: Date.now() + 60_000,
       tokenType: "Bearer",
     });
+    // Observed from inside the mock: by the time revokeToken is called the
+    // session must still be readable, which is what "before deleting" means.
+    // Asserting only the final state would pass for delete-then-revoke too.
+    let sessionVisibleDuringRevoke: unknown = "not-called";
+    mockRevokeToken.mockImplementation(async () => {
+      sessionVisibleDuringRevoke = await getStoredSession();
+      return "revoked";
+    });
 
-    await revokeAndDeleteToken();
+    const outcome = await revokeAndDeleteToken();
 
     expect(mockRevokeToken).toHaveBeenCalledWith("refresh-token", "refresh_token");
+    expect(sessionVisibleDuringRevoke).not.toBeNull();
+    expect(sessionVisibleDuringRevoke).not.toBe("not-called");
+    expect(outcome).toBe("revoked");
     expect(await getStoredSession()).toBeNull();
   });
 
-  test("revokeAndDeleteToken skips revocation when nothing is stored", async () => {
-    await revokeAndDeleteToken();
+  test("revokeAndDeleteToken reports nothing_to_revoke when nothing is stored", async () => {
+    const outcome = await revokeAndDeleteToken();
 
     expect(mockRevokeToken).not.toHaveBeenCalled();
+    expect(outcome).toBe("nothing_to_revoke");
+  });
+
+  test("revokeAndDeleteToken propagates a failed revocation", async () => {
+    await storeToken({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      expiresAt: Date.now() + 60_000,
+      tokenType: "Bearer",
+    });
+    mockRevokeToken.mockResolvedValue("failed");
+
+    expect(await revokeAndDeleteToken()).toBe("failed");
+    expect(await getStoredSession()).toBeNull();
+  });
+
+  test("revokeAndDeleteToken reports failure for unrevocable legacy credentials", async () => {
+    await writeLegacyToken("raw-access-token-with-no-refresh-token");
+
+    const outcome = await revokeAndDeleteToken();
+
+    // Nothing to present to the revocation endpoint, but credentials existed —
+    // that is a failure to revoke, not an absence of anything to revoke.
+    expect(mockRevokeToken).not.toHaveBeenCalled();
+    expect(outcome).toBe("failed");
+    expect(await getToken()).toBeNull();
   });
 
   test("revokeAndDeleteToken deletes local credentials even if revocation throws", async () => {

--- a/packages/cli-core/src/lib/credential-store.ts
+++ b/packages/cli-core/src/lib/credential-store.ts
@@ -19,7 +19,12 @@ import {
   withKeychainAccess,
 } from "./host-execution.ts";
 import { log } from "./log.ts";
-import { refreshAccessToken, revokeToken, type TokenResponse } from "./token-exchange.ts";
+import {
+  refreshAccessToken,
+  revokeToken,
+  type RevocationResult,
+  type TokenResponse,
+} from "./token-exchange.ts";
 import { CURRENT_VERSION, IS_DEV_BUILD } from "./version.ts";
 
 export const KEYCHAIN_SERVICE = "clerk-cli";
@@ -36,6 +41,13 @@ export interface OAuthSession {
   expiresAt: number;
   tokenType: string;
 }
+
+/**
+ * Result of tearing down the stored session. Distinguishes "there was nothing
+ * redeemable to revoke" from "we tried and could not", because only the second
+ * one should warn the user.
+ */
+export type RevocationOutcome = RevocationResult | "nothing_to_revoke";
 
 function keychainAccount(): string {
   const envName = getCurrentEnvName();
@@ -494,26 +506,50 @@ export async function deleteToken(): Promise<void> {
 /**
  * Revoke the stored OAuth grant server-side, then delete it locally.
  *
- * Use this for deliberate session teardown — `clerk auth logout`, and
- * re-authenticating over a live session — where leaving the old refresh token
- * redeemable would make the local delete a false reassurance.
+ * Use this for deliberate session teardown — `clerk auth logout` — where
+ * leaving the refresh token redeemable would make the local delete a false
+ * reassurance. The local delete always happens; the return value reports
+ * whether the server-side half succeeded so the caller can say so.
+ *
+ * `"nothing_to_revoke"` means there was no redeemable refresh token in the
+ * first place, which is a success, not a failure.
  *
  * Not used by the refresh path: a session that failed with `invalid_grant` has
- * already been spent server-side, so there is nothing left to revoke and the
- * extra round trip would only slow down the re-auth prompt.
+ * a spent token, so revoking it would be a no-op round trip.
  */
-export async function revokeAndDeleteToken(): Promise<void> {
-  const session = await getStoredSession().catch(() => null);
+export async function revokeAndDeleteToken(): Promise<RevocationOutcome> {
+  let session: OAuthSession | null = null;
+  let readFailed = false;
+
+  try {
+    session = await getStoredSession();
+  } catch (error) {
+    // "Nothing is stored" and "the store could not be read" lead to opposite
+    // security conclusions, so they must not collapse into the same branch.
+    readFailed = true;
+    log.debug(`credentials: could not read stored session — ${errorMessage(error)}`);
+  }
 
   try {
     if (session) {
       log.debug("credentials: revoking stored OAuth session");
-      await revokeToken(session.refreshToken, "refresh_token");
+      return await revokeToken(session.refreshToken, "refresh_token");
     }
+
+    if (readFailed) return "failed";
+
+    // A pre-JSON raw token, or a corrupt blob, parses to null. There are
+    // credentials here and they may still be redeemable, but we have no
+    // refresh token to present, so this is a failure to revoke — not an
+    // absence of anything to revoke.
+    if (await hasStoredCredentials()) {
+      log.debug("credentials: stored credentials are not a revocable OAuth session");
+      return "failed";
+    }
+
+    return "nothing_to_revoke";
   } finally {
-    // Deleting locally is the part the user asked for and the part that must
-    // not be skippable. `revokeToken` already swallows its own failures, so
-    // this only guards against an unexpected throw further up.
+    // Deleting locally is what the user asked for and must not be skippable.
     await deleteToken();
   }
 }

--- a/packages/cli-core/src/lib/token-exchange.test.ts
+++ b/packages/cli-core/src/lib/token-exchange.test.ts
@@ -5,6 +5,8 @@ import {
   revokeToken,
   fetchUserInfo,
 } from "./token-exchange.ts";
+import { setLogLevel } from "./log.ts";
+import { useCaptureLog } from "../test/lib/stubs.ts";
 
 const originalFetch = globalThis.fetch;
 
@@ -179,6 +181,8 @@ describe("refreshAccessToken", () => {
 });
 
 describe("revokeToken", () => {
+  const captured = useCaptureLog();
+
   afterEach(() => {
     globalThis.fetch = originalFetch;
   });
@@ -188,7 +192,7 @@ describe("revokeToken", () => {
       async () => new Response("", { status: 200 }),
     ) as unknown as typeof fetch;
 
-    await revokeToken("refresh-token-123", "refresh_token");
+    expect(await revokeToken("refresh-token-123", "refresh_token")).toBe("revoked");
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
 
@@ -204,19 +208,55 @@ describe("revokeToken", () => {
     expect(body.get("client_id")).toBeTruthy();
   });
 
-  test("resolves without throwing when the endpoint returns an error status", async () => {
+  test("reports failure when the endpoint returns an error status", async () => {
     globalThis.fetch = mock(
       async () => new Response(JSON.stringify({ error: "invalid_request" }), { status: 400 }),
     ) as unknown as typeof fetch;
 
-    expect(await revokeToken("spent-token", "refresh_token")).toBeUndefined();
+    // A permanent 4xx must not read as success, or a misconfigured client
+    // silently never revokes anything while reporting a clean logout.
+    expect(await revokeToken("spent-token", "refresh_token")).toBe("failed");
   });
 
-  test("resolves without throwing when the request fails outright", async () => {
+  test("reports failure without throwing when the request fails outright", async () => {
     globalThis.fetch = mock(async () => {
       throw new Error("network unreachable");
     }) as unknown as typeof fetch;
 
-    expect(await revokeToken("refresh-token-123", "refresh_token")).toBeUndefined();
+    expect(await revokeToken("refresh-token-123", "refresh_token")).toBe("failed");
+  });
+
+  test("reports failure without throwing when the OAuth base URL is malformed", async () => {
+    const previous = process.env.CLERK_OAUTH_BASE_URL;
+    process.env.CLERK_OAUTH_BASE_URL = "not-a-url";
+    globalThis.fetch = mock(
+      async () => new Response("", { status: 200 }),
+    ) as unknown as typeof fetch;
+
+    try {
+      // Resolving the config throws here. If that escapes, it aborts the
+      // caller's teardown partway through — credentials deleted, config left
+      // stale. It must surface as a failed result instead.
+      expect(await revokeToken("refresh-token-123", "refresh_token")).toBe("failed");
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    } finally {
+      if (previous === undefined) delete process.env.CLERK_OAUTH_BASE_URL;
+      else process.env.CLERK_OAUTH_BASE_URL = previous;
+    }
+  });
+
+  test("logs the failure reason under --verbose", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("network unreachable");
+    }) as unknown as typeof fetch;
+
+    setLogLevel("debug");
+    try {
+      await revokeToken("refresh-token-123", "refresh_token");
+    } finally {
+      setLogLevel("info");
+    }
+
+    expect(captured.err).toContain("token revocation failed");
   });
 });

--- a/packages/cli-core/src/lib/token-exchange.ts
+++ b/packages/cli-core/src/lib/token-exchange.ts
@@ -24,6 +24,12 @@ export interface TokenResponse {
 /** `token_type_hint` values the revocation endpoint accepts (RFC 7009 §2.1). */
 export type TokenTypeHint = "access_token" | "refresh_token";
 
+/**
+ * Outcome of a revocation attempt. `"failed"` means the server was not reached
+ * or refused the request, so the grant should be assumed still live.
+ */
+export type RevocationResult = "revoked" | "failed";
+
 export interface UserInfo {
   userId: string;
   email: string;
@@ -94,35 +100,52 @@ export async function refreshAccessToken(refreshToken: string): Promise<TokenRes
 /**
  * Revoke a token at the OAuth revocation endpoint (RFC 7009).
  *
- * Revoking the refresh token invalidates the whole grant server-side, so a
- * stored session that has been discarded locally cannot be replayed by anyone
- * who recovered it from a backup, a shared machine, or a CI cache.
+ * Revoking a refresh token invalidates that token and, when the instance issues
+ * opaque access tokens, the access token from the same grant. It does **not**
+ * invalidate a JWT access token: the server refuses to revoke those outright
+ * (`JWT access tokens cannot be revoked`), and a JWT stays valid until it
+ * expires because it is verified by signature rather than by a lookup. Callers
+ * must not describe revocation as ending the session everywhere.
  *
- * Best-effort by contract: the caller is already discarding the credentials,
- * and a network blip or a server error must not leave the user unable to log
- * out. Failures are logged under `--verbose` and swallowed. Per RFC 7009 §2.2
- * the endpoint also answers 200 for a token it does not recognise, so an
- * already-expired session is indistinguishable from a successful revocation —
- * which is exactly the outcome we want either way.
+ * Never throws: the caller is already discarding the credentials, and a network
+ * blip or a server error must not leave the user unable to log out. Failures
+ * are reported through the return value and logged under `--verbose` so the
+ * caller can tell the user rather than claiming a success that did not happen.
+ *
+ * Note that `"revoked"` is weaker than it looks. Per RFC 7009 §2.2 the endpoint
+ * answers 200 for a token it does not recognise, and it also answers 200 for a
+ * token that another process already rotated away — in that case the grant
+ * survives under the new token and nothing was actually revoked.
  */
-export async function revokeToken(token: string, tokenTypeHint: TokenTypeHint): Promise<void> {
-  const oauth = getOAuthConfig();
-  const body = new URLSearchParams({
-    token,
-    token_type_hint: tokenTypeHint,
-    client_id: oauth.clientId,
-  });
-
+export async function revokeToken(
+  token: string,
+  tokenTypeHint: TokenTypeHint,
+): Promise<RevocationResult> {
   try {
-    await loggedFetch(oauth.revokeUrl, {
+    // Inside the try: getOAuthConfig() parses URLs and throws on a malformed
+    // CLERK_OAUTH_BASE_URL. Escaping here would abort the caller's teardown
+    // partway through, which is exactly what this function promises not to do.
+    const oauth = getOAuthConfig();
+    const body = new URLSearchParams({
+      token,
+      token_type_hint: tokenTypeHint,
+      client_id: oauth.clientId,
+    });
+
+    const response = await loggedFetch(oauth.revokeUrl, {
       tag: "oauth",
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body: body.toString(),
-      bestEffort: true,
     });
+
+    // A 4xx here is permanent — a wrong client_id, or an instance whose OAuth
+    // provider does not implement revocation. Without this check that failure
+    // is indistinguishable from success on every run, forever.
+    return response.ok ? "revoked" : "failed";
   } catch (error) {
     log.debug(`oauth: token revocation failed — ${errorMessage(error)}`);
+    return "failed";
   }
 }
 

--- a/packages/cli-core/src/test/integration/lib/harness.ts
+++ b/packages/cli-core/src/test/integration/lib/harness.ts
@@ -76,7 +76,9 @@ mock.module(
         tokenType: tokenResponse.token_type,
       }),
       revokeAndDeleteToken: async () => {
+        const had = mockState.storedToken !== null;
         mockState.storedToken = null;
+        return had ? ("revoked" as const) : ("nothing_to_revoke" as const);
       },
       _setTokenOverride: () => {},
       KEYCHAIN_SERVICE: "clerk-cli",
@@ -224,7 +226,7 @@ mock.module(
         expires_in: 3600,
         refresh_token: "mock_refresh_token",
       }),
-      revokeToken: async () => {},
+      revokeToken: async () => "revoked" as const,
       fetchUserInfo: async (token: string) => {
         if (!token || token === "expired_token") throw new Error("Unauthorized");
         return { userId: "user_123", email: "test@example.com" };

--- a/packages/cli-core/src/test/lib/stubs.ts
+++ b/packages/cli-core/src/test/lib/stubs.ts
@@ -194,7 +194,7 @@ export const credentialStoreStubs = {
   hasAccountCredentials: async () => Boolean(process.env.CLERK_PLATFORM_API_KEY),
   storeToken: async () => {},
   deleteToken: async () => {},
-  revokeAndDeleteToken: async () => {},
+  revokeAndDeleteToken: async () => "nothing_to_revoke" as const,
   createOAuthSession: (tokenResponse: {
     access_token: string;
     refresh_token: string;
@@ -234,7 +234,7 @@ export { listageStubs } from "./listage-stubs.ts";
 export const tokenExchangeStubs = {
   exchangeCodeForToken: async () => ({}),
   refreshAccessToken: async () => ({}),
-  revokeToken: async () => {},
+  revokeToken: async () => "revoked" as const,
   fetchUserInfo: async () => ({}),
 };
 


### PR DESCRIPTION
## Summary

Follow-up to #418, which could fail to revoke a session while still reporting success. `revokeToken` now returns its outcome instead of void, checks the response status so a permanent 4xx stops looking like success, and resolves the OAuth config inside its try block so a malformed `CLERK_OAUTH_BASE_URL` no longer aborts sign-out before `clearAuth` runs. Logout and re-auth warn on failure instead of printing an unconditional success, and logout flags `CLERK_PLATFORM_API_KEY` when set.

The outgoing session is now read inside the OAuth flow, just before the token exchange overwrites it, rather than before the browser flow and gated on a network probe that swallows its errors. That gate could orphan a live grant; the earlier placement also let a concurrent refresh rotate the token away, which makes revocation a silent no-op. The new placement closes the first and shrinks the second to one token request.

Docs corrected: revocation ends the current environment's grant and its refresh token, but the access token is a JWT the server refuses to revoke, valid until it expires.

## Test plan

- [x] `format:check`, `lint`, `typecheck`, `test` (2618 pass, 0 fail)
- [x] New tests fail when either fix is reverted; both mutations passed the old suite
- [ ] Manual: `clerk auth logout --verbose`, confirm the refresh token no longer redeems
- [ ] Manual: `CLERK_OAUTH_BASE_URL=not-a-url clerk auth logout`, confirm it warns and still clears