### PR TITLE
ci(lint): catch unawaited promises and unhandled rejections

### DIFF
--- a/.changeset/promise-lint.md
+++ b/.changeset/promise-lint.md
@@ -1,0 +1,7 @@
+---
+"clerk": patch
+---
+
+Stop a failing interrupt sequence from printing an unhandled rejection on Ctrl-C.
+
+The SIGINT handler is async so it can await the telemetry flush that reports the interrupted run, but it was registered directly with `process.on`, which discards a listener's return value. If anything in that sequence rejected — the lazy telemetry import, the flush itself — the failure surfaced as an unhandled rejection stack trace at the exact moment the user was trying to get their shell back, and the process never reached the signal death that a wrapping script reads. The registered listener is now a synchronous wrapper that exits by the route the interrupt calls for even when the sequence fails.

--- a/.claude/rules/interrupts.md
+++ b/.claude/rules/interrupts.md
@@ -141,6 +141,27 @@ SIGINT handler so it can drain in-flight forwards first; before this helper
 existed it called `exitInterrupted` directly, which left the one command most
 likely to actually receive a SIGINT as the one that never reported it.
 
+## Registering a handler
+
+The sequence itself is `runInterruptSequence` — async, because awaiting the
+telemetry flush is what keeps the event loop alive long enough to report the
+run. **Never hand that function to `process.on` directly.** `process.on`
+discards a listener's return value, so a rejection anywhere in the sequence
+becomes an unhandled rejection _during shutdown_, where the user gets a stack
+trace instead of their shell back.
+
+`CLI_SIGINT_HANDLER` is the registration-safe wrapper and the identity that
+gets added and removed:
+
+```ts
+process.on("SIGINT", CLI_SIGINT_HANDLER);
+process.removeListener("SIGINT", CLI_SIGINT_HANDLER); // webhooks listen
+```
+
+It returns `void` and routes a failed sequence to `exitInterrupted` anyway — a
+drain that could not report itself is still an interrupt. Tests that need to
+observe the sequence await `runInterruptSequence()` directly.
+
 ## Printing on the way out
 
 `runProgram` returns early the moment an interrupt is latched, handing

--- a/.claude/rules/promises.md
+++ b/.claude/rules/promises.md
@@ -1,0 +1,99 @@
+---
+description: Type-aware oxlint rules that catch unawaited promises and unhandled rejections, and the Bun-specific gaps they have
+paths:
+  - "packages/*/src/**"
+  - "scripts/**"
+  - "test/e2e/**"
+  - ".oxlintrc.json"
+alwaysApply: false
+---
+
+`bun run lint` runs oxlint with `--type-aware`, which needs type information and
+therefore the `oxlint-tsgolint` companion binary (a devDependency; its version
+tracks the TypeScript version, currently `7.0.2001` against `typescript@7`).
+Without it oxlint fails with `Failed to find tsgolint executable`. The whole
+repo lints in well under a second, so the pass runs everywhere the plain lint
+did: the workspace `lint` scripts, the `nano-staged` pre-commit hook, and CI.
+
+## The rules
+
+| Rule                                      | What it catches                                                                                                                |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `typescript/no-floating-promises`         | A promise nobody awaits, `.catch`es, or `void`s                                                                                |
+| `typescript/no-misused-promises`          | A promise passed where a `void` return is expected — async event listeners, `array.forEach(async …)`, a promise in a condition |
+| `typescript/await-thenable`               | `await` on something that was never a promise                                                                                  |
+| `typescript/return-await`                 | `return await` outside a `try` (redundant) or missing inside one (loses the frame)                                             |
+| `typescript/prefer-promise-reject-errors` | `Promise.reject` with a non-`Error`                                                                                            |
+| `typescript/promise-function-async`       | A function returning a promise that isn't declared `async`                                                                     |
+
+`--type-aware` also switches on several type-aware `correctness` rules unrelated
+to promises (`no-base-to-string`, `restrict-template-expressions`,
+`unbound-method`, …). Those are explicitly `"off"` in `.oxlintrc.json` — they
+have a real backlog and turning them on is a separate decision, not a side
+effect of wanting promise safety.
+
+## Fire-and-forget needs to say so
+
+`no-floating-promises` accepts three endings: `await`, a rejection handler, or an
+explicit `void`. Reach for `void` only where there is genuinely nowhere to
+return the promise — a timer callback, a request handler, a shutdown path that
+has already settled the flow:
+
+```ts
+setTimeout(() => void server?.stop(), 100);
+```
+
+Never register an `async` function as an event listener. `process.on` and
+friends discard the return value, so a rejection lands as an unhandled rejection
+with no context. Wrap it in a synchronous listener that catches — see
+[interrupts.md](./interrupts.md) for the `CLI_SIGINT_HANDLER` shape.
+
+## Where the rules are off, and why
+
+Two rules are disabled for test files (`packages/*/src/**/*.test.ts`,
+`packages/*/src/test/**`, `scripts/**/*.test.ts`, `test/e2e/**`) because Bun's
+own type definitions make them fire on correct code:
+
+- **`await-thenable`** — `bun-types` declares `expect(p).rejects.toThrow()` as
+  returning `void` (`Matchers<unknown>` whose members return `void`), but at
+  runtime it returns a promise; it cannot synchronously inspect a pending one.
+  The `await` is load-bearing. Deleting it, as the rule suggests, turns every
+  rejection test into a silent false pass. 248 sites.
+- **`promise-function-async`** — test stubs are async to match the shape of the
+  API they replace (`ensureMachineUuid: async () => "0000…"`), not because they
+  do async work.
+
+`no-floating-promises` stays **on** in tests, with one allowance:
+`bun:test`'s `mock.module()` is typed as promise-returning but is
+fire-and-forget by design, so it is listed under `allowForKnownSafeCalls`.
+
+`typescript/require-await` is **not enabled anywhere.** It and
+`promise-function-async` are mutually unsatisfiable for a function that must
+return `Promise<T>` but has nothing to await — one shape trips each, and there
+is no third:
+
+```ts
+async scaffold(n: number): Promise<string> { return `a${n}`; }        // require-await
+scaffold(n: number): Promise<string> { return Promise.resolve(`b${n}`); } // promise-function-async
+```
+
+Such functions are common here because callback contracts demand a promise
+(`FrameworkScaffold.scaffold(): Promise<ScaffoldPlan>`,
+`withGutter(fn: (c) => Promise<T>)`).
+
+## Don't `async` a memoized promise getter
+
+`promise-function-async` will flag a getter that hands back a cached promise.
+Adding `async` there allocates a fresh wrapper per call, so
+`getToken() === getToken()` stops holding even though the cache still works.
+`doctor/context.ts` pins that identity in its tests. Suppress instead:
+
+```ts
+// oxlint-disable-next-line typescript/promise-function-async
+function resolveUserAgent(): Promise<string> {
+  userAgentPromise ??= (async () => {
+    /* … */
+  })();
+  return userAgentPromise;
+}
+```

--- a/.claude/rules/promises.md
+++ b/.claude/rules/promises.md
@@ -15,6 +15,30 @@ Without it oxlint fails with `Failed to find tsgolint executable`. The whole
 repo lints in well under a second, so the pass runs everywhere the plain lint
 did: the workspace `lint` scripts, the `nano-staged` pre-commit hook, and CI.
 
+The `lint` scripts also pass
+`--report-unused-disable-directives-severity=error`, so a suppression that has
+outlived its violation fails the build instead of rotting in place. Use the
+`-severity=error` form, not the bare `--report-unused-disable-directives`: that
+one reports at `warning`, and oxlint exits `0` on warnings, so it would never
+gate anything. The pre-commit hook deliberately omits it — it lints only staged
+files, and a directive is not unused just because the line it covers wasn't
+staged.
+
+## Type-aware linting needs a tsconfig that claims the file
+
+tsgolint maps each file to the nearest `tsconfig.json` and builds a program per
+project. A file no tsconfig claims is reported as `Unmatched` and **silently
+skipped** — type-aware rules never run on it, and the exit code stays `0`. Run
+`OXC_LOG=debug bun run lint` and check the `Done assigning files to programs`
+line if you suspect a file is being skipped.
+
+The root `tsconfig.json` is a base config with `"files": []`. It must stay that
+way. Dropping that makes it default to the entire repository, so it becomes the
+fallback project for every unclaimed file and builds a program of ~1300 source
+files where the scoped ones need ~950. New source belongs under a directory an
+existing project already includes (`packages/*/src`, `scripts`, `test/e2e`), or
+it needs its own `tsconfig.json`.
+
 ## The rules
 
 | Rule                                      | What it catches                                                                                                                |

--- a/.claude/rules/promises.md
+++ b/.claude/rules/promises.md
@@ -67,14 +67,25 @@ effect of wanting promise safety.
 
 ## Fire-and-forget needs to say so
 
-`no-floating-promises` accepts three endings: `await`, a rejection handler, or an
-explicit `void`. Reach for `void` only where there is genuinely nowhere to
-return the promise — a timer callback, a request handler, a shutdown path that
-has already settled the flow:
+`no-floating-promises` accepts four endings: `await` it, `return` it, attach a
+rejection handler, or mark it `void`.
+
+The first three keep the rejection reachable. **`void` does not.** It silences
+the diagnostic, not the rejection — a promise that rejects after being `void`ed
+is still an unhandled rejection at runtime, exactly the failure the rest of this
+rule set exists to prevent. Read it as a claim that the promise cannot
+meaningfully fail, not as a way of handling it when it does.
+
+So reach for `void` only where there is genuinely nowhere to return the promise
+_and_ a rejection would be nothing to act on — a timer callback, a request
+handler, a shutdown path that has already settled the flow:
 
 ```ts
 setTimeout(() => void server?.stop(), 100);
 ```
+
+If it can fail in a way anyone would want to know about, attach a `.catch()` and
+log there instead. `void` will not do it for you.
 
 Never register an `async` function as an event listener. `process.on` and
 friends discard the return value, so a rejection lands as an unhandled rejection

--- a/.claude/rules/promises.md
+++ b/.claude/rules/promises.md
@@ -8,12 +8,21 @@ paths:
 alwaysApply: false
 ---
 
-`bun run lint` runs oxlint with `--type-aware`, which needs type information and
+`bun run lint` runs oxlint in type-aware mode, which needs type information and
 therefore the `oxlint-tsgolint` companion binary (a devDependency; its version
 tracks the TypeScript version, currently `7.0.2001` against `typescript@7`).
 Without it oxlint fails with `Failed to find tsgolint executable`. The whole
 repo lints in well under a second, so the pass runs everywhere the plain lint
 did: the workspace `lint` scripts, the `nano-staged` pre-commit hook, and CI.
