### PR TITLE
fix(ci): scope release failure notifications to their channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,10 +168,14 @@ jobs:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
   notify-stable-failure:
+    # `ci` and `versioning` are deliberately excluded: they run on every push to
+    # main, before the release channel is decided, so a failure there is not a
+    # stable release failure. `notify-ci-failure` covers those.
     if: >-
       always() &&
+      needs.versioning.outputs.release_created == 'true' &&
       contains(needs.*.result, 'failure')
-    needs: [ci, versioning, build, sign-macos, smoke-test, publish-npm, publish-github, homebrew]
+    needs: [versioning, build, sign-macos, smoke-test, publish-npm, publish-github, homebrew]
     uses: ./.github/workflows/notify-failure.yml
     with:
       workflow-name: Stable release
@@ -318,12 +322,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
   notify-canary-failure:
+    # Gate on `== 'false'`, never `!= 'true'`: when `versioning` is skipped the
+    # output is the empty string, which satisfies `!= 'true'` and would fire this
+    # notification for failures that never reached the canary path.
     if: >-
       always() &&
+      needs.versioning.outputs.release_created == 'false' &&
       contains(needs.*.result, 'failure')
     needs:
       [
-        ci,
+        versioning,
         canary-version,
         canary-build,
         canary-sign-macos,
@@ -334,6 +342,21 @@ jobs:
     uses: ./.github/workflows/notify-failure.yml
     with:
       workflow-name: Canary release
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  # ─── Pre-release CI ────────────────────────────────────────────────
+
+  notify-ci-failure:
+    # Covers failures in the jobs shared by both channels, which run before the
+    # release channel is decided and so belong to neither.
+    if: >-
+      always() &&
+      contains(needs.*.result, 'failure')
+    needs: [ci, versioning]
+    uses: ./.github/workflows/notify-failure.yml
+    with:
+      workflow-name: Main CI
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 


### PR DESCRIPTION
## Summary

The `notify-stable-failure` job gated only on `contains(needs.*.result, 'failure')` with no check on which release channel the run belonged to, and it listed `ci` and `versioning` among its needs. Those two jobs run on every push to `main`, before the channel is decided, so any CI failure fired the "Stable release" Slack alert even when no stable release was attempted. Because `notify-canary-failure` carried `ci` in its needs with the same ungated condition, a single CI failure fired both alerts at once. Runs 32062420511, 32057332859, and 32056314474 all show this: `ci` failed, every build and publish job was skipped, and both notifications went out anyway.

Each channel notification now gates on the `release_created` output from `versioning`, and `ci` is dropped from both needs lists. A new `notify-ci-failure` job covers the shared pre-release jobs and reports them as "Main CI", so a failure that belongs to neither channel is named for what it actually is. This also removes the duplicate alert, since `ci` is no longer a shared trigger.

The canary gate is written as `== 'false'` rather than `!= 'true'` on purpose. When `versioning` is skipped its output is the empty string, which satisfies `!= 'true'` and would reintroduce the same false positive this PR is fixing.

## Behavior

| Failure | Before | After |
| --- | --- | --- |
| `ci` or `versioning` | Stable + Canary | Main CI |
| Stable build/publish | Stable | Stable |
| Canary build/publish | Canary | Canary |

## Test plan

- [ ] Push to `main` with a failing CI job and confirm only the "Main CI" alert fires
- [ ] Push to `main` with no release-worthy changeset and a failing canary publish; confirm only the "Canary release" alert fires
- [ ] Land a changeset and confirm a stable publish failure still fires "Stable release"
- [ ] Confirm `notify-stable-success` is unaffected on a successful stable release
