### PR TITLE
fix(cli): report interrupted runs in deploy status and telemetry

### DIFF
--- a/.changeset/interrupt-report-gaps.md
+++ b/.changeset/interrupt-report-gaps.md
@@ -1,0 +1,8 @@
+---
+"clerk": patch
+---
+
+Report what was established when Ctrl-C interrupts `clerk deploy status`, and record interrupted runs in usage telemetry.
+
+- `clerk deploy status` no longer exits silently when the interrupt arrives before the deploy state is read. Agent mode emits a report with `state: "interrupted"`, which asserts nothing about the deploy.
+- An interrupted command now sends its `abort` outcome instead of no event at all.

--- a/packages/cli-core/src/commands/deploy/README.md
+++ b/packages/cli-core/src/commands/deploy/README.md
@@ -47,7 +47,7 @@ Agent-mode `clerk deploy` exits successfully for linked projects because it is i
 In agent mode, `clerk deploy status` emits JSON on stdout with:
 
 - `complete`: `true` only when the domain is verified and all supported OAuth providers enabled in development have production credentials.
-- `state`: `complete`, `domain_pending`, `oauth_pending`, `domain_provisioning`, or `not_started`.
+- `state`: `complete`, `domain_pending`, `oauth_pending`, `domain_provisioning`, `not_started`, or `interrupted`.
 - `domainStatus`: per-component DNS, SSL, and email DNS status when a domain exists.
 - `pendingDnsRecords`: CNAME records still tied to pending DNS-backed checks.
 - `oauth`: configured, pending, and unsupported provider slugs.
@@ -86,6 +86,8 @@ After displaying the DNS records block, when CNAME records are present the CLI p
 PLAPI errors are translated to typed `CliError`s by `commands/deploy/errors.ts`. The CLI does not auto-retry SSL issuance or email DNS verification beyond the shared DNS verification loop. When domain status polling times out with SSL or email DNS still incomplete, the CLI surfaces the component status and instructs the user to rerun `clerk deploy` once DNS propagates.
 
 If the user presses Ctrl-C after the production instance has been created — at a prompt or during the DNS wait — the wizard tells them to run `clerk deploy` again and exits with SIGINT code 130. The deploy is unfinished either way, so `clerk deploy && ./cutover.sh` stops rather than proceeding against a half-configured instance. The next run derives the current DNS or OAuth step from API state and resumes without starting another production instance.
+
+`clerk deploy status` also exits 130 on Ctrl-C, and always emits a report on the way out. Interrupted mid-wait, it reports what the last completed poll established. Interrupted before the live state resolves — during the preflight DNS check or the state read — it reports `state: "interrupted"`, which asserts nothing about the deploy. See [`.claude/rules/interrupts.md`](../../../../../.claude/rules/interrupts.md).
 
 ## Sequence Diagram
 