+
+Type-aware mode is switched on by `options.typeAware` in `.oxlintrc.json`, not by
+a `--type-aware` flag on each script. There are four invocation sites — the root
+`lint`, the two package `lint` scripts, and the `nano-staged` hook — and a flag
+that has to be repeated four times is a flag that drifts. The failure is silent:
+a site that loses it runs zero type-aware rules and still exits `0`. **Only the
+root config may set `options.typeAware`**; oxlint ignores it in nested configs,
+so it has to live in the one config every site resolves to. The package scripts
+pass no `-c` at all and find that config by walking up from their cwd.
 
 The `lint` scripts also pass
 `--report-unused-disable-directives-severity=error`, so a suppression that has

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,5 +1,14 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
+  // Type-aware linting lives here rather than as a `--type-aware` flag on each
+  // `lint` script: there are four invocation sites (root, two packages, the
+  // nano-staged hook) and a rule set this large is only meaningful if every one
+  // of them runs it. A flag that has to be repeated is a flag that drifts, and a
+  // site that loses it fails open — type-aware rules just stop running, exit 0.
+  // Only the root config may set this; nested configs must not.
+  "options": {
+    "typeAware": true
+  },
   "rules": {
     "unicorn/no-process-exit": "error",
     "no-console": "error",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -2,7 +2,24 @@
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "rules": {
     "unicorn/no-process-exit": "error",
-    "no-console": "error"
+    "no-console": "error",
+    "typescript/await-thenable": "error",
+    "typescript/no-floating-promises": [
+      "error",
+      {
+        "allowForKnownSafeCalls": [{ "from": "package", "package": "bun:test", "name": ["module"] }]
+      }
+    ],
+    "typescript/no-misused-promises": "error",
+    "typescript/prefer-promise-reject-errors": "error",
+    "typescript/promise-function-async": "error",
+    "typescript/return-await": "error",
+    "typescript/no-base-to-string": "off",
+    "typescript/no-misused-spread": "off",
+    "typescript/no-redundant-type-constituents": "off",
+    "typescript/no-useless-default-assignment": "off",
+    "typescript/restrict-template-expressions": "off",
+    "typescript/unbound-method": "off"
   },
   "ignorePatterns": ["test/e2e/fixtures/**", "test/e2e/templates/**"],
   "overrides": [
@@ -27,6 +44,18 @@
       ],
       "rules": {
         "no-console": "off"
+      }
+    },
+    {
+      "files": [
+        "packages/*/src/**/*.test.ts",
+        "packages/*/src/test/**",
+        "scripts/**/*.test.ts",
+        "test/e2e/**"
+      ],
+      "rules": {
+        "typescript/await-thenable": "off",
+        "typescript/promise-function-async": "off"
       }
     }
   ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ After modifying files, run these commands to match what CI enforces on pull requ
 
 ```sh
 bun run format       # Format with oxfmt (writes changes)
-bun run lint         # Lint with oxlint
+bun run lint         # Lint with oxlint (type-aware; see .claude/rules/promises.md)
 bun run typecheck    # Type-check all packages and scripts
 bun run test         # Run unit tests
 bun run test:e2e:op  # Run E2E tests with secrets resolved from 1Password (preferred locally)

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "nano-staged": "^1.0.2",
         "oxfmt": "^0.62.0",
         "oxlint": "^1.76.0",
+        "oxlint-tsgolint": "^7.0.2001",
         "playwright": "^1.60.0",
         "semver": "^7.8.5",
         "typescript": "^7",
@@ -200,6 +201,18 @@
     "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.62.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-P9uDDNFRzghO3X8QAzhkjKhK7JvtABsVn8UYtFX7uor12IAnwNt8nNIctvfWj1JkQU/kE+fmLRPiw7XlrIHsZw=="],
 
     "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.62.0", "", { "os": "win32", "cpu": "x64" }, "sha512-dlI5SY7XYQCiCBafntWagCR6HcAJB/NpsLtdlPx8x08+Osz8Ok1HHz1GZuusegCe/VoJ6pAnF5a4pd5OZAq7qQ=="],
+
+    "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@7.0.2001", "", { "os": "darwin", "cpu": "arm64" }, "sha512-CUJEdbSZ54+Xy9OXqOhWLTKZKV0BBiV7C2i/ygyVmXtkUNXx5YCzN8DpSSshTAKktoL7S+tnQ/ftFG/i7X896w=="],
+
+    "@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@7.0.2001", "", { "os": "darwin", "cpu": "x64" }, "sha512-pXfBb5BqONCcgrXQNUZWXgiYmRSWJzd97S8i41VVOh6ut0tyo+cJ5FKFpczDHxiVNfj/3e7c9B4MtztNdpIVCw=="],
+
+    "@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@7.0.2001", "", { "os": "linux", "cpu": "arm64" }, "sha512-roP7zujb/QDPzDwEKsFFpzNHHy91/Y7oX9vQXk78ekyZtcQj1QXDIMH33gjDdHBfRl4K9pZ36xhRgrP4Zr+R8A=="],
+
+    "@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@7.0.2001", "", { "os": "linux", "cpu": "x64" }, "sha512-UDezNqdECVmngu2TPnjaS1YoAmcTaBoI5lV9vk3VahBxoi+I5r9k3iJTT7qZoYWOXTD/7T7bNcwRgrocR6BscQ=="],
+
+    "@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@7.0.2001", "", { "os": "win32", "cpu": "arm64" }, "sha512-uJZhqB6pdXLuN+AD1F5082byyQti/NPmJA77GtcFlmT2HzRelqbNls3SaIqxpjdFgvSBF9g0yOKGBkGFg7kX8Q=="],
+
+    "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@7.0.2001", "", { "os": "win32", "cpu": "x64" }, "sha512-FkDRm8hx9OwzGQqyWG1tO5QrTLRApff9DzSgpz9QZau37BR8d1VYKOxMLGf6shPZntJFoTwIIJYT68VndYDCog=="],
 
     "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.76.0", "", { "os": "android", "cpu": "arm" }, "sha512-ZHIE5Zt9AsPDcY4nOlofXt0YfneEeo+QrKMPcPzLf2Z6Q8VtV2W73d7SFJ920WUwyik783u/doKCs3KXdwG+7w=="],
 
@@ -518,6 +531,8 @@
     "oxfmt": ["oxfmt@0.62.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.62.0", "@oxfmt/binding-android-arm64": "0.62.0", "@oxfmt/binding-darwin-arm64": "0.62.0", "@oxfmt/binding-darwin-x64": "0.62.0", "@oxfmt/binding-freebsd-x64": "0.62.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.62.0", "@oxfmt/binding-linux-arm-musleabihf": "0.62.0", "@oxfmt/binding-linux-arm64-gnu": "0.62.0", "@oxfmt/binding-linux-arm64-musl": "0.62.0", "@oxfmt/binding-linux-ppc64-gnu": "0.62.0", "@oxfmt/binding-linux-riscv64-gnu": "0.62.0", "@oxfmt/binding-linux-riscv64-musl": "0.62.0", "@oxfmt/binding-linux-s390x-gnu": "0.62.0", "@oxfmt/binding-linux-x64-gnu": "0.62.0", "@oxfmt/binding-linux-x64-musl": "0.62.0", "@oxfmt/binding-openharmony-arm64": "0.62.0", "@oxfmt/binding-win32-arm64-msvc": "0.62.0", "@oxfmt/binding-win32-ia32-msvc": "0.62.0", "@oxfmt/binding-win32-x64-msvc": "0.62.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-vxgGHTmnDU9j4CX7dDBLzxgmHxfda/yPcgJkGCMUSCwRmz+euo/V08xXLNgXTeqAB9Fhf3Pe2nO1RNKLCVgphQ=="],
 
     "oxlint": ["oxlint@1.76.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.76.0", "@oxlint/binding-android-arm64": "1.76.0", "@oxlint/binding-darwin-arm64": "1.76.0", "@oxlint/binding-darwin-x64": "1.76.0", "@oxlint/binding-freebsd-x64": "1.76.0", "@oxlint/binding-linux-arm-gnueabihf": "1.76.0", "@oxlint/binding-linux-arm-musleabihf": "1.76.0", "@oxlint/binding-linux-arm64-gnu": "1.76.0", "@oxlint/binding-linux-arm64-musl": "1.76.0", "@oxlint/binding-linux-ppc64-gnu": "1.76.0", "@oxlint/binding-linux-riscv64-gnu": "1.76.0", "@oxlint/binding-linux-riscv64-musl": "1.76.0", "@oxlint/binding-linux-s390x-gnu": "1.76.0", "@oxlint/binding-linux-x64-gnu": "1.76.0", "@oxlint/binding-linux-x64-musl": "1.76.0", "@oxlint/binding-openharmony-arm64": "1.76.0", "@oxlint/binding-win32-arm64-msvc": "1.76.0", "@oxlint/binding-win32-ia32-msvc": "1.76.0", "@oxlint/binding-win32-x64-msvc": "1.76.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-6QoFioEU4fNdiUx/2Eo6TRd6NG7H7njnRCz8rhB66cZmMHDTqcm1Rjvl8Wry+ZTQMBAmyb4Mlf62Mk5X+eHSOw=="],
+
+    "oxlint-tsgolint": ["oxlint-tsgolint@7.0.2001", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "7.0.2001", "@oxlint-tsgolint/darwin-x64": "7.0.2001", "@oxlint-tsgolint/linux-arm64": "7.0.2001", "@oxlint-tsgolint/linux-x64": "7.0.2001", "@oxlint-tsgolint/win32-arm64": "7.0.2001", "@oxlint-tsgolint/win32-x64": "7.0.2001" }, "bin": { "tsgolint": "./bin/tsgolint.js" } }, "sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg=="],
 
     "p-filter": ["p-filter@2.1.0", "", { "dependencies": { "p-map": "^2.0.0" } }, "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw=="],
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:e2e:op": "bun run scripts/run-e2e-op.ts",
     "e2e:refresh-fixtures": "bun run scripts/refresh-e2e-fixtures.ts",
     "typecheck": "bun run --filter './packages/*' typecheck && tsc --noEmit -p scripts/tsconfig.json && tsc --noEmit -p test/e2e/tsconfig.json",
-    "lint": "bun run --filter './packages/*' lint && oxlint -c .oxlintrc.json scripts/ test/e2e/",
+    "lint": "bun run --filter './packages/*' lint && oxlint --type-aware -c .oxlintrc.json scripts/ test/e2e/",
     "format": "bun run --filter './packages/*' format && oxfmt --write scripts/ test/e2e/",
     "format:check": "bun run --filter './packages/*' format:check && oxfmt --check scripts/ test/e2e/",
     "check:patches": "bun run scripts/check-patches.ts",
@@ -38,6 +38,7 @@
     "nano-staged": "^1.0.2",
     "oxfmt": "^0.62.0",
     "oxlint": "^1.76.0",
+    "oxlint-tsgolint": "^7.0.2001",
     "playwright": "^1.60.0",
     "semver": "^7.8.5",
     "typescript": "^7"
@@ -45,7 +46,7 @@
   "nano-staged": {
     "*.{ts,tsx,js,jsx}": [
       "oxfmt --write --no-error-on-unmatched-pattern",
-      "oxlint -c .oxlintrc.json --no-error-on-unmatched-pattern"
+      "oxlint --type-aware -c .oxlintrc.json --no-error-on-unmatched-pattern"
     ],
     "*.{md,json,css}": "oxfmt --write --no-error-on-unmatched-pattern"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:e2e:op": "bun run scripts/run-e2e-op.ts",
     "e2e:refresh-fixtures": "bun run scripts/refresh-e2e-fixtures.ts",
     "typecheck": "bun run --filter './packages/*' typecheck && tsc --noEmit -p scripts/tsconfig.json && tsc --noEmit -p test/e2e/tsconfig.json",
-    "lint": "bun run --filter './packages/*' lint && oxlint --type-aware --report-unused-disable-directives-severity=error -c .oxlintrc.json scripts/ test/e2e/",
+    "lint": "bun run --filter './packages/*' lint && oxlint --report-unused-disable-directives-severity=error -c .oxlintrc.json scripts/ test/e2e/",
     "format": "bun run --filter './packages/*' format && oxfmt --write scripts/ test/e2e/",
     "format:check": "bun run --filter './packages/*' format:check && oxfmt --check scripts/ test/e2e/",
     "check:patches": "bun run scripts/check-patches.ts",
@@ -46,7 +46,7 @@
   "nano-staged": {
     "*.{ts,tsx,js,jsx}": [
       "oxfmt --write --no-error-on-unmatched-pattern",
-      "oxlint --type-aware -c .oxlintrc.json --no-error-on-unmatched-pattern"
+      "oxlint -c .oxlintrc.json --no-error-on-unmatched-pattern"
     ],
     "*.{md,json,css}": "oxfmt --write --no-error-on-unmatched-pattern"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:e2e:op": "bun run scripts/run-e2e-op.ts",
     "e2e:refresh-fixtures": "bun run scripts/refresh-e2e-fixtures.ts",
     "typecheck": "bun run --filter './packages/*' typecheck && tsc --noEmit -p scripts/tsconfig.json && tsc --noEmit -p test/e2e/tsconfig.json",
-    "lint": "bun run --filter './packages/*' lint && oxlint --type-aware -c .oxlintrc.json scripts/ test/e2e/",
+    "lint": "bun run --filter './packages/*' lint && oxlint --type-aware --report-unused-disable-directives-severity=error -c .oxlintrc.json scripts/ test/e2e/",
     "format": "bun run --filter './packages/*' format && oxfmt --write scripts/ test/e2e/",
     "format:check": "bun run --filter './packages/*' format:check && oxfmt --check scripts/ test/e2e/",
     "check:patches": "bun run scripts/check-patches.ts",

--- a/packages/cli-core/package.json
+++ b/packages/cli-core/package.json
@@ -11,7 +11,7 @@
     "build:compile": "bun build --compile --minify --no-compile-autoload-dotenv --no-compile-autoload-bunfig ./src/cli.ts --outfile ./dist/clerk",
     "dev": "bun run ./src/cli.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "lint": "oxlint src/",
+    "lint": "oxlint --type-aware src/",
     "format": "oxfmt --write src/",
     "format:check": "oxfmt --check src/",
     "test": "bun test src/ --parallel"

--- a/packages/cli-core/package.json
+++ b/packages/cli-core/package.json
@@ -11,7 +11,7 @@
     "build:compile": "bun build --compile --minify --no-compile-autoload-dotenv --no-compile-autoload-bunfig ./src/cli.ts --outfile ./dist/clerk",
     "dev": "bun run ./src/cli.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "lint": "oxlint --type-aware src/",
+    "lint": "oxlint --type-aware --report-unused-disable-directives-severity=error src/",
     "format": "oxfmt --write src/",
     "format:check": "oxfmt --check src/",
     "test": "bun test src/ --parallel"

--- a/packages/cli-core/package.json
+++ b/packages/cli-core/package.json
@@ -11,7 +11,7 @@
     "build:compile": "bun build --compile --minify --no-compile-autoload-dotenv --no-compile-autoload-bunfig ./src/cli.ts --outfile ./dist/clerk",
     "dev": "bun run ./src/cli.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "lint": "oxlint --type-aware --report-unused-disable-directives-severity=error src/",
+    "lint": "oxlint --report-unused-disable-directives-severity=error src/",
     "format": "oxfmt --write src/",
     "format:check": "oxfmt --check src/",
     "test": "bun test src/ --parallel"

--- a/packages/cli-core/src/cli.ts
+++ b/packages/cli-core/src/cli.ts
@@ -14,4 +14,4 @@ if (args[0] === "__complete") {
   process.exit(0);
 }
 
-runProgram(createProgram());
+await runProgram(createProgram());

--- a/packages/cli-core/src/commands/api/index.ts
+++ b/packages/cli-core/src/commands/api/index.ts
@@ -48,18 +48,18 @@ async function resolveApiTarget(
   if (options.fapi) {
     const fapiHost = await resolveFapiHost(options);
     const baseUrl = `https://${fapiHost}`;
