### PR TITLE
feat(api): make the endpoint catalog discoverable from help and 404s

### DIFF
--- a/.changeset/api-endpoint-discoverability.md
+++ b/.changeset/api-endpoint-discoverability.md
@@ -1,0 +1,9 @@
+---
+"clerk": patch
+---
+
+Make the `clerk api` endpoint catalog discoverable from help output and 404 responses.
+
+- Root help now describes `api` as "Call any Clerk API endpoint (200+; `clerk api ls` to browse)" instead of "Make authenticated requests to the Clerk API", and `clerk api --help` explains that this command covers what the dedicated commands do not.
+- `--platform` now explains that the Platform API has its own endpoint list, `clerk api ls` examples say which API they list (they cover the Backend API, not every endpoint), and `clerk api ls --platform` is shown as an example.
+- A 404 with no parsed Clerk error code now suggests `clerk api ls <keyword>` on stderr, leaving stdout as the pipeable response body. The suggestion is scoped per surface: `--platform` appends that flag, and `--fapi` gets none since it has no endpoint catalog.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Commands:
   telemetry                                       Control CLI usage telemetry (status, disable, enable)
   enable                                          Enable Clerk features on the linked instance
   disable                                         Disable Clerk features on the linked instance
-  api              [options] [endpoint] [filter]  Make authenticated requests to the Clerk API
+  api              [options] [endpoint] [filter]  Call any Clerk API endpoint (200+; `clerk api ls` to browse)
   doctor           [options]                      Check your project's Clerk integration health
   mcp                                             Manage the Clerk remote MCP server connection for AI editors and CLIs
   completion       [shell]                        Generate shell autocompletion script