--- a/packages/cli-core/src/commands/deploy/status-command.test.ts
+++ b/packages/cli-core/src/commands/deploy/status-command.test.ts
@@ -22,7 +22,13 @@ mock.module("../../lib/sleep.ts", () => ({
 
 const { _setConfigDir, setProfile } = await import("../../lib/config.ts");
 const { setMode } = await import("../../mode.ts");
+const { beginInterrupt, _resetInterruptState } = await import("../../lib/signals.ts");
 const { deployStatus } = await import("./status-command.ts");
+
+/** What an in-flight request rejects with once Ctrl-C aborts the shared signal. */
+function abortError(): Error {
+  return new DOMException("The operation was aborted.", "AbortError");
+}
 
 function stripAnsi(value: string): string {
   return value.replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g"), "");
@@ -131,6 +137,7 @@ describe("deploy status", () => {
   });
 
   afterEach(async () => {
+    _resetInterruptState();
     _setConfigDir(undefined);
     if (tempDir) await rm(tempDir, { recursive: true, force: true });
     process.exitCode = exitCodeBefore ?? EXIT_CODE.SUCCESS;
@@ -244,6 +251,80 @@ describe("deploy status", () => {
 
     expect(stripAnsi(captured.err)).toContain("Waiting for Clerk DNS check to process");
     expect(mockSleep).toHaveBeenCalledWith(2000);
+  });
+
+  test("agent mode Ctrl-C during the preflight emits an interrupted report", async () => {
+    mockFetchApplication.mockResolvedValue(appWith(true));
+    mockDomain();
+    mockOAuthComplete();
+    mockTriggerApplicationDomainDNSCheck.mockImplementation(() => {
+      beginInterrupt();
+      throw abortError();
+    });
+
+    await expect(deployStatus()).rejects.toThrow();
+
+    const payload = JSON.parse(captured.out);
+    expect(payload).toMatchObject({ complete: false, state: "interrupted", domain: null });
+    expect(payload.nextAction).toContain("Run `clerk deploy status` again");
+    // The state read never happened, so the command must not claim there is no
+    // production instance.
+    expect(payload.state).not.toBe("not_started");
+  });
+
+  test("agent mode Ctrl-C during the state read emits an interrupted report", async () => {
+    mockFetchApplication.mockResolvedValue(appWith(true));
+    mockDomain();
+    mockOAuthComplete();
+    mockTriggerApplicationDomainDNSCheck.mockResolvedValue(pendingDnsDomainStatus());
+    mockGetApplicationDomainStatus.mockImplementation(() => {
+      beginInterrupt();
+      throw abortError();
+    });
+
+    await expect(deployStatus()).rejects.toThrow();
+
+    expect(JSON.parse(captured.out).state).toBe("interrupted");
+  });
+
+  test("agent mode Ctrl-C mid-wait reports what the last completed poll established", async () => {
+    mockFetchApplication.mockResolvedValue(appWith(true));
+    mockDomain();
+    mockOAuthComplete();
+    mockTriggerApplicationDomainDNSCheck.mockResolvedValue(pendingDnsDomainStatus());
+    let polls = 0;
+    mockGetApplicationDomainStatus.mockImplementation(() => {
+      polls++;
+      if (polls === 1) return pendingDnsDomainStatus();
+      if (polls === 2) return pendingSslDomainStatus();
+      beginInterrupt();
+      throw abortError();
+    });
+
+    await expect(deployStatus({ wait: true })).rejects.toThrow();
+
+    const payload = JSON.parse(captured.out);
+    expect(payload.state).toBe("domain_pending");
+    // From the second poll, not the pre-wait snapshot — which still had DNS pending.
+    expect(payload.domainStatus).toEqual({ dns: "complete", ssl: "pending", mail: "complete" });
+  });
+
+  test("human mode Ctrl-C during the preflight prints only the next action", async () => {
+    setMode("human");
+    mockFetchApplication.mockResolvedValue(appWith(true));
+    mockDomain();
+    mockOAuthComplete();
+    mockTriggerApplicationDomainDNSCheck.mockImplementation(() => {
+      beginInterrupt();
+      throw abortError();
+    });
+
+    await expect(deployStatus()).rejects.toThrow();
+
+    const output = stripAnsi(captured.err);
+    expect(output).toContain("Interrupted before the deploy status could be read");
+    expect(output).not.toContain("OAuth");
+    expect(captured.out).toBe("");
   });
 
   test("human mode shows dashboard monitoring guidance without agent handoff copy", async () => {

--- a/packages/cli-core/src/commands/deploy/status-command.test.ts
+++ b/packages/cli-core/src/commands/deploy/status-command.test.ts
@@ -253,6 +253,18 @@ describe("deploy status", () => {
     expect(mockSleep).toHaveBeenCalledWith(2000);
   });
 
+  test("agent mode Ctrl-C while resolving the linked application emits an interrupted report", async () => {
+    // The first PLAPI read of the command, inside `resolveDeployContext`.
+    mockFetchApplication.mockImplementation(() => {
+      beginInterrupt();
+      throw abortError();
+    });
+
+    await expect(deployStatus()).rejects.toThrow();
+
+    expect(JSON.parse(captured.out).state).toBe("interrupted");
+  });
+
   test("agent mode Ctrl-C during the preflight emits an interrupted report", async () => {
     mockFetchApplication.mockResolvedValue(appWith(true));
     mockDomain();

--- a/packages/cli-core/src/commands/deploy/status-command.ts
+++ b/packages/cli-core/src/commands/deploy/status-command.ts
@@ -26,18 +26,10 @@ type DeployStatusOptions = {
 const DEPLOY_STATUS_PREFLIGHT_DELAY_MS = 2000;
 
 export async function deployStatus(options: DeployStatusOptions = {}): Promise<void> {
-  const ctx = await resolveDeployContext();
-  if (!ctx.appId || !ctx.developmentInstanceId) {
-    throw new CliError(
-      "No Clerk project linked to this directory. Run `clerk link`, then rerun `clerk deploy status`.",
-      { code: ERROR_CODE.NOT_LINKED },
-    );
-  }
-
-  // Everything from the preflight on is covered by one interrupt catch.
-  // `runProgram` returns early the moment an interrupt latches, so nothing
-  // below this frame runs and an uncovered stretch prints nothing at all — the
-  // preflight was such a stretch until it moved inside.
+  // The whole command is covered by one interrupt catch, starting at the first
+  // await. `runProgram` returns early the moment an interrupt latches, so
+  // nothing below this frame runs and any stretch left outside prints nothing
+  // at all — every await here reaches the Platform API or the config file.
   //
   // Both of these are read by the catch, so they live outside the `try`:
   // `state` is what a report can be built from, and `lastPolledStatus` is what
@@ -47,6 +39,15 @@ export async function deployStatus(options: DeployStatusOptions = {}): Promise<v
   let state: DeployState | null = null;
   let lastPolledStatus: DeployComponentStatus | undefined;
   try {
+    const ctx = await resolveDeployContext();
+    // Not an interrupt, so the catch rethrows this untouched.
+    if (!ctx.appId || !ctx.developmentInstanceId) {
+      throw new CliError(
+        "No Clerk project linked to this directory. Run `clerk link`, then rerun `clerk deploy status`.",
+        { code: ERROR_CODE.NOT_LINKED },
+      );
+    }
+
     const preflightTriggered = await runPreflightDeployStatusCheck(ctx);
     state = await resolveDeployState(ctx);
     const shouldWait = options.wait === true || !isAgent();

--- a/packages/cli-core/src/commands/deploy/status-command.ts
+++ b/packages/cli-core/src/commands/deploy/status-command.ts
@@ -7,6 +7,7 @@ import { withSpinner } from "../../lib/spinner.ts";
 import { deployComponentLabels, type DeployComponentStatus } from "./copy.ts";
 import {
   buildDeployStatusReport,
+  buildInterruptedDeployStatusReport,
   loadProductionDomain,
   resolveDeployContext,
   resolveDeployState,
@@ -33,40 +34,58 @@ export async function deployStatus(options: DeployStatusOptions = {}): Promise<v
     );
   }
 
-  const preflightTriggered = await runPreflightDeployStatusCheck(ctx);
-  const state = await resolveDeployState(ctx);
-  const shouldWait = options.wait === true || !isAgent();
+  // Everything from the preflight on is covered by one interrupt catch.
+  // `runProgram` returns early the moment an interrupt latches, so nothing
+  // below this frame runs and an uncovered stretch prints nothing at all — the
+  // preflight was such a stretch until it moved inside.
+  //
+  // Both of these are read by the catch, so they live outside the `try`:
+  // `state` is what a report can be built from, and `lastPolledStatus` is what
+  // the wait loop established. The loop's own status is local to it and Ctrl-C
+  // rejects out of the next poll before it returns, so without capturing each
+  // poll the report would list components as pending after they verified.
+  let state: DeployState | null = null;
+  let lastPolledStatus: DeployComponentStatus | undefined;
+  try {
+    const preflightTriggered = await runPreflightDeployStatusCheck(ctx);
+    state = await resolveDeployState(ctx);
+    const shouldWait = options.wait === true || !isAgent();
 
-  let outcome: DeployStatusOutcome | null = null;
-  if (state.kind === "active" && shouldWait) {
-    // The wait loop's status is local to it, and Ctrl-C rejects out of the next
-    // poll before it returns. Capture each poll's result so the interrupt path
-    // below reports what was actually established rather than the pre-wait
-    // snapshot, which would list components as pending after they verified.
-    let lastPolledStatus: DeployComponentStatus | undefined;
-    try {
+    let outcome: DeployStatusOutcome | null = null;
+    if (state.kind === "active" && shouldWait) {
       outcome = await runWait(state, {
         triggerCheck: !preflightTriggered,
         onStatus: (status) => {
           lastPolledStatus = status;
         },
       });
-    } catch (error) {
-      if (interruptedExitCode() === null) throw error;
-      // Ctrl-C mid-poll. `runProgram` hands the exit to the signal handler, so
-      // nothing below this frame runs and the command would otherwise print
-      // nothing at all. Emit what the last completed poll established; the exit
-      // code stays 130, so no script reads this as a finished deploy.
-      const partial = lastPolledStatus ? { verified: false, status: lastPolledStatus } : null;
-      emitReport(buildDeployStatusReport(state, partial));
-      throw error;
     }
+
+    const report = buildDeployStatusReport(state, outcome);
+
+    emitReport(report);
+    process.exitCode = report.complete ? EXIT_CODE.SUCCESS : EXIT_CODE.GENERAL;
+  } catch (error) {
+    if (interruptedExitCode() === null) throw error;
+    // Report what was established, then rethrow: the exit code stays 130, so no
+    // script reads this as a finished deploy.
+    emitReport(buildInterruptedReport(state, lastPolledStatus));
+    throw error;
   }
+}
 
-  const report = buildDeployStatusReport(state, outcome);
-
-  emitReport(report);
-  process.exitCode = report.complete ? EXIT_CODE.SUCCESS : EXIT_CODE.GENERAL;
+/**
+ * The best report available when Ctrl-C cut the command short. Before
+ * `resolveDeployState` answers there is nothing to build one from, so this
+ * falls back to the "interrupted" report rather than claiming a state.
+ */
+function buildInterruptedReport(
+  state: DeployState | null,
+  lastPolledStatus: DeployComponentStatus | undefined,
+): DeployStatusReport {
+  if (!state) return buildInterruptedDeployStatusReport();
+  const partial = lastPolledStatus ? { verified: false, status: lastPolledStatus } : null;
+  return buildDeployStatusReport(state, partial);
 }
 
 async function runPreflightDeployStatusCheck(ctx: DeployContext): Promise<boolean> {
@@ -119,6 +138,16 @@ function renderHuman(report: DeployStatusReport): void {
     log.info(`Deploy status for \`${report.domain}\``);
   } else {
     log.info("Deploy status");
+  }
+
+  // Nothing was read, so the empty OAuth and domain rows below would read as
+  // "checked, found nothing" rather than "never checked". Only the next action
+  // is true here.
+  if (report.state === "interrupted") {
+    log.blank();
+    log.info(report.nextAction);
+    log.blank();
+    return;
   }
 
   if (report.domainStatus) {

--- a/packages/cli-core/src/commands/deploy/status.ts
+++ b/packages/cli-core/src/commands/deploy/status.ts
@@ -55,7 +55,11 @@ export type DeployStatusState =
   | "domain_pending"
   | "oauth_pending"
   | "domain_provisioning"
-  | "not_started";
+  | "not_started"
+  // Ctrl-C landed before the live state could be read, so nothing about the
+  // deploy is known. Never means "no production instance" — see
+  // buildInterruptedDeployStatusReport.
+  | "interrupted";
 
 export interface DeployStatusReport {
   complete: boolean;
@@ -383,6 +387,30 @@ export function buildDeployStatusReport(
         ? domainsDashboardUrl(snapshot.appId, snapshot.productionInstanceId)
         : null,
     ),
+  };
+}
+
+/**
+ * The report for a Ctrl-C that arrived before {@link resolveDeployState} could
+ * answer — during the preflight DNS check, or during the state read itself.
+ *
+ * `not_started` would be a lie here: it asserts there is no production
+ * instance, which is exactly the question that never got answered. This says
+ * "unknown" instead, so an agent parsing stdout gets a well-formed document
+ * rather than the empty output this path used to produce.
+ */
+export function buildInterruptedDeployStatusReport(): DeployStatusReport {
+  return {
+    complete: false,
+    state: "interrupted",
+    domain: null,
+    productionInstanceId: null,
+    domainStatus: null,
+    pendingDnsRecords: [],
+    oauth: { complete: false, configured: [], pending: [], unsupported: [] },
+    nextAction:
+      "Interrupted before the deploy status could be read, so nothing is known about this " +
+      "deploy. Run `clerk deploy status` again to check it.",
   };
 }
 

--- a/packages/cli-core/src/lib/telemetry.test.ts
+++ b/packages/cli-core/src/lib/telemetry.test.ts
@@ -280,6 +280,33 @@ describe("finalizeAndSendTelemetry", () => {
       expect(landed[0]).toContain('"outcome":"abort"');
     });
 
+    test("the shutdown flush is not held up by a normal flush that ignores the interrupt", async () => {
+      await markTelemetryNoticeShown();
+      process.env.CLERK_TELEMETRY_URL = "https://capture.invalid/v1/event";
+      const landed: string[] = [];
+      globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+        const body = String(init?.body ?? "");
+        if (body.includes('"outcome":"abort"')) {
+          landed.push(body);
+          return new Response("{}");
+        }
+        // Stands in for the config, Git, and user-agent reads a normal flush
+        // does around its POST: slow, and blind to the interrupt signal.
+        return await new Promise<Response>(() => {});
+      }) as unknown as typeof fetch;
+      startCommandTelemetry(fakeCommand());
+
+      const normal = finalizeAndSendTelemetry({ outcome: "success", exitCode: 0 }, 300);
+      beginInterrupt();
+      abortInFlight();
+      await finalizeAndSendTelemetry({ outcome: "abort", exitCode: EXIT_CODE.SIGINT }, 250, true);
+
+      // Landed inside the shutdown budget rather than being starved by work
+      // the interrupt cannot cancel.
+      expect(landed).toHaveLength(1);
+      await normal;
+    });
+
     test("a landed normal flush is not reported a second time", async () => {
       await markTelemetryNoticeShown();
       process.env.CLERK_TELEMETRY_URL = "https://capture.invalid/v1/event";

--- a/packages/cli-core/src/lib/telemetry.test.ts
+++ b/packages/cli-core/src/lib/telemetry.test.ts
@@ -12,6 +12,7 @@ import {
   type TelemetryCommand,
 } from "./telemetry.ts";
 import { ApiError, CliError, EXIT_CODE, UserAbortError } from "./errors.ts";
+import { abortInFlight, beginInterrupt, _resetInterruptState } from "./signals.ts";
 import { setLogLevel } from "./log.ts";
 import { useCaptureLog } from "../test/lib/stubs.ts";
 
@@ -217,6 +218,84 @@ describe("finalizeAndSendTelemetry", () => {
     startCommandTelemetry(fakeCommand());
     await finalizeAndSendTelemetry({ outcome: "success", exitCode: 0 });
     expect(called).toBe(0);
+  });
+
+  // A run gets one event across both flushes: the normal end-of-command one and
+  // the shutdown one the SIGINT handler starts.
+  describe("interrupted runs", () => {
+    afterEach(() => {
+      _resetInterruptState();
+    });
+
+    /** Lands the abort event; the success event only ever settles by aborting. */
+    function fetchThatOnlyLandsAborts(landed: string[]): typeof fetch {
+      return (async (_url: string, init?: RequestInit) => {
+        const body = String(init?.body ?? "");
+        if (body.includes('"outcome":"abort"')) {
+          landed.push(body);
+          return new Response("{}");
+        }
+        return await new Promise<Response>((_resolve, reject) => {
+          const fail = () => reject(new DOMException("The operation was aborted.", "AbortError"));
+          const signal = init?.signal;
+          if (!signal) return;
+          if (signal.aborted) return fail();
+          signal.addEventListener("abort", fail, { once: true });
+        });
+      }) as unknown as typeof fetch;
+    }
+
+    test("an aborted normal flush leaves the run for the shutdown flush to report", async () => {
+      await markTelemetryNoticeShown();
+      process.env.CLERK_TELEMETRY_URL = "https://capture.invalid/v1/event";
+      const landed: string[] = [];
+      globalThis.fetch = fetchThatOnlyLandsAborts(landed);
+      startCommandTelemetry(fakeCommand());
+
+      beginInterrupt();
+      abortInFlight();
+      await finalizeAndSendTelemetry({ outcome: "success", exitCode: 0 }, 1000);
+      expect(landed).toEqual([]);
+
+      await finalizeAndSendTelemetry({ outcome: "abort", exitCode: EXIT_CODE.SIGINT }, 250, true);
+
+      expect(landed).toHaveLength(1);
+      expect(landed[0]).toContain('"outcome":"abort"');
+    });
+
+    test("a flush still in flight when the interrupt lands still yields one event", async () => {
+      await markTelemetryNoticeShown();
+      process.env.CLERK_TELEMETRY_URL = "https://capture.invalid/v1/event";
+      const landed: string[] = [];
+      globalThis.fetch = fetchThatOnlyLandsAborts(landed);
+      startCommandTelemetry(fakeCommand());
+
+      const normal = finalizeAndSendTelemetry({ outcome: "success", exitCode: 0 }, 1000);
+      beginInterrupt();
+      abortInFlight();
+      await finalizeAndSendTelemetry({ outcome: "abort", exitCode: EXIT_CODE.SIGINT }, 250, true);
+      await normal;
+
+      expect(landed).toHaveLength(1);
+      expect(landed[0]).toContain('"outcome":"abort"');
+    });
+
+    test("a landed normal flush is not reported a second time", async () => {
+      await markTelemetryNoticeShown();
+      process.env.CLERK_TELEMETRY_URL = "https://capture.invalid/v1/event";
+      const bodies: string[] = [];
+      globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+        bodies.push(String(init?.body ?? ""));
+        return new Response("{}");
+      }) as unknown as typeof fetch;
+      startCommandTelemetry(fakeCommand());
+
+      await finalizeAndSendTelemetry({ outcome: "success", exitCode: 0 });
+      await finalizeAndSendTelemetry({ outcome: "abort", exitCode: EXIT_CODE.SIGINT }, 250, true);
+
+      expect(bodies).toHaveLength(1);
+      expect(bodies[0]).toContain('"outcome":"success"');
+    });
   });
 
   describe("sandbox-looking failures", () => {

--- a/packages/cli-core/src/lib/telemetry.ts
+++ b/packages/cli-core/src/lib/telemetry.ts
@@ -67,20 +67,18 @@ let context: TelemetryContext | null = null;
  * normal flush, which leaves the context in place for the shutdown flush to
  * re-send as `outcome: "abort"` — before this the context was already gone and
  * an interrupted run reported nothing at all.
+ *
+ * This flag alone is what keeps a run to one event, and it is enough because a
+ * normal flush still running when the shutdown flush starts can no longer
+ * land: it passes `ignoreInterrupt: false`, so its POST is composed with
+ * `interruptSignal()` and the interrupt that triggered the shutdown flush
+ * already aborted it. One that landed *before* the interrupt has already set
+ * this flag — its continuations are microtasks and the signal handler is a
+ * macrotask, so they run first. The shutdown flush therefore never waits on
+ * the normal one, whose remaining config, Git, and user-agent reads observe no
+ * signal and could otherwise burn its entire 250ms budget.
  */
 let finalized = false;
-
-/**
- * The flush currently running, resolving to whether it finalized the run.
- *
- * Both flushes can be alive at once: the normal one is racing a 1500ms deadline
- * while the interrupt that aborted it starts the shutdown flush on a 250ms one,
- * and `reportAndExitInterrupted`'s dynamic `import("./telemetry.ts")` makes the
- * ordering between them unpredictable. A second flush therefore waits out the
- * first and only sends if the first did not, so a run produces at most one
- * event.
- */
-let inFlight: Promise<boolean> | null = null;
 
 /** Pure env + build check; the persisted opt-out lives in getTelemetryStatus. */
 export function telemetryEnabled(
@@ -142,7 +140,6 @@ export function startCommandTelemetry(actionCommand: TelemetryCommand): void {
     // A process runs one command, but tests reuse the module — start each run
     // owing an event.
     finalized = false;
-    inFlight = null;
     // `completion` runs without a user asking for it: every new shell with
     // `eval "$(clerk completion zsh)"` in its rc file re-runs it, so a handful
     // of machines drowned out the real command mix. (`__complete`, fired on
@@ -194,58 +191,26 @@ export async function finalizeAndSendTelemetry(
 ): Promise<void> {
   if (finalized || !context) return;
 
+  const current = context;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), deadlineMs);
   try {
-    // The deadline covers waiting out an earlier flush as well as our own send,
-    // so a shutdown flush cannot be held past its budget by the normal one it
-    // interrupted.
-    await Promise.race([
-      flush(result, controller.signal, outlivesInterrupt),
-      abortedToResolved(controller.signal),
-    ]);
+    const work = buildAndSend(current, result, controller.signal, outlivesInterrupt)
+      .then(() => {
+        // Reached the endpoint, or decided nothing would be sent at all. Either
+        // way the run is accounted for and no later flush reports it again.
+        finalized = true;
+        context = null;
+      })
+      .catch((error: unknown) => {
+        // Aborted or failed. The context stays put so the shutdown flush can
+        // report the interrupt that most likely caused this.
+        log.debug(`telemetry: send failed: ${error}`);
+      });
+    await Promise.race([work, abortedToResolved(controller.signal)]);
   } finally {
     clearTimeout(timer);
   }
-}
-
-/**
- * Send this run's event, unless a flush already accounted for it.
- *
- * The `inFlight` handoff is what keeps the two flushes to one event between
- * them. It is assigned before the first await, so a flush that starts later
- * always observes it.
- */
-async function flush(
-  result: TelemetryResult,
-  signal: AbortSignal,
-  outlivesInterrupt: boolean,
-): Promise<void> {
-  if (inFlight && (await inFlight)) return;
-  if (finalized) return;
-
-  const current = context;
-  if (!current) return;
-
-  const work = buildAndSend(current, result, signal, outlivesInterrupt)
-    .then(() => {
-      // Reached the endpoint, or decided nothing would be sent at all. Either
-      // way the run is accounted for and no later flush should report it again.
-      finalized = true;
-      context = null;
-      return true;
-    })
-    .catch((error: unknown) => {
-      // Aborted or failed. The context stays put so the shutdown flush can
-      // report the interrupt that most likely caused this.
-      log.debug(`telemetry: send failed: ${error}`);
-      return false;
-    })
-    .finally(() => {
-      inFlight = null;
-    });
-  inFlight = work;
-  await work;
 }
 
 function abortedToResolved(signal: AbortSignal): Promise<void> {

--- a/packages/cli-core/src/lib/telemetry.ts
+++ b/packages/cli-core/src/lib/telemetry.ts
@@ -58,6 +58,30 @@ type TelemetryContext = {
 
 let context: TelemetryContext | null = null;
 
+/**
+ * Whether this run has been accounted for — the send completed, or it was
+ * decided that nothing would be sent at all (opt-out, disclosure notice).
+ *
+ * The context is what a flush needs to build an event, so it is held until one
+ * of those settles rather than cleared at entry. A Ctrl-C mid-POST aborts the
+ * normal flush, which leaves the context in place for the shutdown flush to
+ * re-send as `outcome: "abort"` — before this the context was already gone and
+ * an interrupted run reported nothing at all.
+ */
+let finalized = false;
+
+/**
+ * The flush currently running, resolving to whether it finalized the run.
+ *
+ * Both flushes can be alive at once: the normal one is racing a 1500ms deadline
+ * while the interrupt that aborted it starts the shutdown flush on a 250ms one,
+ * and `reportAndExitInterrupted`'s dynamic `import("./telemetry.ts")` makes the
+ * ordering between them unpredictable. A second flush therefore waits out the
+ * first and only sends if the first did not, so a run produces at most one
+ * event.
+ */
+let inFlight: Promise<boolean> | null = null;
+
 /** Pure env + build check; the persisted opt-out lives in getTelemetryStatus. */
 export function telemetryEnabled(
   env: EnvLike = process.env,
@@ -115,6 +139,10 @@ function collectSetFlagNames(cmd: TelemetryCommand): string[] {
 export function startCommandTelemetry(actionCommand: TelemetryCommand): void {
   try {
     const command = commandPathOf(actionCommand);
+    // A process runs one command, but tests reuse the module — start each run
+    // owing an event.
+    finalized = false;
+    inFlight = null;
     // `completion` runs without a user asking for it: every new shell with
     // `eval "$(clerk completion zsh)"` in its rc file re-runs it, so a handful
     // of machines drowned out the real command mix. (`__complete`, fired on
@@ -152,28 +180,72 @@ export function telemetryResultForError(error: unknown): TelemetryResult {
  * `deadlineMs` by more than scheduling noise. The deadline covers the entire
  * job — config I/O, git profile lookup, and the POST — not just the fetch;
  * on timeout the event is dropped (`deadlineMs` is overridden in tests).
+ *
+ * Callable twice per run — once normally, once from the SIGINT handler — and
+ * emits at most one event across both. The one case a run is still reported as
+ * a success it did not have is a Ctrl-C in the bookkeeping tail *after* the
+ * POST has already landed: that event cannot be retracted, and sending a second
+ * would double-count the run.
  */
 export async function finalizeAndSendTelemetry(
   result: TelemetryResult,
   deadlineMs: number = TELEMETRY_TIMEOUT_MS,
   outlivesInterrupt = false,
 ): Promise<void> {
-  const current = context;
-  context = null;
-  if (!current) return;
+  if (finalized || !context) return;
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), deadlineMs);
   try {
-    const work = buildAndSend(current, result, controller.signal, outlivesInterrupt).catch(
-      (error: unknown) => {
-        log.debug(`telemetry: send failed: ${error}`);
-      },
-    );
-    await Promise.race([work, abortedToResolved(controller.signal)]);
+    // The deadline covers waiting out an earlier flush as well as our own send,
+    // so a shutdown flush cannot be held past its budget by the normal one it
+    // interrupted.
+    await Promise.race([
+      flush(result, controller.signal, outlivesInterrupt),
+      abortedToResolved(controller.signal),
+    ]);
   } finally {
     clearTimeout(timer);
   }
+}
+
+/**
+ * Send this run's event, unless a flush already accounted for it.
+ *
+ * The `inFlight` handoff is what keeps the two flushes to one event between
+ * them. It is assigned before the first await, so a flush that starts later
+ * always observes it.
+ */
+async function flush(
+  result: TelemetryResult,
+  signal: AbortSignal,
+  outlivesInterrupt: boolean,
+): Promise<void> {
+  if (inFlight && (await inFlight)) return;
+  if (finalized) return;
+
+  const current = context;
+  if (!current) return;
+
+  const work = buildAndSend(current, result, signal, outlivesInterrupt)
+    .then(() => {
+      // Reached the endpoint, or decided nothing would be sent at all. Either
+      // way the run is accounted for and no later flush should report it again.
+      finalized = true;
+      context = null;
+      return true;
+    })
+    .catch((error: unknown) => {
+      // Aborted or failed. The context stays put so the shutdown flush can
+      // report the interrupt that most likely caused this.
+      log.debug(`telemetry: send failed: ${error}`);
+      return false;
+    })
+    .finally(() => {
+      inFlight = null;
+    });
+  inFlight = work;
+  await work;
 }
 
 function abortedToResolved(signal: AbortSignal): Promise<void> {
@@ -239,8 +311,8 @@ async function buildAndSend(
     // Only the shutdown flush reports the interrupt, so only it may outlive
     // one. A normal end-of-command flush must stay interruptible: bypassing
     // the signal there would let a Ctrl-C mid-POST record the run's success
-    // event, and `context` is already cleared so the handler cannot replace
-    // it with the abort event.
+    // event. Being aborted is how it hands the run to the shutdown flush,
+    // which finds the context still in place and re-sends it as an abort.
     ignoreInterrupt: outlivesInterrupt,
   });
 }


### PR DESCRIPTION
## Summary

Two reporting gaps left open by #420, both on the Ctrl-C path.

`clerk deploy status` prints nothing at all when an interrupt lands before its wait loop starts. Only the wait was covered by the interrupt catch that #420 added, so an interrupt during application resolution, the preflight DNS check, or the state read escaped uncovered, and `runProgram` returns early without rendering anything. The catch now spans the whole command and emits whatever has been established: a full report once the live state resolves, and a `state: "interrupted"` report before that. The latter asserts nothing about the deploy, so agent-mode stdout stays parseable without claiming there is no production instance — the question an interrupted run never got to answer.

An interrupted run also sent no telemetry event at all. `finalizeAndSendTelemetry` cleared the module context at entry, so a Ctrl-C mid-POST left the shutdown flush with nothing to report and the `outcome: "abort"` event was never sent. The context is now held until a send actually lands, which is enough on its own to keep a run to one event: a normal flush still running when the shutdown flush starts can no longer land, because its POST is composed with the interrupt signal that has already been aborted, and one that landed before the interrupt has already recorded itself. The shutdown flush therefore never waits on the normal one, whose remaining config and Git reads observe no signal and could otherwise burn its entire 250ms budget.

One case is left alone deliberately: a Ctrl-C in the bookkeeping tail after the POST has landed still records the success. That event cannot be retracted, and sending a second would double-count the run.

## Test plan

- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` — 2650 pass, 0 fail