-    return { baseUrl, runRequest: (req) => fapiRequest({ ...req, fapiHost }) };
+    return { baseUrl, runRequest: async (req) => fapiRequest({ ...req, fapiHost }) };
   }
 
   if (options.platform) {
     const secretKey = await getAuthToken();
     const baseUrl = getPlapiBaseUrl();
-    return { baseUrl, runRequest: (req) => bapiRequest({ ...req, secretKey, baseUrl }) };
+    return { baseUrl, runRequest: async (req) => bapiRequest({ ...req, secretKey, baseUrl }) };
   }
 
   const secretKey = await resolveBapiSecretKey(options);
   const baseUrl = getBapiBaseUrl();
-  return { baseUrl, runRequest: (req) => bapiRequest({ ...req, secretKey, baseUrl }) };
+  return { baseUrl, runRequest: async (req) => bapiRequest({ ...req, secretKey, baseUrl }) };
 }
 
 export async function api(
@@ -127,7 +127,7 @@ export async function api(
 
     // 6. Execute request
     try {
-      const response = await withSpinner("Executing request...", () =>
+      const response = await withSpinner("Executing request...", async () =>
         runRequest({ method, path: endpoint, body: body ?? undefined }),
       );
 

--- a/packages/cli-core/src/commands/apps/list.ts
+++ b/packages/cli-core/src/commands/apps/list.ts
@@ -32,7 +32,7 @@ export async function list(options: AppsOptions = {}): Promise<void> {
   let closeStatus: "success" | "failed" | "paused" | undefined;
 
   try {
-    const fetchApps = () => withApiContext(listApplications(), "Failed to list applications");
+    const fetchApps = async () => withApiContext(listApplications(), "Failed to list applications");
     const result = shouldWrap
       ? await withSpinner("Fetching applications...", fetchApps)
       : await fetchApps();

--- a/packages/cli-core/src/commands/auth/login.test.ts
+++ b/packages/cli-core/src/commands/auth/login.test.ts
@@ -62,7 +62,7 @@ mock.module("../../lib/constants.ts", () => ({
 
 mock.module("../../lib/pkce.ts", () => ({
   generateCodeVerifier: () => "test-code-verifier",
-  generateCodeChallenge: async () => "test-code-challenge",
+  generateCodeChallenge: () => "test-code-challenge",
   generateState: () => "test-state-value",
 }));
 

--- a/packages/cli-core/src/commands/auth/login.ts
+++ b/packages/cli-core/src/commands/auth/login.ts
@@ -56,7 +56,7 @@ interface OAuthFlowResult {
 
 async function performOAuthFlow(): Promise<OAuthFlowResult> {
   const codeVerifier = generateCodeVerifier();
-  const codeChallenge = await generateCodeChallenge(codeVerifier);
+  const codeChallenge = generateCodeChallenge(codeVerifier);
   const state = generateState();
 
   const authServer = startAuthServer(state);
@@ -92,7 +92,7 @@ async function performOAuthFlow(): Promise<OAuthFlowResult> {
   const timeoutMinutes = Math.round(AUTH_TIMEOUT_MS / 60_000);
   log.info(`Waiting for authentication (timeout in ${timeoutMinutes}m)...`);
 
-  const { code } = await withSpinner("Waiting for authentication...", () =>
+  const { code } = await withSpinner("Waiting for authentication...", async () =>
     authServer.waitForCallback().catch((error: unknown) => {
       authServer.stop();
       throw error;
@@ -113,7 +113,7 @@ async function performOAuthFlow(): Promise<OAuthFlowResult> {
     log.debug(`credentials: could not read outgoing session — ${errorMessage(error)}`);
   }
 
-  const tokenResponse = await withSpinner("Completing authentication...", () =>
+  const tokenResponse = await withSpinner("Completing authentication...", async () =>
     exchangeCodeForToken({
       code,
       codeVerifier,
@@ -132,7 +132,9 @@ async function performOAuthFlow(): Promise<OAuthFlowResult> {
 export async function login(options: LoginOptions = {}): Promise<UserInfo> {
   const { showNextSteps = true, yes } = options;
   intro("Signing in");
-  const existingSession = await withSpinner("Checking session...", () => getExistingSession());
+  const existingSession = await withSpinner("Checking session...", async () =>
+    getExistingSession(),
+  );
 
   if (existingSession && !isHuman()) {
     log.success(`Logged in as ${existingSession.email}`);
@@ -166,7 +168,7 @@ export async function login(options: LoginOptions = {}): Promise<UserInfo> {
   // Revoked only after the replacement is safely stored: doing it up front
   // would leave the user with no session at all if the flow were abandoned.
   if (previousSession) {
-    const outcome = await withSpinner("Revoking previous session...", () =>
+    const outcome = await withSpinner("Revoking previous session...", async () =>
       revokeToken(previousSession.refreshToken, "refresh_token"),
     );
     if (outcome === "failed") {
@@ -178,7 +180,7 @@ export async function login(options: LoginOptions = {}): Promise<UserInfo> {
 
   // Best-effort: ensure the user has at least one application so downstream
   // commands (clerk link, clerk init) have something to operate on.
-  await withSpinner("Setting up your default application...", () => ensureFirstApplication());
+  await withSpinner("Setting up your default application...", async () => ensureFirstApplication());
 
   bar();
   log.success(`Logged in as ${userInfo.email}`);

--- a/packages/cli-core/src/commands/auth/logout.ts
+++ b/packages/cli-core/src/commands/auth/logout.ts
@@ -6,7 +6,7 @@ import { NEXT_STEPS } from "../../lib/next-steps.ts";
 
 export async function logout(): Promise<void> {
   intro("Signing out");
-  const outcome = await withSpinner("Revoking session...", () => revokeAndDeleteToken());
+  const outcome = await withSpinner("Revoking session...", async () => revokeAndDeleteToken());
   await clearAuth();
 
   if (outcome === "failed") {

--- a/packages/cli-core/src/commands/config/apply-patch.ts
+++ b/packages/cli-core/src/commands/config/apply-patch.ts
@@ -34,7 +34,9 @@ export async function applyConfigPatch(opts: ApplyPatchOptions): Promise<boolean
 
   const current =
     opts.currentConfig ??
-    (await withSpinner("Fetching current config...", () => readInstanceConfig(target, payload)));
+    (await withSpinner("Fetching current config...", async () =>
+      readInstanceConfig(target, payload),
+    ));
 
   if (!hasConfigChanges(current, payload, true)) {
     log.info(dryRun ? "[dry-run] No changes detected" : "No changes detected");
@@ -60,7 +62,7 @@ export async function applyConfigPatch(opts: ApplyPatchOptions): Promise<boolean
   }
 
   const spinnerMsg = `${dryRun ? "[dry-run] " : ""}${verb} on ${target.label}...`;
-  const result = await withSpinner(spinnerMsg, () =>
+  const result = await withSpinner(spinnerMsg, async () =>
     writeInstanceConfig(target, payload, { method: "PATCH", dryRun, failureContext }),
   );
 

--- a/packages/cli-core/src/commands/config/io.ts
+++ b/packages/cli-core/src/commands/config/io.ts
@@ -49,7 +49,7 @@ export function assertPayloadWritable(
  * has no document, so `scope` selects which resources to read — passing the
  * pending payload keeps the read to the groups being diffed.
  */
-export function readInstanceConfig(
+export async function readInstanceConfig(
   target: InstanceTarget,
   scope: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {

--- a/packages/cli-core/src/commands/config/pull.ts
+++ b/packages/cli-core/src/commands/config/pull.ts
@@ -16,7 +16,7 @@ export async function configPull(options: ConfigPullOptions): Promise<void> {
   await withGutter("Pulling configuration", async () => {
     const target = await resolveInstanceTarget(options);
 
-    const config = await withSpinner(`Pulling config from ${target.label}...`, () =>
+    const config = await withSpinner(`Pulling config from ${target.label}...`, async () =>
       target.kind === "keyless"
         ? pullKeylessConfig(target.keyless, options.keys)
         : withApiContext(

--- a/packages/cli-core/src/commands/config/push.ts
+++ b/packages/cli-core/src/commands/config/push.ts
@@ -73,7 +73,7 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
   let closeStatus: "success" | "failed" | "paused" | undefined;
 
   try {
-    const currentConfig = await withSpinner("Fetching current config...", () =>
+    const currentConfig = await withSpinner("Fetching current config...", async () =>
       readInstanceConfig(target, configPayload),
     );
     delete currentConfig.config_version;
@@ -110,7 +110,7 @@ async function configPush(options: ConfigPushOptions, op: Operation): Promise<vo
     const spinnerMsg = options.dryRun
       ? `[dry-run] Validating config on ${target.label}...`
       : `${op.verb} config on ${target.label}...`;
-    const result = await withSpinner(spinnerMsg, () =>
+    const result = await withSpinner(spinnerMsg, async () =>
       writeInstanceConfig(target, configPayload, {
         method: op.method,
         destructive: options.destructive,

--- a/packages/cli-core/src/commands/deploy/index.ts
+++ b/packages/cli-core/src/commands/deploy/index.ts
@@ -170,7 +170,7 @@ async function startNewDeploy(ctx: DeployContext): Promise<void> {
       "A production instance already exists for this application. Resuming the existing deploy.",
     );
     log.blank();
-    const refreshed = await withSpinner("Refreshing application state...", () =>
+    const refreshed = await withSpinner("Refreshing application state...", async () =>
       resolveLiveApplicationContext(ctx.profile),
     );
     ctx.productionInstanceId = refreshed.productionInstanceId;
@@ -476,7 +476,7 @@ async function pollDeployStatus(
   domain: string,
 ): Promise<DeployStatusOutcome> {
   return waitForDeployStatus(appId, domainIdOrName, domain, {
-    runVerification: (progressLabel, work) => withSpinner(progressLabel, work),
+    runVerification: async (progressLabel, work) => withSpinner(progressLabel, work),
     onVerified: () => log.success(deployComponentLabels("dns", domain).done),
   });
 }

--- a/packages/cli-core/src/commands/deploy/status-command.ts
+++ b/packages/cli-core/src/commands/deploy/status-command.ts
@@ -97,13 +97,13 @@ async function runPreflightDeployStatusCheck(ctx: DeployContext): Promise<boolea
 
   const domainIdOrName = domain.id ?? domain.name;
   await triggerDeployStatusCheck(ctx.appId, domainIdOrName);
-  await withSpinner("Waiting for Clerk DNS check to process...", () =>
+  await withSpinner("Waiting for Clerk DNS check to process...", async () =>
     sleep(DEPLOY_STATUS_PREFLIGHT_DELAY_MS),
   );
   return true;
 }
 
-function runWait(
+async function runWait(
   state: Extract<DeployState, { kind: "active" }>,
   options: { triggerCheck?: boolean; onStatus?: (status: DeployComponentStatus) => void } = {},
 ): Promise<DeployStatusOutcome> {
@@ -115,7 +115,7 @@ function runWait(
     domainIdOrName,
     snapshot.domain,
     {
-      runVerification: (progressLabel, work) => withSpinner(progressLabel, work),
+      runVerification: async (progressLabel, work) => withSpinner(progressLabel, work),
       onVerified: () => {
         if (!isAgent()) log.success(deployComponentLabels("dns", snapshot.domain).done);
       },

--- a/packages/cli-core/src/commands/deploy/status.ts
+++ b/packages/cli-core/src/commands/deploy/status.ts
@@ -107,7 +107,7 @@ export type DiscoveredOAuthProviders = {
 };
 
 export async function resolveDeployContext(): Promise<DeployContext> {
-  const resolved = await withSpinner("Resolving linked Clerk application...", () =>
+  const resolved = await withSpinner("Resolving linked Clerk application...", async () =>
     resolveProfile(process.cwd()),
   );
   if (!resolved) {
@@ -127,7 +127,7 @@ export async function resolveDeployContext(): Promise<DeployContext> {
   return {
     profileKey: resolved.path,
     profile: resolved.profile,
-    ...(await withSpinner("Checking for production instance...", () =>
+    ...(await withSpinner("Checking for production instance...", async () =>
       resolveLiveApplicationContext(resolved.profile),
     )),
   };

--- a/packages/cli-core/src/commands/doctor/checks.ts
+++ b/packages/cli-core/src/commands/doctor/checks.ts
@@ -504,12 +504,13 @@ const SHELL_COMPLETION: Record<
   }
 > = {
   fish: {
-    isInstalled: (home) => Bun.file(join(home, ".config/fish/completions/clerk.fish")).exists(),
+    isInstalled: async (home) =>
+      Bun.file(join(home, ".config/fish/completions/clerk.fish")).exists(),
     remedy:
       "Run `mkdir -p ~/.config/fish/completions && clerk completion fish > ~/.config/fish/completions/clerk.fish`",
   },
   bash: {
-    isInstalled: (home) =>
+    isInstalled: async (home) =>
       fileContains([join(home, ".bashrc"), join(home, ".bash_profile")], "clerk completion"),
     remedy: 'Add `eval "$(clerk completion bash)"` to your ~/.bashrc',
   },

--- a/packages/cli-core/src/commands/doctor/context.ts
+++ b/packages/cli-core/src/commands/doctor/context.ts
@@ -8,6 +8,13 @@ import { log } from "../../lib/log.ts";
 import { CliError, ERROR_CODE, errorMessage } from "../../lib/errors.ts";
 import type { DoctorContext, KeylessInstanceInfo, ResolvedProfile } from "./types.ts";
 
+// Every getter below hands back a memoized promise *by identity*, so that N
+// checks calling `ctx.getToken()` share one credential read. Marking them
+// `async` would wrap the cached promise in a fresh one per call — the cache
+// would still work, but `getToken() === getToken()` would stop holding, which
+// is the property `context.test.ts` pins.
+// oxlint-disable typescript/promise-function-async
+
 export function createDoctorContext(): DoctorContext {
   let tokenPromise: Promise<string | null> | undefined;
   let validTokenPromise: Promise<string | null> | undefined;

--- a/packages/cli-core/src/commands/doctor/index.ts
+++ b/packages/cli-core/src/commands/doctor/index.ts
@@ -69,7 +69,7 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
   }
 
   const ctx = createDoctorContext();
-  const allResults = await withSpinner("Running diagnostics...", () => runChecks(ctx));
+  const allResults = await withSpinner("Running diagnostics...", async () => runChecks(ctx));
 
   if (!options.json) {
     printResults(allResults, options);
@@ -119,7 +119,9 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
       bar();
 
       const verifyCtx = createDoctorContext();
-      const verifyResults = await withSpinner("Verifying fixes...", () => runChecks(verifyCtx));
+      const verifyResults = await withSpinner("Verifying fixes...", async () =>
+        runChecks(verifyCtx),
+      );
       printResults(verifyResults, { ...options, fix: false, spotlight: false });
 
       const hasVerifyFailure = verifyResults.some((r) => r.status === "fail");

--- a/packages/cli-core/src/commands/impersonate/impersonate.ts
+++ b/packages/cli-core/src/commands/impersonate/impersonate.ts
@@ -133,7 +133,7 @@ export async function impersonate(options: ImpersonateOptions = {}): Promise<voi
   let token;
   try {
     token = await withApiContext(
-      withSpinner("Creating impersonation session...", () =>
+      withSpinner("Creating impersonation session...", async () =>
         createActorToken(ctx.secretKey, {
           userId,
           actor: { sub: actor.sub, iss: actor.iss },

--- a/packages/cli-core/src/commands/impersonate/index.ts
+++ b/packages/cli-core/src/commands/impersonate/index.ts
@@ -34,7 +34,7 @@ export function registerImpersonate(program: Program): void {
       },
       { command: "clerk imp revoke act_29w9...", description: "Revoke a pending actor token" },
     ])
-    .action((user, _opts, cmd) =>
+    .action(async (user, _opts, cmd) =>
       impersonate({
         ...(cmd.optsWithGlobals() as Parameters<typeof impersonate>[0]),
         user,
@@ -59,7 +59,7 @@ export function registerImpersonate(program: Program): void {
         description: "Also end the live impersonation session if the token was already accepted",
       },
     ])
-    .action((actorTokenId, _opts, cmd) =>
+    .action(async (actorTokenId, _opts, cmd) =>
       revoke({
         ...(cmd.optsWithGlobals() as Parameters<typeof revoke>[0]),
         actorTokenId,

--- a/packages/cli-core/src/commands/impersonate/revoke.ts
+++ b/packages/cli-core/src/commands/impersonate/revoke.ts
@@ -33,7 +33,7 @@ export async function revoke(options: RevokeOptions): Promise<void> {
   let body;
   try {
     body = await withApiContext(
-      withSpinner(`Revoking actor token ${options.actorTokenId}...`, () =>
+      withSpinner(`Revoking actor token ${options.actorTokenId}...`, async () =>
         revokeActorToken(ctx.secretKey, options.actorTokenId),
       ),
       `Failed to revoke actor token ${options.actorTokenId}`,
@@ -83,7 +83,7 @@ async function revokeImpersonationSessions(
   log.warn("Token already accepted — an active impersonation session exists.");
 
   const sessions = await withApiContext(
-    withSpinner(`Looking up active sessions for ${userId}...`, () =>
+    withSpinner(`Looking up active sessions for ${userId}...`, async () =>
       listUserSessions(secretKey, { userId, status: "active" }),
     ),
     `Failed to list sessions for ${userId}`,

--- a/packages/cli-core/src/commands/init/frameworks/astro.ts
+++ b/packages/cli-core/src/commands/init/frameworks/astro.ts
@@ -84,7 +84,7 @@ function addClerkIntegration(content: string, enableSsr = false): string {
   return result;
 }
 
-function scaffoldConfig(ctx: ProjectContext): Promise<FileAction> {
+async function scaffoldConfig(ctx: ProjectContext): Promise<FileAction> {
   return scaffoldConfigFile(ctx.cwd, {
     candidates: ["astro.config.mjs", "astro.config.ts", "astro.config.js"],
     existsCheck: "@clerk/astro",

--- a/packages/cli-core/src/commands/init/frameworks/fastify.ts
+++ b/packages/cli-core/src/commands/init/frameworks/fastify.ts
@@ -22,5 +22,5 @@ export const fastify: FrameworkScaffold = {
 
   matches: (ctx) => ctx.framework.dep === "fastify",
 
-  scaffold: (ctx) => scaffoldServerFramework(ctx, FASTIFY_CONFIG),
+  scaffold: async (ctx) => scaffoldServerFramework(ctx, FASTIFY_CONFIG),
 };

--- a/packages/cli-core/src/commands/init/frameworks/helpers.ts
+++ b/packages/cli-core/src/commands/init/frameworks/helpers.ts
@@ -613,6 +613,8 @@ export async function scaffoldAuthFiles(
   specs: readonly AuthFileSpec[],
 ): Promise<FileAction[]> {
   return Promise.all(
-    specs.map((spec) => scaffoldAuthFile(cwd, spec.path, spec.content, spec.kind, spec.surface)),
+    specs.map(async (spec) =>
+      scaffoldAuthFile(cwd, spec.path, spec.content, spec.kind, spec.surface),
+    ),
   );
 }

--- a/packages/cli-core/src/commands/init/frameworks/nuxt.ts
+++ b/packages/cli-core/src/commands/init/frameworks/nuxt.ts
@@ -55,7 +55,7 @@ function addNuxtModule(content: string): string {
   }
 }
 
-function scaffoldConfig(ctx: ProjectContext): Promise<FileAction> {
+async function scaffoldConfig(ctx: ProjectContext): Promise<FileAction> {
   return scaffoldConfigFile(ctx.cwd, {
     candidates: ["nuxt.config.ts", "nuxt.config.js"],
     existsCheck: "@clerk/nuxt",

--- a/packages/cli-core/src/commands/init/frameworks/react-router.ts
+++ b/packages/cli-core/src/commands/init/frameworks/react-router.ts
@@ -370,7 +370,7 @@ function shouldEnableV8MiddlewareFlag(ctx: ProjectContext): boolean {
 }
 
 async function scaffoldConfig(ctx: ProjectContext): Promise<FileAction | null> {
-  if (!shouldEnableV8MiddlewareFlag(ctx)) return Promise.resolve(null);
+  if (!shouldEnableV8MiddlewareFlag(ctx)) return null;
 
   return scaffoldConfigFile(ctx.cwd, {
     candidates: ["react-router.config.ts", "react-router.config.js"],

--- a/packages/cli-core/src/commands/init/frameworks/react-router.ts
+++ b/packages/cli-core/src/commands/init/frameworks/react-router.ts
@@ -369,7 +369,7 @@ function shouldEnableV8MiddlewareFlag(ctx: ProjectContext): boolean {
   return major !== null && major < 8;
 }
 
-function scaffoldConfig(ctx: ProjectContext): Promise<FileAction | null> {
+async function scaffoldConfig(ctx: ProjectContext): Promise<FileAction | null> {
   if (!shouldEnableV8MiddlewareFlag(ctx)) return Promise.resolve(null);
 
   return scaffoldConfigFile(ctx.cwd, {

--- a/packages/cli-core/src/commands/init/index.ts
+++ b/packages/cli-core/src/commands/init/index.ts
@@ -313,7 +313,7 @@ async function resolveProjectContext(
     return bootstrapAndDetect(cwd, frameworkOverride, overrides);
   }
 
-  const ctx = await withSpinner("Detecting framework...", () =>
+  const ctx = await withSpinner("Detecting framework...", async () =>
     gatherContext(cwd, frameworkOverride, overrides.pmOverride),
   );
   if (ctx) return { ctx, bootstrap: null };
@@ -516,7 +516,7 @@ async function setupKeylessApp(
       template
         ? `Creating development application (${template})...`
         : "Creating development application...",
-      () => createAccountlessApp(frameworkDep, template),
+      async () => createAccountlessApp(frameworkDep, template),
     );
 
     await writeKeysToEnvFile(cwd, {
@@ -564,7 +564,7 @@ async function detectAndInstall(
   // Non-npm ecosystems (Swift Package Manager, Gradle) can't be installed by a
   // package manager here — the framework's scaffold plan prints install steps.
 
-  return await scaffoldAndWrite(cwd, ctx, skipConfirm);
+  return scaffoldAndWrite(cwd, ctx, skipConfirm);
 }
 
 async function scaffoldAndWrite(
@@ -607,7 +607,7 @@ async function scaffoldAndWrite(
   const writtenFiles = await writePlan(cwd, plan);
   await runFormatters(ctx, writtenFiles);
 
-  const findings = await withSpinner("Scanning for issues...", () =>
+  const findings = await withSpinner("Scanning for issues...", async () =>
     scanForIssues(cwd, ctx.framework.dep),
   );
   printOutro(plan, findings);

--- a/packages/cli-core/src/commands/mcp/clients/cursor.ts
+++ b/packages/cli-core/src/commands/mcp/clients/cursor.ts
@@ -18,5 +18,5 @@ export const cursorClient = makeJsonClient({
   encode: clerkRunDescriptor,
   extractUrl: clerkRunUrl,
   configPath: () => userPath(".cursor", "mcp.json"),
-  detect: () => pathExists(userPath(".cursor")),
+  detect: async () => pathExists(userPath(".cursor")),
 });

--- a/packages/cli-core/src/commands/mcp/clients/make-cli-client.ts
+++ b/packages/cli-core/src/commands/mcp/clients/make-cli-client.ts
@@ -101,8 +101,8 @@ export function makeCliClient(spec: CliClientSpec): McpClient {
     scope: base.scope,
     activation: base.activation,
     configPath: (cwd) => base.configPath(cwd),
-    detect: () => Promise.resolve(findClientBinary(binary) !== null),
-    list: (cwd) => base.list(cwd),
+    detect: async () => Promise.resolve(findClientBinary(binary) !== null),
+    list: async (cwd) => base.list(cwd),
 
     async upsert(entry: McpServerEntry, cwd: string): Promise<UpsertResult> {
       const bin = requireBinary(binary, spec.installHint);

--- a/packages/cli-core/src/commands/mcp/clients/make-cli-client.ts
+++ b/packages/cli-core/src/commands/mcp/clients/make-cli-client.ts
@@ -101,7 +101,7 @@ export function makeCliClient(spec: CliClientSpec): McpClient {
     scope: base.scope,
     activation: base.activation,
     configPath: (cwd) => base.configPath(cwd),
-    detect: async () => Promise.resolve(findClientBinary(binary) !== null),
+    detect: async () => findClientBinary(binary) !== null,
     list: async (cwd) => base.list(cwd),
 
     async upsert(entry: McpServerEntry, cwd: string): Promise<UpsertResult> {

--- a/packages/cli-core/src/commands/mcp/clients/make-client.ts
+++ b/packages/cli-core/src/commands/mcp/clients/make-client.ts
@@ -133,7 +133,7 @@ function makeFileClient(spec: FileClientSpec, codec: ConfigCodec): McpClient {
     scope: spec.scope,
     activation: spec.activation,
     configPath: spec.configPath,
-    detect: spec.detect ?? (() => Promise.resolve(false)),
+    detect: spec.detect ?? (async () => Promise.resolve(false)),
 
     async upsert(entry: McpServerEntry, cwd: string): Promise<UpsertResult> {
       const configPath = spec.configPath(cwd);

--- a/packages/cli-core/src/commands/mcp/clients/make-client.ts
+++ b/packages/cli-core/src/commands/mcp/clients/make-client.ts
@@ -133,7 +133,7 @@ function makeFileClient(spec: FileClientSpec, codec: ConfigCodec): McpClient {
     scope: spec.scope,
     activation: spec.activation,
     configPath: spec.configPath,
-    detect: spec.detect ?? (async () => Promise.resolve(false)),
+    detect: spec.detect ?? (async () => false),
 
     async upsert(entry: McpServerEntry, cwd: string): Promise<UpsertResult> {
       const configPath = spec.configPath(cwd);

--- a/packages/cli-core/src/commands/mcp/clients/opencode.ts
+++ b/packages/cli-core/src/commands/mcp/clients/opencode.ts
@@ -48,5 +48,5 @@ export const opencodeClient = makeJsonClient({
   extractUrl: extractOpencodeUrl,
   isOurs: isOpencodeBridge,
   configPath: () => xdgConfigPath("opencode", "opencode.json"),
-  detect: () => pathExists(xdgConfigPath("opencode")),
+  detect: async () => pathExists(xdgConfigPath("opencode")),
 });

--- a/packages/cli-core/src/commands/mcp/clients/registry.ts
+++ b/packages/cli-core/src/commands/mcp/clients/registry.ts
@@ -40,6 +40,6 @@ export const CLIENT_ALIASES: Readonly<Record<string, ClientId>> = { copilot: "vs
 export const CLIENT_ID_CHOICES: readonly string[] = [...CLIENT_IDS, ...Object.keys(CLIENT_ALIASES)];
 
 export async function detectInstalledClients(cwd: string): Promise<McpClient[]> {
-  const flags = await Promise.all(CLIENTS.map((c) => c.detect(cwd)));
+  const flags = await Promise.all(CLIENTS.map(async (c) => c.detect(cwd)));
   return CLIENTS.filter((_, i) => flags[i]);
 }

--- a/packages/cli-core/src/commands/mcp/clients/warp.ts
+++ b/packages/cli-core/src/commands/mcp/clients/warp.ts
@@ -20,5 +20,5 @@ export const warpClient = makeJsonClient({
   encode: clerkRunDescriptor,
   extractUrl: clerkRunUrl,
   configPath: () => userPath(".warp", ".mcp.json"),
-  detect: () => pathExists(userPath(".warp")),
+  detect: async () => pathExists(userPath(".warp")),
 });

--- a/packages/cli-core/src/commands/mcp/clients/windsurf.ts
+++ b/packages/cli-core/src/commands/mcp/clients/windsurf.ts
@@ -17,5 +17,5 @@ export const windsurfClient = makeJsonClient({
   encode: clerkRunDescriptor,
   extractUrl: clerkRunUrl,
   configPath: () => userPath(".codeium", "windsurf", "mcp_config.json"),
-  detect: () => pathExists(userPath(".codeium", "windsurf")),
+  detect: async () => pathExists(userPath(".codeium", "windsurf")),
 });

--- a/packages/cli-core/src/commands/mcp/collect.ts
+++ b/packages/cli-core/src/commands/mcp/collect.ts
@@ -27,7 +27,7 @@ export interface CollectResult {
 }
 
 export async function collectEntries(cwd: string): Promise<CollectResult> {
-  const settled = await Promise.allSettled(CLIENTS.map((c) => c.list(cwd)));
+  const settled = await Promise.allSettled(CLIENTS.map(async (c) => c.list(cwd)));
   const entries: ListEntry[] = [];
   const failures: CollectFailure[] = [];
   for (const [i, outcome] of settled.entries()) {

--- a/packages/cli-core/src/commands/mcp/index.ts
+++ b/packages/cli-core/src/commands/mcp/index.ts
@@ -56,14 +56,14 @@ export function registerMcp(program: Program): void {
         description: "Install into specific clients",
       },
     ])
-    .action((options) => mcp.install(options));
+    .action(async (options) => mcp.install(options));
 
   mcpCmd
     .command("list")
     .description("List Clerk MCP entries registered across detected clients")
     .option("--json", "Output as JSON")
     .setExamples([{ command: "clerk mcp list", description: "List Clerk entries everywhere" }])
-    .action((options) => mcp.list(options));
+    .action(async (options) => mcp.list(options));
 
   mcpCmd
     .command("run")
@@ -76,7 +76,7 @@ export function registerMcp(program: Program): void {
         description: "Forward stdio JSON-RPC to the remote server",
       },
     ])
-    .action((options) => mcp.run(options));
+    .action(async (options) => mcp.run(options));
 
   mcpCmd
     .command("uninstall")
@@ -104,5 +104,5 @@ export function registerMcp(program: Program): void {
         description: "Remove from Claude Code only",
       },
     ])
-    .action((options) => mcp.uninstall(options));
+    .action(async (options) => mcp.uninstall(options));
 }

--- a/packages/cli-core/src/commands/mcp/install.ts
+++ b/packages/cli-core/src/commands/mcp/install.ts
@@ -77,7 +77,7 @@ export async function mcpInstall(options: McpOptions = {}): Promise<void> {
   await withGutter(
     `Installing Clerk MCP (${cyan(url)})`,
     async ({ setNextSteps }) => {
-      const outcome = await settleClients(clients, (c) => c.upsert({ name, url }, cwd));
+      const outcome = await settleClients(clients, async (c) => c.upsert({ name, url }, cwd));
       const { succeeded, failed } = outcome;
       if (json) {
         log.data(

--- a/packages/cli-core/src/commands/mcp/run.ts
+++ b/packages/cli-core/src/commands/mcp/run.ts
@@ -49,7 +49,7 @@ export async function mcpRun(options: McpOptions = {}, streams: RunStreams = {})
   // Serialize stdout writes: concurrent SSE drains and the server→client stream
   // all emit, and a frame must never interleave with another.
   let writeTail: Promise<void> = Promise.resolve();
-  const emit: Emit = (message) => {
+  const emit: Emit = async (message) => {
     captureProtocolVersion(message, session);
     const line = JSON.stringify(message) + "\n";
     // Swallow write errors (e.g. EPIPE) so one failed frame doesn't wedge the chain.
@@ -73,7 +73,7 @@ export async function mcpRun(options: McpOptions = {}, streams: RunStreams = {})
   const abort = new AbortController();
   // A drain that ends because we're shutting down is expected; anything else is
   // a real (non-fatal) error worth surfacing under --verbose.
-  const suppress = (work: Promise<void>): Promise<void> =>
+  const suppress = async (work: Promise<void>): Promise<void> =>
     work.catch((error: unknown) => {
       if (!abort.signal.aborted)
         log.debug(`mcp run: response drain error — ${errorMessage(error)}`);

--- a/packages/cli-core/src/commands/mcp/uninstall.ts
+++ b/packages/cli-core/src/commands/mcp/uninstall.ts
@@ -54,7 +54,7 @@ async function removeFrom(
   cwd: string,
   json: boolean,
 ): Promise<void> {
-  const outcome = await settleClients(clients, (c) => c.remove(name, cwd));
+  const outcome = await settleClients(clients, async (c) => c.remove(name, cwd));
   const { succeeded, failed } = outcome;
   const results = succeeded.map((s) => s.result);
   const removedCount = results.filter((r) => r.removed).length;

--- a/packages/cli-core/src/commands/open/index.ts
+++ b/packages/cli-core/src/commands/open/index.ts
@@ -156,7 +156,7 @@ async function openKeylessDashboard(
   // missing secret key shouldn't block opening it — it just means the
   // output won't include instance details.
   const instance = await resolveKeylessTarget({ cwd })
-    .then((keyless) => (keyless ? describeKeylessInstance(keyless.secretKey) : null))
+    .then(async (keyless) => (keyless ? describeKeylessInstance(keyless.secretKey) : null))
     .catch(() => null);
 
   // Output strategy mirrors the linked-app flow above:
@@ -215,5 +215,5 @@ export function registerOpen(program: Program): void {
       { command: "clerk open api-keys", description: "Open the API keys page" },
       { command: "clerk open --print", description: "Print the dashboard URL" },
     ])
-    .action((subpath, options) => openDashboard(subpath, options));
+    .action(async (subpath, options) => openDashboard(subpath, options));
 }

--- a/packages/cli-core/src/commands/orgs/index.ts
+++ b/packages/cli-core/src/commands/orgs/index.ts
@@ -77,7 +77,7 @@ export async function orgsDisable(options: OrgsOptions): Promise<void> {
     // applyConfigPatch reads the group it needs on its own.
     const current =
       target.kind === "account"
-        ? await withSpinner("Fetching current config...", () =>
+        ? await withSpinner("Fetching current config...", async () =>
             withApiContext(
               fetchInstanceConfig(target.ctx.appId, target.ctx.instanceId, [
                 "billing",

--- a/packages/cli-core/src/commands/update/index.ts
+++ b/packages/cli-core/src/commands/update/index.ts
@@ -51,7 +51,7 @@ async function resolveTargets(
     safeRealpath(runningPath),
   ]);
 
-  const resolved = await Promise.all(onPath.map((p) => resolveAsdfShim(p)));
+  const resolved = await Promise.all(onPath.map(async (p) => resolveAsdfShim(p)));
   const candidates = onPath.map((displayPath, i) => ({
     displayPath,
     resolvedPath: resolved[i]!,
@@ -262,7 +262,7 @@ export async function update(options: UpdateOptions): Promise<void> {
   if (isHuman()) intro("Checking for updates");
 
   const [latest, installDirs] = await Promise.all([
-    withSpinner("Checking for updates...", () => fetchLatestVersion(channel)).catch(() => {
+    withSpinner("Checking for updates...", async () => fetchLatestVersion(channel)).catch(() => {
       throw new CliError("Could not reach npm registry. Check your network connection.");
     }),
     getInstallerPackageDirs(),
@@ -360,7 +360,7 @@ export async function update(options: UpdateOptions): Promise<void> {
     try {
       await withSpinner(
         `Installing ${packageSpec} via ${owner} (${t.displayPath})...`,
-        () => runGlobalInstall(owner, packageSpec, latest),
+        async () => runGlobalInstall(owner, packageSpec, latest),
         `Updated ${owner}: ${t.displayPath}`,
       );
       results.push({ target: t, ok: true });

--- a/packages/cli-core/src/commands/users/create.ts
+++ b/packages/cli-core/src/commands/users/create.ts
@@ -73,7 +73,7 @@ export async function create(options: CreateUserOptions): Promise<void> {
       }
     }
 
-    const response = await withSpinner("Creating user...", () =>
+    const response = await withSpinner("Creating user...", async () =>
       bapiRequest({
         method: "POST",
         path: "/users",

--- a/packages/cli-core/src/commands/users/index.ts
+++ b/packages/cli-core/src/commands/users/index.ts
@@ -54,7 +54,9 @@ export function registerUsers(program: Program): void {
         description: "Create a user from an inline BAPI request body",
       },
     ])
-    .action((_opts, cmd) => users.menu(cmd.optsWithGlobals() as Parameters<typeof users.menu>[0]));
+    .action(async (_opts, cmd) =>
+      users.menu(cmd.optsWithGlobals() as Parameters<typeof users.menu>[0]),
+    );
 
   usersCommand
     .command("list")
@@ -118,7 +120,9 @@ export function registerUsers(program: Program): void {
         description: "Filter by common identifiers and sort by recent sign-in",
       },
     ])
-    .action((_opts, cmd) => users.list(cmd.optsWithGlobals() as Parameters<typeof users.list>[0]));
+    .action(async (_opts, cmd) =>
+      users.list(cmd.optsWithGlobals() as Parameters<typeof users.list>[0]),
+    );
 
   usersCommand
     .command("create")
@@ -149,7 +153,7 @@ export function registerUsers(program: Program): void {
         description: "Preview a request from a file without executing",
       },
     ])
-    .action((_opts, cmd) =>
+    .action(async (_opts, cmd) =>
       users.create(cmd.optsWithGlobals() as Parameters<typeof users.create>[0]),
     );
 
@@ -176,7 +180,7 @@ export function registerUsers(program: Program): void {
         description: "Print the dashboard URL instead of opening",
       },
     ])
-    .action((userId, _opts, cmd) =>
+    .action(async (userId, _opts, cmd) =>
       users.open({
         ...(cmd.optsWithGlobals() as Parameters<typeof users.open>[0]),
         userId,

--- a/packages/cli-core/src/commands/users/lifecycle-runner.ts
+++ b/packages/cli-core/src/commands/users/lifecycle-runner.ts
@@ -59,7 +59,7 @@ export async function runUserLifecycleCommand(
   }
 
   try {
-    const response = await withSpinner(command.spinnerMessage, () =>
+    const response = await withSpinner(command.spinnerMessage, async () =>
       bapiRequest({
         method: command.method,
         path: command.path,

--- a/packages/cli-core/src/commands/users/list.ts
+++ b/packages/cli-core/src/commands/users/list.ts
@@ -175,7 +175,7 @@ export async function list(options: UsersListOptions = {}): Promise<void> {
     // Request one extra row so we can detect whether more pages exist without
     // a separate /users/count round-trip. The CLI's --limit caps at 250, so
     // pageSize + 1 always fits under BAPI's MaxLimit of 500.
-    const response = await withSpinner("Fetching users...", () =>
+    const response = await withSpinner("Fetching users...", async () =>
       bapiRequest({
         method: "GET",
         path: buildUsersListPath(options, limit + 1),

--- a/packages/cli-core/src/commands/webhooks/index.ts
+++ b/packages/cli-core/src/commands/webhooks/index.ts
@@ -40,7 +40,7 @@ export function registerWebhooks(program: Program): void {
         description: "Generate and pin a token in one step",
       },
     ])
-    .action((_opts, cmd) =>
+    .action(async (_opts, cmd) =>
       webhooksToken(cmd.optsWithGlobals() as Parameters<typeof webhooksToken>[0]),
     );
 
@@ -70,7 +70,7 @@ export function registerWebhooks(program: Program): void {
         description: "Emit NDJSON event lines (pipe into a file for `webhooks verify --delivery`)",
       },
     ])
-    .action((_opts, cmd) =>
+    .action(async (_opts, cmd) =>
       webhooksListen(cmd.optsWithGlobals() as Parameters<typeof webhooksListen>[0]),
     );
 
@@ -98,7 +98,7 @@ export function registerWebhooks(program: Program): void {
         description: "Verify from the four header values",
       },
     ])
-    .action((_opts, cmd) =>
+    .action(async (_opts, cmd) =>
       webhooksVerify(cmd.optsWithGlobals() as Parameters<typeof webhooksVerify>[0]),
     );
 }

--- a/packages/cli-core/src/commands/webhooks/listen.ts
+++ b/packages/cli-core/src/commands/webhooks/listen.ts
@@ -227,7 +227,7 @@ export async function webhooksListen(options: WebhooksListenOptions = {}): Promi
       inFlight.add(task);
       void task.finally(() => inFlight.delete(task));
     },
-    onTokenRotated: (newToken) => {
+    onTokenRotated: async (newToken) => {
       // Persist the new token so the next run reuses it. There's no registered
       // endpoint to re-point (a dashboard endpoint needs a manual URL update
       // after a collision, which is rare).
@@ -245,7 +245,7 @@ export async function webhooksListen(options: WebhooksListenOptions = {}): Promi
 
   // Spinner is a no-op in agent/--json mode (isHuman() guard in lib/spinner.ts),
   // so NDJSON stdout stays clean; on a failed handshake it stops with "Failed".
-  await withSpinner("Connecting to the webhook relay…", () => client.start());
+  await withSpinner("Connecting to the webhook relay…", async () => client.start());
 
   const readyInfo = { relayUrl: relayReceiveUrl(client.token), forwardTo };
   if (ndjson) {

--- a/packages/cli-core/src/commands/webhooks/relay-client.ts
+++ b/packages/cli-core/src/commands/webhooks/relay-client.ts
@@ -51,7 +51,7 @@ export class RelayClient implements IRelayClient {
   }
 
   /** Dial and resolve once the first connection is open and handshaken. */
-  start(): Promise<void> {
+  async start(): Promise<void> {
     const FIRST_CONNECT_TIMEOUT_MS = this.options.firstConnectTimeoutMs ?? 30_000;
     const { promise: opened, resolve, reject } = Promise.withResolvers<void>();
     this.rejectFirstOpen = reject;

--- a/packages/cli-core/src/commands/webhooks/verify.ts
+++ b/packages/cli-core/src/commands/webhooks/verify.ts
@@ -104,7 +104,7 @@ export function parseDeliveryLine(raw: string): DeliveryFields {
 
 async function readFileOrStdin(value: string, flag: string): Promise<string> {
   if (value === "-") {
-    return await Bun.stdin.text();
+    return Bun.stdin.text();
   }
   if (value.startsWith("@")) {
     const path = value.slice(1);

--- a/packages/cli-core/src/commands/whoami/index.ts
+++ b/packages/cli-core/src/commands/whoami/index.ts
@@ -87,7 +87,7 @@ async function resolveIdentity(): Promise<Identity> {
 
   let userInfo;
   try {
-    userInfo = await withSpinner("Fetching account info...", () => fetchUserInfo(token));
+    userInfo = await withSpinner("Fetching account info...", async () => fetchUserInfo(token));
   } catch {
     throw new AuthError({ reason: "session_expired" });
   }
@@ -232,5 +232,5 @@ export function registerWhoami(program: Program): void {
       { command: "clerk whoami", description: "Show your email and linked app" },
       { command: "clerk whoami --json", description: "Emit a structured payload on stdout" },
     ])
-    .action((options) => whoami({ json: options.json }));
+    .action(async (options) => whoami({ json: options.json }));
 }

--- a/packages/cli-core/src/lib/app-picker.ts
+++ b/packages/cli-core/src/lib/app-picker.ts
@@ -29,7 +29,7 @@ export function appLabel(app: Application): string {
  */
 export async function fetchAppsTolerantly(): Promise<Application[]> {
   try {
-    return await withSpinner("Fetching applications...", () =>
+    return await withSpinner("Fetching applications...", async () =>
       withApiContext(listApplications(), "Failed to fetch applications"),
     );
   } catch (error) {

--- a/packages/cli-core/src/lib/auth-server.ts
+++ b/packages/cli-core/src/lib/auth-server.ts
@@ -192,7 +192,10 @@ export function startAuthServer(expectedState: string): AuthServerResult {
         "Authentication timed out. Run `clerk auth login` to try again — if your browser did not open, copy the printed URL into any browser on this machine.",
       ),
     );
-    server?.stop();
+    // `stop()` is a promise nothing can wait on: the login flow has already
+    // settled by every point we close from, and these are timer and request
+    // callbacks with nowhere to return it. Dropped explicitly, here and below.
+    void server?.stop();
   }, AUTH_TIMEOUT_MS);
 
   try {
@@ -212,7 +215,7 @@ export function startAuthServer(expectedState: string): AuthServerResult {
               log.debug(`auth-server: OAuth error in callback — ${error}: ${description}`);
               rejectCallback(new Error(`OAuth error: ${description}`));
               clearTimeout(timeout);
-              setTimeout(() => server?.stop(), 100);
+              setTimeout(() => void server?.stop(), 100);
               return new Response(ERROR_HTML(description), {
                 headers: { "Content-Type": "text/html; charset=utf-8" },
               });
@@ -222,7 +225,7 @@ export function startAuthServer(expectedState: string): AuthServerResult {
               log.debug(`auth-server: state mismatch (expected=${expectedState}, got=${state})`);
               rejectCallback(new Error("Invalid state parameter. Possible CSRF attack."));
               clearTimeout(timeout);
-              setTimeout(() => server?.stop(), 100);
+              setTimeout(() => void server?.stop(), 100);
               return new Response(ERROR_HTML("Invalid state parameter."), {
                 status: 400,
                 headers: { "Content-Type": "text/html; charset=utf-8" },
@@ -233,7 +236,7 @@ export function startAuthServer(expectedState: string): AuthServerResult {
               log.debug("auth-server: callback received with no authorization code");
               rejectCallback(new Error("No authorization code received."));
               clearTimeout(timeout);
-              setTimeout(() => server?.stop(), 100);
+              setTimeout(() => void server?.stop(), 100);
               return new Response(ERROR_HTML("No authorization code received."), {
                 status: 400,
                 headers: { "Content-Type": "text/html; charset=utf-8" },
@@ -243,7 +246,7 @@ export function startAuthServer(expectedState: string): AuthServerResult {
             log.debug("auth-server: callback received with valid code and state");
             resolveCallback({ code });
             clearTimeout(timeout);
-            setTimeout(() => server?.stop(), 100);
+            setTimeout(() => void server?.stop(), 100);
             return new Response(SUCCESS_HTML, {
               headers: { "Content-Type": "text/html; charset=utf-8" },
             });
@@ -273,10 +276,10 @@ export function startAuthServer(expectedState: string): AuthServerResult {
     port: activeServer.port!,
     // The CLI is idle here while the user signs in through their browser, so
     // Ctrl-C is them abandoning the login rather than an interrupted operation.
-    waitForCallback: () => whileAwaitingUser(callbackPromise),
+    waitForCallback: async () => whileAwaitingUser(callbackPromise),
     stop: () => {
       clearTimeout(timeout);
-      activeServer.stop();
+      void activeServer.stop();
     },
   };
 }

--- a/packages/cli-core/src/lib/errors.ts
+++ b/packages/cli-core/src/lib/errors.ts
@@ -498,7 +498,7 @@ export function throwUserAbort(): never {
  * );
  * ```
  */
-export function withApiContext<T>(promise: Promise<T>, context: string): Promise<T> {
+export async function withApiContext<T>(promise: Promise<T>, context: string): Promise<T> {
   return promise.catch((error) => {
     if (error instanceof ApiError) {
       error.context = context;

--- a/packages/cli-core/src/lib/fetch.ts
+++ b/packages/cli-core/src/lib/fetch.ts
@@ -22,6 +22,9 @@ export function _resetUserAgentCache(): void {
   userAgentPromise = undefined;
 }
 
+// Not `async`: the body hands back a memoized promise, and wrapping it per call
+// would allocate a fresh one on every request for no gain.
+// oxlint-disable-next-line typescript/promise-function-async
 function resolveUserAgent(): Promise<string> {
   // The AIAgent segment exists purely for analytics classification, so it
   // honors the telemetry opt-outs (env vars and `clerk telemetry disable`)

--- a/packages/cli-core/src/lib/framework.ts
+++ b/packages/cli-core/src/lib/framework.ts
@@ -212,7 +212,7 @@ async function matchesMarker(cwd: string, marker: string): Promise<boolean> {
 
 async function detectNativeFramework(cwd: string): Promise<FrameworkInfo | null> {
   for (const fw of NATIVE_FRAMEWORK_MAP) {
-    const results = await Promise.all(fw.markers.map((marker) => matchesMarker(cwd, marker)));
+    const results = await Promise.all(fw.markers.map(async (marker) => matchesMarker(cwd, marker)));
     const matched = fw.markers.find((_, i) => results[i]);
     if (matched !== undefined) {
       log.debug(`framework: detected "${fw.name}" via marker "${matched}"`);

--- a/packages/cli-core/src/lib/gradient.ts
+++ b/packages/cli-core/src/lib/gradient.ts
@@ -89,7 +89,7 @@ const colorDisabled = () => "NO_COLOR" in process.env && !forceColor();
 
 const supportsTruecolor = () => /truecolor|24bit/i.test(process.env.COLORTERM ?? "");
 
-const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+const sleep = async (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 let cursorHidden = false;
 let exitGuardRegistered = false;

--- a/packages/cli-core/src/lib/help.ts
+++ b/packages/cli-core/src/lib/help.ts
@@ -27,7 +27,8 @@ const examplesMap = new WeakMap<object, Example[]>();
 
 // Augment Commander's Command type with .setExamples()
 declare module "@commander-js/extra-typings" {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- generics required for declaration merging
+  // The generics are unused here but required: declaration merging only applies
+  // when the augmenting interface's parameter list matches the original's.
   interface Command<Args, Opts, GlobalOpts> {
     setExamples(examples: Example[]): this;
   }

--- a/packages/cli-core/src/lib/host-execution.ts
+++ b/packages/cli-core/src/lib/host-execution.ts
@@ -218,7 +218,7 @@ export function observeHostCapabilityFailure(
 export async function probeHostStateAccess(): Promise<HostStateProbeResult> {
   const failures = (
     await Promise.all(
-      getProbeTargets().map((target) => probeDirectoryWrite(target.label, target.dir)),
+      getProbeTargets().map(async (target) => probeDirectoryWrite(target.label, target.dir)),
     )
   ).filter((failure): failure is HostStateProbeFailure => failure !== null);
 

--- a/packages/cli-core/src/lib/input-json.test.ts
+++ b/packages/cli-core/src/lib/input-json.test.ts
@@ -317,8 +317,8 @@ describe("expandInputJson", () => {
         stderr: "pipe",
       });
 
-      proc.stdin.write(stdinData);
-      proc.stdin.end();
+      await proc.stdin.write(stdinData);
+      await proc.stdin.end();
 
       const stdout = await new Response(proc.stdout).text();
       await proc.exited;

--- a/packages/cli-core/src/lib/installer.ts
+++ b/packages/cli-core/src/lib/installer.ts
@@ -192,17 +192,17 @@ async function queryNpmPackageDir(): Promise<string | null> {
   // (POSIX: `<prefix>/lib/node_modules`; Windows: `<prefix>\node_modules`, no
   // `lib` segment). Constructing the path manually breaks on Windows.
   const dir = await probePmDir(["npm", "root", "-g"]);
-  return dir ? await safeRealpath(dir) : null;
+  return dir ? safeRealpath(dir) : null;
 }
 
 async function queryPnpmPackageDir(): Promise<string | null> {
   const dir = await probePmDir(["pnpm", "root", "-g"]);
-  return dir ? await safeRealpath(dir) : null;
+  return dir ? safeRealpath(dir) : null;
 }
 
 async function queryYarnPackageDir(): Promise<string | null> {
   const dir = await probePmDir(["yarn", "global", "dir"]);
-  return dir ? await safeRealpath(join(dir, "node_modules")) : null;
+  return dir ? safeRealpath(join(dir, "node_modules")) : null;
 }
 
 async function queryBunPackageDir(): Promise<string | null> {
@@ -214,7 +214,7 @@ async function queryBunPackageDir(): Promise<string | null> {
   } catch {
     return null;
   }
-  return await safeRealpath(dir);
+  return safeRealpath(dir);
 }
 
 // ── asdf shim handling ───────────────────────────────────────────────────────

--- a/packages/cli-core/src/lib/pkce.test.ts
+++ b/packages/cli-core/src/lib/pkce.test.ts
@@ -62,7 +62,7 @@ describe("PKCE", () => {
 
   test("generateCodeChallenge produces valid base64url S256 hash", async () => {
     const verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
-    const challenge = await generateCodeChallenge(verifier);
+    const challenge = generateCodeChallenge(verifier);
     // base64url: no +, /, or = padding
     expect(challenge).toMatch(/^[A-Za-z0-9\-_]+$/);
     expect(challenge.length).toBeGreaterThan(0);
@@ -70,14 +70,14 @@ describe("PKCE", () => {
 
   test("generateCodeChallenge is deterministic for same input", async () => {
     const verifier = "test-verifier-value";
-    const a = await generateCodeChallenge(verifier);
-    const b = await generateCodeChallenge(verifier);
+    const a = generateCodeChallenge(verifier);
+    const b = generateCodeChallenge(verifier);
     expect(a).toBe(b);
   });
 
   test("generateCodeChallenge differs for different inputs", async () => {
-    const a = await generateCodeChallenge("verifier-a");
-    const b = await generateCodeChallenge("verifier-b");
+    const a = generateCodeChallenge("verifier-a");
+    const b = generateCodeChallenge("verifier-b");
     expect(a).not.toBe(b);
   });
 

--- a/packages/cli-core/src/lib/pkce.ts
+++ b/packages/cli-core/src/lib/pkce.ts
@@ -22,7 +22,7 @@ export function generateCodeVerifier(): string {
   return verifier.join("");
 }
 
-export async function generateCodeChallenge(verifier: string): Promise<string> {
+export function generateCodeChallenge(verifier: string): string {
   const hasher = new Bun.CryptoHasher("sha256");
   hasher.update(verifier);
   const digest = hasher.digest();

--- a/packages/cli-core/src/lib/plapi.ts
+++ b/packages/cli-core/src/lib/plapi.ts
@@ -298,14 +298,14 @@ async function sendInstanceConfig(
   return response.json() as Promise<Record<string, unknown>>;
 }
 
-export const putInstanceConfig = (
+export const putInstanceConfig = async (
   applicationId: string,
   instanceId: string,
   config: Record<string, unknown>,
   options?: { destructive?: boolean; dryRun?: boolean },
 ) => sendInstanceConfig("PUT", applicationId, instanceId, config, options);
 
-export const patchInstanceConfig = (
+export const patchInstanceConfig = async (
   applicationId: string,
   instanceId: string,
   config: Record<string, unknown>,

--- a/packages/cli-core/src/lib/signals.test.ts
+++ b/packages/cli-core/src/lib/signals.test.ts
@@ -261,4 +261,36 @@ describe("CLI_SIGINT_HANDLER", () => {
 
     expect(await exited).toBe(EXIT_CODE.SIGINT);
   });
+
+  test("plain-exits when the re-raise inside the fallback throws", async () => {
+    // The last line of defence. A failing sequence routes to `exitInterrupted`,
+    // which re-raises via `process.kill` — and if *that* throws (EPERM, ESRCH)
+    // the handler would reject and land as the unhandled rejection the whole
+    // wrapper exists to prevent. Drive it with the escape hatch off so the
+    // re-raise is actually attempted.
+    const exited = stubExitQuietly();
+    const killSpy = spyOn(process, "kill").mockImplementation((() => {
+      throw new Error("kill: operation not permitted");
+    }) as never);
+    // Stubbed so restoring the default disposition cannot strip the runner's
+    // own SIGINT listeners; only the re-raise attempt is under test here.
+    const removeAllSpy = spyOn(process, "removeAllListeners").mockImplementation(
+      (() => process) as never,
+    );
+    mock.module("./telemetry.ts", () => ({
+      finalizeAndSendTelemetry: mock(() => Promise.reject(new Error("flush exploded"))),
+    }));
+
+    try {
+      delete process.env[NO_RERAISE];
+      CLI_SIGINT_HANDLER();
+
+      expect(await exited).toBe(EXIT_CODE.SIGINT);
+      expect(killSpy).toHaveBeenCalled(); // the re-raise was attempted, not skipped
+    } finally {
+      process.env[NO_RERAISE] = "1";
+      removeAllSpy.mockRestore();
+      killSpy.mockRestore();
+    }
+  });
 });

--- a/packages/cli-core/src/lib/signals.test.ts
+++ b/packages/cli-core/src/lib/signals.test.ts
@@ -226,36 +226,39 @@ describe("CLI_SIGINT_HANDLER", () => {
   /**
    * The shared stub throws to make `exitInterrupted` observable, but this
    * handler's whole job is to survive a failing sequence — a throwing exit
-   * would just move the explosion into the fallback. Record instead.
+   * would just move the explosion into the fallback.
+   *
+   * Resolves a promise instead of recording, so the test awaits the exit
+   * itself. Waiting a fixed number of turns would be guessing: the handler's
+   * chain runs a dynamic `import()` of the telemetry module, and how many
+   * turns that costs is not ours to pin.
    */
-  function stubExitQuietly() {
+  function stubExitQuietly(): Promise<number> {
+    const { promise, resolve } = Promise.withResolvers<number>();
     exitSpy.mockRestore();
-    exitSpy = spyOn(process, "exit").mockImplementation((() => undefined) as never);
-    return exitSpy;
+    exitSpy = spyOn(process, "exit").mockImplementation(((code: number) => {
+      resolve(code);
+    }) as never);
+    return promise;
   }
 
-  /** One macrotask, so the handler's promise chain settles. Not `sleep`, which aborts on interrupt. */
-  const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
-
   test("returns void so process.on never sees a promise", async () => {
-    const exit = stubExitQuietly();
+    const exited = stubExitQuietly();
     mock.module("./telemetry.ts", () => ({ finalizeAndSendTelemetry: mock(async () => {}) }));
 
     expect(CLI_SIGINT_HANDLER()).toBeUndefined();
 
-    await tick();
-    expect(exit).toHaveBeenCalledWith(EXIT_CODE.SIGINT);
+    expect(await exited).toBe(EXIT_CODE.SIGINT);
   });
 
   test("a failing interrupt sequence still exits instead of rejecting", async () => {
-    const exit = stubExitQuietly();
+    const exited = stubExitQuietly();
     mock.module("./telemetry.ts", () => ({
       finalizeAndSendTelemetry: mock(() => Promise.reject(new Error("flush exploded"))),
     }));
 
     CLI_SIGINT_HANDLER();
-    await tick();
 
-    expect(exit).toHaveBeenCalledWith(EXIT_CODE.SIGINT);
+    expect(await exited).toBe(EXIT_CODE.SIGINT);
   });
 });

--- a/packages/cli-core/src/lib/signals.test.ts
+++ b/packages/cli-core/src/lib/signals.test.ts
@@ -9,6 +9,7 @@ import {
   exitInterrupted,
   interruptedExitCode,
   interruptSignal,
+  runInterruptSequence,
   whileAwaitingUser,
 } from "./signals.ts";
 
@@ -168,7 +169,7 @@ describe("exitInterrupted", () => {
   });
 });
 
-describe("CLI_SIGINT_HANDLER", () => {
+describe("runInterruptSequence", () => {
   /** `finalizeAndSendTelemetry`'s shape, so `.mock.calls` stays typed. */
   const flushSpy = () => mock(async (_result: { outcome: string; exitCode: number }) => {});
 
@@ -193,7 +194,7 @@ describe("CLI_SIGINT_HANDLER", () => {
 
     try {
       expect(interruptSignal().aborted).toBe(false);
-      await expect(CLI_SIGINT_HANDLER()).rejects.toThrow("process.exit");
+      await expect(runInterruptSequence()).rejects.toThrow("process.exit");
 
       expect(interruptSignal().aborted).toBe(true); // in-flight requests cancelled
       expect(writes.join("")).toContain("\x1b[?25h"); // cursor restored
@@ -214,9 +215,47 @@ describe("CLI_SIGINT_HANDLER", () => {
     mock.module("./telemetry.ts", () => ({ finalizeAndSendTelemetry: flush }));
 
     beginInterrupt(); // stand in for the first press having already landed
-    await expect(CLI_SIGINT_HANDLER()).rejects.toThrow("process.exit");
+    await expect(runInterruptSequence()).rejects.toThrow("process.exit");
 
     expect(flush).not.toHaveBeenCalled();
     expect(exitSpy).toHaveBeenCalledWith(EXIT_CODE.SIGINT);
+  });
+});
+
+describe("CLI_SIGINT_HANDLER", () => {
+  /**
+   * The shared stub throws to make `exitInterrupted` observable, but this
+   * handler's whole job is to survive a failing sequence — a throwing exit
+   * would just move the explosion into the fallback. Record instead.
+   */
+  function stubExitQuietly() {
+    exitSpy.mockRestore();
+    exitSpy = spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    return exitSpy;
+  }
+
+  /** One macrotask, so the handler's promise chain settles. Not `sleep`, which aborts on interrupt. */
+  const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+  test("returns void so process.on never sees a promise", async () => {
+    const exit = stubExitQuietly();
+    mock.module("./telemetry.ts", () => ({ finalizeAndSendTelemetry: mock(async () => {}) }));
+
+    expect(CLI_SIGINT_HANDLER()).toBeUndefined();
+
+    await tick();
+    expect(exit).toHaveBeenCalledWith(EXIT_CODE.SIGINT);
+  });
+
+  test("a failing interrupt sequence still exits instead of rejecting", async () => {
+    const exit = stubExitQuietly();
+    mock.module("./telemetry.ts", () => ({
+      finalizeAndSendTelemetry: mock(() => Promise.reject(new Error("flush exploded"))),
+    }));
+
+    CLI_SIGINT_HANDLER();
+    await tick();
+
+    expect(exit).toHaveBeenCalledWith(EXIT_CODE.SIGINT);
   });
 });

--- a/packages/cli-core/src/lib/signals.ts
+++ b/packages/cli-core/src/lib/signals.ts
@@ -180,16 +180,16 @@ export async function reportAndExitInterrupted(code: number): Promise<never> {
 }
 
 /**
- * The CLI's SIGINT handler. Named (not an inline arrow) so `webhooks listen`
- * can `process.removeListener("SIGINT", CLI_SIGINT_HANDLER)` and install its own
- * graceful-drain handling without disturbing anything else.
+ * The interrupt sequence itself.
  *
  * Async on purpose: awaiting the telemetry flush keeps the event loop alive
  * long enough to report the interrupted run, which `process.exit` from a
  * synchronous handler never could. A second Ctrl-C during that window quits
  * immediately.
+ *
+ * Exported for testing; the process registers {@link CLI_SIGINT_HANDLER}.
  */
-export const CLI_SIGINT_HANDLER = async (): Promise<void> => {
+export const runInterruptSequence = async (): Promise<void> => {
   if (interrupted !== null) return exitInterrupted(interrupted);
   const code = beginInterrupt();
   abortInFlight();
@@ -198,6 +198,24 @@ export const CLI_SIGINT_HANDLER = async (): Promise<void> => {
   // emitting to a terminal; in a pipe or CI log it is just noise.
   if (process.stderr.isTTY) log.ui("\x1b[?25h");
   await reportAndExitInterrupted(code);
+};
+
+/**
+ * The CLI's SIGINT listener. Named (not an inline arrow) so `webhooks listen`
+ * can `process.removeListener("SIGINT", CLI_SIGINT_HANDLER)` and install its own
+ * graceful-drain handling without disturbing anything else.
+ *
+ * Synchronous because `process.on` discards a listener's return value: handing
+ * it {@link runInterruptSequence} directly would leave a rejection — a failed
+ * telemetry import, a throwing flush — as an unhandled rejection *during
+ * shutdown*, where the user sees a stack trace instead of their shell back. The
+ * fallback still exits by the route the interrupt calls for.
+ */
+export const CLI_SIGINT_HANDLER = (): void => {
+  runInterruptSequence().catch((error: unknown) => {
+    log.debug(`signals: interrupt sequence failed — ${String(error)}`);
+    exitInterrupted(interrupted ?? EXIT_CODE.SIGINT);
+  });
 };
 
 /** Test-only: clear every latch, including the controller the signal comes from. */

--- a/packages/cli-core/src/lib/signals.ts
+++ b/packages/cli-core/src/lib/signals.ts
@@ -214,7 +214,16 @@ export const runInterruptSequence = async (): Promise<void> => {
 export const CLI_SIGINT_HANDLER = (): void => {
   runInterruptSequence().catch((error: unknown) => {
     log.debug(`signals: interrupt sequence failed — ${String(error)}`);
-    exitInterrupted(interrupted ?? EXIT_CODE.SIGINT);
+    try {
+      exitInterrupted(interrupted ?? EXIT_CODE.SIGINT);
+    } catch {
+      // The fallback is the one thing here that may not fail: `exitInterrupted`
+      // re-raises through `process.kill`, which can throw (EPERM, ESRCH), and a
+      // throw from this handler rejects the `.catch` chain — landing as exactly
+      // the unhandled-rejection-during-shutdown this wrapper exists to prevent.
+      // Plain-exit instead: the code is still right, only `WIFSIGNALED` is lost.
+      process.exit(EXIT_CODE.SIGINT);
+    }
   });
 };
 

--- a/packages/cli-core/src/lib/skills.ts
+++ b/packages/cli-core/src/lib/skills.ts
@@ -115,7 +115,7 @@ export async function resolveSkillsRunner(
   const preferred = preferredRunner(packageManager, available);
 
   if (interactive && available.length > 1) {
-    return await select<Runner>({
+    return select<Runner>({
       message: "Which package runner should install the skills?",
       choices: available.map((r) => ({
         name: r.id === preferred.id ? `${r.display} ${dim("(detected)")}` : r.display,

--- a/packages/cli-core/src/lib/sleep.ts
+++ b/packages/cli-core/src/lib/sleep.ts
@@ -11,6 +11,6 @@ import { interruptSignal } from "./signals.ts";
  * exit 0 when interrupted mid-countdown, and that command's exit code is what
  * a script reads as "the deploy is complete".
  */
-export function sleep(ms: number): Promise<void> {
+export async function sleep(ms: number): Promise<void> {
   return delay(ms, undefined, { signal: interruptSignal() });
 }

--- a/packages/cli-core/src/lib/spinner.test.ts
+++ b/packages/cli-core/src/lib/spinner.test.ts
@@ -95,21 +95,21 @@ beforeEach(() => {
   stderrChunks = [];
 });
 
-test("intro forwards the title to clack and pushes the gutter prefix", () => {
+test("intro forwards the title to clack and pushes the gutter prefix", async () => {
   expect(isInsideGutter()).toBe(false);
   intro("Welcome");
   expect(introCalls).toBe(1);
   expect(lastIntroTitle).toBe("Welcome");
   expect(isInsideGutter()).toBe(true);
   // Cleanup so other tests don't see prefix leak
-  outro("Done");
+  await outro("Done");
   expect(isInsideGutter()).toBe(false);
 });
 
-test("outro forwards the label to clack and pops the gutter prefix", () => {
+test("outro forwards the label to clack and pops the gutter prefix", async () => {
   intro("Hello");
   expect(isInsideGutter()).toBe(true);
-  outro("All done");
+  await outro("All done");
   expect(outroCalls).toBe(1);
   expect(lastOutroLabel).toBe("All done");
   expect(isInsideGutter()).toBe(false);

--- a/packages/cli-core/src/lib/telemetry.test.ts
+++ b/packages/cli-core/src/lib/telemetry.test.ts
@@ -235,7 +235,7 @@ describe("finalizeAndSendTelemetry", () => {
           landed.push(body);
           return new Response("{}");
         }
-        return await new Promise<Response>((_resolve, reject) => {
+        return new Promise<Response>((_resolve, reject) => {
           const fail = () => reject(new DOMException("The operation was aborted.", "AbortError"));
           const signal = init?.signal;
           if (!signal) return;
@@ -292,7 +292,7 @@ describe("finalizeAndSendTelemetry", () => {
         }
         // Stands in for the config, Git, and user-agent reads a normal flush
         // does around its POST: slow, and blind to the interrupt signal.
-        return await new Promise<Response>(() => {});
+        return new Promise<Response>(() => {});
       }) as unknown as typeof fetch;
       startCommandTelemetry(fakeCommand());
 

--- a/packages/cli-core/src/lib/telemetry.ts
+++ b/packages/cli-core/src/lib/telemetry.ts
@@ -213,7 +213,7 @@ export async function finalizeAndSendTelemetry(
   }
 }
 
-function abortedToResolved(signal: AbortSignal): Promise<void> {
+async function abortedToResolved(signal: AbortSignal): Promise<void> {
   return new Promise((resolve) => {
     if (signal.aborted) return resolve();
     signal.addEventListener("abort", () => resolve(), { once: true });

--- a/packages/cli-core/src/test/integration/lib/harness.ts
+++ b/packages/cli-core/src/test/integration/lib/harness.ts
@@ -251,7 +251,7 @@ mock.module(
   () =>
     ({
       generateCodeVerifier: () => "mock_verifier",
-      generateCodeChallenge: async () => "mock_challenge",
+      generateCodeChallenge: () => "mock_challenge",
       generateState: () => "mock_state",
     }) satisfies typeof import("../../../lib/pkce.ts"),
 );

--- a/packages/extras/package.json
+++ b/packages/extras/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "lint": "oxlint --type-aware src/",
+    "lint": "oxlint --type-aware --report-unused-disable-directives-severity=error src/",
     "format": "oxfmt --write src/",
     "format:check": "oxfmt --check src/"
   },

--- a/packages/extras/package.json
+++ b/packages/extras/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "lint": "oxlint src/",
+    "lint": "oxlint --type-aware src/",
     "format": "oxfmt --write src/",
     "format:check": "oxfmt --check src/"
   },

--- a/packages/extras/package.json
+++ b/packages/extras/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "lint": "oxlint --type-aware --report-unused-disable-directives-severity=error src/",
+    "lint": "oxlint --report-unused-disable-directives-severity=error src/",
     "format": "oxfmt --write src/",
     "format:check": "oxfmt --check src/"
   },

--- a/scripts/cleanup-test-users.ts
+++ b/scripts/cleanup-test-users.ts
@@ -163,5 +163,5 @@ async function main() {
 }
 
 if (import.meta.main) {
-  main();
+  await main();
 }

--- a/scripts/lib/op.ts
+++ b/scripts/lib/op.ts
@@ -98,5 +98,5 @@ export async function runWithOpSecrets(
     env: { ...process.env, OP_ACCOUNT, ...references },
   });
 
-  return await proc.exited;
+  return proc.exited;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,10 @@
 {
+  // Base config only — every real project (packages/*, scripts, test/e2e) extends
+  // this and declares its own `include`. Without `files: []` this would default to
+  // the whole repo, and type-aware oxlint would build a program from it for any
+  // file no other tsconfig claims. Children inherit the empty `files` but supply
+  // their own `include`, which is what populates them.
+  "files": [],
   "compilerOptions": {
     // Environment setup & latest features
     "lib": ["ESNext"],


### PR DESCRIPTION
## Summary

`bun run lint` now runs oxlint in type-aware mode via the `oxlint-tsgolint` companion binary, so it can catch unawaited promises and unhandled rejections. `no-floating-promises` and `no-misused-promises` are the point; `await-thenable`, `return-await`, `prefer-promise-reject-errors`, and `promise-function-async` come along behind them. Type-aware mode is switched on by `options.typeAware` in `.oxlintrc.json` rather than a flag on each `lint` script, because there are four invocation sites and a site that loses the flag runs zero type-aware rules while still exiting 0. The root `tsconfig.json` is now `"files": []`, since a base config with no `include` defaults to the whole repository and becomes the fallback project for every unclaimed file. The `lint` scripts also fail on suppressions that have outlived their violation.

The gate surfaced one real defect. `CLI_SIGINT_HANDLER` was async and registered straight onto `process.on`, which discards a listener's return value, so a rejection in the interrupt sequence became an unhandled rejection during shutdown: a stack trace instead of the user's shell back, and no signal death for a wrapping script to read. It is now a synchronous wrapper around `runInterruptSequence` that catches, and whose fallback plain-exits rather than rejecting if the re-raise itself throws. The rest is mechanical: `void` on fire-and-forget calls, `await` on top-level `runProgram`, dropped redundant `return await`, added `async`.

Two rules are off for test files, since Bun types `expect(p).rejects.toThrow()` as returning `void` when at runtime it returns a promise. `require-await` is omitted entirely because it and `promise-function-async` are mutually unsatisfiable for a function that must return a promise with nothing to await. Full rationale in `.claude/rules/promises.md`.

## Test plan

- [x] `format:check`, `lint`, `typecheck` clean; 2656 unit tests pass
- [x] Gate verified by planting a floating promise under each linted root and confirming all four invocation shapes report it
- [x] Each commit green independently, so the branch stays bisectable
- [ ] E2E not run locally; CI covers it
- Changeset: `clerk` patch