--- a/packages/cli-core/src/commands/api/index.test.ts
+++ b/packages/cli-core/src/commands/api/index.test.ts
@@ -631,6 +631,55 @@ describe("api command", () => {
     expect(captured.out).toContain(JSON.stringify(errorBody, null, 2));
     expect(captured.err).toContain("Failed");
     expect(captured.err).not.toContain("Done");
+    // A structured Clerk error means the endpoint resolved; don't suggest searching.
+    expect(captured.err).not.toContain("clerk api ls");
+  });
+
+  // --- 404 endpoint-search hint ---
+
+  test("suggests the endpoint search on an unstructured 404", async () => {
+    setMode("human");
+    stubFetch(async () => new Response("404 page not found", { status: 404 }));
+
+    await runApi("/organization_role");
+    expect(process.exitCode).toBe(1);
+    expect(captured.err).toContain("If the endpoint path was a guess");
+    expect(captured.err).toContain("clerk api ls <keyword>");
+    // Diagnostics on stderr only; stdout stays the raw response body for piping.
+    expect(captured.out).not.toContain("clerk api ls");
+    expect(captured.out).toContain("404 page not found");
+  });
+
+  test("scopes the endpoint search hint to the platform catalog with --platform", async () => {
+    setMode("human");
+    process.env.CLERK_PLATFORM_API_KEY = "plat_key_123";
+    stubFetch(async () => new Response("404 page not found", { status: 404 }));
+
+    await runApi("/v1/platform/bogus", { platform: true });
+    expect(captured.err).toContain("clerk api ls <keyword> --platform");
+  });
+
+  test("omits the endpoint search hint for FAPI, which has no catalog", async () => {
+    setMode("human");
+    process.env.CLERK_PLATFORM_API_KEY = "ak_test_platform";
+    const pk = `pk_test_${btoa("clerk.example.com$")}`;
+    stubFetch(async (input) => {
+      if (input.toString().includes("/v1/platform/applications/app_1")) {
+        return new Response(
+          JSON.stringify({
+            application_id: "app_1",
+            instances: [
+              { instance_id: "ins_dev", environment_type: "development", publishable_key: pk },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response("404 page not found", { status: 404 });
+    });
+
+    await runApi("/bogus", { fapi: true, app: "app_1", instance: "dev" });
+    expect(captured.err).not.toContain("clerk api ls");
   });
 
   test("shows Paused with instructions when a confirmation prompt is cancelled", async () => {

--- a/packages/cli-core/src/commands/api/index.ts
+++ b/packages/cli-core/src/commands/api/index.ts
@@ -144,6 +144,15 @@ export async function api(
           printHeaders(error.status, error.headers);
         }
         prettyPrint(error.body);
+        // A 404 can mean either "no such endpoint" or "endpoint exists, resource
+        // doesn't", so the wording stays conditional. A parsed Clerk error code is
+        // evidence the request reached the API and was rejected semantically, so we
+        // skip the hint there to keep it off the common resource-not-found path —
+        // a heuristic, not a guarantee. FAPI has no endpoint catalog to search.
+        if (error.status === 404 && error.code === null && !options.fapi) {
+          const scope = options.platform ? " --platform" : "";
+          log.info(`If the endpoint path was a guess, search with: clerk api ls <keyword>${scope}`);
+        }
         process.exitCode = 1;
         closeStatus = "failed";
         return;
@@ -227,7 +236,13 @@ function prettyPrintToStderr(text: string): void {
 export function registerApi(program: Program): void {
   program
     .command("api")
-    .description("Make authenticated requests to the Clerk API")
+    .summary("Call any Clerk API endpoint (200+; `clerk api ls` to browse)")
+    .description(
+      "Call any endpoint in the Clerk API directly.\n\n" +
+        "The other commands cover common operations. This one reaches everything " +
+        "else — invitations and waitlist entries, billing subscriptions and credits, " +
+        "organization roles and permissions, enterprise SSO connections.",
+    )
     .argument(
       "[endpoint]",
       "API endpoint path, 'ls' to list endpoints, or omit for interactive mode",
@@ -240,7 +255,10 @@ export function registerApi(program: Program): void {
     .option("--app <id>", "Application ID to target when resolving keys")
     .option("--secret-key <key>", "Override the secret key")
     .option("--instance <id>", "Instance to target (dev, prod, or instance ID)")
-    .option("--platform", "Use Platform API instead of Backend API")
+    .option(
+      "--platform",
+      "Use the Platform API (applications and instances) instead of the Backend API; has its own endpoint list",
+    )
     .option(
       "--fapi",
       "Use the instance's public Frontend API (unauthenticated endpoints only; host derived from the publishable key)",
@@ -248,8 +266,12 @@ export function registerApi(program: Program): void {
     .option("--dry-run", "Show the request without executing it")
     .option("--yes", "Skip confirmation for mutating requests")
     .setExamples([
-      { command: "clerk api ls", description: "List all available endpoints" },
-      { command: "clerk api ls users", description: 'List endpoints matching "users"' },
+      { command: "clerk api ls", description: "List Backend API endpoints" },
+      { command: "clerk api ls users", description: 'List Backend API endpoints matching "users"' },
+      {
+        command: "clerk api ls --platform",
+        description: "List Platform API endpoints (applications, instances)",
+      },
       { command: "clerk api /users", description: "GET /v1/users" },
       {
         command: 'clerk api /users -d \'{"first_name":"Alice"}\'',


### PR DESCRIPTION
## Why

This came out of a project looking at how coding agents (Claude Code, Cursor, Codex) actually experience the CLI while building apps with Clerk.

The recurring failure isn't agents using commands wrongly — it's agents not finding them, then confidently telling the user a capability is Dashboard-only. Two things compound: our docs describe most features as Dashboard flows (which is what models are trained on and what they consult mid-task), and `clerk api` — the command that actually reaches those capabilities — reads as low-level plumbing in help output. So an agent asked to remove the "Secured by Clerk" badge or set up SAML checks the ~20 named commands, sees nothing, and routes the user to the Dashboard. `POST /saml_connections` was there the whole time.

That failure is commercially nasty because it's invisible: the app still works, the user just did by hand what the CLI could have scripted, and nobody files a bug about it. The agent-driven setup silently degrades into a human-driven one.

This PR is the cheapest slice of the fix — making the capability surface visible from help output and from the moment someone guesses an endpoint wrong. Docs and the skills bundle are the bigger levers and are separate work.

`clerk api` reaches ~239 Backend endpoints plus 51 Platform ones — including things people commonly assume are Dashboard-only (enterprise SSO connections, organization roles and permissions, machines, API keys). The help described it only as *"Make authenticated requests to the Clerk API"*, which reads as low-level plumbing and gives no hint that the catalog is browsable with `clerk api ls`.

## What changed

**1. Root help line.** Split into `.summary()` (root list) and `.description()` (`clerk api --help`) — the custom formatter already supports this via `subcommandDescription()`, so no formatter changes were needed. Says "200+" rather than an exact count so it doesn't go stale.

```
# before
api  [options] [endpoint] [filter]  Make authenticated requests to the Clerk API

# after
api  [options] [endpoint] [filter]  Call any Clerk API endpoint (200+; `clerk api ls` to browse)
```

**2. The two catalogs were conflated.** `clerk api ls` described itself as *"List all available endpoints"* but only lists the 239 Backend endpoints — the 51 Platform ones were invisible unless you already knew to pass `--platform`. Anyone trusting that description would conclude the missing endpoints don't exist.

```
# before
--platform             Use Platform API instead of Backend API
$ clerk api ls         List all available endpoints

# after
--platform             Use the Platform API (applications and instances) instead of
                       the Backend API; has its own endpoint list
$ clerk api ls             List Backend API endpoints
$ clerk api ls --platform  List Platform API endpoints (applications, instances)
```

**3. 404 hint.** On a 404 with no parsed Clerk error code, suggest the endpoint search on **stderr**, keeping stdout as the pipeable response body:

```
If the endpoint path was a guess, search with: clerk api ls <keyword>
```

Wording is conditional because a 404 can also mean the endpoint resolved and the *resource* was missing. The no-error-code check keeps the hint off that common path (`/users/bad_id` returns a structured Clerk error) — a heuristic to reduce noise, not a correctness guarantee, which is why the wording hedges regardless. Scoped per surface: `--platform` appends that flag, `--fapi` gets no hint since it has no catalog.

**4. README.** Updated the published root-help snapshot so GitHub/npm readers don't see text that disagrees with the CLI. That block is maintained by hand and will drift again — worth a follow-up to generate or snapshot-test it.

## Evidence

Tested both root-help descriptions on 6 cold agents given only the help text, asked how they'd accomplish five tasks:

| | current text | new text |
|---|---|---|
| mentioned `clerk api ls` | 0/3 | 3/3 |
| `low` confidence ratings | 4 | 1 |
| produced literally-correct commands | 1 | 3 |

One agent produced `clerk api ls saml`, `clerk api ls role`, and `clerk api ls machine` unprompted — inferring the `ls <keyword>` form from the summary line alone.

Worth stating what this does **not** show: zero agents in either arm said "use the Dashboard." The original hypothesis — that the old text causes agents to wrongly conclude something is Dashboard-only — was not reproduced. The measured effect is narrower: knowing the surface is browsable and how to search it.

## Testing

- New: unstructured 404 emits the hint; `--platform` scopes it; `--fapi` omits it; hint is on stderr and not stdout.
- Updated: the existing `/users/bad_id` test now asserts the hint is **absent** — that's the resource-not-found regression guard.
- `format`, `lint`, `typecheck` clean; 2653 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
