### PR TITLE
feat(init): add transactional local iOS setup

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -32,9 +32,11 @@
         "clerk": "./src/cli.ts",
       },
       "dependencies": {
+        "@bacons/xcode": "1.0.0-alpha.33",
         "@clack/prompts": "^1.7.0",
         "@clerk/cli-extras": "workspace:*",
         "@commander-js/extra-typings": "^15.0.0",
+        "@expo/plist": "0.0.18",
         "@napi-rs/keyring": "^1.3.0",
         "commander": "^15.0.0",
         "env-paths": "^4.0.0",
@@ -71,6 +73,8 @@
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@bacons/xcode": ["@bacons/xcode@1.0.0-alpha.33", "", { "dependencies": { "@expo/plist": "^0.0.18", "debug": "^4.3.4", "uuid": "^8.3.2" } }, "sha512-+vwXK3mLnW8NOYSHNpCa7sAYR7qWmIHM3xBbBkLailN81F1CdSVsJBH1TAnTMHb+rDEh5ehsZ8AQRNVxvhWR/Q=="],
 
     "@changesets/apply-release-plan": ["@changesets/apply-release-plan@7.1.1", "", { "dependencies": { "@changesets/config": "^3.1.4", "@changesets/get-version-range-type": "^0.4.0", "@changesets/git": "^3.0.4", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "detect-indent": "^6.0.0", "fs-extra": "^7.0.1", "lodash.startcase": "^4.4.0", "outdent": "^0.5.0", "prettier": "^2.7.1", "resolve-from": "^5.0.0", "semver": "^7.5.3" } }, "sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA=="],
 
@@ -121,6 +125,8 @@
     "@clerk/testing": ["@clerk/testing@2.2.19", "", { "dependencies": { "@clerk/backend": "^3.16.1", "@clerk/shared": "^4.27.1", "dotenv": "17.2.2" }, "peerDependencies": { "@playwright/test": "^1", "cypress": "^13 || ^14 || ^15" }, "optionalPeers": ["@playwright/test", "cypress"] }, "sha512-A5dBdHfdNXw70PFeXcDPAonir/bLhblL3sz2NAJZmFOXWwp03rN8IYh8m0E4w4evFOR62vx7E46iJeXMH5MnMg=="],
 
     "@commander-js/extra-typings": ["@commander-js/extra-typings@15.0.0", "", { "peerDependencies": { "commander": "~15.0.0" } }, "sha512-yeJlba62xqmkgELUsn7356MEnzLLu/fw2x4lofFqGnXh6YysRdEs2BaLeLtg1+KU0AXvMeqQvTTp+3hBEBK+EA=="],
+
+    "@expo/plist": ["@expo/plist@0.0.18", "", { "dependencies": { "@xmldom/xmldom": "~0.7.0", "base64-js": "^1.2.3", "xmlbuilder": "^14.0.0" } }, "sha512-+48gRqUiz65R21CZ/IXa7RNBXgAI/uPSdvJqoN9x1hfL44DNbUoWHgHiEXTx7XelcATpDwNTz6sHLfy0iNqf+w=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
@@ -302,6 +308,8 @@
 
     "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
+    "@xmldom/xmldom": ["@xmldom/xmldom@0.7.13", "", {}, "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g=="],
+
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
@@ -315,6 +323,8 @@
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
 
@@ -658,11 +668,15 @@
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
+    "uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
+
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "xmlbuilder": ["xmlbuilder@14.0.0", "", {}, "sha512-ts+B2rSe4fIckR6iquDjsKbQFK2NlUk6iG5nf14mDEyldgoc2nEKZ3jZWMPTxGQwVgToSjt6VGIho1H8/fNFTg=="],
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 

--- a/packages/cli-core/package.json
+++ b/packages/cli-core/package.json
@@ -17,9 +17,11 @@
     "test": "bun test src/ --parallel"
   },
   "dependencies": {
+    "@bacons/xcode": "1.0.0-alpha.33",
     "@clack/prompts": "^1.7.0",
     "@clerk/cli-extras": "workspace:*",
     "@commander-js/extra-typings": "^15.0.0",
+    "@expo/plist": "0.0.18",
     "@napi-rs/keyring": "^1.3.0",
     "commander": "^15.0.0",
     "env-paths": "^4.0.0",

--- a/packages/cli-core/src/commands/init/ios/associated-domain.test.ts
+++ b/packages/cli-core/src/commands/init/ios/associated-domain.test.ts
@@ -1,0 +1,461 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmod, link, lstat, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parse as parsePbxProject } from "@bacons/xcode/json";
+import {
+  applyIOSAssociatedDomain,
+  planIOSAssociatedDomain,
+  prepareIOSAssociatedDomainMutation,
+} from "./associated-domain.ts";
+import {
+  convertIOSFixtureToSynchronizedMissingEntitlements,
+  createIOSFixture,
+  IOS_FIXTURE_IDS,
+  treeDigest,
+} from "./test-helpers.ts";
+import type { PbxObjects } from "./pbx.ts";
+
+const temporaryDirectories: string[] = [];
+const HOST = "direct.clerk.example";
+const KEY = `pk_test_${Buffer.from(`${HOST}$`).toString("base64")}`;
+
+async function temporaryRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "clerk-ios-associated-domain-"));
+  temporaryDirectories.push(root);
+  return root;
+}
+
+function directSource(key = KEY): string {
+  return `import ClerkKit
+import SwiftUI
+
+@main
+struct MyApp: App {
+  init() {
+    Clerk.configure(publishableKey: "${key}")
+  }
+
+  var body: some Scene { WindowGroup { Text("Hello") } }
+}
+`;
+}
+
+async function directFixture(
+  options: Parameters<typeof createIOSFixture>[1] = {},
+): Promise<string> {
+  const root = await temporaryRoot();
+  await createIOSFixture(root, { ...options, includeKey: false });
+  await Bun.write(join(root, "MyApp", "MyAppApp.swift"), directSource());
+  return root;
+}
+
+function planOptions(root: string, deferToPublishableKey = false) {
+  return {
+    root,
+    projectPath: "MyApp.xcodeproj",
+    targetId: IOS_FIXTURE_IDS.appTarget,
+    deferToPublishableKey,
+  };
+}
+
+async function removeAssociatedDomains(root: string, newline = "\n"): Promise<void> {
+  const path = join(root, "MyApp", "MyApp.entitlements");
+  const source = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+    '<plist version="1.0">',
+    "<dict>",
+    "\t<!-- preserve this comment -->",
+    "\t<key>application-identifier</key>",
+    "\t<string>LEGACY1234.com.example.MyApp</string>",
+    "\t<key>com.apple.developer.team-identifier</key>",
+    "\t<string>ABCDE12345</string>",
+    "</dict>",
+    "</plist>",
+    "",
+  ].join(newline);
+  await writeFile(path, source);
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+describe("iOS Associated Domains setup", () => {
+  test("creates and attaches an iOS-only entitlements file for a synchronized multiplatform target", async () => {
+    const root = await directFixture();
+    await convertIOSFixtureToSynchronizedMissingEntitlements(root);
+    const path = join(root, "MyApp", "MyApp.entitlements");
+
+    const plan = await planIOSAssociatedDomain({
+      ...planOptions(root),
+      allowMissingEntitlementsCreation: true,
+    });
+    expect(plan).toMatchObject({
+      status: "ready",
+      files: [{ path: "MyApp/MyApp.entitlements", operation: "create" }],
+      missingEntitlementsSettings: {
+        status: "ready",
+        buildSettingPath: "MyApp/MyApp.entitlements",
+      },
+    });
+    expect(JSON.stringify(plan)).not.toContain(KEY);
+
+    const result = await applyIOSAssociatedDomain(plan);
+    expect(result.status).toBe("applied");
+    const entitlements = await readFile(path, "utf8");
+    expect(entitlements).toContain(`<string>webcredentials:${HOST}</string>`);
+    expect(entitlements).not.toContain("application-identifier");
+    expect((await lstat(path)).mode & 0o7777).toBe(0o644);
+
+    const archive = parsePbxProject(
+      await readFile(join(root, "MyApp.xcodeproj", "project.pbxproj"), "utf8"),
+    ) as unknown as { objects: PbxObjects };
+    for (const id of [IOS_FIXTURE_IDS.targetDebug, IOS_FIXTURE_IDS.targetRelease]) {
+      const settings = archive.objects[id]!.buildSettings as Record<string, unknown>;
+      expect(settings.CODE_SIGN_ENTITLEMENTS).toBeUndefined();
+      expect(settings["CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]"]).toBe("MyApp/MyApp.entitlements");
+      expect(settings["CODE_SIGN_ENTITLEMENTS[sdk=iphonesimulator*]"]).toBe(
+        "MyApp/MyApp.entitlements",
+      );
+      expect(settings["CODE_SIGN_ENTITLEMENTS[sdk=macosx*]"]).toBe("MyApp/MyApp.mac.entitlements");
+    }
+
+    const digest = await treeDigest(root);
+    const rerun = await planIOSAssociatedDomain(planOptions(root));
+    expect(rerun.status).toBe("satisfied");
+    expect((await applyIOSAssociatedDomain(rerun)).status).toBe("satisfied");
+    expect(await treeDigest(root)).toEqual(digest);
+  });
+
+  test("plans and applies the exact domain to an existing XML entitlements file", async () => {
+    const root = await directFixture();
+    const path = join(root, "MyApp", "MyApp.entitlements");
+    await removeAssociatedDomains(root, "\r\n");
+    await chmod(path, 0o640);
+
+    const plan = await planIOSAssociatedDomain(planOptions(root));
+
+    expect(plan).toMatchObject({
+      status: "ready",
+      expectedDomain: `webcredentials:${HOST}`,
+      requiresPublishableKey: false,
+      files: [{ path: "MyApp/MyApp.entitlements" }],
+    });
+    const result = await applyIOSAssociatedDomain(plan);
+    const source = await readFile(path, "utf8");
+    expect(result.status).toBe("applied");
+    expect(source).toContain(`\t\t<string>webcredentials:${HOST}</string>`);
+    expect(source).toContain("<!-- preserve this comment -->");
+    expect(source).toContain("\r\n");
+    expect((await lstat(path)).mode & 0o7777).toBe(0o640);
+    expect(JSON.stringify({ plan, result })).not.toContain(KEY);
+
+    const digest = await treeDigest(root);
+    const secondPlan = await planIOSAssociatedDomain(planOptions(root));
+    expect(secondPlan.status).toBe("satisfied");
+    expect((await applyIOSAssociatedDomain(secondPlan)).status).toBe("satisfied");
+    expect(await treeDigest(root)).toEqual(digest);
+  });
+
+  test("adds a bare entry while preserving Apple's developer-mode entry", async () => {
+    const root = await directFixture();
+    const path = join(root, "MyApp", "MyApp.entitlements");
+    const source = await readFile(path, "utf8");
+    await writeFile(
+      path,
+      source.replace("webcredentials:clerk.example.test", `webcredentials:${HOST}?mode=developer`),
+    );
+
+    const plan = await planIOSAssociatedDomain(planOptions(root));
+    const result = await applyIOSAssociatedDomain(plan);
+    const updated = await readFile(path, "utf8");
+
+    expect(plan.status).toBe("ready");
+    expect(result.status).toBe("applied");
+    expect(updated).toContain(`webcredentials:${HOST}?mode=developer`);
+    expect(updated).toContain(`webcredentials:${HOST}`);
+  });
+
+  test("preserves a multiline nonempty array's closing line and indentation", async () => {
+    const root = await directFixture();
+    const path = join(root, "MyApp", "MyApp.entitlements");
+    const compact =
+      "<key>com.apple.developer.associated-domains</key><array><string>webcredentials:clerk.example.test</string></array>";
+    const existingBlock = [
+      "\t<key>com.apple.developer.associated-domains</key>",
+      "\t<array>",
+      "\t\t<string>webcredentials:clerk.example.test</string>",
+      "\t</array>",
+    ].join("\n");
+    const source = (await readFile(path, "utf8")).replace(compact, existingBlock);
+    await writeFile(path, source);
+
+    const plan = await planIOSAssociatedDomain(planOptions(root));
+    const result = await applyIOSAssociatedDomain(plan);
+    const expectedBlock = existingBlock.replace(
+      "\t</array>",
+      `\t\t<string>webcredentials:${HOST}</string>\n\t</array>`,
+    );
+
+    expect(plan.status).toBe("ready");
+    expect(result.status).toBe("applied");
+    expect(await readFile(path, "utf8")).toBe(source.replace(existingBlock, expectedBlock));
+  });
+
+  test("patches every distinct existing entitlements file", async () => {
+    const root = await directFixture();
+    const projectPath = join(root, "MyApp.xcodeproj", "project.pbxproj");
+    await removeAssociatedDomains(root);
+    await writeFile(
+      join(root, "MyApp", "MyApp-Release.entitlements"),
+      (await readFile(join(root, "MyApp", "MyApp.entitlements"), "utf8")).replace(
+        "preserve this comment",
+        "release comment",
+      ),
+    );
+    const project = await readFile(projectPath, "utf8");
+    const releaseMarker = `${IOS_FIXTURE_IDS.targetRelease} = { isa = XCBuildConfiguration;`;
+    const releaseStart = project.indexOf(releaseMarker);
+    expect(releaseStart).toBeGreaterThan(-1);
+    const nextObject = project.indexOf("\n    ", releaseStart + releaseMarker.length);
+    const releaseObject = project.slice(releaseStart, nextObject);
+    await writeFile(
+      projectPath,
+      `${project.slice(0, releaseStart)}${releaseObject.replace(
+        "CODE_SIGN_ENTITLEMENTS = MyApp/MyApp.entitlements;",
+        "CODE_SIGN_ENTITLEMENTS = MyApp/MyApp-Release.entitlements;",
+      )}${project.slice(nextObject)}`,
+    );
+
+    const plan = await planIOSAssociatedDomain(planOptions(root));
+    const result = await applyIOSAssociatedDomain(plan);
+
+    expect(plan.files.map((file) => file.path)).toEqual([
+      "MyApp/MyApp-Release.entitlements",
+      "MyApp/MyApp.entitlements",
+    ]);
+    expect(result.status).toBe("applied");
+    for (const file of plan.files) {
+      expect(await readFile(join(root, file.path), "utf8")).toContain(`webcredentials:${HOST}`);
+    }
+  });
+
+  test("blocks distinct selected-target paths that hardlink the same entitlements file", async () => {
+    const root = await directFixture();
+    const projectPath = join(root, "MyApp.xcodeproj", "project.pbxproj");
+    const debugEntitlements = join(root, "MyApp", "MyApp.entitlements");
+    const releaseEntitlements = join(root, "MyApp", "MyApp-Release.entitlements");
+    await removeAssociatedDomains(root);
+    await link(debugEntitlements, releaseEntitlements);
+    const project = await readFile(projectPath, "utf8");
+    const releaseMarker = `${IOS_FIXTURE_IDS.targetRelease} = { isa = XCBuildConfiguration;`;
+    const releaseStart = project.indexOf(releaseMarker);
+    expect(releaseStart).toBeGreaterThan(-1);
+    const nextObject = project.indexOf("\n    ", releaseStart + releaseMarker.length);
+    const releaseObject = project.slice(releaseStart, nextObject);
+    await writeFile(
+      projectPath,
+      `${project.slice(0, releaseStart)}${releaseObject.replace(
+        "CODE_SIGN_ENTITLEMENTS = MyApp/MyApp.entitlements;",
+        "CODE_SIGN_ENTITLEMENTS = MyApp/MyApp-Release.entitlements;",
+      )}${project.slice(nextObject)}`,
+    );
+
+    const before = await treeDigest(root);
+    const plan = await planIOSAssociatedDomain(planOptions(root));
+
+    expect(plan.status).toBe("blocked");
+    expect(plan.blockers).toContainEqual(expect.objectContaining({ code: "shared-entitlements" }));
+    expect(await treeDigest(root)).toEqual(before);
+  });
+
+  test("blocks an entitlements file referenced by a target in another Xcode project", async () => {
+    const root = await directFixture();
+    const secondaryRoot = join(root, "Secondary");
+    const secondaryProjectPath = join(secondaryRoot, "MyApp.xcodeproj", "project.pbxproj");
+    const secondaryTargetId = "919191919191919191919191";
+    await createIOSFixture(secondaryRoot, { includeKey: false });
+    const secondaryProject = (await readFile(secondaryProjectPath, "utf8"))
+      .replaceAll(IOS_FIXTURE_IDS.appTarget, secondaryTargetId)
+      .replaceAll(
+        "CODE_SIGN_ENTITLEMENTS = MyApp/MyApp.entitlements;",
+        "CODE_SIGN_ENTITLEMENTS = ../MyApp/MyApp.entitlements;",
+      );
+    await writeFile(secondaryProjectPath, secondaryProject);
+
+    const before = await treeDigest(root);
+    const plan = await planIOSAssociatedDomain(planOptions(root));
+
+    expect(plan.status).toBe("blocked");
+    expect(plan.blockers).toContainEqual(expect.objectContaining({ code: "shared-entitlements" }));
+    expect(await treeDigest(root)).toEqual(before);
+  });
+
+  test("blocks nested selected projects owned by XcodeGen or Tuist", async () => {
+    for (const [marker, contents] of [
+      ["project.yml", "name: MyApp\n"],
+      ["Project.swift", "import ProjectDescription\n"],
+    ] as const) {
+      const root = await temporaryRoot();
+      const nestedRoot = join(root, "ios");
+      await createIOSFixture(nestedRoot, { includeKey: false });
+      await writeFile(join(nestedRoot, "MyApp", "MyAppApp.swift"), directSource());
+      await writeFile(join(nestedRoot, marker), contents);
+      const before = await treeDigest(root);
+
+      const plan = await planIOSAssociatedDomain({
+        root,
+        projectPath: "ios/MyApp.xcodeproj",
+        targetId: IOS_FIXTURE_IDS.appTarget,
+      });
+
+      expect(plan.status).toBe("blocked");
+      expect(plan.blockers).toContainEqual(expect.objectContaining({ code: "generated-project" }));
+      expect(await treeDigest(root)).toEqual(before);
+    }
+  });
+
+  test("preauthorizes a redacted deferred host for the aggregate direct-config transaction", async () => {
+    const root = await temporaryRoot();
+    await createIOSFixture(root, { includeKey: false });
+    await removeAssociatedDomains(root);
+
+    const plan = await planIOSAssociatedDomain(planOptions(root, true));
+    const prepared = await prepareIOSAssociatedDomainMutation(plan, KEY);
+
+    expect(plan).toMatchObject({
+      status: "ready",
+      requiresPublishableKey: true,
+    });
+    expect(plan.expectedDomain).toBeUndefined();
+    expect(prepared.status).toBe("ready");
+    expect(JSON.stringify({ plan, prepared })).not.toContain(KEY);
+    expect(JSON.stringify(prepared)).not.toContain("candidateBytes");
+  });
+
+  test("returns stale when the selected target's inline key host changes after planning", async () => {
+    const root = await directFixture();
+    const path = join(root, "MyApp", "MyApp.entitlements");
+    await removeAssociatedDomains(root);
+    const originalEntitlements = await readFile(path, "utf8");
+    const plan = await planIOSAssociatedDomain(planOptions(root));
+    const newerKey = `pk_test_${Buffer.from("newer.clerk.example$").toString("base64")}`;
+    await writeFile(join(root, "MyApp", "MyAppApp.swift"), directSource(newerKey));
+
+    const prepared = await prepareIOSAssociatedDomainMutation(plan);
+
+    expect(prepared.status).toBe("stale");
+    expect(await readFile(path, "utf8")).toBe(originalEntitlements);
+  });
+
+  test("blocks mixed, malformed, binary, and symlinked entitlements without writing", async () => {
+    const mixed = await directFixture({ releaseEntitlements: false });
+    expect((await planIOSAssociatedDomain(planOptions(mixed))).blockers[0]?.code).toBe(
+      "mixed-entitlements",
+    );
+
+    const malformed = await directFixture();
+    await writeFile(join(malformed, "MyApp", "MyApp.entitlements"), "<plist><dict>");
+    expect((await planIOSAssociatedDomain(planOptions(malformed))).blockers[0]?.code).toBe(
+      "unreadable-entitlements",
+    );
+
+    const binary = await directFixture();
+    await writeFile(join(binary, "MyApp", "MyApp.entitlements"), "bplist00not-real");
+    expect((await planIOSAssociatedDomain(planOptions(binary))).blockers[0]?.code).toBe(
+      "unsupported-entitlements",
+    );
+
+    const linked = await directFixture();
+    const target = join(linked, "MyApp", "MyApp.entitlements");
+    const real = join(linked, "MyApp", "Real.entitlements");
+    await writeFile(real, await readFile(target));
+    await rm(target);
+    await symlink(real, target);
+    const before = await treeDigest(linked);
+    expect((await planIOSAssociatedDomain(planOptions(linked))).blockers[0]?.code).toBe(
+      "unsupported-entitlements",
+    );
+    expect(await treeDigest(linked)).toEqual(before);
+  });
+
+  test("blocks an entity-encoded Associated Domains key without rewriting it", async () => {
+    const root = await directFixture();
+    const path = join(root, "MyApp", "MyApp.entitlements");
+    const encoded = (await readFile(path, "utf8")).replace(
+      "com.apple.developer.associated-domains",
+      "com.apple.developer.associated&#45;domains",
+    );
+    await writeFile(path, encoded);
+    const before = await treeDigest(root);
+
+    const plan = await planIOSAssociatedDomain(planOptions(root));
+    const result = await applyIOSAssociatedDomain(plan);
+
+    expect(plan.status).toBe("blocked");
+    expect(plan.blockers).toContainEqual(
+      expect.objectContaining({ code: "unsupported-entitlements" }),
+    );
+    expect(result.status).toBe("blocked");
+    expect(await readFile(path, "utf8")).toBe(encoded);
+    expect(await treeDigest(root)).toEqual(before);
+  });
+
+  test("blocks literal and entity-encoded duplicate Associated Domains keys", async () => {
+    const root = await directFixture();
+    const path = join(root, "MyApp", "MyApp.entitlements");
+    const literal =
+      "<key>com.apple.developer.associated-domains</key><array><string>webcredentials:clerk.example.test</string></array>";
+    const encoded =
+      "<key>com.apple.developer.associated&#45;domains</key><array><string>applinks:preserve.example</string></array>";
+    const source = (await readFile(path, "utf8")).replace(literal, `${encoded}${literal}`);
+    await writeFile(path, source);
+
+    const plan = await planIOSAssociatedDomain(planOptions(root));
+
+    expect(plan.status).toBe("blocked");
+    expect(plan.blockers).toContainEqual(
+      expect.objectContaining({ code: "unsupported-entitlements" }),
+    );
+    expect(await readFile(path, "utf8")).toBe(source);
+  });
+
+  test("blocks an entitlements file shared by another native target", async () => {
+    const root = await directFixture({ secondTarget: true });
+    const projectPath = join(root, "MyApp.xcodeproj", "project.pbxproj");
+    await removeAssociatedDomains(root);
+    let project = await readFile(projectPath, "utf8");
+    for (const id of [IOS_FIXTURE_IDS.secondDebug, IOS_FIXTURE_IDS.secondRelease]) {
+      const marker = `${id} = { isa = XCBuildConfiguration; buildSettings = { `;
+      project = project.replace(
+        marker,
+        `${marker}CODE_SIGN_ENTITLEMENTS = MyApp/MyApp.entitlements; `,
+      );
+    }
+    await writeFile(projectPath, project);
+
+    const before = await treeDigest(root);
+    const plan = await planIOSAssociatedDomain(planOptions(root));
+
+    expect(plan.status).toBe("blocked");
+    expect(plan.blockers).toContainEqual(expect.objectContaining({ code: "shared-entitlements" }));
+    expect(await treeDigest(root)).toEqual(before);
+  });
+
+  test("returns stale and preserves newer bytes", async () => {
+    const root = await directFixture();
+    const path = join(root, "MyApp", "MyApp.entitlements");
+    await removeAssociatedDomains(root);
+    const plan = await planIOSAssociatedDomain(planOptions(root));
+    await writeFile(path, "newer user bytes\n");
+
+    const result = await applyIOSAssociatedDomain(plan);
+
+    expect(result.status).toBe("stale");
+    expect(await readFile(path, "utf8")).toBe("newer user bytes\n");
+  });
+});

--- a/packages/cli-core/src/commands/init/ios/associated-domain.ts
+++ b/packages/cli-core/src/commands/init/ios/associated-domain.ts
@@ -1,0 +1,1044 @@
+import { lstat, readFile, realpath } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { parse as parsePbxProject } from "@bacons/xcode/json";
+import plist from "@expo/plist";
+import { decodePublishableKey } from "../../../lib/fapi.ts";
+import { inspectTargetBuildConfigurations } from "./build-settings.ts";
+import {
+  discoverIOSContainers,
+  inspectWorkspace,
+  pathIsSafelyWithinIOSRoot,
+  relativeIOSPath,
+} from "./discovery.ts";
+import {
+  applyIOSFileTransaction,
+  hashIOSFileBytes,
+  type IOSCreateFileMutation,
+  type IOSExistingFileMutation,
+  type IOSFileMutation,
+} from "./file-transaction.ts";
+import {
+  planIOSMissingEntitlementsSettings,
+  prepareIOSMissingEntitlementsSettingsMutation,
+  validateIOSMissingEntitlementsSettingsPostcondition,
+  type IOSMissingEntitlementsSettingsPlan,
+} from "./entitlements-settings.ts";
+import { inspectIOSProject } from "./inspect.ts";
+import {
+  asString,
+  asStringArray,
+  buildPbxParentIndex,
+  isRecord,
+  type PbxObject,
+  type PbxObjects,
+} from "./pbx.ts";
+import type { IOSAppTarget, IOSDiagnostic, IOSProjectInspectionResult } from "./types.ts";
+
+const ASSOCIATED_DOMAINS_KEY = "com.apple.developer.associated-domains";
+const MAX_ENTITLEMENTS_BYTES = 1_000_000;
+
+export type IOSAssociatedDomainBlockerCode =
+  | "invalid-selection"
+  | "generated-project"
+  | "runtime-key-unproven"
+  | "missing-entitlements"
+  | "mixed-entitlements"
+  | "unresolved-entitlements"
+  | "unsafe-entitlements"
+  | "unreadable-entitlements"
+  | "unsupported-entitlements"
+  | "shared-entitlements"
+  | "stale-entitlements";
+
+export interface IOSAssociatedDomainBlocker {
+  code: IOSAssociatedDomainBlockerCode;
+  message: string;
+}
+
+export interface IOSAssociatedDomainPlanFile {
+  /** Invocation-root-relative path. */
+  path: string;
+  operation: "create" | "modify";
+  expectedHash?: string;
+}
+
+export interface IOSAssociatedDomainPlan {
+  schemaVersion: 1;
+  kind: "clerk-ios-associated-domain";
+  status: "ready" | "satisfied" | "blocked";
+  root: string;
+  projectPath: string;
+  targetId: string;
+  targetName?: string;
+  /** Public Frontend API hostname only. A publishable key is never retained. */
+  expectedDomain?: string;
+  /** True when the exact domain will be derived from the in-memory development key after auth. */
+  requiresPublishableKey: boolean;
+  files: IOSAssociatedDomainPlanFile[];
+  /** PBX settings needed only when the target has no entitlements file yet. */
+  missingEntitlementsSettings?: IOSMissingEntitlementsSettingsPlan;
+  actions: string[];
+  blockers: IOSAssociatedDomainBlocker[];
+}
+
+export interface IOSAssociatedDomainPlanOptions {
+  root: string;
+  /** Invocation-root-relative selected .xcodeproj path. */
+  projectPath: string;
+  targetId: string;
+  /** A separately proven direct Swift configuration will supply the runtime key after auth. */
+  deferToPublishableKey?: boolean;
+  /** Allows the strict synchronized-root planner to create and attach a new file. */
+  allowMissingEntitlementsCreation?: boolean;
+}
+
+export type PreparedIOSAssociatedDomainMutation =
+  | {
+      status: "satisfied";
+      plan: IOSAssociatedDomainPlan;
+      expectedDomain: string;
+    }
+  | { status: "blocked"; plan: IOSAssociatedDomainPlan }
+  | { status: "stale"; plan: IOSAssociatedDomainPlan }
+  | {
+      status: "ready";
+      plan: IOSAssociatedDomainPlan;
+      expectedDomain: string;
+      /** @internal Candidate bytes must never be serialized into output or telemetry. */
+      mutations: IOSFileMutation[];
+      /** True when mutations contains the caller's PBX candidate after semantic composition. */
+      consumesBasePbxMutation: boolean;
+    };
+
+export interface IOSAssociatedDomainApplyResult {
+  status: "applied" | "satisfied" | "blocked" | "stale" | "rolled-back";
+  plan: IOSAssociatedDomainPlan;
+  message?: string;
+}
+
+interface EntitlementsFile {
+  absolutePath: string;
+  relativePath: string;
+  bytes: Uint8Array;
+  hash: string;
+  mode: number;
+  source: string;
+  bom: boolean;
+  domains: string[];
+}
+
+function blocker(
+  code: IOSAssociatedDomainBlockerCode,
+  message: string,
+): IOSAssociatedDomainBlocker {
+  return { code, message };
+}
+
+function blockedPlan(
+  options: IOSAssociatedDomainPlanOptions,
+  blockers: IOSAssociatedDomainBlocker[],
+  targetName?: string,
+): IOSAssociatedDomainPlan {
+  return {
+    schemaVersion: 1,
+    kind: "clerk-ios-associated-domain",
+    status: "blocked",
+    root: resolve(options.root),
+    projectPath: options.projectPath,
+    targetId: options.targetId,
+    ...(targetName ? { targetName } : {}),
+    requiresPublishableKey: options.deferToPublishableKey === true,
+    files: [],
+    actions: [],
+    blockers,
+  };
+}
+
+function selectedTarget(
+  inspection: IOSProjectInspectionResult,
+  projectPath: string,
+  targetId: string,
+): IOSAppTarget | undefined {
+  const selection = inspection.selection;
+  if (
+    selection.state !== "selected" ||
+    selection.projectPath !== projectPath ||
+    selection.targetId !== targetId
+  ) {
+    return undefined;
+  }
+  return inspection.appTargets.find(
+    (target) => target.projectPath === projectPath && target.id === targetId,
+  );
+}
+
+function runtimeFrontendHost(
+  inspection: IOSProjectInspectionResult,
+  target: IOSAppTarget,
+): string | undefined {
+  const key = inspection.localPublishableKey;
+  if (!key.found || key.conflict || !key.source || !key.frontendApiHost) return undefined;
+  const source = key.source;
+  const connected = target.swift.configureCalls.some((call) => {
+    if (call.startupBinding !== "app-init") return false;
+    if (call.publishableKeyWiring === "inline-literal") {
+      return call.path === source && call.inlinePublishableKey?.state === "valid";
+    }
+    if (call.publishableKeyWiring === "local-secrets-loader") {
+      return (
+        call.localSecretsRuntimeBinding === "proven" &&
+        target.runtimeKeySinks.some((sink) => sink.path === source)
+      );
+    }
+    return call.publishableKeyWiring === "process-info-environment" && source.endsWith(".xcscheme");
+  });
+  return connected ? key.frontendApiHost : undefined;
+}
+
+function stripXMLCommentsPreservingOffsets(source: string): string {
+  return source.replace(/<!--[\s\S]*?-->/g, (comment) => " ".repeat(comment.length));
+}
+
+function countAssociatedDomainKeys(source: string): number {
+  const structural = stripXMLCommentsPreservingOffsets(source);
+  return [
+    ...structural.matchAll(/<key\b[^>]*>\s*com\.apple\.developer\.associated-domains\s*<\/key>/g),
+  ].length;
+}
+
+function decodeXMLText(value: string): string | undefined {
+  if (/[<>]/.test(value)) return undefined;
+  let unsupported = false;
+  const decoded = value.replace(
+    /&(?:#x([0-9a-f]+)|#([0-9]+)|(amp|lt|gt|quot|apos));/gi,
+    (_entity, hex: string | undefined, decimal: string | undefined, named: string | undefined) => {
+      if (hex) return String.fromCodePoint(Number.parseInt(hex, 16));
+      if (decimal) return String.fromCodePoint(Number.parseInt(decimal, 10));
+      if (named === "amp") return "&";
+      if (named === "lt") return "<";
+      if (named === "gt") return ">";
+      if (named === "quot") return '"';
+      if (named === "apos") return "'";
+      unsupported = true;
+      return "";
+    },
+  );
+  if (unsupported || /&[^;\s]*;/.test(decoded)) return undefined;
+  return decoded;
+}
+
+function associatedDomainKeyStructure(source: string): {
+  semanticCount: number;
+  safelyDecoded: boolean;
+} {
+  const structural = stripXMLCommentsPreservingOffsets(source);
+  let semanticCount = 0;
+  let safelyDecoded = true;
+  for (const match of structural.matchAll(/<key\b[^>]*>([\s\S]*?)<\/key>/g)) {
+    const decoded = decodeXMLText(match[1] ?? "");
+    if (decoded == null) {
+      safelyDecoded = false;
+      continue;
+    }
+    if (decoded.trim() === ASSOCIATED_DOMAINS_KEY) semanticCount += 1;
+  }
+  return { semanticCount, safelyDecoded };
+}
+
+function hasUnresolvedDomain(value: string): boolean {
+  return /\$\([^)]+\)|\$\{[^}]+\}/.test(value);
+}
+
+async function inspectEntitlementsFile(
+  root: string,
+  absolutePath: string,
+): Promise<{ file?: EntitlementsFile; blocker?: IOSAssociatedDomainBlocker }> {
+  if (!(await pathIsSafelyWithinIOSRoot(root, absolutePath))) {
+    return {
+      blocker: blocker(
+        "unsafe-entitlements",
+        `${relativeIOSPath(root, absolutePath)} resolves outside the inspected project root.`,
+      ),
+    };
+  }
+
+  try {
+    const info = await lstat(absolutePath);
+    if (!info.isFile() || info.isSymbolicLink() || info.size > MAX_ENTITLEMENTS_BYTES) {
+      return {
+        blocker: blocker(
+          "unsupported-entitlements",
+          `${relativeIOSPath(
+            root,
+            absolutePath,
+          )} must be a regular, non-symlink XML plist no larger than 1 MB.`,
+        ),
+      };
+    }
+    const bytes = new Uint8Array(await readFile(absolutePath));
+    if (new TextDecoder().decode(bytes.slice(0, 8)).startsWith("bplist")) {
+      return {
+        blocker: blocker(
+          "unsupported-entitlements",
+          `${relativeIOSPath(
+            root,
+            absolutePath,
+          )} is a binary plist. Save it as XML before automatic setup.`,
+        ),
+      };
+    }
+    const bom = bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf;
+    const textBytes = bom ? bytes.slice(3) : bytes;
+    const source = new TextDecoder("utf-8", { fatal: true }).decode(textBytes);
+    const parsed: unknown = plist.parse(source);
+    if (!isRecord(parsed)) throw new Error("plist root is not a dictionary");
+    const rawDomains = parsed[ASSOCIATED_DOMAINS_KEY];
+    const structuralKeyCount = countAssociatedDomainKeys(source);
+    const semanticKeyStructure = associatedDomainKeyStructure(source);
+    if (
+      rawDomains !== undefined &&
+      (!Array.isArray(rawDomains) || rawDomains.some((value) => typeof value !== "string"))
+    ) {
+      return {
+        blocker: blocker(
+          "unsupported-entitlements",
+          `${relativeIOSPath(root, absolutePath)} has a non-string Associated Domains value.`,
+        ),
+      };
+    }
+    if (
+      !semanticKeyStructure.safelyDecoded ||
+      semanticKeyStructure.semanticCount > 1 ||
+      structuralKeyCount > 1 ||
+      (rawDomains !== undefined &&
+        (structuralKeyCount !== 1 || semanticKeyStructure.semanticCount !== 1)) ||
+      (rawDomains === undefined &&
+        (structuralKeyCount !== 0 || semanticKeyStructure.semanticCount !== 0))
+    ) {
+      return {
+        blocker: blocker(
+          "unsupported-entitlements",
+          `${relativeIOSPath(
+            root,
+            absolutePath,
+          )} does not contain one safely editable literal Associated Domains key.`,
+        ),
+      };
+    }
+    const domains = (rawDomains as string[] | undefined) ?? [];
+    if (domains.some(hasUnresolvedDomain)) {
+      return {
+        blocker: blocker(
+          "unresolved-entitlements",
+          `${relativeIOSPath(
+            root,
+            absolutePath,
+          )} contains Associated Domains entries with unresolved build settings.`,
+        ),
+      };
+    }
+    return {
+      file: {
+        absolutePath,
+        relativePath: relativeIOSPath(root, absolutePath),
+        bytes,
+        hash: hashIOSFileBytes(bytes),
+        mode: info.mode & 0o7777,
+        source,
+        bom,
+        domains,
+      },
+    };
+  } catch {
+    return {
+      blocker: blocker(
+        "unreadable-entitlements",
+        `${relativeIOSPath(root, absolutePath)} could not be read as a UTF-8 XML plist dictionary.`,
+      ),
+    };
+  }
+}
+
+function normalizeObjects(value: unknown): PbxObjects | undefined {
+  if (!isRecord(value)) return undefined;
+  const objects: PbxObjects = {};
+  for (const [id, object] of Object.entries(value)) {
+    if (isRecord(object)) objects[id] = object as PbxObject;
+  }
+  return objects;
+}
+
+async function ownershipIsExclusive(
+  root: string,
+  projectPath: string,
+  selectedTargetId: string,
+  selectedFiles: readonly EntitlementsFile[],
+): Promise<boolean> {
+  try {
+    const selectedCanonical = new Set<string>();
+    const selectedInodes = new Set<string>();
+    for (const file of selectedFiles) {
+      const canonical = await realpath(file.absolutePath);
+      const info = await lstat(file.absolutePath);
+      const inode = `${info.dev}:${info.ino}`;
+      // Two selected configuration paths that resolve to the same file are
+      // not independent transaction targets. Refuse both symlink/canonical
+      // aliases and hard-link aliases rather than silently splitting them.
+      if (selectedCanonical.has(canonical) || selectedInodes.has(inode)) return false;
+      selectedCanonical.add(canonical);
+      selectedInodes.add(inode);
+    }
+
+    const selectedProject = resolve(root, projectPath);
+    const discovered = await discoverIOSContainers(root);
+    const projectPaths = new Set([...discovered.projectPaths, selectedProject]);
+    for (const workspacePath of discovered.workspacePaths) {
+      const workspace = await inspectWorkspace(root, workspacePath);
+      for (const localProjectPath of workspace.localProjectPaths) {
+        projectPaths.add(localProjectPath);
+      }
+    }
+    for (const absoluteProject of [...projectPaths].sort()) {
+      const pbxprojPath = resolve(absoluteProject, "project.pbxproj");
+      if (!(await pathIsSafelyWithinIOSRoot(root, pbxprojPath))) return false;
+      const bytes = new Uint8Array(await readFile(pbxprojPath));
+      if (bytes.byteLength > 15_000_000) return false;
+      const archive = parsePbxProject(new TextDecoder().decode(bytes));
+      const objects = normalizeObjects(archive.objects);
+      if (!objects) return false;
+      const rootObjectId = asString(archive.rootObject);
+      const projectObject =
+        (rootObjectId ? objects[rootObjectId] : undefined) ??
+        Object.values(objects).find((object) => object.isa === "PBXProject");
+      if (projectObject?.isa !== "PBXProject") return false;
+      const parents = buildPbxParentIndex(objects);
+      const groupRootDirectory = resolve(
+        dirname(absoluteProject),
+        asString(projectObject.projectDirPath) ?? "",
+      );
+
+      for (const targetId of asStringArray(projectObject.targets)) {
+        if (absoluteProject === selectedProject && targetId === selectedTargetId) continue;
+        const targetObject = objects[targetId];
+        if (targetObject?.isa !== "PBXNativeTarget") continue;
+        const diagnostics: IOSDiagnostic[] = [];
+        const configurations = await inspectTargetBuildConfigurations({
+          root,
+          projectPath: absoluteProject,
+          groupRootDirectory,
+          projectObject,
+          targetId,
+          targetObject,
+          objects,
+          parents,
+          diagnostics,
+        });
+        if (diagnostics.some((diagnostic) => diagnostic.severity === "error")) return false;
+        for (const configuration of configurations) {
+          const resolution = configuration.model.entitlementsPath;
+          if (resolution.state === "unresolved") return false;
+          if (resolution.state !== "resolved") continue;
+          const siblingPath = resolve(dirname(absoluteProject), resolution.value);
+          if (!(await pathIsSafelyWithinIOSRoot(root, siblingPath))) return false;
+          try {
+            const canonical = await realpath(siblingPath);
+            const info = await lstat(siblingPath);
+            if (selectedCanonical.has(canonical) || selectedInodes.has(`${info.dev}:${info.ino}`)) {
+              return false;
+            }
+          } catch {
+            // A missing sibling entitlements path cannot currently alias an existing selected file.
+          }
+        }
+      }
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function exactDomainPresent(domains: readonly string[], expectedDomain: string): boolean {
+  return domains.includes(expectedDomain);
+}
+
+async function generatedProjectKind(
+  root: string,
+  absoluteProjectPath: string,
+): Promise<"xcodegen" | "tuist" | null> {
+  let directory = dirname(absoluteProjectPath);
+  while (await pathIsSafelyWithinIOSRoot(root, directory)) {
+    for (const [relativePath, kind] of [
+      ["project.yml", "xcodegen"],
+      ["Project.swift", "tuist"],
+      ["Workspace.swift", "tuist"],
+      ["Tuist/ProjectDescriptionHelpers", "tuist"],
+    ] as const) {
+      const marker = resolve(directory, relativePath);
+      if ((await pathIsSafelyWithinIOSRoot(root, marker)) && (await Bun.file(marker).exists())) {
+        return kind;
+      }
+    }
+    if (directory === root) break;
+    const parent = dirname(directory);
+    if (parent === directory) break;
+    directory = parent;
+  }
+  return null;
+}
+
+/**
+ * Plans the conservative v1 Associated Domains edit. It only patches existing
+ * XML entitlements files that cover every selected-target configuration.
+ */
+export async function planIOSAssociatedDomain(
+  options: IOSAssociatedDomainPlanOptions,
+): Promise<IOSAssociatedDomainPlan> {
+  const root = resolve(options.root);
+  const inspection = await inspectIOSProject(root, {
+    target: options.targetId,
+  });
+  const target = selectedTarget(inspection, options.projectPath, options.targetId);
+  if (!target) {
+    return blockedPlan(options, [
+      blocker("invalid-selection", "The selected iOS target could not be resolved exactly."),
+    ]);
+  }
+  const generator =
+    inspection.generatedProject ??
+    (await generatedProjectKind(root, resolve(root, options.projectPath)));
+  if (generator) {
+    return blockedPlan(
+      options,
+      [
+        blocker(
+          "generated-project",
+          `This is a ${
+            generator === "xcodegen" ? "XcodeGen" : "Tuist"
+          } project; update its source manifest instead of generated entitlements.`,
+        ),
+      ],
+      target.name,
+    );
+  }
+
+  const host = runtimeFrontendHost(inspection, target);
+  if (!host && !options.deferToPublishableKey) {
+    return blockedPlan(
+      options,
+      [
+        blocker(
+          "runtime-key-unproven",
+          "The exact Frontend API host is not connected to a proven selected-target runtime key.",
+        ),
+      ],
+      target.name,
+    );
+  }
+
+  if (target.configurations.length === 0) {
+    return blockedPlan(
+      options,
+      [
+        blocker(
+          "missing-entitlements",
+          "The selected target has no inspectable build configurations.",
+        ),
+      ],
+      target.name,
+    );
+  }
+  const expectedDomain = host ? `webcredentials:${host}` : undefined;
+  const resolvedPaths = target.configurations.flatMap((configuration) =>
+    configuration.entitlementsPath.state === "resolved"
+      ? [configuration.entitlementsPath.value]
+      : [],
+  );
+  if (resolvedPaths.length === 0) {
+    if (
+      target.configurations.some(
+        (configuration) => configuration.entitlementsPath.state !== "missing",
+      )
+    ) {
+      return blockedPlan(
+        options,
+        [
+          blocker(
+            "unresolved-entitlements",
+            "One or more CODE_SIGN_ENTITLEMENTS settings could not be resolved exactly.",
+          ),
+        ],
+        target.name,
+      );
+    }
+    if (options.allowMissingEntitlementsCreation) {
+      const settingsPlan = await planIOSMissingEntitlementsSettings({
+        root,
+        projectPath: options.projectPath,
+        targetId: options.targetId,
+      });
+      if (settingsPlan.status === "ready" && settingsPlan.entitlementsPath) {
+        return {
+          schemaVersion: 1,
+          kind: "clerk-ios-associated-domain",
+          status: "ready",
+          root,
+          projectPath: options.projectPath,
+          targetId: options.targetId,
+          targetName: target.name,
+          ...(expectedDomain ? { expectedDomain } : {}),
+          requiresPublishableKey: expectedDomain == null,
+          files: [{ path: settingsPlan.entitlementsPath, operation: "create" }],
+          missingEntitlementsSettings: settingsPlan,
+          actions: [
+            expectedDomain
+              ? `Create ${settingsPlan.entitlementsPath} with ${expectedDomain}.`
+              : `Create ${settingsPlan.entitlementsPath} with the linked development instance's exact webcredentials host (resolved after authentication).`,
+            `Attach ${settingsPlan.entitlementsPath} only to iPhone and iPad SDK builds for every selected-target configuration.`,
+          ],
+          blockers: [],
+        };
+      }
+      return blockedPlan(
+        options,
+        settingsPlan.blockers.length > 0
+          ? settingsPlan.blockers.map((item) => blocker("missing-entitlements", item.message))
+          : [
+              blocker(
+                "missing-entitlements",
+                "The missing-entitlements plan did not identify one safe destination.",
+              ),
+            ],
+        target.name,
+      );
+    }
+    return blockedPlan(
+      options,
+      [
+        blocker(
+          "missing-entitlements",
+          "No selected-target configuration has an existing entitlements file, and this runtime route cannot safely create one automatically.",
+        ),
+      ],
+      target.name,
+    );
+  }
+  if (resolvedPaths.length !== target.configurations.length) {
+    return blockedPlan(
+      options,
+      [
+        blocker(
+          "mixed-entitlements",
+          "Some selected-target configurations have entitlements while others do not. Choose the intended files in Xcode before automatic setup.",
+        ),
+      ],
+      target.name,
+    );
+  }
+  if (
+    target.configurations.some(
+      (configuration) => configuration.entitlementsPath.state !== "resolved",
+    )
+  ) {
+    return blockedPlan(
+      options,
+      [
+        blocker(
+          "unresolved-entitlements",
+          "One or more CODE_SIGN_ENTITLEMENTS settings could not be resolved exactly.",
+        ),
+      ],
+      target.name,
+    );
+  }
+
+  const filesByPath = new Map<string, EntitlementsFile>();
+  const blockers: IOSAssociatedDomainBlocker[] = [];
+  for (const configuredPath of new Set(resolvedPaths)) {
+    const absolutePath = resolve(root, options.projectPath, "..", configuredPath);
+    const inspected = await inspectEntitlementsFile(root, absolutePath);
+    if (inspected.blocker) blockers.push(inspected.blocker);
+    if (inspected.file) filesByPath.set(inspected.file.absolutePath, inspected.file);
+  }
+  if (blockers.length > 0 || filesByPath.size !== new Set(resolvedPaths).size) {
+    return blockedPlan(options, blockers, target.name);
+  }
+  const files = [...filesByPath.values()].sort((a, b) =>
+    a.relativePath.localeCompare(b.relativePath),
+  );
+  if (!(await ownershipIsExclusive(root, options.projectPath, options.targetId, files))) {
+    return blockedPlan(
+      options,
+      [
+        blocker(
+          "shared-entitlements",
+          "An entitlements file may be shared with another target, or exclusive ownership could not be proven.",
+        ),
+      ],
+      target.name,
+    );
+  }
+
+  const satisfied =
+    expectedDomain != null &&
+    files.every((file) => exactDomainPresent(file.domains, expectedDomain));
+  return {
+    schemaVersion: 1,
+    kind: "clerk-ios-associated-domain",
+    status: satisfied ? "satisfied" : "ready",
+    root,
+    projectPath: options.projectPath,
+    targetId: options.targetId,
+    targetName: target.name,
+    ...(expectedDomain ? { expectedDomain } : {}),
+    requiresPublishableKey: expectedDomain == null,
+    files: files.map((file) => ({
+      path: file.relativePath,
+      operation: "modify" as const,
+      expectedHash: file.hash,
+    })),
+    actions: satisfied
+      ? []
+      : [
+          expectedDomain
+            ? `Add ${expectedDomain} to every selected-target entitlements configuration.`
+            : "Add the linked development instance's exact webcredentials host to every selected-target entitlements configuration (host resolved after authentication).",
+        ],
+    blockers: [],
+  };
+}
+
+function xmlEscape(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+function lineIndentAt(source: string, index: number): string {
+  const start = source.lastIndexOf("\n", index - 1) + 1;
+  return /^[\t ]*/.exec(source.slice(start, index))?.[0] ?? "";
+}
+
+function addDomainToXML(source: string, expectedDomain: string): string | undefined {
+  const structural = stripXMLCommentsPreservingOffsets(source);
+  const keyMatches = [
+    ...structural.matchAll(/<key\b[^>]*>\s*com\.apple\.developer\.associated-domains\s*<\/key>/g),
+  ];
+  if (keyMatches.length > 1) return undefined;
+  const newline = source.includes("\r\n") ? "\r\n" : "\n";
+  const encoded = xmlEscape(expectedDomain);
+
+  const keyMatch = keyMatches[0];
+  if (!keyMatch || keyMatch.index == null) {
+    const dictClose = structural.lastIndexOf("</dict>");
+    if (dictClose < 0) return undefined;
+    const closingIndent = lineIndentAt(source, dictClose);
+    const firstKey = /<key\b/.exec(structural);
+    const childIndent =
+      firstKey?.index == null ? `${closingIndent}\t` : lineIndentAt(source, firstKey.index);
+    const startsOnOwnLine = source.slice(0, dictClose).endsWith("\n");
+    const prefix = startsOnOwnLine ? "" : newline;
+    const insertion = `${prefix}${childIndent}<key>${ASSOCIATED_DOMAINS_KEY}</key>${newline}${childIndent}<array>${newline}${childIndent}\t<string>${encoded}</string>${newline}${childIndent}</array>${newline}`;
+    return `${source.slice(0, dictClose)}${insertion}${source.slice(dictClose)}`;
+  }
+
+  const afterKey = keyMatch.index + keyMatch[0].length;
+  const tail = structural.slice(afterKey);
+  const selfClosing = /^\s*<array\b[^>]*\/\s*>/.exec(tail);
+  if (selfClosing) {
+    const start = afterKey + (selfClosing.index ?? 0);
+    const end = start + selfClosing[0].length;
+    const keyIndent = lineIndentAt(source, keyMatch.index);
+    const replacement = `${newline}${keyIndent}<array>${newline}${keyIndent}\t<string>${encoded}</string>${newline}${keyIndent}</array>`;
+    return `${source.slice(0, start)}${replacement}${source.slice(end)}`;
+  }
+  const open = /^\s*<array\b[^>]*>/.exec(tail);
+  if (!open) return undefined;
+  const arrayStart = afterKey + (open.index ?? 0);
+  const contentStart = arrayStart + open[0].length;
+  const closeOffset = structural.slice(contentStart).indexOf("</array>");
+  if (closeOffset < 0) return undefined;
+  const close = contentStart + closeOffset;
+  const arrayIndent = lineIndentAt(source, arrayStart);
+  const existingContent = source.slice(contentStart, close);
+  const closingLine = /\r?\n[\t ]*$/.exec(existingContent);
+  if (closingLine?.index != null) {
+    const insertionIndex = contentStart + closingLine.index;
+    const insertion = `${newline}${arrayIndent}\t<string>${encoded}</string>`;
+    return `${source.slice(0, insertionIndex)}${insertion}${source.slice(insertionIndex)}`;
+  }
+  // Preserve compact arrays as compact rather than moving their closing tag.
+  const insertion = `<string>${encoded}</string>`;
+  return `${source.slice(0, close)}${insertion}${source.slice(close)}`;
+}
+
+function bytesWithOptionalBOM(source: string, bom: boolean): Uint8Array {
+  const encoded = new TextEncoder().encode(source);
+  if (!bom) return encoded;
+  const bytes = new Uint8Array(encoded.length + 3);
+  bytes.set([0xef, 0xbb, 0xbf]);
+  bytes.set(encoded, 3);
+  return bytes;
+}
+
+function newEntitlementsBytes(expectedDomain: string): Uint8Array {
+  return new TextEncoder().encode(
+    [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+      '<plist version="1.0">',
+      "<dict>",
+      `\t<key>${ASSOCIATED_DOMAINS_KEY}</key>`,
+      "\t<array>",
+      `\t\t<string>${xmlEscape(expectedDomain)}</string>`,
+      "\t</array>",
+      "</dict>",
+      "</plist>",
+      "",
+    ].join("\n"),
+  );
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "ENOENT"
+  );
+}
+
+function preparedWithHiddenMutations(
+  plan: IOSAssociatedDomainPlan,
+  expectedDomain: string,
+  mutations: IOSFileMutation[],
+  consumesBasePbxMutation: boolean,
+): Extract<PreparedIOSAssociatedDomainMutation, { status: "ready" }> {
+  const result = {
+    status: "ready" as const,
+    plan,
+    expectedDomain,
+    consumesBasePbxMutation,
+  } as Extract<PreparedIOSAssociatedDomainMutation, { status: "ready" }>;
+  Object.defineProperty(result, "mutations", {
+    value: mutations,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  return result;
+}
+
+export async function prepareIOSAssociatedDomainMutation(
+  plan: IOSAssociatedDomainPlan,
+  publishableKey?: string,
+  options: { basePbxMutation?: IOSExistingFileMutation } = {},
+): Promise<PreparedIOSAssociatedDomainMutation> {
+  if (plan.status === "blocked") return { status: "blocked", plan };
+  let expectedDomain = plan.expectedDomain;
+  if (publishableKey) {
+    try {
+      const decoded = decodePublishableKey(publishableKey);
+      if (decoded.instanceType !== "development") return { status: "blocked", plan };
+      const fromKey = `webcredentials:${decoded.fapiHost}`;
+      if (expectedDomain && expectedDomain !== fromKey) return { status: "blocked", plan };
+      expectedDomain = fromKey;
+    } catch {
+      return { status: "blocked", plan };
+    }
+  }
+  if (!expectedDomain || (plan.requiresPublishableKey && !publishableKey)) {
+    return { status: "blocked", plan };
+  }
+
+  // Compare the exact authorized bytes before reparsing them. A concurrent
+  // edit that also makes the plist malformed is still a stale plan, not a new
+  // structural blocker, and the newer bytes must remain untouched.
+  for (const plannedFile of plan.files) {
+    const absolutePath = resolve(plan.root, plannedFile.path);
+    if (plannedFile.operation === "create") {
+      try {
+        await lstat(absolutePath);
+        return { status: "stale", plan };
+      } catch (error) {
+        if (!isMissingFileError(error)) return { status: "stale", plan };
+      }
+      continue;
+    }
+    try {
+      if (!plannedFile.expectedHash) return { status: "blocked", plan };
+      const info = await lstat(absolutePath);
+      if (
+        !info.isFile() ||
+        info.isSymbolicLink() ||
+        hashIOSFileBytes(await readFile(absolutePath)) !== plannedFile.expectedHash
+      ) {
+        return { status: "stale", plan };
+      }
+    } catch {
+      return { status: "stale", plan };
+    }
+  }
+
+  const replanned = await planIOSAssociatedDomain({
+    root: plan.root,
+    projectPath: plan.projectPath,
+    targetId: plan.targetId,
+    deferToPublishableKey: plan.requiresPublishableKey,
+    allowMissingEntitlementsCreation: plan.missingEntitlementsSettings != null,
+  });
+  if (replanned.status === "blocked") return { status: "blocked", plan: replanned };
+  if (
+    replanned.status !== plan.status ||
+    replanned.expectedDomain !== plan.expectedDomain ||
+    replanned.requiresPublishableKey !== plan.requiresPublishableKey ||
+    replanned.files.length !== plan.files.length ||
+    replanned.files.some(
+      (file, index) =>
+        file.path !== plan.files[index]?.path ||
+        file.operation !== plan.files[index]?.operation ||
+        file.expectedHash !== plan.files[index]?.expectedHash,
+    )
+  ) {
+    return { status: "stale", plan };
+  }
+
+  if (plan.missingEntitlementsSettings) {
+    const plannedFile = plan.files[0];
+    if (
+      plan.files.length !== 1 ||
+      plannedFile?.operation !== "create" ||
+      plannedFile.path !== plan.missingEntitlementsSettings.entitlementsPath
+    ) {
+      return { status: "blocked", plan };
+    }
+    const preparedSettings = await prepareIOSMissingEntitlementsSettingsMutation(
+      plan.missingEntitlementsSettings,
+      options.basePbxMutation,
+    );
+    if (preparedSettings.status === "stale") return { status: "stale", plan };
+    if (preparedSettings.status !== "ready") return { status: "blocked", plan };
+    const expectedParentIdentity =
+      plan.missingEntitlementsSettings.expectedSynchronizedRootIdentity;
+    const synchronizedRootPath = plan.missingEntitlementsSettings.synchronizedRootPath;
+    const createPath = resolve(plan.root, plannedFile.path);
+    if (
+      !expectedParentIdentity ||
+      !synchronizedRootPath ||
+      dirname(createPath) !== resolve(plan.root, synchronizedRootPath)
+    ) {
+      return { status: "blocked", plan };
+    }
+    const candidateBytes = newEntitlementsBytes(expectedDomain);
+    const createMutation: IOSCreateFileMutation = {
+      kind: "create",
+      path: createPath,
+      expectedParentIdentity: { ...expectedParentIdentity },
+      candidateBytes,
+      candidateHash: hashIOSFileBytes(candidateBytes),
+      mode: 0o644,
+    };
+    return preparedWithHiddenMutations(
+      plan,
+      expectedDomain,
+      // Commit the harmless new plist before project.pbxproj starts pointing
+      // at it. The aggregate transaction still rolls both back on failure.
+      [createMutation, preparedSettings.mutation],
+      options.basePbxMutation != null,
+    );
+  }
+
+  const mutations: IOSExistingFileMutation[] = [];
+  for (const plannedFile of plan.files) {
+    if (plannedFile.operation !== "modify" || !plannedFile.expectedHash) {
+      return { status: "blocked", plan };
+    }
+    const absolutePath = resolve(plan.root, plannedFile.path);
+    const inspected = await inspectEntitlementsFile(plan.root, absolutePath);
+    if (!inspected.file || inspected.file.hash !== plannedFile.expectedHash) {
+      return { status: "stale", plan };
+    }
+    if (exactDomainPresent(inspected.file.domains, expectedDomain)) continue;
+    const candidateSource = addDomainToXML(inspected.file.source, expectedDomain);
+    if (!candidateSource) return { status: "blocked", plan };
+    const candidateBytes = bytesWithOptionalBOM(candidateSource, inspected.file.bom);
+    mutations.push({
+      path: inspected.file.absolutePath,
+      originalBytes: inspected.file.bytes,
+      originalHash: inspected.file.hash,
+      candidateBytes,
+      candidateHash: hashIOSFileBytes(candidateBytes),
+      mode: inspected.file.mode,
+    });
+  }
+  if (mutations.length === 0) return { status: "satisfied", plan, expectedDomain };
+  return preparedWithHiddenMutations(plan, expectedDomain, mutations, false);
+}
+
+export async function validatePreparedIOSAssociatedDomain(
+  prepared: Extract<PreparedIOSAssociatedDomainMutation, { status: "ready" }>,
+): Promise<boolean> {
+  if (
+    prepared.plan.missingEntitlementsSettings &&
+    !(await validateIOSMissingEntitlementsSettingsPostcondition(
+      prepared.plan.missingEntitlementsSettings,
+    ))
+  ) {
+    return false;
+  }
+  const inspection = await inspectIOSProject(prepared.plan.root, {
+    target: prepared.plan.targetId,
+  });
+  const target = selectedTarget(inspection, prepared.plan.projectPath, prepared.plan.targetId);
+  if (!target) return false;
+  if (
+    inspection.generatedProject != null ||
+    (await generatedProjectKind(
+      prepared.plan.root,
+      resolve(prepared.plan.root, prepared.plan.projectPath),
+    )) != null
+  ) {
+    return false;
+  }
+  const expectedHost = prepared.expectedDomain.slice("webcredentials:".length);
+  if (runtimeFrontendHost(inspection, target) !== expectedHost) return false;
+  if (target.configurations.length === 0) return false;
+  const files: EntitlementsFile[] = [];
+  for (const configuration of target.configurations) {
+    if (configuration.entitlementsPath.state !== "resolved") return false;
+    const absolutePath = resolve(
+      prepared.plan.root,
+      prepared.plan.projectPath,
+      "..",
+      configuration.entitlementsPath.value,
+    );
+    const inspected = await inspectEntitlementsFile(prepared.plan.root, absolutePath);
+    if (!inspected.file || !exactDomainPresent(inspected.file.domains, prepared.expectedDomain)) {
+      return false;
+    }
+    files.push(inspected.file);
+  }
+  return ownershipIsExclusive(
+    prepared.plan.root,
+    prepared.plan.projectPath,
+    prepared.plan.targetId,
+    [...new Map(files.map((file) => [file.absolutePath, file])).values()],
+  );
+}
+
+export async function applyIOSAssociatedDomain(
+  plan: IOSAssociatedDomainPlan,
+  publishableKey?: string,
+): Promise<IOSAssociatedDomainApplyResult> {
+  const prepared = await prepareIOSAssociatedDomainMutation(plan, publishableKey);
+  if (prepared.status === "blocked") return { status: "blocked", plan: prepared.plan };
+  if (prepared.status === "stale") return { status: "stale", plan: prepared.plan };
+  if (prepared.status === "satisfied") return { status: "satisfied", plan: prepared.plan };
+  const result = await applyIOSFileTransaction(prepared.mutations, [
+    async () => validatePreparedIOSAssociatedDomain(prepared),
+  ]);
+  return { status: result.status, plan: prepared.plan };
+}

--- a/packages/cli-core/src/commands/init/ios/build-settings.test.ts
+++ b/packages/cli-core/src/commands/init/ios/build-settings.test.ts
@@ -1,0 +1,496 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { inspectTargetBuildConfigurations } from "./build-settings.ts";
+import type { PbxObject, PbxObjects } from "./pbx.ts";
+import type { IOSDiagnostic } from "./types.ts";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true })));
+});
+
+interface BuildSettingsFixtureOptions {
+  xcconfig?: string;
+  includedXCConfig?: string;
+  projectDirPath?: string;
+  targetBuildSettings?: Record<string, string>;
+  projectConfigurationIds?: string[];
+  targetConfigurationIds?: string[];
+}
+
+async function inspectFixture(options: BuildSettingsFixtureOptions = {}) {
+  const root = await mkdtemp(join(tmpdir(), "clerk-build-settings-"));
+  temporaryDirectories.push(root);
+  const projectPath = join(root, "Example.xcodeproj");
+  const groupRootDirectory = resolve(root, options.projectDirPath ?? "");
+  await mkdir(projectPath, { recursive: true });
+
+  const objects: PbxObjects = {
+    "project-list": {
+      isa: "XCConfigurationList",
+      buildConfigurations: options.projectConfigurationIds ?? ["project-debug"],
+    },
+    "project-debug": {
+      isa: "XCBuildConfiguration",
+      name: "Debug",
+      buildSettings: { SDKROOT: "iphoneos" },
+    },
+    "target-list": {
+      isa: "XCConfigurationList",
+      buildConfigurations: options.targetConfigurationIds ?? ["target-debug"],
+    },
+    "target-debug": {
+      isa: "XCBuildConfiguration",
+      name: "Debug",
+      ...(options.xcconfig ? { baseConfigurationReference: "target-xcconfig" } : {}),
+      buildSettings: {
+        PRODUCT_BUNDLE_IDENTIFIER: "com.example.Example",
+        DEVELOPMENT_TEAM: "ABCDE12345",
+        IPHONEOS_DEPLOYMENT_TARGET: "17.0",
+        SUPPORTED_PLATFORMS: "iphoneos iphonesimulator",
+        ...options.targetBuildSettings,
+      },
+    },
+    "target-release": {
+      isa: "XCBuildConfiguration",
+      name: "Release",
+      buildSettings: {
+        PRODUCT_BUNDLE_IDENTIFIER: "com.example.Example",
+        DEVELOPMENT_TEAM: "ABCDE12345",
+        IPHONEOS_DEPLOYMENT_TARGET: "17.0",
+        SUPPORTED_PLATFORMS: "iphoneos iphonesimulator",
+      },
+    },
+    "target-xcconfig": {
+      isa: "PBXFileReference",
+      path: "Config/Target.xcconfig",
+      sourceTree: "<group>",
+    },
+  };
+
+  if (options.xcconfig) {
+    await mkdir(join(groupRootDirectory, "Config"), { recursive: true });
+    await Bun.write(join(groupRootDirectory, "Config", "Target.xcconfig"), options.xcconfig);
+    if (options.includedXCConfig != null) {
+      await Bun.write(
+        join(groupRootDirectory, "Config", "Included.xcconfig"),
+        options.includedXCConfig,
+      );
+    }
+  }
+
+  const projectObject: PbxObject = {
+    isa: "PBXProject",
+    projectDirPath: options.projectDirPath ?? "",
+    buildConfigurationList: "project-list",
+  };
+  const targetObject: PbxObject = {
+    isa: "PBXNativeTarget",
+    name: "Example",
+    productName: "Example",
+    buildConfigurationList: "target-list",
+  };
+  const diagnostics: IOSDiagnostic[] = [];
+  const configurations = await inspectTargetBuildConfigurations({
+    root,
+    projectPath,
+    groupRootDirectory,
+    projectObject,
+    targetId: "target",
+    targetObject,
+    objects,
+    parents: new Map(),
+    diagnostics,
+  });
+  return { configurations, diagnostics, root };
+}
+
+describe("inspectTargetBuildConfigurations", () => {
+  test("merges braced inherited values across project and target settings", async () => {
+    const projectObject: PbxObject = {
+      isa: "PBXProject",
+      buildConfigurationList: "project-list",
+    };
+    const targetObject: PbxObject = {
+      isa: "PBXNativeTarget",
+      name: "Example",
+      productName: "Example",
+      buildConfigurationList: "target-list",
+    };
+    const objects: PbxObjects = {
+      "project-list": {
+        isa: "XCConfigurationList",
+        buildConfigurations: ["project-debug"],
+      },
+      "project-debug": {
+        isa: "XCBuildConfiguration",
+        name: "Debug",
+        buildSettings: { PRODUCT_BUNDLE_IDENTIFIER: "com.example", SDKROOT: "iphoneos" },
+      },
+      "target-list": {
+        isa: "XCConfigurationList",
+        buildConfigurations: ["target-debug"],
+      },
+      "target-debug": {
+        isa: "XCBuildConfiguration",
+        name: "Debug",
+        buildSettings: {
+          PRODUCT_BUNDLE_IDENTIFIER: "${inherited}.MyApp",
+          IPHONEOS_DEPLOYMENT_TARGET: "17.0",
+          SUPPORTED_PLATFORMS: "iphoneos iphonesimulator",
+        },
+      },
+    };
+
+    const configurations = await inspectTargetBuildConfigurations({
+      root: "/tmp/Example",
+      projectPath: "/tmp/Example/Example.xcodeproj",
+      groupRootDirectory: "/tmp/Example",
+      projectObject,
+      targetId: "target",
+      targetObject,
+      objects,
+      parents: new Map(),
+      diagnostics: [],
+    });
+
+    expect(configurations[0]?.model.bundleIdentifier).toMatchObject({
+      state: "resolved",
+      value: "com.example.MyApp",
+    });
+  });
+
+  test("keeps unsupported Xcode build-setting modifiers unresolved", async () => {
+    const projectObject: PbxObject = {
+      isa: "PBXProject",
+      buildConfigurationList: "project-list",
+    };
+    const targetObject: PbxObject = {
+      isa: "PBXNativeTarget",
+      name: "Example",
+      productName: "Example",
+      buildConfigurationList: "target-list",
+    };
+    const objects: PbxObjects = {
+      "project-list": {
+        isa: "XCConfigurationList",
+        buildConfigurations: ["project-debug"],
+      },
+      "project-debug": {
+        isa: "XCBuildConfiguration",
+        name: "Debug",
+        buildSettings: { SDKROOT: "iphoneos" },
+      },
+      "target-list": {
+        isa: "XCConfigurationList",
+        buildConfigurations: ["target-debug"],
+      },
+      "target-debug": {
+        isa: "XCBuildConfiguration",
+        name: "Debug",
+        buildSettings: {
+          PRODUCT_NAME: "My App",
+          PRODUCT_BUNDLE_IDENTIFIER: "com.example.$(PRODUCT_NAME:rfc1034identifier)",
+          IPHONEOS_DEPLOYMENT_TARGET: "17.0",
+          SUPPORTED_PLATFORMS: "iphoneos iphonesimulator",
+        },
+      },
+    };
+    const diagnostics: IOSDiagnostic[] = [];
+
+    const configurations = await inspectTargetBuildConfigurations({
+      root: "/tmp/Example",
+      projectPath: "/tmp/Example/Example.xcodeproj",
+      groupRootDirectory: "/tmp/Example",
+      projectObject,
+      targetId: "target",
+      targetObject,
+      objects,
+      parents: new Map(),
+      diagnostics,
+    });
+
+    expect(configurations[0]?.model.bundleIdentifier).toMatchObject({
+      state: "unresolved",
+      raw: "com.example.$(PRODUCT_NAME:rfc1034identifier)",
+      missingVariables: ["PRODUCT_NAME:rfc1034identifier"],
+    });
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        code: "xcode.unresolved-build-setting",
+        message: expect.stringContaining("PRODUCT_NAME:rfc1034identifier"),
+      }),
+    ]);
+  });
+
+  test("uses projectDirPath for group refs while keeping SRCROOT and PROJECT_DIR at the project container", async () => {
+    const { configurations, root } = await inspectFixture({
+      projectDirPath: "Sources",
+      xcconfig: [
+        "PRODUCT_BUNDLE_IDENTIFIER = com.example.$(PROJECT_NAME)",
+        "DEVELOPMENT_TEAM = $(PROJECT_DIR)",
+        "CODE_SIGN_ENTITLEMENTS = $(SRCROOT)/Example.entitlements",
+      ].join("\n"),
+      targetBuildSettings: {
+        PRODUCT_BUNDLE_IDENTIFIER: "$(inherited)",
+        DEVELOPMENT_TEAM: "$(inherited)",
+        CODE_SIGN_ENTITLEMENTS: "$(inherited)",
+      },
+    });
+
+    expect(configurations[0]?.model.bundleIdentifier).toMatchObject({
+      state: "resolved",
+      value: "com.example.Example",
+    });
+    expect(configurations[0]?.model.developmentTeam).toMatchObject({
+      state: "resolved",
+      value: root,
+    });
+    expect(configurations[0]?.model.entitlementsPath).toMatchObject({
+      state: "resolved",
+      value: join(root, "Example.entitlements"),
+    });
+  });
+
+  test("surfaces device and simulator conditional build-setting differences", async () => {
+    const { configurations, diagnostics } = await inspectFixture({
+      targetBuildSettings: {
+        PRODUCT_BUNDLE_IDENTIFIER: "com.example.Base",
+        "PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]": "com.example.Device",
+        "PRODUCT_BUNDLE_IDENTIFIER[sdk=iphonesimulator*]": "com.example.Simulator",
+      },
+    });
+
+    expect(configurations[0]?.model.bundleIdentifier).toMatchObject({
+      state: "unresolved",
+      missingVariables: ["sdk-conditioned build setting"],
+    });
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "xcode.conflicting-build-setting",
+        message: expect.stringContaining(
+          "iphoneos=com.example.Device, iphonesimulator=com.example.Simulator",
+        ),
+      }),
+    );
+  });
+
+  test("accepts matching device and simulator conditional build settings", async () => {
+    const { configurations } = await inspectFixture({
+      targetBuildSettings: {
+        PRODUCT_BUNDLE_IDENTIFIER: "com.example.Base",
+        "PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]": "com.example.Native",
+        "PRODUCT_BUNDLE_IDENTIFIER[sdk=iphonesimulator*]": "com.example.Native",
+      },
+    });
+
+    expect(configurations[0]?.model.bundleIdentifier).toMatchObject({
+      state: "resolved",
+      value: "com.example.Native",
+    });
+  });
+
+  test("preserves the textual order of xcconfig assignments and includes", async () => {
+    const includeLast = await inspectFixture({
+      xcconfig: [
+        "PRODUCT_BUNDLE_IDENTIFIER = com.example.Before",
+        '#include "Included.xcconfig"',
+      ].join("\n"),
+      includedXCConfig: "PRODUCT_BUNDLE_IDENTIFIER = com.example.Included\n",
+      targetBuildSettings: { PRODUCT_BUNDLE_IDENTIFIER: "$(inherited)" },
+    });
+    const assignmentLast = await inspectFixture({
+      xcconfig: [
+        '#include "Included.xcconfig"',
+        "PRODUCT_BUNDLE_IDENTIFIER = com.example.After",
+      ].join("\n"),
+      includedXCConfig: "PRODUCT_BUNDLE_IDENTIFIER = com.example.Included\n",
+      targetBuildSettings: { PRODUCT_BUNDLE_IDENTIFIER: "$(inherited)" },
+    });
+
+    expect(includeLast.configurations[0]?.model.bundleIdentifier).toMatchObject({
+      state: "resolved",
+      value: "com.example.Included",
+    });
+    expect(assignmentLast.configurations[0]?.model.bundleIdentifier).toMatchObject({
+      state: "resolved",
+      value: "com.example.After",
+    });
+  });
+
+  test("taints fallback settings when a required xcconfig include is missing", async () => {
+    const { configurations, diagnostics } = await inspectFixture({
+      xcconfig: [
+        "PRODUCT_BUNDLE_IDENTIFIER = com.example.Fallback",
+        '#include "Missing.xcconfig"',
+      ].join("\n"),
+      targetBuildSettings: { PRODUCT_BUNDLE_IDENTIFIER: "$(inherited)" },
+    });
+
+    expect(configurations[0]?.model.bundleIdentifier).toMatchObject({
+      state: "unresolved",
+      missingVariables: ["required xcconfig include"],
+    });
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "xcode.unresolved-build-setting",
+        message: expect.stringContaining("Required xcconfig include"),
+      }),
+    );
+  });
+
+  test("clears an earlier unknown-include taint only with a later literal assignment", async () => {
+    const { configurations } = await inspectFixture({
+      xcconfig: [
+        '#include "Missing.xcconfig"',
+        "PRODUCT_BUNDLE_IDENTIFIER = com.example.Resolved",
+        "TEAM_VALUE = ABCDE12345",
+        "DEVELOPMENT_TEAM = $(TEAM_VALUE)",
+      ].join("\n"),
+      targetBuildSettings: {
+        PRODUCT_BUNDLE_IDENTIFIER: "$(inherited)",
+        DEVELOPMENT_TEAM: "$(inherited)",
+      },
+    });
+
+    expect(configurations[0]?.model.bundleIdentifier).toMatchObject({
+      state: "resolved",
+      value: "com.example.Resolved",
+    });
+    expect(configurations[0]?.model.developmentTeam).toMatchObject({
+      state: "unresolved",
+      missingVariables: ["required xcconfig include"],
+    });
+  });
+
+  test("taints settings for variable include paths but permits a missing literal optional include", async () => {
+    const variable = await inspectFixture({
+      xcconfig: [
+        "PRODUCT_BUNDLE_IDENTIFIER = com.example.Fallback",
+        '#include? "$(CONFIG_DIR)/Optional.xcconfig"',
+      ].join("\n"),
+      targetBuildSettings: { PRODUCT_BUNDLE_IDENTIFIER: "$(inherited)" },
+    });
+    const literalOptional = await inspectFixture({
+      xcconfig: [
+        '#include? "Missing.xcconfig"',
+        "PRODUCT_BUNDLE_IDENTIFIER = com.example.Resolved",
+      ].join("\n"),
+      targetBuildSettings: { PRODUCT_BUNDLE_IDENTIFIER: "$(inherited)" },
+    });
+
+    expect(variable.configurations[0]?.model.bundleIdentifier).toMatchObject({
+      state: "unresolved",
+      missingVariables: ["variable xcconfig include path"],
+    });
+    expect(variable.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "xcode.unresolved-build-setting",
+        message: expect.stringContaining("path contains build-setting variables"),
+      }),
+    );
+    expect(literalOptional.configurations[0]?.model.bundleIdentifier).toMatchObject({
+      state: "resolved",
+      value: "com.example.Resolved",
+    });
+  });
+
+  test("keeps targets with variable-based platform settings as iOS candidates", async () => {
+    const { configurations, diagnostics } = await inspectFixture({
+      targetBuildSettings: {
+        SDKROOT: "$(UNKNOWN_SDK)",
+        SUPPORTED_PLATFORMS: "$(UNKNOWN_PLATFORMS)",
+        IPHONEOS_DEPLOYMENT_TARGET: "",
+      },
+    });
+
+    expect(configurations[0]?.isIOS).toBe(true);
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "xcode.unresolved-build-setting",
+          message: expect.stringContaining("SDKROOT"),
+        }),
+        expect.objectContaining({
+          code: "xcode.unresolved-build-setting",
+          message: expect.stringContaining("SUPPORTED_PLATFORMS"),
+        }),
+      ]),
+    );
+  });
+
+  test("keeps targets with include-tainted platform settings as iOS candidates", async () => {
+    const { configurations } = await inspectFixture({
+      xcconfig: [
+        '#include "Missing.xcconfig"',
+        "SDKROOT = $(UNKNOWN_SDK)",
+        "SUPPORTED_PLATFORMS = $(UNKNOWN_PLATFORMS)",
+      ].join("\n"),
+      targetBuildSettings: {
+        SDKROOT: "$(inherited)",
+        SUPPORTED_PLATFORMS: "$(inherited)",
+        IPHONEOS_DEPLOYMENT_TARGET: "",
+      },
+    });
+
+    expect(configurations[0]?.isIOS).toBe(true);
+  });
+
+  test("still rejects targets with fully resolved non-iOS platform evidence", async () => {
+    const { configurations } = await inspectFixture({
+      targetBuildSettings: {
+        SDKROOT: "watchos",
+        SUPPORTED_PLATFORMS: "watchos watchsimulator",
+        IPHONEOS_DEPLOYMENT_TARGET: "",
+      },
+    });
+
+    expect(configurations[0]?.isIOS).toBe(false);
+  });
+
+  test("preserves dangling target configurations as blocking placeholders", async () => {
+    const { configurations, diagnostics } = await inspectFixture({
+      targetConfigurationIds: ["target-debug", "missing-target-release"],
+    });
+
+    expect(configurations).toHaveLength(2);
+    expect(configurations[1]?.model).toMatchObject({
+      name: "Unresolved (missing-target-release)",
+      bundleIdentifier: { state: "missing" },
+    });
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "xcode.dangling-reference",
+        severity: "error",
+        message: expect.stringContaining("missing-target-release"),
+      }),
+    );
+  });
+
+  test("taints target settings when the project configuration list is incomplete", async () => {
+    const { configurations, diagnostics } = await inspectFixture({
+      projectConfigurationIds: ["project-debug", "missing-project-release"],
+      targetConfigurationIds: ["target-debug", "target-release"],
+    });
+
+    expect(configurations.map((configuration) => configuration.model.bundleIdentifier)).toEqual([
+      expect.objectContaining({
+        state: "unresolved",
+        missingVariables: ["incomplete project configuration list"],
+      }),
+      expect.objectContaining({
+        state: "unresolved",
+        missingVariables: ["incomplete project configuration list"],
+      }),
+    ]);
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "xcode.dangling-reference",
+        message: expect.stringContaining("missing-project-release"),
+      }),
+    );
+  });
+});

--- a/packages/cli-core/src/commands/init/ios/build-settings.ts
+++ b/packages/cli-core/src/commands/init/ios/build-settings.ts
@@ -1,0 +1,973 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve, sep } from "node:path";
+import { parse as parseXCConfig } from "@bacons/xcode/xcconfig";
+import { pathIsSafelyWithinIOSRoot, pathIsWithinIOSRoot, relativeIOSPath } from "./discovery.ts";
+import {
+  asString,
+  asStringArray,
+  asStringRecord,
+  resolvePbxFilePath,
+  type PbxObject,
+  type PbxObjects,
+} from "./pbx.ts";
+import type {
+  IOSBuildConfiguration,
+  IOSDiagnostic,
+  IOSSourceEvidence,
+  IOSValueResolution,
+} from "./types.ts";
+
+const MAX_XCCONFIG_DEPTH = 12;
+const BUILD_SETTING_VARIABLE = /\$\(([^)]+)\)|\$\{([^}]+)\}/g;
+const INSPECTED_BUILD_SETTING_KEYS = [
+  "PRODUCT_BUNDLE_IDENTIFIER",
+  "DEVELOPMENT_TEAM",
+  "CODE_SIGN_ENTITLEMENTS",
+  "IPHONEOS_DEPLOYMENT_TARGET",
+  "SDKROOT",
+  "SUPPORTED_PLATFORMS",
+] as const;
+const INSPECTED_BUILD_SETTINGS = new Set<string>(INSPECTED_BUILD_SETTING_KEYS);
+
+interface BuildContext {
+  label: "iphoneos" | "iphonesimulator";
+  sdk: "iphoneos" | "iphonesimulator";
+  arch: "arm64";
+}
+
+interface BuildSettingsEvaluation {
+  settings: Record<string, string>;
+  /** Unknown inputs are tracked independently for each inspected setting. */
+  settingTaints: Map<string, string[]>;
+}
+
+type XCConfigOperation =
+  | { kind: "include"; path: string; optional: boolean }
+  | { kind: "setting"; key: string; value: string; conditions?: XCConfigCondition[] };
+
+const BUILD_CONTEXTS: BuildContext[] = [
+  { label: "iphoneos", sdk: "iphoneos", arch: "arm64" },
+  { label: "iphonesimulator", sdk: "iphonesimulator", arch: "arm64" },
+];
+
+interface XCConfigCondition {
+  sdk?: string;
+  arch?: string;
+  config?: string;
+}
+
+function wildcardMatches(value: string, pattern: string): boolean {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&").replaceAll("*", ".*");
+  return new RegExp(`^${escaped}$`, "i").test(value);
+}
+
+function conditionsMatch(
+  conditions: XCConfigCondition[] | undefined,
+  configuration: string,
+  context: BuildContext,
+): boolean {
+  return (conditions ?? []).every((condition) => {
+    if (condition.sdk && !wildcardMatches(context.sdk, condition.sdk)) return false;
+    if (condition.arch && !wildcardMatches(context.arch, condition.arch)) return false;
+    if (condition.config && !wildcardMatches(configuration, condition.config)) return false;
+    return true;
+  });
+}
+
+function applySettings(base: Record<string, string>, next: Record<string, string>): void {
+  for (const [key, value] of Object.entries(next)) {
+    base[key] = value.replace(/\$(?:\(inherited\)|\{inherited\})/gi, base[key] ?? "").trim();
+  }
+}
+
+function cloneEvaluation(evaluation: BuildSettingsEvaluation): BuildSettingsEvaluation {
+  return {
+    settings: { ...evaluation.settings },
+    settingTaints: cloneSettingTaints(evaluation.settingTaints),
+  };
+}
+
+function taintInspectedSettings(evaluation: BuildSettingsEvaluation, taint: string): void {
+  for (const key of INSPECTED_BUILD_SETTING_KEYS) {
+    addSettingTaint(evaluation.settingTaints, key, taint);
+  }
+}
+
+function applyEvaluatedSetting(
+  evaluation: BuildSettingsEvaluation,
+  key: string,
+  value: string,
+  conditions: XCConfigCondition[] | undefined,
+): void {
+  applySettings(evaluation.settings, { [key]: value });
+  if (!INSPECTED_BUILD_SETTINGS.has(key)) return;
+
+  // An unconditional literal assignment fully overrides any earlier unknown
+  // include for this setting. Inherited or variable-derived values may still
+  // depend on the skipped input, so retain their existing taint.
+  if ((conditions?.length ?? 0) === 0 && !hasBuildSettingVariable(value)) {
+    evaluation.settingTaints.delete(key);
+  }
+}
+
+function hasBuildSettingVariable(value: string): boolean {
+  BUILD_SETTING_VARIABLE.lastIndex = 0;
+  const result = BUILD_SETTING_VARIABLE.test(value);
+  BUILD_SETTING_VARIABLE.lastIndex = 0;
+  return result;
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function addDiagnosticOnce(diagnostics: IOSDiagnostic[], diagnostic: IOSDiagnostic): void {
+  if (
+    diagnostics.some(
+      (candidate) => candidate.code === diagnostic.code && candidate.message === diagnostic.message,
+    )
+  ) {
+    return;
+  }
+  diagnostics.push(diagnostic);
+}
+
+function parseXCConfigOperations(content: string): XCConfigOperation[] {
+  const operations: XCConfigOperation[] = [];
+  // @bacons/xcode intentionally exposes includes and assignments separately.
+  // Parsing one source line at a time retains their interleaving, which is
+  // significant because a later include can override an earlier assignment.
+  for (const line of content.split(/\r?\n/)) {
+    const parsed = parseXCConfig(line);
+    const include = parsed.includes[0]?.include;
+    if (include) {
+      operations.push({
+        kind: "include",
+        path: include.path,
+        optional: include.optional,
+      });
+      continue;
+    }
+    const setting = parsed.buildSettings[0];
+    if (setting) {
+      operations.push({
+        kind: "setting",
+        key: setting.key,
+        value: setting.value,
+        conditions: setting.conditions,
+      });
+    }
+  }
+  return operations;
+}
+
+function unresolvedXCConfig(
+  root: string,
+  path: string,
+  diagnostics: IOSDiagnostic[],
+  message: string,
+  taint: string,
+  inherited: BuildSettingsEvaluation,
+): BuildSettingsEvaluation {
+  addDiagnosticOnce(diagnostics, {
+    code: "xcode.unresolved-build-setting",
+    severity: "warning",
+    message,
+    remedy:
+      "Check in the required xcconfig and use a literal include path before automating setup.",
+    evidence: [{ path: relativeIOSPath(root, path), keyPath: "include" }],
+  });
+  const evaluation = cloneEvaluation(inherited);
+  taintInspectedSettings(evaluation, taint);
+  return evaluation;
+}
+
+async function readXCConfigSettings(
+  root: string,
+  path: string,
+  configuration: string,
+  context: BuildContext,
+  diagnostics: IOSDiagnostic[],
+  inherited: BuildSettingsEvaluation = { settings: {}, settingTaints: new Map() },
+  visited: Set<string> = new Set(),
+  depth = 0,
+  optional = false,
+): Promise<BuildSettingsEvaluation> {
+  if (depth >= MAX_XCCONFIG_DEPTH) {
+    const unresolved = unresolvedXCConfig(
+      root,
+      path,
+      diagnostics,
+      `Could not fully evaluate ${relativeIOSPath(root, path)} because xcconfig includes exceeded the inspection depth limit.`,
+      "xcconfig include depth",
+      inherited,
+    );
+    return unresolved;
+  }
+  if (visited.has(path)) {
+    const unresolved = unresolvedXCConfig(
+      root,
+      path,
+      diagnostics,
+      `Could not fully evaluate ${relativeIOSPath(root, path)} because its xcconfig includes form a cycle.`,
+      "xcconfig include cycle",
+      inherited,
+    );
+    return unresolved;
+  }
+  if (!(await pathIsSafelyWithinIOSRoot(root, path))) {
+    addDiagnosticOnce(diagnostics, {
+      code: "xcode.external-path",
+      severity: "warning",
+      message: `Skipped xcconfig outside the inspected project root: ${path}`,
+      evidence: [{ path }],
+    });
+    const evaluation = cloneEvaluation(inherited);
+    // Even an optional include can exist outside the inspected root and
+    // override local values. Since we intentionally do not read it, its
+    // contribution remains unknown.
+    taintInspectedSettings(evaluation, "xcconfig outside project root");
+    return evaluation;
+  }
+
+  let content: string;
+  try {
+    const file = Bun.file(path);
+    if (!(await file.exists())) {
+      if (optional) {
+        return cloneEvaluation(inherited);
+      }
+      const unresolved = unresolvedXCConfig(
+        root,
+        path,
+        diagnostics,
+        `Required xcconfig include ${relativeIOSPath(root, path)} does not exist.`,
+        "required xcconfig include",
+        inherited,
+      );
+      return unresolved;
+    }
+    if (file.size > 1_000_000) {
+      const unresolved = unresolvedXCConfig(
+        root,
+        path,
+        diagnostics,
+        `Could not evaluate ${relativeIOSPath(root, path)} because the xcconfig is too large to inspect safely.`,
+        "unreadable xcconfig include",
+        inherited,
+      );
+      return unresolved;
+    }
+    content = await readFile(path, "utf8");
+  } catch {
+    const unresolved = unresolvedXCConfig(
+      root,
+      path,
+      diagnostics,
+      `Could not read required xcconfig include ${relativeIOSPath(root, path)}.`,
+      "unreadable xcconfig include",
+      inherited,
+    );
+    return unresolved;
+  }
+
+  const nextVisited = new Set(visited);
+  nextVisited.add(path);
+  let evaluation = cloneEvaluation(inherited);
+
+  for (const operation of parseXCConfigOperations(content)) {
+    if (operation.kind === "setting") {
+      if (!conditionsMatch(operation.conditions, configuration, context)) continue;
+      applyEvaluatedSetting(evaluation, operation.key, operation.value, operation.conditions);
+      continue;
+    }
+    // Paths containing build variables cannot be resolved safely without an
+    // Xcode build context. Leave those settings unresolved rather than guess.
+    if (hasBuildSettingVariable(operation.path)) {
+      taintInspectedSettings(evaluation, "variable xcconfig include path");
+      addDiagnosticOnce(diagnostics, {
+        code: "xcode.unresolved-build-setting",
+        severity: "warning",
+        message: `${relativeIOSPath(root, path)} has an xcconfig include whose path contains build-setting variables.`,
+        remedy: "Use a literal checked-in include path before automating setup.",
+        evidence: [{ path: relativeIOSPath(root, path), keyPath: "include" }],
+      });
+      continue;
+    }
+    const includePath = resolve(dirname(path), operation.path);
+    const included = await readXCConfigSettings(
+      root,
+      includePath,
+      configuration,
+      context,
+      diagnostics,
+      evaluation,
+      nextVisited,
+      depth + 1,
+      operation.optional,
+    );
+    evaluation = included;
+  }
+
+  return evaluation;
+}
+
+function stripSurroundingQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (
+    trimmed.length >= 2 &&
+    ((trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+      (trimmed.startsWith("'") && trimmed.endsWith("'")))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function cloneSettingTaints(source: Map<string, string[]>): Map<string, string[]> {
+  return new Map([...source].map(([key, values]) => [key, [...values]]));
+}
+
+function addSettingTaint(settingTaints: Map<string, string[]>, key: string, taint: string): void {
+  settingTaints.set(key, unique([...(settingTaints.get(key) ?? []), taint]));
+}
+
+function parseInlineBuildSettingKey(
+  rawKey: string,
+):
+  | { key: string; conditions: XCConfigCondition[]; supported: true }
+  | { key: string; supported: false } {
+  const match = rawKey.match(/^([a-zA-Z_][a-zA-Z0-9_]*)((?:\[[^\]]+\])*)$/);
+  if (!match) return { key: rawKey, supported: false };
+  const key = match[1];
+  if (!key) return { key: rawKey, supported: false };
+  const suffix = match[2] ?? "";
+  if (!suffix) return { key, conditions: [], supported: true };
+
+  const conditions: XCConfigCondition[] = [];
+  let consumed = "";
+  for (const conditionMatch of suffix.matchAll(/\[([a-zA-Z]+)=([^\]]+)\]/g)) {
+    consumed += conditionMatch[0];
+    const rawType = conditionMatch[1];
+    const value = conditionMatch[2];
+    if (!rawType || !value) return { key, supported: false };
+    const type = rawType.toLowerCase();
+    if (!["sdk", "arch", "config"].includes(type)) {
+      return { key, supported: false };
+    }
+    if (type === "sdk") conditions.push({ sdk: value });
+    if (type === "arch") conditions.push({ arch: value });
+    if (type === "config") conditions.push({ config: value });
+  }
+  if (consumed !== suffix) return { key, supported: false };
+  return { key, conditions, supported: true };
+}
+
+function applyInlineBuildSettings(
+  evaluation: BuildSettingsEvaluation,
+  rawSettings: Record<string, string>,
+  configuration: string,
+  context: BuildContext,
+): void {
+  const parsed = Object.entries(rawSettings).map(([rawKey, value], order) => ({
+    parsedKey: parseInlineBuildSettingKey(rawKey),
+    value,
+    order,
+  }));
+
+  // A PBX buildSettings value is a dictionary, not an ordered instruction
+  // stream. Apply unconditional values first, followed by increasingly
+  // specific matching conditions. This lets an SDK-qualified value override
+  // its base value regardless of serialization order.
+  parsed.sort((left, right) => {
+    const leftSpecificity =
+      left.parsedKey.supported && "conditions" in left.parsedKey
+        ? left.parsedKey.conditions.length
+        : Number.MAX_SAFE_INTEGER;
+    const rightSpecificity =
+      right.parsedKey.supported && "conditions" in right.parsedKey
+        ? right.parsedKey.conditions.length
+        : Number.MAX_SAFE_INTEGER;
+    return leftSpecificity - rightSpecificity || left.order - right.order;
+  });
+
+  for (const entry of parsed) {
+    if (!entry.parsedKey.supported) {
+      addSettingTaint(
+        evaluation.settingTaints,
+        entry.parsedKey.key,
+        "unsupported conditional build setting",
+      );
+      continue;
+    }
+    if (!conditionsMatch(entry.parsedKey.conditions, configuration, context)) continue;
+    applyEvaluatedSetting(evaluation, entry.parsedKey.key, entry.value, entry.parsedKey.conditions);
+  }
+}
+
+function resolveSetting(
+  key: string,
+  evaluation: BuildSettingsEvaluation,
+  builtins: Record<string, string>,
+  evidence: IOSSourceEvidence,
+): IOSValueResolution {
+  const settings = evaluation.settings;
+  const initial = settings[key];
+  const taints = evaluation.settingTaints.get(key) ?? [];
+  if ((initial == null || initial.trim() === "") && taints.length === 0) {
+    return { state: "missing", evidence: [evidence] };
+  }
+
+  const missingVariables = new Set<string>(taints);
+  const resolveValue = (raw: string, stack: Set<string>): string => {
+    BUILD_SETTING_VARIABLE.lastIndex = 0;
+    return raw.replace(BUILD_SETTING_VARIABLE, (match, parenthesized, braced) => {
+      const variableWithModifier = String(parenthesized ?? braced);
+      // Xcode build-setting modifiers transform values (for example,
+      // `:rfc1034identifier`). Replacing only the base variable would silently
+      // produce a different value, so preserve the expression as unresolved.
+      if (variableWithModifier.includes(":")) {
+        missingVariables.add(variableWithModifier);
+        return match;
+      }
+      const variable = variableWithModifier.split(":", 1)[0] ?? variableWithModifier;
+      if (variable.toLowerCase() === "inherited") return "";
+      if (stack.has(variable)) {
+        missingVariables.add(variable);
+        return `$(${variableWithModifier})`;
+      }
+
+      const replacement = settings[variable] ?? builtins[variable];
+      if (replacement == null) {
+        missingVariables.add(variable);
+        return `$(${variableWithModifier})`;
+      }
+
+      const nextStack = new Set(stack);
+      nextStack.add(variable);
+      return resolveValue(replacement, nextStack);
+    });
+  };
+
+  const raw = initial ?? "";
+  const value = stripSurroundingQuotes(resolveValue(raw, new Set([key])));
+  if (missingVariables.size > 0 || hasBuildSettingVariable(value)) {
+    return {
+      state: "unresolved",
+      raw,
+      missingVariables: [...missingVariables].sort(),
+      evidence: [evidence],
+    };
+  }
+
+  return { state: "resolved", value, evidence: [evidence] };
+}
+
+interface ConfigurationReference {
+  id: string;
+  object?: PbxObject;
+}
+
+function configurationReferences(
+  listId: string | undefined,
+  objects: PbxObjects,
+  diagnostics: IOSDiagnostic[],
+  evidencePath: string,
+  owner: string,
+): { references: ConfigurationReference[]; complete: boolean } {
+  if (!listId) {
+    addDiagnosticOnce(diagnostics, {
+      code: "xcode.dangling-reference",
+      severity: "error",
+      message: `${owner} has no XCConfigurationList reference.`,
+      remedy: "Repair the Xcode project build-configuration list before automating setup.",
+      evidence: [{ path: evidencePath, keyPath: "buildConfigurationList" }],
+    });
+    return { references: [], complete: false };
+  }
+  const list = objects[listId];
+  if (list?.isa !== "XCConfigurationList") {
+    addDiagnosticOnce(diagnostics, {
+      code: "xcode.dangling-reference",
+      severity: "error",
+      message: `${owner} references a missing or invalid XCConfigurationList (${listId}).`,
+      remedy: "Repair the Xcode project build-configuration list before automating setup.",
+      evidence: [{ path: evidencePath, objectId: listId }],
+    });
+    return { references: [], complete: false };
+  }
+
+  let complete = true;
+  const references = asStringArray(list.buildConfigurations).map((id) => {
+    const object = objects[id];
+    if (object?.isa === "XCBuildConfiguration") return { id, object };
+    complete = false;
+    addDiagnosticOnce(diagnostics, {
+      code: "xcode.dangling-reference",
+      severity: "error",
+      message: `${owner} references a missing or invalid XCBuildConfiguration (${id}).`,
+      remedy:
+        "Repair or remove the dangling build-configuration reference before automating setup.",
+      evidence: [{ path: evidencePath, objectId: listId, keyPath: "buildConfigurations" }],
+    });
+    return { id };
+  });
+  return { references, complete };
+}
+
+async function settingsForConfiguration(
+  root: string,
+  projectPath: string,
+  projectDirectory: string,
+  groupRootDirectory: string,
+  configuration: PbxObject | undefined,
+  configurationName: string,
+  context: BuildContext,
+  objects: PbxObjects,
+  parents: Map<string, string>,
+  diagnostics: IOSDiagnostic[],
+  inherited: BuildSettingsEvaluation = {
+    settings: {},
+    settingTaints: new Map(),
+  },
+): Promise<BuildSettingsEvaluation> {
+  let evaluation = cloneEvaluation(inherited);
+  if (!configuration) return evaluation;
+  const baseReference = asString(configuration.baseConfigurationReference);
+  if (baseReference) {
+    const configPath = resolvePbxFilePath(
+      baseReference,
+      objects,
+      parents,
+      projectDirectory,
+      groupRootDirectory,
+    );
+    if (configPath) {
+      if (hasBuildSettingVariable(configPath)) {
+        taintInspectedSettings(evaluation, "variable base xcconfig path");
+        addDiagnosticOnce(diagnostics, {
+          code: "xcode.unresolved-build-setting",
+          severity: "warning",
+          message: "An XCBuildConfiguration base xcconfig path contains build-setting variables.",
+          remedy: "Use a literal checked-in base xcconfig path before automating setup.",
+          evidence: [
+            {
+              path: relativeIOSPath(root, resolve(projectPath, "project.pbxproj")),
+              objectId: baseReference,
+              keyPath: "baseConfigurationReference",
+            },
+          ],
+        });
+      } else {
+        evaluation = await readXCConfigSettings(
+          root,
+          configPath,
+          configurationName,
+          context,
+          diagnostics,
+          evaluation,
+        );
+      }
+    } else {
+      taintInspectedSettings(evaluation, "unresolved base xcconfig reference");
+      addDiagnosticOnce(diagnostics, {
+        code: "xcode.dangling-reference",
+        severity: "error",
+        message: `Could not resolve an XCBuildConfiguration baseConfigurationReference (${baseReference}).`,
+        remedy: "Repair the base xcconfig file reference before automating setup.",
+        evidence: [
+          {
+            path: relativeIOSPath(root, resolve(projectPath, "project.pbxproj")),
+            objectId: baseReference,
+            keyPath: "baseConfigurationReference",
+          },
+        ],
+      });
+    }
+  }
+  applyInlineBuildSettings(
+    evaluation,
+    asStringRecord(configuration.buildSettings),
+    configurationName,
+    context,
+  );
+  return evaluation;
+}
+
+export interface InspectedTargetConfiguration {
+  model: IOSBuildConfiguration;
+  settings: Record<string, string>;
+  isIOS: boolean;
+}
+
+interface EvaluatedBuildContext {
+  context: BuildContext;
+  evaluation: BuildSettingsEvaluation;
+  builtins: Record<string, string>;
+}
+
+function resolutionSignature(resolution: IOSValueResolution): string {
+  if (resolution.state === "resolved") return `resolved:${resolution.value}`;
+  if (resolution.state === "missing") return "missing";
+  return `unresolved:${resolution.raw}:${resolution.missingVariables.join(",")}`;
+}
+
+function resolutionDisplay(resolution: IOSValueResolution): string {
+  if (resolution.state === "resolved") return resolution.value;
+  return resolution.state === "missing" ? "<missing>" : "<unresolved>";
+}
+
+function resolveSettingAcrossContexts(
+  key: string,
+  contexts: EvaluatedBuildContext[],
+  evidence: IOSSourceEvidence,
+  targetName: string,
+  configurationName: string,
+  diagnostics: IOSDiagnostic[],
+): IOSValueResolution {
+  const variants = contexts.map(({ context, evaluation, builtins }) => ({
+    context,
+    resolution: resolveSetting(key, evaluation, builtins, evidence),
+  }));
+  const signatures = new Set(variants.map(({ resolution }) => resolutionSignature(resolution)));
+  if (signatures.size <= 1)
+    return variants[0]?.resolution ?? { state: "missing", evidence: [evidence] };
+
+  addDiagnosticOnce(diagnostics, {
+    code: "xcode.conflicting-build-setting",
+    severity: "warning",
+    message: `${targetName} ${configurationName} has different ${key} values by SDK: ${variants
+      .map(({ context, resolution }) => `${context.label}=${resolutionDisplay(resolution)}`)
+      .join(", ")}`,
+    remedy: "Make device and simulator values consistent or select the intended SDK explicitly.",
+    evidence: variants.flatMap(({ resolution }) => resolution.evidence),
+  });
+
+  return {
+    state: "unresolved",
+    raw: variants
+      .map(({ context, resolution }) => `${context.label}=${resolutionDisplay(resolution)}`)
+      .join("; "),
+    missingVariables: unique([
+      "sdk-conditioned build setting",
+      ...variants.flatMap(({ resolution }) =>
+        resolution.state === "unresolved" ? resolution.missingVariables : [],
+      ),
+    ]).sort(),
+    evidence: variants.flatMap(({ resolution }) => resolution.evidence),
+  };
+}
+
+function missingConfiguration(
+  root: string,
+  projectPath: string,
+  configurationId: string,
+): InspectedTargetConfiguration {
+  const evidence: IOSSourceEvidence = {
+    path: relativeIOSPath(root, resolve(projectPath, "project.pbxproj")),
+    objectId: configurationId,
+    keyPath: "buildConfigurations",
+  };
+  const missing: IOSValueResolution = { state: "missing", evidence: [evidence] };
+  return {
+    model: {
+      name: `Unresolved (${configurationId})`,
+      bundleIdentifier: missing,
+      developmentTeam: missing,
+      entitlementsPath: missing,
+      deploymentTarget: missing,
+    },
+    settings: {},
+    // The product type identifies this as an application target, but the
+    // dangling configuration does not contain enough evidence to exclude iOS.
+    isIOS: true,
+  };
+}
+
+export async function inspectTargetBuildConfigurations(options: {
+  root: string;
+  projectPath: string;
+  groupRootDirectory: string;
+  projectObject: PbxObject;
+  targetId: string;
+  targetObject: PbxObject;
+  objects: PbxObjects;
+  parents: Map<string, string>;
+  diagnostics: IOSDiagnostic[];
+}): Promise<InspectedTargetConfiguration[]> {
+  const {
+    root,
+    projectPath,
+    groupRootDirectory,
+    projectObject,
+    targetId,
+    targetObject,
+    objects,
+    parents,
+    diagnostics,
+  } = options;
+  const projectDirectory = dirname(projectPath);
+  const pbxprojRelativePath = relativeIOSPath(root, resolve(projectPath, "project.pbxproj"));
+  const projectConfigurationReferences = configurationReferences(
+    asString(projectObject.buildConfigurationList),
+    objects,
+    diagnostics,
+    pbxprojRelativePath,
+    "PBXProject",
+  );
+  const projectConfigsByName = new Map(
+    projectConfigurationReferences.references.flatMap(({ object }) =>
+      object ? [[asString(object.name) ?? "", object] as const] : [],
+    ),
+  );
+  const targetName = asString(targetObject.name) ?? "App";
+  const targetConfigurationReferences = configurationReferences(
+    asString(targetObject.buildConfigurationList),
+    objects,
+    diagnostics,
+    pbxprojRelativePath,
+    `Target ${targetName}`,
+  );
+  const inspected: InspectedTargetConfiguration[] = [];
+
+  for (const targetReference of targetConfigurationReferences.references.sort((a, b) =>
+    (asString(a.object?.name) ?? a.id).localeCompare(asString(b.object?.name) ?? b.id),
+  )) {
+    const targetConfig = targetReference.object;
+    if (!targetConfig) {
+      inspected.push(missingConfiguration(root, projectPath, targetReference.id));
+      continue;
+    }
+    const name = asString(targetConfig.name) ?? "Unnamed";
+    const evaluatedContexts: EvaluatedBuildContext[] = [];
+    for (const context of BUILD_CONTEXTS) {
+      const inherited: BuildSettingsEvaluation = {
+        settings: {},
+        settingTaints: new Map(),
+      };
+      const projectSettings = await settingsForConfiguration(
+        root,
+        projectPath,
+        projectDirectory,
+        groupRootDirectory,
+        projectConfigsByName.get(name),
+        name,
+        context,
+        objects,
+        parents,
+        diagnostics,
+        inherited,
+      );
+      const evaluation = await settingsForConfiguration(
+        root,
+        projectPath,
+        projectDirectory,
+        groupRootDirectory,
+        targetConfig,
+        name,
+        context,
+        objects,
+        parents,
+        diagnostics,
+        projectSettings,
+      );
+      // A dangling project configuration cannot be attributed to Debug or
+      // Release, so keep completeness unknown even when another layer has a
+      // literal override. This is structural evidence, not an ordered
+      // xcconfig include that a later assignment can supersede.
+      if (!projectConfigurationReferences.complete) {
+        taintInspectedSettings(evaluation, "incomplete project configuration list");
+      }
+
+      const productName =
+        evaluation.settings.PRODUCT_NAME ?? asString(targetObject.productName) ?? targetName;
+      evaluatedContexts.push({
+        context,
+        evaluation,
+        builtins: {
+          SRCROOT: projectDirectory,
+          PROJECT_DIR: projectDirectory,
+          PROJECT_NAME:
+            projectPath
+              .split(sep)
+              .at(-1)
+              ?.replace(/\.xcodeproj$/, "") ?? targetName,
+          TARGET_NAME: targetName,
+          PRODUCT_NAME: productName,
+          CONFIGURATION: name,
+        },
+      });
+    }
+
+    const deviceContext = evaluatedContexts[0];
+    if (!deviceContext) continue;
+    const evidence = (setting: string): IOSSourceEvidence => ({
+      path: pbxprojRelativePath,
+      objectId: targetId,
+      keyPath: `buildConfigurations.${name}.buildSettings.${setting}`,
+    });
+    const supportedPlatformsResolution = resolveSettingAcrossContexts(
+      "SUPPORTED_PLATFORMS",
+      evaluatedContexts,
+      evidence("SUPPORTED_PLATFORMS"),
+      targetName,
+      name,
+      diagnostics,
+    );
+    const supportedPlatforms =
+      supportedPlatformsResolution.state === "resolved" ? supportedPlatformsResolution.value : "";
+    const activeContexts =
+      supportedPlatformsResolution.state === "resolved" &&
+      supportedPlatforms.trim() !== "" &&
+      !/\biphonesimulator\b/.test(supportedPlatforms)
+        ? [deviceContext]
+        : evaluatedContexts;
+    const sdkRootResolution = resolveSettingAcrossContexts(
+      "SDKROOT",
+      activeContexts,
+      evidence("SDKROOT"),
+      targetName,
+      name,
+      diagnostics,
+    );
+    const deploymentTarget = resolveSettingAcrossContexts(
+      "IPHONEOS_DEPLOYMENT_TARGET",
+      activeContexts,
+      evidence("IPHONEOS_DEPLOYMENT_TARGET"),
+      targetName,
+      name,
+      diagnostics,
+    );
+    const sdkRoot = sdkRootResolution.state === "resolved" ? sdkRootResolution.value : "";
+    const hasIOSSDK = sdkRootResolution.state === "resolved" && sdkRoot.includes("iphoneos");
+    const hasIOSPlatform =
+      supportedPlatformsResolution.state === "resolved" &&
+      /iphone(?:os|simulator)/.test(supportedPlatforms);
+    const hasPositiveIOSEvidence =
+      deploymentTarget.state !== "missing" || hasIOSSDK || hasIOSPlatform;
+    const hasUnknownPlatformEvidence =
+      sdkRootResolution.state === "unresolved" ||
+      supportedPlatformsResolution.state === "unresolved";
+    const hasResolvedNonIOSEvidence =
+      (sdkRootResolution.state === "resolved" && sdkRoot !== "" && !hasIOSSDK) ||
+      (supportedPlatformsResolution.state === "resolved" &&
+        supportedPlatforms !== "" &&
+        !hasIOSPlatform);
+    const explicitlyNonIOS =
+      !hasPositiveIOSEvidence && !hasUnknownPlatformEvidence && hasResolvedNonIOSEvidence;
+
+    const model: IOSBuildConfiguration = {
+      name,
+      bundleIdentifier: resolveSettingAcrossContexts(
+        "PRODUCT_BUNDLE_IDENTIFIER",
+        activeContexts,
+        evidence("PRODUCT_BUNDLE_IDENTIFIER"),
+        targetName,
+        name,
+        diagnostics,
+      ),
+      developmentTeam: resolveSettingAcrossContexts(
+        "DEVELOPMENT_TEAM",
+        activeContexts,
+        evidence("DEVELOPMENT_TEAM"),
+        targetName,
+        name,
+        diagnostics,
+      ),
+      entitlementsPath: resolveSettingAcrossContexts(
+        "CODE_SIGN_ENTITLEMENTS",
+        activeContexts,
+        evidence("CODE_SIGN_ENTITLEMENTS"),
+        targetName,
+        name,
+        diagnostics,
+      ),
+      deploymentTarget,
+    };
+    const relevantSettings: Array<[string, IOSValueResolution]> = [
+      ["PRODUCT_BUNDLE_IDENTIFIER", model.bundleIdentifier],
+      ["DEVELOPMENT_TEAM", model.developmentTeam],
+      ["CODE_SIGN_ENTITLEMENTS", model.entitlementsPath],
+      ["IPHONEOS_DEPLOYMENT_TARGET", model.deploymentTarget],
+      ["SDKROOT", sdkRootResolution],
+      ["SUPPORTED_PLATFORMS", supportedPlatformsResolution],
+    ];
+    for (const [setting, resolution] of relevantSettings) {
+      if (resolution.state !== "unresolved") continue;
+      addDiagnosticOnce(diagnostics, {
+        code: "xcode.unresolved-build-setting",
+        severity: "warning",
+        message: `${targetName} ${name} has an unresolved ${setting} value (${resolution.missingVariables.join(", ") || "unknown variable"}).`,
+        remedy: "Make the setting resolvable from the project or its checked-in xcconfig files.",
+        evidence: resolution.evidence,
+      });
+    }
+
+    inspected.push({
+      model,
+      settings: deviceContext.evaluation.settings,
+      isIOS: !explicitlyNonIOS,
+    });
+  }
+
+  return inspected;
+}
+
+export function addBuildSettingConflictDiagnostics(
+  targetName: string,
+  configurations: IOSBuildConfiguration[],
+  diagnostics: IOSDiagnostic[],
+): void {
+  const checks: Array<[string, (config: IOSBuildConfiguration) => IOSValueResolution]> = [
+    ["PRODUCT_BUNDLE_IDENTIFIER", (config) => config.bundleIdentifier],
+    ["DEVELOPMENT_TEAM", (config) => config.developmentTeam],
+    ["CODE_SIGN_ENTITLEMENTS", (config) => config.entitlementsPath],
+  ];
+
+  for (const [setting, select] of checks) {
+    const values = configurations.map((configuration) => ({
+      name: configuration.name,
+      resolution: select(configuration),
+    }));
+    const signatures = new Set(
+      values.map(({ resolution }) =>
+        resolution.state === "resolved"
+          ? `resolved:${resolution.value}`
+          : resolution.state === "unresolved"
+            ? `unresolved:${resolution.raw}`
+            : "missing",
+      ),
+    );
+    if (signatures.size <= 1) continue;
+
+    diagnostics.push({
+      code: "xcode.conflicting-build-setting",
+      severity: "warning",
+      message: `${targetName} has different ${setting} values across build configurations: ${values
+        .map(
+          ({ name, resolution }) =>
+            `${name}=${
+              resolution.state === "resolved"
+                ? resolution.value
+                : resolution.state === "unresolved"
+                  ? "<unresolved>"
+                  : "<missing>"
+            }`,
+        )
+        .join(", ")}`,
+      remedy: "Select one configuration or make the values consistent before automating setup.",
+      evidence: values.flatMap((item) => item.resolution.evidence),
+    });
+  }
+}
+
+export function resolveEntitlementsAbsolutePath(
+  root: string,
+  projectPath: string,
+  resolution: IOSValueResolution,
+): string | undefined {
+  if (resolution.state !== "resolved") return undefined;
+  const path = resolution.value;
+  const absolute = resolve(dirname(projectPath), path);
+  return pathIsWithinIOSRoot(root, absolute) ? absolute : undefined;
+}

--- a/packages/cli-core/src/commands/init/ios/direct-config.test.ts
+++ b/packages/cli-core/src/commands/init/ios/direct-config.test.ts
@@ -1,0 +1,663 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmod, lstat, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  applyIOSDirectConfig,
+  planIOSDirectConfig,
+  prepareIOSDirectConfigMutation,
+  validatePreparedIOSDirectConfig,
+  type IOSDirectConfigBlockerCode,
+} from "./direct-config.ts";
+import { createIOSFixture, IOS_FIXTURE_IDS, treeDigest } from "./test-helpers.ts";
+
+const DEVELOPMENT_KEY = `pk_test_${Buffer.from("direct-config.clerk.accounts.dev$").toString("base64")}`;
+const OTHER_DEVELOPMENT_KEY = `pk_test_${Buffer.from("other-app.clerk.accounts.dev$").toString("base64")}`;
+const PRODUCTION_KEY = `pk_live_${Buffer.from("production.example.com$").toString("base64")}`;
+const temporaryDirectories: string[] = [];
+
+async function temporaryRoot(prefix = "clerk-ios-direct-config-"): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  temporaryDirectories.push(root);
+  return root;
+}
+
+async function fixture(options: Parameters<typeof createIOSFixture>[1] = {}): Promise<string> {
+  const root = await temporaryRoot();
+  await createIOSFixture(root, options);
+  return root;
+}
+
+function appSourcePath(root: string): string {
+  return join(root, "MyApp", "MyAppApp.swift");
+}
+
+function planOptions(root: string, targetId: string = IOS_FIXTURE_IDS.appTarget) {
+  return {
+    root,
+    projectPath: "MyApp.xcodeproj",
+    targetId,
+  };
+}
+
+async function source(root: string): Promise<string> {
+  return readFile(appSourcePath(root), "utf8");
+}
+
+async function replaceSource(root: string, value: string | Uint8Array): Promise<void> {
+  await writeFile(appSourcePath(root), value);
+}
+
+function blockerCodes(
+  plan: Awaited<ReturnType<typeof planIOSDirectConfig>>,
+): IOSDirectConfigBlockerCode[] {
+  return plan.blockers.map((blocker) => blocker.code);
+}
+
+async function run(...args: string[]): Promise<void> {
+  const child = Bun.spawn(args, { stdout: "ignore", stderr: "ignore" });
+  if ((await child.exited) !== 0) throw new Error(`Command failed: ${args[0]}`);
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+describe("iOS direct Clerk configuration", () => {
+  test("plans a fully redacted pristine SwiftUI setup without writing", async () => {
+    const root = await fixture();
+    const before = await treeDigest(root);
+
+    const plan = await planIOSDirectConfig(planOptions(root));
+
+    expect(plan).toMatchObject({
+      status: "ready",
+      sourcePath: "MyApp/MyAppApp.swift",
+      changes: {
+        clerkKitImport: "insert",
+        configuration: "insert-initializer",
+        environment: "insert",
+      },
+      blockers: [],
+    });
+    expect(plan.actions).toHaveLength(3);
+    expect(JSON.stringify(plan)).not.toContain("pk_test_");
+    expect(JSON.stringify(plan)).not.toContain(DEVELOPMENT_KEY);
+    expect(await treeDigest(root)).toEqual(before);
+  });
+
+  test("parses repeated Swift import attributes in linear time", async () => {
+    const root = await fixture();
+    const attributes = "@A() ".repeat(2_000);
+    await replaceSource(
+      root,
+      `${attributes}import SwiftUI
+
+@main
+struct MyApp: App {
+  var body: some Scene { WindowGroup { Text("Hello") } }
+}
+`,
+    );
+
+    const plan = await planIOSDirectConfig(planOptions(root));
+
+    expect(plan.status).toBe("ready");
+    expect(plan.changes?.clerkKitImport).toBe("insert");
+  });
+
+  test("refuses an attributed ClerkKit import instead of adding a duplicate", async () => {
+    const root = await fixture();
+    await replaceSource(
+      root,
+      `@_exported import ClerkKit
+import SwiftUI
+
+@main
+struct MyApp: App {
+  var body: some Scene { WindowGroup { Text("Hello") } }
+}
+`,
+    );
+
+    expect(blockerCodes(await planIOSDirectConfig(planOptions(root)))).toContain(
+      "unsupported-app-structure",
+    );
+  });
+
+  test("configures a compact pristine app and is byte-idempotent", async () => {
+    const root = await fixture();
+    const firstPlan = await planIOSDirectConfig(planOptions(root));
+
+    expect((await applyIOSDirectConfig(firstPlan, DEVELOPMENT_KEY)).status).toBe("applied");
+    const configured = await source(root);
+    expect(configured).toContain("import SwiftUI\nimport ClerkKit\n");
+    expect(configured).toContain(`Clerk.configure(publishableKey: "${DEVELOPMENT_KEY}")`);
+    expect(configured).toContain('Text("Hello").environment(Clerk.shared)');
+
+    const secondPlan = await planIOSDirectConfig(planOptions(root));
+    expect(secondPlan.changes).toEqual({
+      clerkKitImport: "satisfied",
+      configuration: "verify-existing",
+      environment: "satisfied",
+    });
+    const beforeSecondApply = await readFile(appSourcePath(root));
+    expect((await applyIOSDirectConfig(secondPlan, DEVELOPMENT_KEY)).status).toBe("satisfied");
+    expect(await readFile(appSourcePath(root))).toEqual(beforeSecondApply);
+  });
+
+  test("inserts configuration first in one existing initializer", async () => {
+    const root = await fixture();
+    await replaceSource(
+      root,
+      `import SwiftUI
+
+@main
+struct MyApp: App {
+  init() {
+    // Existing startup behavior.
+    bootstrap()
+  }
+
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
+    }
+  }
+
+  private func bootstrap() {}
+}
+`,
+    );
+
+    const plan = await planIOSDirectConfig(planOptions(root));
+    expect(plan.changes?.configuration).toBe("insert-statement");
+    expect((await applyIOSDirectConfig(plan, DEVELOPMENT_KEY)).status).toBe("applied");
+    const configured = await source(root);
+    expect(configured.indexOf("Clerk.configure")).toBeLessThan(configured.indexOf("bootstrap()"));
+    expect(configured).toContain("// Existing startup behavior.");
+    expect(configured).toContain("private func bootstrap() {}");
+  });
+
+  test("treats an existing exact inline literal as verification-required", async () => {
+    const root = await fixture();
+    await replaceSource(
+      root,
+      `import ClerkKit
+import SwiftUI
+
+@main
+struct MyApp: App {
+  init() {
+    Clerk.configure(publishableKey: "${DEVELOPMENT_KEY}")
+  }
+
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
+        .environment(Clerk.shared)
+    }
+  }
+}
+`,
+    );
+    const before = await readFile(appSourcePath(root));
+
+    const plan = await planIOSDirectConfig(planOptions(root));
+
+    expect(plan.status).toBe("ready");
+    expect(plan.changes?.configuration).toBe("verify-existing");
+    expect(plan.actions.join(" ")).toContain("Verify the existing inline Clerk configuration");
+    expect(JSON.stringify(plan)).not.toContain(DEVELOPMENT_KEY);
+    expect((await applyIOSDirectConfig(plan, DEVELOPMENT_KEY)).status).toBe("satisfied");
+    expect(await readFile(appSourcePath(root))).toEqual(before);
+  });
+
+  test("refuses indirect Clerk access before an existing inline configuration", async () => {
+    const root = await fixture();
+    await replaceSource(
+      root,
+      `import ClerkKit
+import SwiftUI
+
+@main
+struct MyApp: App {
+  init() {
+    bootstrap()
+    Clerk.configure(publishableKey: "${DEVELOPMENT_KEY}")
+  }
+
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
+        .environment(Clerk.shared)
+    }
+  }
+
+  private func bootstrap() { consume(Clerk.shared) }
+  private func consume(_ clerk: Clerk) {}
+}
+`,
+    );
+
+    const plan = await planIOSDirectConfig(planOptions(root));
+
+    expect(blockerCodes(plan)).toContain("preinitialization-clerk-access");
+    expect(plan.blockers[0]?.message).toContain("first executable statement");
+  });
+
+  test("refuses stored startup state even when an explicit initializer exists", async () => {
+    for (const initializer of [
+      "init() { bootstrap() }",
+      `init() { Clerk.configure(publishableKey: "${DEVELOPMENT_KEY}") }`,
+    ]) {
+      const root = await fixture();
+      await replaceSource(
+        root,
+        `import ClerkKit
+import SwiftUI
+
+private func earlyClerk() -> Clerk { Clerk.shared }
+
+@main
+struct MyApp: App {
+  let early = earlyClerk()
+  ${initializer}
+  var body: some Scene { WindowGroup { ContentView().environment(Clerk.shared) } }
+  private func bootstrap() {}
+}
+`,
+      );
+
+      const plan = await planIOSDirectConfig(planOptions(root));
+
+      expect(blockerCodes(plan)).toContain("unsupported-initializer");
+      expect(plan.blockers[0]?.message).toContain("stored startup state");
+    }
+  });
+
+  test("preserves a different existing inline development key", async () => {
+    const root = await fixture();
+    await replaceSource(
+      root,
+      `import ClerkKit
+import SwiftUI
+
+@main
+struct MyApp: App {
+  init() { Clerk.configure(publishableKey: "${OTHER_DEVELOPMENT_KEY}") }
+  var body: some Scene { WindowGroup { ContentView().environment(Clerk.shared) } }
+}
+`,
+    );
+    const before = await readFile(appSourcePath(root));
+    const plan = await planIOSDirectConfig(planOptions(root));
+
+    const result = await applyIOSDirectConfig(plan, DEVELOPMENT_KEY);
+
+    expect(result.status).toBe("blocked");
+    expect(result.plan.blockers[0]?.code).toBe("different-inline-publishable-key");
+    expect(JSON.stringify(result)).not.toContain(DEVELOPMENT_KEY);
+    expect(JSON.stringify(result)).not.toContain(OTHER_DEVELOPMENT_KEY);
+    expect(await readFile(appSourcePath(root))).toEqual(before);
+  });
+
+  test("refuses malformed, production, and indirect existing configurations", async () => {
+    const cases = [
+      {
+        call: 'Clerk.configure(publishableKey: "pk_test_not-valid")',
+        code: "invalid-inline-publishable-key",
+      },
+      {
+        call: `Clerk.configure(publishableKey: "${PRODUCTION_KEY}")`,
+        code: "production-inline-publishable-key",
+      },
+      {
+        call: 'Clerk.configure(publishableKey: LocalSecrets.load().publishableKey ?? "")',
+        code: "conflicting-configuration",
+      },
+    ] as const;
+
+    for (const item of cases) {
+      const root = await fixture();
+      await replaceSource(
+        root,
+        `import ClerkKit
+import SwiftUI
+
+@main
+struct MyApp: App {
+  init() { ${item.call} }
+  var body: some Scene { WindowGroup { ContentView() } }
+}
+`,
+      );
+      const plan = await planIOSDirectConfig(planOptions(root));
+      expect(blockerCodes(plan)).toContain(item.code);
+    }
+  });
+
+  test("refuses multiple @main declarations and complex scene roots", async () => {
+    const multipleRoot = await fixture();
+    await replaceSource(
+      multipleRoot,
+      `import SwiftUI
+
+@main
+struct MyApp: App {
+  var body: some Scene { WindowGroup { ContentView() } }
+}
+
+@main
+struct OtherApp: App {
+  var body: some Scene { WindowGroup { Text("Other") } }
+}
+`,
+    );
+    expect((await planIOSDirectConfig(planOptions(multipleRoot))).status).toBe("blocked");
+
+    const complexScene = await fixture();
+    await replaceSource(
+      complexScene,
+      `import SwiftUI
+
+@main
+struct MyApp: App {
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
+      Text("Second root")
+    }
+  }
+}
+`,
+    );
+    expect(blockerCodes(await planIOSDirectConfig(planOptions(complexScene)))).toContain(
+      "unsupported-scene",
+    );
+  });
+
+  test("refuses Clerk.shared access that can run before App initialization", async () => {
+    const globalAccess = await fixture();
+    await replaceSource(
+      globalAccess,
+      `import ClerkKit
+import SwiftUI
+
+let earlyClerk = Clerk.shared
+
+@main
+struct MyApp: App {
+  var body: some Scene { WindowGroup { ContentView() } }
+}
+`,
+    );
+    expect(blockerCodes(await planIOSDirectConfig(planOptions(globalAccess)))).toContain(
+      "preinitialization-clerk-access",
+    );
+
+    const memberAccess = await fixture();
+    await replaceSource(
+      memberAccess,
+      `import ClerkKit
+import SwiftUI
+
+@main
+struct MyApp: App {
+  let earlyClerk = Clerk.shared
+  var body: some Scene { WindowGroup { ContentView() } }
+}
+`,
+    );
+    expect(blockerCodes(await planIOSDirectConfig(planOptions(memberAccess)))).toContain(
+      "unsupported-initializer",
+    );
+
+    const beforeExistingConfig = await fixture();
+    await replaceSource(
+      beforeExistingConfig,
+      `import ClerkKit
+import SwiftUI
+
+@main
+struct MyApp: App {
+  init() {
+    use(Clerk.shared)
+    Clerk.configure(publishableKey: "${DEVELOPMENT_KEY}")
+  }
+  var body: some Scene { WindowGroup { ContentView().environment(Clerk.shared) } }
+}
+`,
+    );
+    expect(blockerCodes(await planIOSDirectConfig(planOptions(beforeExistingConfig)))).toContain(
+      "preinitialization-clerk-access",
+    );
+  });
+
+  test("does not mistake method-body or WindowGroup environment use for early access", async () => {
+    const root = await fixture();
+    await replaceSource(
+      root,
+      `import ClerkKit
+import SwiftUI
+
+@main
+struct MyApp: App {
+  init() {
+    Clerk.configure(publishableKey: "${DEVELOPMENT_KEY}")
+  }
+  var body: some Scene { WindowGroup { ContentView().environment(Clerk.shared) } }
+  private func later() { use(Clerk.shared) }
+}
+`,
+    );
+
+    expect((await planIOSDirectConfig(planOptions(root))).status).toBe("ready");
+  });
+
+  test("refuses generated projects and an unsafe external source path", async () => {
+    const generated = await fixture({ generated: "xcodegen" });
+    expect(blockerCodes(await planIOSDirectConfig(planOptions(generated)))).toContain(
+      "generated-project",
+    );
+
+    const parentRoot = await temporaryRoot();
+    const nestedRoot = join(parentRoot, "Nested");
+    await createIOSFixture(nestedRoot);
+    await writeFile(join(nestedRoot, "project.yml"), "name: MyApp\n");
+    expect(
+      blockerCodes(
+        await planIOSDirectConfig({
+          root: parentRoot,
+          projectPath: "Nested/MyApp.xcodeproj",
+          targetId: IOS_FIXTURE_IDS.appTarget,
+        }),
+      ),
+    ).toContain("generated-project");
+
+    const externalRoot = await fixture();
+    const outside = await temporaryRoot("clerk-ios-outside-");
+    await writeFile(join(outside, "Outside.swift"), await source(externalRoot));
+    await rm(appSourcePath(externalRoot));
+    await symlink(join(outside, "Outside.swift"), appSourcePath(externalRoot));
+    expect(blockerCodes(await planIOSDirectConfig(planOptions(externalRoot)))).toContain(
+      "incomplete-source-membership",
+    );
+  });
+
+  test("edits only the explicitly selected target", async () => {
+    const root = await fixture({ secondTarget: true });
+    const mainBefore = await readFile(appSourcePath(root));
+    const adminPath = join(root, "AdminApp", "AdminAppApp.swift");
+
+    const plan = await planIOSDirectConfig(planOptions(root, IOS_FIXTURE_IDS.secondTarget));
+    expect(plan.sourcePath).toBe("AdminApp/AdminAppApp.swift");
+    expect((await applyIOSDirectConfig(plan, DEVELOPMENT_KEY)).status).toBe("applied");
+
+    expect(await readFile(appSourcePath(root))).toEqual(mainBefore);
+    expect(await readFile(adminPath, "utf8")).toContain("Clerk.configure");
+  });
+
+  test("detects stale source bytes before writing", async () => {
+    const root = await fixture();
+    const plan = await planIOSDirectConfig(planOptions(root));
+    await writeFile(appSourcePath(root), `${await source(root)}// Concurrent edit.\n`);
+    const changed = await readFile(appSourcePath(root));
+
+    const result = await applyIOSDirectConfig(plan, DEVELOPMENT_KEY);
+
+    expect(result.status).toBe("stale");
+    expect(await readFile(appSourcePath(root))).toEqual(changed);
+  });
+
+  test("detects a commit-time race without overwriting it", async () => {
+    const root = await fixture();
+    const plan = await planIOSDirectConfig(planOptions(root));
+    let raced = Buffer.alloc(0);
+
+    const result = await applyIOSDirectConfig(plan, DEVELOPMENT_KEY, {
+      beforeCommit: async () => {
+        await writeFile(appSourcePath(root), `${await source(root)}// Commit race.\n`);
+        raced = await readFile(appSourcePath(root));
+      },
+    });
+
+    expect(result.status).toBe("stale");
+    expect(await readFile(appSourcePath(root))).toEqual(raced);
+  });
+
+  test("rolls back an exact candidate after post-write validation fails", async () => {
+    const root = await fixture();
+    const before = await readFile(appSourcePath(root));
+    const plan = await planIOSDirectConfig(planOptions(root));
+
+    const result = await applyIOSDirectConfig(plan, DEVELOPMENT_KEY, {
+      forcePostWriteValidationFailure: true,
+    });
+
+    expect(result.status).toBe("rolled-back");
+    expect(await readFile(appSourcePath(root))).toEqual(before);
+  });
+
+  test("preserves CRLF, comments, file mode, and unrelated Swift bytes", async () => {
+    const root = await fixture();
+    const crlf = [
+      "// Keep this header.",
+      "import SwiftUI",
+      "",
+      "@main",
+      "struct MyApp: App {",
+      "    var body: some Scene {",
+      "        WindowGroup {",
+      "            ContentView() // Keep this root comment.",
+      "        }",
+      "    }",
+      "",
+      "    private func unrelated() {",
+      '        print("Leave me byte-identical.")',
+      "    }",
+      "}",
+      "",
+    ].join("\r\n");
+    await replaceSource(root, crlf);
+    await chmod(appSourcePath(root), 0o640);
+
+    const plan = await planIOSDirectConfig(planOptions(root));
+    expect((await applyIOSDirectConfig(plan, DEVELOPMENT_KEY)).status).toBe("applied");
+    const configuredBytes = await readFile(appSourcePath(root));
+    const configured = configuredBytes.toString("utf8");
+    expect(configured.replaceAll("\r\n", "")).not.toContain("\n");
+    expect(configured).toContain("// Keep this header.");
+    expect(configured).toContain(
+      "ContentView().environment(Clerk.shared) // Keep this root comment.",
+    );
+    expect(configured).toContain(
+      '    private func unrelated() {\r\n        print("Leave me byte-identical.")\r\n    }',
+    );
+    expect((await lstat(appSourcePath(root))).mode & 0o777).toBe(0o640);
+  });
+
+  test("blocks a dirty planned Swift source unless explicitly allowed", async () => {
+    const root = await fixture();
+    await run("git", "init", "-q", root);
+    await run("git", "-C", root, "config", "user.email", "test@example.com");
+    await run("git", "-C", root, "config", "user.name", "Test User");
+    await run("git", "-C", root, "add", "MyApp/MyAppApp.swift");
+    await run("git", "-C", root, "commit", "-qm", "fixture");
+    await writeFile(appSourcePath(root), `${await source(root)}// Dirty.\n`);
+
+    expect(blockerCodes(await planIOSDirectConfig(planOptions(root)))).toContain("dirty-source");
+    expect(
+      (
+        await planIOSDirectConfig({
+          ...planOptions(root),
+          allowDirty: true,
+        })
+      ).status,
+    ).toBe("ready");
+  });
+
+  test("allows dirty source when an exact inline setup only needs key verification", async () => {
+    const root = await fixture();
+    await replaceSource(
+      root,
+      `import ClerkKit
+import SwiftUI
+
+@main
+struct MyApp: App {
+  init() { Clerk.configure(publishableKey: "${DEVELOPMENT_KEY}") }
+  var body: some Scene { WindowGroup { ContentView().environment(Clerk.shared) } }
+}
+`,
+    );
+    await run("git", "init", "-q", root);
+    await run("git", "-C", root, "config", "user.email", "test@example.com");
+    await run("git", "-C", root, "config", "user.name", "Test User");
+    await run("git", "-C", root, "add", "MyApp/MyAppApp.swift");
+    await run("git", "-C", root, "commit", "-qm", "fixture");
+    await writeFile(appSourcePath(root), `${await source(root)}// Dirty but not rewritten.\n`);
+
+    const plan = await planIOSDirectConfig(planOptions(root));
+    expect(plan.status).toBe("ready");
+    expect(plan.changes).toEqual({
+      clerkKitImport: "satisfied",
+      configuration: "verify-existing",
+      environment: "satisfied",
+    });
+    expect((await applyIOSDirectConfig(plan, DEVELOPMENT_KEY)).status).toBe("satisfied");
+  });
+
+  test("prepares a non-enumerable in-memory mutation and validates an external commit", async () => {
+    const root = await fixture();
+    const plan = await planIOSDirectConfig(planOptions(root));
+    const prepared = await prepareIOSDirectConfigMutation(plan, DEVELOPMENT_KEY);
+
+    expect(prepared.status).toBe("ready");
+    if (prepared.status !== "ready") throw new Error("Expected a prepared mutation.");
+    expect(prepared.mutation.candidateBytes.toString()).not.toBe("");
+    expect(new TextDecoder().decode(prepared.mutation.candidateBytes)).toContain(DEVELOPMENT_KEY);
+    expect(JSON.stringify(prepared)).not.toContain(DEVELOPMENT_KEY);
+    expect(JSON.stringify(prepared.mutation)).not.toContain(DEVELOPMENT_KEY);
+    expect(await source(root)).not.toContain(DEVELOPMENT_KEY);
+
+    await writeFile(prepared.mutation.absolutePath, prepared.mutation.candidateBytes);
+    await chmod(prepared.mutation.absolutePath, prepared.mutation.mode);
+    expect(await validatePreparedIOSDirectConfig(prepared)).toBe(true);
+  });
+
+  test("never includes a supplied key in ordinary apply results", async () => {
+    const root = await fixture();
+    const plan = await planIOSDirectConfig(planOptions(root));
+
+    const invalidResult = await applyIOSDirectConfig(plan, "pk_test_do-not-print");
+    expect(invalidResult.status).toBe("blocked");
+    expect(JSON.stringify(invalidResult)).not.toContain("pk_test_do-not-print");
+
+    const productionResult = await applyIOSDirectConfig(plan, PRODUCTION_KEY);
+    expect(productionResult.status).toBe("blocked");
+    expect(JSON.stringify(productionResult)).not.toContain(PRODUCTION_KEY);
+  });
+});

--- a/packages/cli-core/src/commands/init/ios/direct-config.ts
+++ b/packages/cli-core/src/commands/init/ios/direct-config.ts
@@ -1,0 +1,1778 @@
+import { randomUUID } from "node:crypto";
+import { chmod, lstat, open, readFile, rename, rm } from "node:fs/promises";
+import { basename, dirname, relative, resolve } from "node:path";
+import { decodePublishableKey } from "../../../lib/fapi.ts";
+import { pathIsSafelyWithinIOSRoot, relativeIOSPath } from "./discovery.ts";
+import { inspectIOSProject } from "./inspect.ts";
+import { sanitizeSwiftSource } from "./swift.ts";
+
+const MAX_SWIFT_FILE_BYTES = 1_000_000;
+
+export interface IOSDirectConfigPlanOptions {
+  root: string;
+  /** Project-root-relative path selected by the iOS inspector. */
+  projectPath: string;
+  targetId: string;
+  /** Low-level escape hatch. The aggregate init flow also checks every local mutation. */
+  allowDirty?: boolean;
+}
+
+export type IOSDirectConfigBlockerCode =
+  | "invalid-selection"
+  | "external-path"
+  | "generated-project"
+  | "target-not-found"
+  | "incomplete-source-membership"
+  | "ambiguous-entry-point"
+  | "unreadable-source"
+  | "unsupported-encoding"
+  | "unsupported-line-endings"
+  | "unsupported-app-structure"
+  | "unsupported-initializer"
+  | "unsupported-scene"
+  | "conflicting-configuration"
+  | "conflicting-environment"
+  | "preinitialization-clerk-access"
+  | "invalid-inline-publishable-key"
+  | "production-inline-publishable-key"
+  | "dirty-source"
+  | "git-state-unknown"
+  | "invalid-publishable-key"
+  | "production-publishable-key"
+  | "different-inline-publishable-key";
+
+export interface IOSDirectConfigBlocker {
+  code: IOSDirectConfigBlockerCode;
+  message: string;
+}
+
+export interface IOSDirectConfigChanges {
+  clerkKitImport: "insert" | "satisfied";
+  configuration: "insert-initializer" | "insert-statement" | "verify-existing";
+  environment: "insert" | "satisfied";
+}
+
+/**
+ * A redacted, serializable plan. It deliberately contains neither a key nor
+ * candidate source bytes. A direct literal remains verification-required
+ * until prepare/apply receives the selected application's development key.
+ */
+export interface IOSDirectConfigPlan {
+  schemaVersion: 1;
+  kind: "clerk-ios-direct-config";
+  status: "ready" | "blocked";
+  root: string;
+  projectPath: string;
+  targetId: string;
+  allowDirty: boolean;
+  sourcePath?: string;
+  /** SHA-256 of the exact source bytes inspected by this plan. */
+  expectedSourceHash?: string;
+  changes?: IOSDirectConfigChanges;
+  /** Semantic, publishable-key-redacted preview. */
+  actions: string[];
+  blockers: IOSDirectConfigBlocker[];
+}
+
+export interface IOSDirectConfigApplyResult {
+  status: "applied" | "satisfied" | "blocked" | "stale" | "rolled-back";
+  plan: IOSDirectConfigPlan;
+  message?: string;
+}
+
+/** @internal A key-bearing in-memory mutation for a multi-file transaction coordinator. */
+export interface IOSDirectConfigFileMutation {
+  absolutePath: string;
+  expectedHash: string;
+  candidateHash: string;
+  mode: number;
+  /** Non-enumerable at runtime so ordinary JSON serialization cannot emit source/key bytes. */
+  originalBytes: Uint8Array;
+  /** Non-enumerable at runtime so ordinary JSON serialization cannot emit source/key bytes. */
+  candidateBytes: Uint8Array;
+}
+
+/**
+ * @internal Transaction-oriented preparation result. `mutation` is
+ * non-enumerable and may contain the raw publishable key in candidate bytes.
+ */
+export type IOSDirectConfigPreparedMutation =
+  | {
+      status: "ready";
+      plan: IOSDirectConfigPlan;
+      mutation: IOSDirectConfigFileMutation;
+    }
+  | {
+      status: "satisfied" | "blocked" | "stale";
+      plan: IOSDirectConfigPlan;
+      message?: string;
+      mutation?: undefined;
+    };
+
+/** @internal Test-only fault injection for the standalone atomic writer. */
+export interface IOSDirectConfigApplyOptions {
+  beforeCommit?: () => void | Promise<void>;
+  beforePostWriteValidation?: () => void | Promise<void>;
+  forcePostWriteValidationFailure?: boolean;
+}
+
+interface FileSnapshot {
+  absolutePath: string;
+  relativePath: string;
+  bytes: Uint8Array;
+  source: string;
+  hash: string;
+  mode: number;
+}
+
+interface Range {
+  start: number;
+  end: number;
+}
+
+interface AppStructure {
+  source: string;
+  sanitized: string;
+  newline: "\n" | "\r\n";
+  appType: Range & { openingBrace: number; closingBrace: number; declarationStart: number };
+  initializer?: Range & { openingBrace: number; closingBrace: number };
+  body: Range & { openingBrace: number; closingBrace: number; declarationStart: number };
+  root: Range & { modifierStarts: number[] };
+  hasClerkKitImport: boolean;
+  importInsertion: number;
+  existingPublishableKey?: string;
+  hasEnvironment: boolean;
+  configurationInsertion:
+    | { kind: "new-initializer"; index: number; memberIndent: string; statementIndent: string }
+    | { kind: "existing-initializer"; index: number; statementIndent: string; multiline: boolean }
+    | { kind: "existing-literal" };
+  environmentInsertion?: { index: number; textBeforeKey: string };
+}
+
+interface PreparedDirectConfig {
+  plan: IOSDirectConfigPlan;
+  snapshot?: FileSnapshot;
+  structure?: AppStructure;
+}
+
+interface SourceEdit {
+  index: number;
+  text: string;
+}
+
+interface StagedSource {
+  temporaryPath: string;
+  mutation: IOSDirectConfigFileMutation;
+  committed: boolean;
+}
+
+const preparedValidators = new WeakMap<IOSDirectConfigPreparedMutation, () => Promise<boolean>>();
+
+function sha256(value: string | Uint8Array): string {
+  return new Bun.CryptoHasher("sha256").update(value).digest("hex");
+}
+
+function makePlan(
+  options: IOSDirectConfigPlanOptions,
+  root: string,
+  projectPath: string,
+  status: IOSDirectConfigPlan["status"],
+  details: Partial<
+    Pick<
+      IOSDirectConfigPlan,
+      "sourcePath" | "expectedSourceHash" | "changes" | "actions" | "blockers"
+    >
+  > = {},
+): IOSDirectConfigPlan {
+  return {
+    schemaVersion: 1,
+    kind: "clerk-ios-direct-config",
+    status,
+    root,
+    projectPath,
+    targetId: options.targetId,
+    allowDirty: options.allowDirty === true,
+    sourcePath: details.sourcePath,
+    expectedSourceHash: details.expectedSourceHash,
+    changes: details.changes,
+    actions: details.actions ?? [],
+    blockers: details.blockers ?? [],
+  };
+}
+
+function blocked(
+  options: IOSDirectConfigPlanOptions,
+  root: string,
+  projectPath: string,
+  code: IOSDirectConfigBlockerCode,
+  message: string,
+  source: Partial<PreparedDirectConfig> = {},
+): PreparedDirectConfig {
+  return {
+    ...source,
+    plan: makePlan(options, root, projectPath, "blocked", {
+      sourcePath: source.plan?.sourcePath,
+      expectedSourceHash: source.plan?.expectedSourceHash,
+      blockers: [{ code, message }],
+    }),
+  };
+}
+
+function skipWhitespace(source: string, start: number, end = source.length): number {
+  let cursor = start;
+  while (cursor < end && /\s/.test(source[cursor] ?? "")) cursor += 1;
+  return cursor;
+}
+
+function trimWhitespaceEnd(source: string, start: number, end: number): number {
+  let cursor = end;
+  while (cursor > start && /\s/.test(source[cursor - 1] ?? "")) cursor -= 1;
+  return cursor;
+}
+
+function matchingDelimiter(
+  source: string,
+  opening: number,
+  openCharacter: "(" | "[" | "{",
+  closeCharacter: ")" | "]" | "}",
+): number | undefined {
+  if (source[opening] !== openCharacter) return undefined;
+  let depth = 0;
+  for (let index = opening; index < source.length; index += 1) {
+    if (source[index] === openCharacter) depth += 1;
+    if (source[index] !== closeCharacter) continue;
+    depth -= 1;
+    if (depth === 0) return index;
+  }
+  return undefined;
+}
+
+function matchingBrace(source: string, opening: number): number | undefined {
+  return matchingDelimiter(source, opening, "{", "}");
+}
+
+function matchingParenthesis(source: string, opening: number): number | undefined {
+  return matchingDelimiter(source, opening, "(", ")");
+}
+
+interface SwiftStructuralIndex {
+  braceDepth: Int32Array;
+  conditionalRanges: Range[];
+}
+
+function buildSwiftStructuralIndex(source: string): SwiftStructuralIndex {
+  const braceDepth = new Int32Array(source.length + 1);
+  for (let position = 0; position < source.length; position += 1) {
+    braceDepth[position + 1] =
+      braceDepth[position]! + (source[position] === "{" ? 1 : source[position] === "}" ? -1 : 0);
+  }
+
+  const conditionalRanges: Range[] = [];
+  const directive = /^[\t ]*#(if|elseif|else|endif)\b/gm;
+  let depth = 0;
+  let rangeStart: number | undefined;
+  let match: RegExpExecArray | null;
+  while ((match = directive.exec(source)) !== null) {
+    if (match[1] === "if") {
+      if (depth === 0) rangeStart = match.index;
+      depth += 1;
+    }
+    if (match[1] === "endif" && depth > 0) {
+      depth -= 1;
+      if (depth === 0 && rangeStart != null) {
+        conditionalRanges.push({ start: rangeStart, end: match.index });
+        rangeStart = undefined;
+      }
+    }
+  }
+  if (rangeStart != null) conditionalRanges.push({ start: rangeStart, end: source.length });
+  return { braceDepth, conditionalRanges };
+}
+
+function braceDepthAt(index: SwiftStructuralIndex, openingBrace: number, position: number): number {
+  return index.braceDepth[position]! - index.braceDepth[openingBrace]!;
+}
+
+function isInsideConditionalCompilation(index: SwiftStructuralIndex, position: number): boolean {
+  let low = 0;
+  let high = index.conditionalRanges.length - 1;
+  while (low <= high) {
+    const middle = (low + high) >>> 1;
+    const range = index.conditionalRanges[middle]!;
+    if (position < range.start) high = middle - 1;
+    else if (position >= range.end) low = middle + 1;
+    else return true;
+  }
+  return false;
+}
+
+function lineStart(source: string, position: number): number {
+  const newline = source.lastIndexOf("\n", Math.max(0, position - 1));
+  return newline === -1 ? 0 : newline + 1;
+}
+
+function lineEnd(source: string, position: number): number {
+  const newline = source.indexOf("\n", position);
+  if (newline === -1) return source.length;
+  return source[newline - 1] === "\r" ? newline - 1 : newline;
+}
+
+function lineIndent(source: string, position: number): string {
+  const start = lineStart(source, position);
+  return /^[\t ]*/.exec(source.slice(start, position))?.[0] ?? "";
+}
+
+function indentationUnit(parentIndent: string, childIndent: string): string {
+  if (childIndent.startsWith(parentIndent) && childIndent.length > parentIndent.length) {
+    return childIndent.slice(parentIndent.length);
+  }
+  if (childIndent.includes("\t")) return "\t";
+  return "  ";
+}
+
+function newlineStyle(source: string): "\n" | "\r\n" | undefined {
+  if (/\r(?!\n)/.test(source)) return undefined;
+  const hasCRLF = source.includes("\r\n");
+  const hasBareLF = /(^|[^\r])\n/.test(source);
+  if (hasCRLF && hasBareLF) return undefined;
+  return hasCRLF ? "\r\n" : "\n";
+}
+
+function decodeUTF8(bytes: Uint8Array): string | undefined {
+  try {
+    // ignoreBOM retains a leading U+FEFF so re-encoding preserves exact bytes.
+    return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(bytes);
+  } catch {
+    return undefined;
+  }
+}
+
+async function sourceSnapshot(
+  root: string,
+  relativePath: string,
+): Promise<FileSnapshot | undefined> {
+  const absolutePath = resolve(root, relativePath);
+  if (!(await pathIsSafelyWithinIOSRoot(root, absolutePath))) return undefined;
+  try {
+    const info = await lstat(absolutePath);
+    if (!info.isFile() || info.isSymbolicLink() || info.size > MAX_SWIFT_FILE_BYTES) {
+      return undefined;
+    }
+    const bytes = new Uint8Array(await readFile(absolutePath));
+    const source = decodeUTF8(bytes);
+    if (source == null || source.includes("\0")) return undefined;
+    return {
+      absolutePath,
+      relativePath,
+      bytes,
+      source,
+      hash: sha256(bytes),
+      mode: info.mode & 0o7777,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+async function generatedProjectKind(
+  root: string,
+  absoluteProjectPath: string,
+): Promise<"xcodegen" | "tuist" | null> {
+  let directory = dirname(absoluteProjectPath);
+  while (await pathIsSafelyWithinIOSRoot(root, directory)) {
+    for (const [markerPath, kind] of [
+      ["project.yml", "xcodegen"],
+      ["Project.swift", "tuist"],
+      ["Workspace.swift", "tuist"],
+      ["Tuist/ProjectDescriptionHelpers", "tuist"],
+    ] as const) {
+      const marker = resolve(directory, markerPath);
+      if ((await pathIsSafelyWithinIOSRoot(root, marker)) && (await Bun.file(marker).exists())) {
+        return kind;
+      }
+    }
+    if (directory === root) break;
+    const parent = dirname(directory);
+    if (parent === directory) break;
+    directory = parent;
+  }
+  return null;
+}
+
+function plainClerkKitImports(sanitized: string, index: SwiftStructuralIndex): number[] {
+  const imports: number[] = [];
+  const pattern = /^[\t ]*import[\t ]+ClerkKit[\t ]*\r?$/gm;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(sanitized)) !== null) {
+    if (!isInsideConditionalCompilation(index, match.index)) imports.push(match.index);
+  }
+  return imports;
+}
+
+interface SwiftImportLine {
+  start: number;
+  end: number;
+  moduleName: string;
+  moduleEnd: number;
+}
+
+const IMPORT_DECLARATION_KINDS = new Set([
+  "typealias",
+  "struct",
+  "class",
+  "enum",
+  "protocol",
+  "actor",
+  "let",
+  "var",
+  "func",
+  "macro",
+]);
+
+function isHorizontalWhitespace(character: string | undefined): boolean {
+  return character === " " || character === "\t";
+}
+
+function skipHorizontalWhitespace(source: string, start: number, end: number): number {
+  let cursor = start;
+  while (cursor < end && isHorizontalWhitespace(source[cursor])) cursor += 1;
+  return cursor;
+}
+
+function swiftIdentifierEnd(source: string, start: number, end: number): number | undefined {
+  if (!/[A-Za-z_]/.test(source[start] ?? "")) return undefined;
+  let cursor = start + 1;
+  while (cursor < end && /[A-Za-z0-9_]/.test(source[cursor] ?? "")) cursor += 1;
+  return cursor;
+}
+
+/**
+ * Parses one sanitized Swift import line without a repeated, variable-width
+ * attribute regex. Attribute arguments are balanced structurally so even a
+ * hostile source line remains linear-time input.
+ */
+function parseSwiftImportLine(
+  source: string,
+  start: number,
+  end: number,
+): SwiftImportLine | undefined {
+  let cursor = skipHorizontalWhitespace(source, start, end);
+  while (source[cursor] === "@") {
+    cursor += 1;
+    const firstComponentEnd = swiftIdentifierEnd(source, cursor, end);
+    if (firstComponentEnd == null) return undefined;
+    cursor = firstComponentEnd;
+    while (source[cursor] === ".") {
+      const componentEnd = swiftIdentifierEnd(source, cursor + 1, end);
+      if (componentEnd == null) return undefined;
+      cursor = componentEnd;
+    }
+    if (source[cursor] === "(") {
+      const closing = matchingParenthesis(source, cursor);
+      if (closing == null || closing >= end) return undefined;
+      cursor = closing + 1;
+    }
+    const whitespaceEnd = skipHorizontalWhitespace(source, cursor, end);
+    if (whitespaceEnd === cursor) return undefined;
+    cursor = whitespaceEnd;
+  }
+
+  if (source.slice(cursor, cursor + 6) !== "import") return undefined;
+  cursor += 6;
+  const importWhitespaceEnd = skipHorizontalWhitespace(source, cursor, end);
+  if (importWhitespaceEnd === cursor) return undefined;
+  cursor = importWhitespaceEnd;
+
+  let moduleEnd = swiftIdentifierEnd(source, cursor, end);
+  if (moduleEnd == null) return undefined;
+  let moduleName = source.slice(cursor, moduleEnd);
+  if (IMPORT_DECLARATION_KINDS.has(moduleName)) {
+    const kindWhitespaceEnd = skipHorizontalWhitespace(source, moduleEnd, end);
+    if (kindWhitespaceEnd === moduleEnd) return undefined;
+    cursor = kindWhitespaceEnd;
+    moduleEnd = swiftIdentifierEnd(source, cursor, end);
+    if (moduleEnd == null) return undefined;
+    moduleName = source.slice(cursor, moduleEnd);
+  }
+
+  return { start, end, moduleName, moduleEnd };
+}
+
+function swiftImportLines(sanitized: string): SwiftImportLine[] {
+  const imports: SwiftImportLine[] = [];
+  let start = 0;
+  while (start <= sanitized.length) {
+    const newline = sanitized.indexOf("\n", start);
+    const end =
+      newline === -1 ? sanitized.length : sanitized[newline - 1] === "\r" ? newline - 1 : newline;
+    const importLine = parseSwiftImportLine(sanitized, start, end);
+    if (importLine) imports.push(importLine);
+    if (newline === -1) break;
+    start = newline + 1;
+  }
+  return imports;
+}
+
+function anyClerkKitImports(sanitized: string): number[] {
+  return swiftImportLines(sanitized)
+    .filter(
+      (line) =>
+        line.moduleName === "ClerkKit" &&
+        (sanitized[line.moduleEnd] === "." ||
+          skipHorizontalWhitespace(sanitized, line.moduleEnd, line.end) === line.end),
+    )
+    .map((line) => line.start);
+}
+
+function importInsertionPosition(
+  sanitized: string,
+  index: SwiftStructuralIndex,
+): number | undefined {
+  const last = swiftImportLines(sanitized)
+    .filter((line) => !isInsideConditionalCompilation(index, line.start))
+    .at(-1);
+  return last?.end;
+}
+
+function appTypeRange(
+  sanitized: string,
+  index: SwiftStructuralIndex,
+): AppStructure["appType"] | undefined {
+  const mainMatches = [...sanitized.matchAll(/@main\b/g)];
+  if (mainMatches.length !== 1 || mainMatches[0]?.index == null) return undefined;
+  const mainIndex = mainMatches[0].index;
+  if (isInsideConditionalCompilation(index, mainIndex) || braceDepthAt(index, 0, mainIndex) !== 0) {
+    return undefined;
+  }
+
+  let cursor = mainIndex + mainMatches[0][0].length;
+  while (true) {
+    cursor = skipWhitespace(sanitized, cursor);
+    const attribute = /^@[A-Za-z_][A-Za-z0-9_.]*/.exec(sanitized.slice(cursor));
+    if (attribute) {
+      cursor += attribute[0].length;
+      cursor = skipWhitespace(sanitized, cursor);
+      if (sanitized[cursor] === "(") {
+        const closing = matchingParenthesis(sanitized, cursor);
+        if (closing == null) return undefined;
+        cursor = closing + 1;
+      }
+      continue;
+    }
+    const modifier = /^(?:public|internal|private|fileprivate|final|nonisolated)\b/.exec(
+      sanitized.slice(cursor),
+    );
+    if (!modifier) break;
+    cursor += modifier[0].length;
+  }
+
+  cursor = skipWhitespace(sanitized, cursor);
+  const declaration = /^struct\s+([A-Za-z_][A-Za-z0-9_]*)/.exec(sanitized.slice(cursor));
+  if (!declaration) return undefined;
+  const headerStart = cursor + declaration[0].length;
+  const openingBrace = sanitized.indexOf("{", headerStart);
+  if (openingBrace === -1) return undefined;
+  const header = sanitized.slice(headerStart, openingBrace);
+  if (/[;{}<>]/.test(header) || /\bwhere\b/.test(header)) return undefined;
+  const inheritance = /^\s*:\s*([A-Za-z0-9_.,\s]+)\s*$/.exec(header)?.[1];
+  if (!inheritance || !inheritance.split(",").some((item) => item.trim() === "App")) {
+    return undefined;
+  }
+  const closingBrace = matchingBrace(sanitized, openingBrace);
+  if (closingBrace == null) return undefined;
+  if (/^[\t ]*#(?:if|elseif|else|endif)\b/m.test(sanitized.slice(openingBrace, closingBrace))) {
+    return undefined;
+  }
+  return {
+    start: mainIndex,
+    end: closingBrace + 1,
+    declarationStart: cursor,
+    openingBrace,
+    closingBrace,
+  };
+}
+
+interface InitializerCandidate {
+  start: number;
+  end: number;
+  openingBrace: number;
+  closingBrace: number;
+  supported: boolean;
+}
+
+function initializerCandidates(
+  sanitized: string,
+  appType: AppStructure["appType"],
+  index: SwiftStructuralIndex,
+): InitializerCandidate[] {
+  const candidates: InitializerCandidate[] = [];
+  const pattern = /\binit\s*([?!])?\s*\(/g;
+  pattern.lastIndex = appType.openingBrace + 1;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(sanitized)) !== null && match.index < appType.closingBrace) {
+    if (braceDepthAt(index, appType.openingBrace, match.index) !== 1) continue;
+    const openingParenthesis = sanitized.indexOf("(", match.index);
+    const closingParenthesis = matchingParenthesis(sanitized, openingParenthesis);
+    if (closingParenthesis == null || closingParenthesis >= appType.closingBrace) {
+      candidates.push({
+        start: match.index,
+        end: match.index + match[0].length,
+        openingBrace: -1,
+        closingBrace: -1,
+        supported: false,
+      });
+      continue;
+    }
+    const openingBrace = sanitized.indexOf("{", closingParenthesis + 1);
+    const header = openingBrace === -1 ? "" : sanitized.slice(closingParenthesis + 1, openingBrace);
+    const closingBrace = openingBrace === -1 ? undefined : matchingBrace(sanitized, openingBrace);
+    const supported =
+      match[1] == null &&
+      sanitized.slice(openingParenthesis + 1, closingParenthesis).trim() === "" &&
+      openingBrace !== -1 &&
+      openingBrace < appType.closingBrace &&
+      header.trim() === "" &&
+      closingBrace != null &&
+      closingBrace <= appType.closingBrace;
+    candidates.push({
+      start: match.index,
+      end: (closingBrace ?? closingParenthesis) + 1,
+      openingBrace,
+      closingBrace: closingBrace ?? -1,
+      supported,
+    });
+    if (closingBrace != null) pattern.lastIndex = closingBrace + 1;
+  }
+  return candidates;
+}
+
+function bodyRange(
+  sanitized: string,
+  appType: AppStructure["appType"],
+  index: SwiftStructuralIndex,
+): AppStructure["body"] | undefined {
+  const candidates: AppStructure["body"][] = [];
+  const pattern = /\bvar\s+body\s*:\s*some\s+Scene\b/g;
+  pattern.lastIndex = appType.openingBrace + 1;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(sanitized)) !== null && match.index < appType.closingBrace) {
+    if (braceDepthAt(index, appType.openingBrace, match.index) !== 1) continue;
+    const openingBrace = skipWhitespace(sanitized, match.index + match[0].length);
+    if (sanitized[openingBrace] !== "{") continue;
+    const closingBrace = matchingBrace(sanitized, openingBrace);
+    if (closingBrace == null || closingBrace > appType.closingBrace) continue;
+    const declarationLineStart = lineStart(sanitized, match.index);
+    if (sanitized.slice(declarationLineStart, match.index).trim() !== "") continue;
+    candidates.push({
+      start: match.index,
+      end: closingBrace + 1,
+      declarationStart: declarationLineStart,
+      openingBrace,
+      closingBrace,
+    });
+    pattern.lastIndex = closingBrace + 1;
+  }
+  return candidates.length === 1 ? candidates[0] : undefined;
+}
+
+interface RootExpression {
+  start: number;
+  end: number;
+  containerStart: number;
+  modifierStarts: number[];
+}
+
+function identifierEnd(source: string, start: number): number | undefined {
+  const match = /^[A-Za-z_][A-Za-z0-9_]*/.exec(source.slice(start));
+  return match ? start + match[0].length : undefined;
+}
+
+function consumeBalancedSuffix(source: string, cursor: number, limit: number): number | undefined {
+  if (source[cursor] === "(") {
+    const closing = matchingParenthesis(source, cursor);
+    if (closing == null || closing >= limit) return undefined;
+    cursor = closing + 1;
+    cursor = skipWhitespace(source, cursor, limit);
+    if (source[cursor] === "{") {
+      const closureEnd = matchingBrace(source, cursor);
+      if (closureEnd == null || closureEnd >= limit) return undefined;
+      cursor = closureEnd + 1;
+    }
+    return cursor;
+  }
+  if (source[cursor] === "{") {
+    const closureEnd = matchingBrace(source, cursor);
+    if (closureEnd == null || closureEnd >= limit) return undefined;
+    return closureEnd + 1;
+  }
+  return undefined;
+}
+
+function rootExpression(
+  sanitized: string,
+  start: number,
+  end: number,
+  containerStart: number,
+): RootExpression | undefined {
+  let cursor = skipWhitespace(sanitized, start, end);
+  const expressionStart = cursor;
+  let identifier = identifierEnd(sanitized, cursor);
+  if (identifier == null) return undefined;
+  cursor = identifier;
+  while (true) {
+    const beforeDot = skipWhitespace(sanitized, cursor, end);
+    if (sanitized[beforeDot] !== ".") break;
+    const memberStart = skipWhitespace(sanitized, beforeDot + 1, end);
+    identifier = identifierEnd(sanitized, memberStart);
+    if (identifier == null) return undefined;
+    const afterMember = skipWhitespace(sanitized, identifier, end);
+    if (sanitized[afterMember] === "(" || sanitized[afterMember] === "{") break;
+    cursor = identifier;
+  }
+  cursor = skipWhitespace(sanitized, cursor, end);
+  const primaryEnd = consumeBalancedSuffix(sanitized, cursor, end);
+  if (primaryEnd == null) return undefined;
+  cursor = primaryEnd;
+
+  const modifierStarts: number[] = [];
+  while (true) {
+    cursor = skipWhitespace(sanitized, cursor, end);
+    if (sanitized[cursor] !== ".") break;
+    const modifierStart = cursor;
+    const nameStart = skipWhitespace(sanitized, cursor + 1, end);
+    const nameEnd = identifierEnd(sanitized, nameStart);
+    if (nameEnd == null) return undefined;
+    cursor = skipWhitespace(sanitized, nameEnd, end);
+    const suffixEnd = consumeBalancedSuffix(sanitized, cursor, end);
+    if (suffixEnd == null) return undefined;
+    modifierStarts.push(modifierStart);
+    cursor = suffixEnd;
+  }
+  cursor = skipWhitespace(sanitized, cursor, end);
+  if (cursor !== end) return undefined;
+  return {
+    start: expressionStart,
+    end: trimWhitespaceEnd(sanitized, expressionStart, end),
+    containerStart,
+    modifierStarts,
+  };
+}
+
+function windowGroupRoot(
+  sanitized: string,
+  body: AppStructure["body"],
+): RootExpression | undefined {
+  let cursor = skipWhitespace(sanitized, body.openingBrace + 1, body.closingBrace);
+  const windowGroupStart = cursor;
+  if (!sanitized.slice(cursor).startsWith("WindowGroup")) return undefined;
+  const wordEnd = cursor + "WindowGroup".length;
+  if (/[A-Za-z0-9_]/.test(sanitized[wordEnd] ?? "")) return undefined;
+  cursor = skipWhitespace(sanitized, wordEnd, body.closingBrace);
+  if (sanitized[cursor] === "(") {
+    const closingParenthesis = matchingParenthesis(sanitized, cursor);
+    if (closingParenthesis == null || closingParenthesis >= body.closingBrace) return undefined;
+    cursor = skipWhitespace(sanitized, closingParenthesis + 1, body.closingBrace);
+  }
+  if (sanitized[cursor] !== "{") return undefined;
+  const groupClosingBrace = matchingBrace(sanitized, cursor);
+  if (groupClosingBrace == null || groupClosingBrace >= body.closingBrace) return undefined;
+  if (skipWhitespace(sanitized, groupClosingBrace + 1, body.closingBrace) !== body.closingBrace) {
+    return undefined;
+  }
+  const expressionStart = skipWhitespace(sanitized, cursor + 1, groupClosingBrace);
+  const expressionEnd = trimWhitespaceEnd(sanitized, expressionStart, groupClosingBrace);
+  if (expressionStart === expressionEnd) return undefined;
+  return rootExpression(sanitized, expressionStart, expressionEnd, windowGroupStart);
+}
+
+/**
+ * Proves the narrow SwiftUI starter root used by the optional AuthView
+ * scaffold. This deliberately shares the direct-config parser's structural
+ * ownership checks: the sole unconditional top-level `@main` declaration must
+ * be a SwiftUI `App`, and its one `body: some Scene` must own the WindowGroup
+ * whose direct root is ContentView.
+ */
+export function hasExactIOSSwiftUIAppContentRoot(source: string): boolean {
+  const sanitized = sanitizeSwiftSource(source);
+  const structuralIndex = buildSwiftStructuralIndex(sanitized);
+  const appType = appTypeRange(sanitized, structuralIndex);
+  if (!appType) return false;
+  const body = bodyRange(sanitized, appType, structuralIndex);
+  if (!body) return false;
+  const root = windowGroupRoot(sanitized, body);
+  if (!root) return false;
+
+  const groupOpeningBrace = sanitized.lastIndexOf("{", root.start);
+  if (groupOpeningBrace < root.containerStart) return false;
+  const container = sanitized.slice(root.containerStart, groupOpeningBrace).replace(/\s+/g, "");
+  if (container !== "WindowGroup") return false;
+
+  const expression = sanitized.slice(root.start, root.end).replace(/\s+/g, "");
+  return expression === "ContentView()" || expression === "ContentView().environment(Clerk.shared)";
+}
+
+function exactEnvironmentModifier(
+  sanitized: string,
+  root: RootExpression,
+): { found: boolean; conflicting: boolean } {
+  let found = false;
+  let conflicting = false;
+  for (const modifierStart of root.modifierStarts) {
+    const remainder = sanitized.slice(modifierStart, root.end);
+    const name = /^\.\s*([A-Za-z_][A-Za-z0-9_]*)/.exec(remainder)?.[1];
+    if (name !== "environment") continue;
+    const openingParenthesis = sanitized.indexOf("(", modifierStart);
+    const closingParenthesis = matchingParenthesis(sanitized, openingParenthesis);
+    if (closingParenthesis == null || closingParenthesis > root.end) {
+      conflicting = true;
+      continue;
+    }
+    const argumentsSource = sanitized.slice(openingParenthesis + 1, closingParenthesis);
+    if (/^\s*(?:\\?\.\s*self\s*,\s*)?Clerk\s*\.\s*shared\s*$/.test(argumentsSource)) {
+      found = true;
+    } else if (/\bClerk\s*\.\s*shared\b/.test(argumentsSource)) {
+      conflicting = true;
+    }
+  }
+  return { found, conflicting };
+}
+
+function exactConfigureCall(
+  source: string,
+  sanitized: string,
+  initializer: AppStructure["initializer"] | undefined,
+  index: SwiftStructuralIndex,
+): { key?: string; callIndex?: number; conflict: boolean } {
+  const calls = [...sanitized.matchAll(/\bClerk\s*\.\s*configure\s*\(/g)];
+  if (calls.length === 0) return { conflict: false };
+  if (calls.length !== 1 || !initializer || calls[0]?.index == null) return { conflict: true };
+  const callIndex = calls[0].index;
+  if (
+    callIndex <= initializer.openingBrace ||
+    callIndex >= initializer.closingBrace ||
+    braceDepthAt(index, initializer.openingBrace, callIndex) !== 1
+  ) {
+    return { conflict: true };
+  }
+  const openingParenthesis = sanitized.indexOf("(", callIndex);
+  const closingParenthesis = matchingParenthesis(sanitized, openingParenthesis);
+  if (closingParenthesis == null || closingParenthesis >= initializer.closingBrace) {
+    return { conflict: true };
+  }
+  let before = callIndex - 1;
+  while (sanitized[before] === " " || sanitized[before] === "\t") before -= 1;
+  let after = closingParenthesis + 1;
+  while (sanitized[after] === " " || sanitized[after] === "\t") after += 1;
+  if (
+    !["{", "}", ";", "\n", "\r"].includes(sanitized[before] ?? "") ||
+    !["}", ";", "\n", "\r"].includes(sanitized[after] ?? "")
+  ) {
+    return { conflict: true };
+  }
+  const originalArguments = source.slice(openingParenthesis + 1, closingParenthesis);
+  const literal = /^\s*publishableKey\s*:\s*"(pk_(?:test|live)_[A-Za-z0-9+/_=-]+)"\s*,?\s*$/.exec(
+    originalArguments,
+  )?.[1];
+  return literal ? { key: literal, callIndex, conflict: false } : { conflict: true };
+}
+
+function validateInlineKey(value: string): "development" | "production" | undefined {
+  try {
+    return decodePublishableKey(value).instanceType;
+  } catch {
+    return undefined;
+  }
+}
+
+function hasDirectStoredProperty(
+  sanitized: string,
+  appType: AppStructure["appType"],
+  body: AppStructure["body"],
+  index: SwiftStructuralIndex,
+): boolean {
+  const pattern = /\b(?:let|var)\s+[A-Za-z_][A-Za-z0-9_]*/g;
+  pattern.lastIndex = appType.openingBrace + 1;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(sanitized)) !== null && match.index < appType.closingBrace) {
+    if (match.index === body.start) continue;
+    if (braceDepthAt(index, appType.openingBrace, match.index) === 1) return true;
+  }
+  return false;
+}
+
+function bodyHasLeadingAttribute(source: string, body: AppStructure["body"]): boolean {
+  let cursor = body.declarationStart;
+  while (cursor > 0) {
+    const previousEnd = cursor - 1;
+    const previousStart = lineStart(source, previousEnd);
+    const line = source.slice(previousStart, previousEnd + 1).trim();
+    if (line === "") {
+      cursor = previousStart;
+      continue;
+    }
+    return line.startsWith("@");
+  }
+  return false;
+}
+
+function hasPreinitializationClerkSharedAccess(
+  sanitized: string,
+  appType: AppStructure["appType"],
+  initializer: AppStructure["initializer"] | undefined,
+  configureCallIndex: number | undefined,
+  index: SwiftStructuralIndex,
+): boolean {
+  for (const match of sanitized.matchAll(/\bClerk\s*\.\s*shared\b/g)) {
+    if (match.index == null) continue;
+    const position = match.index;
+    if (position < appType.start || position >= appType.end) {
+      if (braceDepthAt(index, 0, position) === 0) return true;
+      continue;
+    }
+    if (braceDepthAt(index, appType.openingBrace, position) === 1) return true;
+    if (
+      initializer &&
+      configureCallIndex != null &&
+      position > initializer.openingBrace &&
+      position < configureCallIndex
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function environmentInsertion(
+  source: string,
+  newline: "\n" | "\r\n",
+  root: RootExpression,
+): AppStructure["environmentInsertion"] {
+  const trailingLine = source.slice(root.end, lineEnd(source, root.end));
+  const sharesLineWithComment = /\/\*|\/\//.test(trailingLine);
+  const isCompact = !source.slice(root.start, root.end).includes("\n") && !sharesLineWithComment;
+  if (isCompact || sharesLineWithComment) {
+    return { index: root.end, textBeforeKey: ".environment(Clerk.shared)" };
+  }
+  const rootIndent = lineIndent(source, root.start);
+  const lastModifier = root.modifierStarts.at(-1);
+  const modifierIndent =
+    lastModifier == null
+      ? `${rootIndent}${indentationUnit(lineIndent(source, root.containerStart), rootIndent)}`
+      : lineIndent(source, lastModifier);
+  return {
+    index: root.end,
+    textBeforeKey: `${newline}${modifierIndent}.environment(Clerk.shared)`,
+  };
+}
+
+function parseAppStructure(
+  source: string,
+): { structure: AppStructure } | { blocker: IOSDirectConfigBlocker } {
+  const newline = newlineStyle(source);
+  if (!newline) {
+    return {
+      blocker: {
+        code: "unsupported-line-endings",
+        message: "The Swift entry source uses mixed or unsupported line endings.",
+      },
+    };
+  }
+  const sanitized = sanitizeSwiftSource(source);
+  const structuralIndex = buildSwiftStructuralIndex(sanitized);
+  const appType = appTypeRange(sanitized, structuralIndex);
+  if (!appType) {
+    return {
+      blocker: {
+        code: "unsupported-app-structure",
+        message: "The entry source is not one unconditional, safely editable @main SwiftUI App.",
+      },
+    };
+  }
+  const body = bodyRange(sanitized, appType, structuralIndex);
+  if (!body) {
+    return {
+      blocker: {
+        code: "unsupported-scene",
+        message: "The @main App does not contain exactly one safely editable body: some Scene.",
+      },
+    };
+  }
+  const root = windowGroupRoot(sanitized, body);
+  if (!root) {
+    return {
+      blocker: {
+        code: "unsupported-scene",
+        message:
+          "The App scene is not one WindowGroup with one safely editable root view expression.",
+      },
+    };
+  }
+
+  const initializerMatches = initializerCandidates(sanitized, appType, structuralIndex);
+  if (
+    initializerMatches.length > 1 ||
+    initializerMatches.some((candidate) => !candidate.supported)
+  ) {
+    return {
+      blocker: {
+        code: "unsupported-initializer",
+        message: "The @main App initializer is ambiguous or cannot be edited safely.",
+      },
+    };
+  }
+  const initializerCandidate = initializerMatches[0];
+  const initializer = initializerCandidate
+    ? {
+        start: initializerCandidate.start,
+        end: initializerCandidate.end,
+        openingBrace: initializerCandidate.openingBrace,
+        closingBrace: initializerCandidate.closingBrace,
+      }
+    : undefined;
+  if (hasDirectStoredProperty(sanitized, appType, body, structuralIndex)) {
+    return {
+      blocker: {
+        code: "unsupported-initializer",
+        message:
+          "The @main App has stored startup state whose initialization cannot be proven to occur after Clerk configuration.",
+      },
+    };
+  }
+  if (!initializer && bodyHasLeadingAttribute(source, body)) {
+    return {
+      blocker: {
+        code: "unsupported-initializer",
+        message:
+          "The @main App has attributed startup state but no explicit initializer; add Clerk configuration manually or add a simple init() first.",
+      },
+    };
+  }
+
+  const configure = exactConfigureCall(source, sanitized, initializer, structuralIndex);
+  if (configure.conflict) {
+    return {
+      blocker: {
+        code: "conflicting-configuration",
+        message:
+          "An existing Clerk configuration call is not the exact supported inline initializer form.",
+      },
+    };
+  }
+  if (configure.key) {
+    const instanceType = validateInlineKey(configure.key);
+    if (!instanceType) {
+      return {
+        blocker: {
+          code: "invalid-inline-publishable-key",
+          message: "The existing inline Clerk publishable key is malformed and was preserved.",
+        },
+      };
+    }
+    if (instanceType === "production") {
+      return {
+        blocker: {
+          code: "production-inline-publishable-key",
+          message:
+            "The existing inline production publishable key was preserved for manual review.",
+        },
+      };
+    }
+    if (
+      !initializer ||
+      configure.callIndex == null ||
+      sanitized.slice(initializer.openingBrace + 1, configure.callIndex).trim() !== ""
+    ) {
+      return {
+        blocker: {
+          code: "preinitialization-clerk-access",
+          message:
+            "The existing Clerk configuration is not the first executable statement in the @main App initializer.",
+        },
+      };
+    }
+  }
+  if (
+    hasPreinitializationClerkSharedAccess(
+      sanitized,
+      appType,
+      initializer,
+      configure.callIndex,
+      structuralIndex,
+    )
+  ) {
+    return {
+      blocker: {
+        code: "preinitialization-clerk-access",
+        message: "Clerk.shared is accessed before the proven App initializer configuration point.",
+      },
+    };
+  }
+
+  const environment = exactEnvironmentModifier(sanitized, root);
+  if (environment.conflicting) {
+    return {
+      blocker: {
+        code: "conflicting-environment",
+        message: "The WindowGroup root contains a conflicting Clerk environment modifier.",
+      },
+    };
+  }
+  const importInsertion = importInsertionPosition(sanitized, structuralIndex);
+  if (importInsertion == null) {
+    return {
+      blocker: {
+        code: "unsupported-app-structure",
+        message: "The entry source has no unconditional top-level import section.",
+      },
+    };
+  }
+  const plainImports = plainClerkKitImports(sanitized, structuralIndex);
+  const allClerkImports = anyClerkKitImports(sanitized);
+  if (
+    plainImports.length > 1 ||
+    (allClerkImports.length > 0 &&
+      (plainImports.length !== 1 || allClerkImports.length !== plainImports.length))
+  ) {
+    return {
+      blocker: {
+        code: "unsupported-app-structure",
+        message: "The entry source contains conditional, scoped, or duplicate ClerkKit imports.",
+      },
+    };
+  }
+
+  const appIndent = lineIndent(source, appType.declarationStart);
+  const bodyIndent = lineIndent(source, body.start);
+  const unit = indentationUnit(appIndent, bodyIndent);
+  let configurationInsertion: AppStructure["configurationInsertion"];
+  if (configure.key) {
+    configurationInsertion = { kind: "existing-literal" };
+  } else if (initializer) {
+    const bodyStart = initializer.openingBrace + 1;
+    const firstContent = skipWhitespace(sanitized, bodyStart, initializer.closingBrace);
+    configurationInsertion = {
+      kind: "existing-initializer",
+      index: bodyStart,
+      statementIndent: `${lineIndent(source, initializer.start)}${unit}`,
+      multiline: source.slice(bodyStart, firstContent).includes("\n"),
+    };
+  } else {
+    configurationInsertion = {
+      kind: "new-initializer",
+      index: body.declarationStart,
+      memberIndent: bodyIndent,
+      statementIndent: `${bodyIndent}${unit}`,
+    };
+  }
+
+  return {
+    structure: {
+      source,
+      sanitized,
+      newline,
+      appType,
+      initializer,
+      body,
+      root,
+      hasClerkKitImport: plainImports.length === 1,
+      importInsertion,
+      existingPublishableKey: configure.key,
+      hasEnvironment: environment.found,
+      configurationInsertion,
+      environmentInsertion: environment.found
+        ? undefined
+        : environmentInsertion(source, newline, root),
+    },
+  };
+}
+
+async function gitDirtyState(
+  root: string,
+  absolutePath: string,
+): Promise<"clean" | "dirty" | "not-repository" | "unknown"> {
+  try {
+    const child = Bun.spawn(
+      ["git", "status", "--porcelain=v1", "--untracked-files=all", "--", absolutePath],
+      { cwd: root, stdout: "pipe", stderr: "ignore" },
+    );
+    const output = await new Response(child.stdout).text();
+    const exitCode = await child.exited;
+    if (exitCode === 0) return output.trim() === "" ? "clean" : "dirty";
+    const probe = Bun.spawn(["git", "rev-parse", "--is-inside-work-tree"], {
+      cwd: root,
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    return (await probe.exited) === 0 ? "unknown" : "not-repository";
+  } catch {
+    return "unknown";
+  }
+}
+
+function semanticActions(sourcePath: string, changes: IOSDirectConfigChanges): string[] {
+  const actions: string[] = [];
+  if (changes.clerkKitImport === "insert") {
+    actions.push(`Add import ClerkKit to ${sourcePath}.`);
+  }
+  if (changes.configuration === "insert-initializer") {
+    actions.push(
+      `Add a simple @main App initializer in ${sourcePath} and configure Clerk with the selected development publishable key (redacted).`,
+    );
+  } else if (changes.configuration === "insert-statement") {
+    actions.push(
+      `Configure Clerk first in the existing @main App initializer in ${sourcePath} with the selected development publishable key (redacted).`,
+    );
+  } else {
+    actions.push(
+      `Verify the existing inline Clerk configuration in ${sourcePath} matches the selected development publishable key (redacted).`,
+    );
+  }
+  if (changes.environment === "insert") {
+    actions.push(`Inject Clerk.shared into the WindowGroup root environment in ${sourcePath}.`);
+  }
+  return actions;
+}
+
+async function prepareDirectConfig(
+  options: IOSDirectConfigPlanOptions,
+): Promise<PreparedDirectConfig> {
+  const root = resolve(options.root);
+  const absoluteProjectPath = resolve(root, options.projectPath);
+  if (
+    !options.targetId ||
+    !options.projectPath ||
+    resolve(root, relative(root, absoluteProjectPath)) !== absoluteProjectPath ||
+    !(await pathIsSafelyWithinIOSRoot(root, absoluteProjectPath))
+  ) {
+    return blocked(
+      options,
+      root,
+      options.projectPath,
+      "invalid-selection",
+      "The selected Xcode project or target is invalid.",
+    );
+  }
+  const projectPath = relativeIOSPath(root, absoluteProjectPath);
+  const inspection = await inspectIOSProject(root, { target: options.targetId });
+  if (
+    inspection.selection.state !== "selected" ||
+    inspection.selection.targetId !== options.targetId ||
+    inspection.selection.projectPath !== projectPath
+  ) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "target-not-found",
+      "The selected native iOS application target could not be proven.",
+    );
+  }
+  const generator =
+    inspection.generatedProject ?? (await generatedProjectKind(root, absoluteProjectPath));
+  if (generator != null) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "generated-project",
+      `This is a ${generator === "xcodegen" ? "XcodeGen" : "Tuist"} project; update its source manifest instead of generated Swift sources.`,
+    );
+  }
+  const target = inspection.appTargets.find(
+    (candidate) => candidate.id === options.targetId && candidate.projectPath === projectPath,
+  );
+  if (!target) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "target-not-found",
+      "The selected native iOS application target disappeared during inspection.",
+    );
+  }
+  if (!target.swift.evidenceComplete) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "incomplete-source-membership",
+      "The selected target's complete shipping Swift source membership could not be proven.",
+    );
+  }
+  if (target.swift.entryPoints.length !== 1 || !target.swift.entryPoints[0]?.path) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "ambiguous-entry-point",
+      "The selected target must contain exactly one shipping @main Swift entry point.",
+    );
+  }
+  const sourcePath = target.swift.entryPoints[0].path;
+  const snapshot = await sourceSnapshot(root, sourcePath);
+  if (!snapshot) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "unreadable-source",
+      "The selected @main Swift source is not a safe, readable in-root regular file.",
+      { plan: makePlan(options, root, projectPath, "blocked", { sourcePath }) },
+    );
+  }
+  const sourcePlan = makePlan(options, root, projectPath, "ready", {
+    sourcePath,
+    expectedSourceHash: snapshot.hash,
+  });
+
+  const parsed = parseAppStructure(snapshot.source);
+  if ("blocker" in parsed) {
+    return blocked(options, root, projectPath, parsed.blocker.code, parsed.blocker.message, {
+      plan: sourcePlan,
+      snapshot,
+    });
+  }
+  const structure = parsed.structure;
+
+  const configureElsewhere = target.swift.configureCalls.some((call) => call.path !== sourcePath);
+  if (
+    configureElsewhere ||
+    target.swift.configureCalls.length > (structure.existingPublishableKey ? 1 : 0)
+  ) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "conflicting-configuration",
+      "Another target-owned Clerk configuration call exists outside the exact supported initializer binding.",
+      { plan: sourcePlan, snapshot, structure },
+    );
+  }
+  const environmentElsewhere = target.swift.environmentInjections.some(
+    (evidence) => evidence.path !== sourcePath,
+  );
+  if (
+    environmentElsewhere ||
+    (target.swift.environmentInjections.length > 0 && !structure.hasEnvironment)
+  ) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "conflicting-environment",
+      "Another Clerk environment injection exists outside the exact WindowGroup root binding.",
+      { plan: sourcePlan, snapshot, structure },
+    );
+  }
+
+  const changes: IOSDirectConfigChanges = {
+    clerkKitImport: structure.hasClerkKitImport ? "satisfied" : "insert",
+    configuration:
+      structure.configurationInsertion.kind === "new-initializer"
+        ? "insert-initializer"
+        : structure.configurationInsertion.kind === "existing-initializer"
+          ? "insert-statement"
+          : "verify-existing",
+    environment: structure.hasEnvironment ? "satisfied" : "insert",
+  };
+  const changesSource =
+    changes.clerkKitImport === "insert" ||
+    changes.configuration !== "verify-existing" ||
+    changes.environment === "insert";
+  if (changesSource && !options.allowDirty) {
+    const dirty = await gitDirtyState(root, snapshot.absolutePath);
+    if (dirty === "dirty") {
+      return blocked(
+        options,
+        root,
+        projectPath,
+        "dirty-source",
+        `The planned Swift source ${sourcePath} has existing Git changes; pass the explicit dirty-file override to include it.`,
+        { plan: sourcePlan, snapshot, structure },
+      );
+    }
+    if (dirty === "unknown") {
+      return blocked(
+        options,
+        root,
+        projectPath,
+        "git-state-unknown",
+        `Git state for the planned Swift source ${sourcePath} could not be verified.`,
+        { plan: sourcePlan, snapshot, structure },
+      );
+    }
+  }
+  return {
+    snapshot,
+    structure,
+    plan: makePlan(options, root, projectPath, "ready", {
+      sourcePath,
+      expectedSourceHash: snapshot.hash,
+      changes,
+      actions: semanticActions(sourcePath, changes),
+    }),
+  };
+}
+
+export async function planIOSDirectConfig(
+  options: IOSDirectConfigPlanOptions,
+): Promise<IOSDirectConfigPlan> {
+  return (await prepareDirectConfig(options)).plan;
+}
+
+function validatedDevelopmentKey(value: string): string | undefined {
+  if (value.trim() !== value || !/^pk_test_[A-Za-z0-9+/_=-]+$/.test(value)) return undefined;
+  try {
+    return decodePublishableKey(value).instanceType === "development" ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function applyEdits(source: string, edits: SourceEdit[]): string {
+  let candidate = source;
+  for (const edit of [...edits].sort((a, b) => b.index - a.index)) {
+    candidate = `${candidate.slice(0, edit.index)}${edit.text}${candidate.slice(edit.index)}`;
+  }
+  return candidate;
+}
+
+function directConfigCandidate(structure: AppStructure, publishableKey: string): string {
+  const edits: SourceEdit[] = [];
+  if (!structure.hasClerkKitImport) {
+    edits.push({
+      index: structure.importInsertion,
+      text: `${structure.newline}import ClerkKit`,
+    });
+  }
+  const statement = `Clerk.configure(publishableKey: "${publishableKey}")`;
+  if (structure.configurationInsertion.kind === "new-initializer") {
+    const insertion = structure.configurationInsertion;
+    edits.push({
+      index: insertion.index,
+      text: `${insertion.memberIndent}init() {${structure.newline}${insertion.statementIndent}${statement}${structure.newline}${insertion.memberIndent}}${structure.newline}${structure.newline}`,
+    });
+  } else if (structure.configurationInsertion.kind === "existing-initializer") {
+    const insertion = structure.configurationInsertion;
+    edits.push({
+      index: insertion.index,
+      text: insertion.multiline
+        ? `${structure.newline}${insertion.statementIndent}${statement}`
+        : ` ${statement};`,
+    });
+  }
+  if (!structure.hasEnvironment && structure.environmentInsertion) {
+    edits.push({
+      index: structure.environmentInsertion.index,
+      text: structure.environmentInsertion.textBeforeKey,
+    });
+  }
+  return applyEdits(structure.source, edits);
+}
+
+function redactedKeyBlocker(
+  plan: IOSDirectConfigPlan,
+  code: IOSDirectConfigBlockerCode,
+  message: string,
+): IOSDirectConfigPlan {
+  return { ...plan, status: "blocked", actions: [], blockers: [{ code, message }] };
+}
+
+function mutationWithHiddenBytes(
+  snapshot: FileSnapshot,
+  candidateBytes: Uint8Array,
+): IOSDirectConfigFileMutation {
+  const mutation = {
+    absolutePath: snapshot.absolutePath,
+    expectedHash: snapshot.hash,
+    candidateHash: sha256(candidateBytes),
+    mode: snapshot.mode,
+  } as IOSDirectConfigFileMutation;
+  Object.defineProperties(mutation, {
+    originalBytes: { value: snapshot.bytes, enumerable: false },
+    candidateBytes: { value: candidateBytes, enumerable: false },
+  });
+  return mutation;
+}
+
+function readyPreparedMutation(
+  plan: IOSDirectConfigPlan,
+  mutation: IOSDirectConfigFileMutation,
+  validator: () => Promise<boolean>,
+): IOSDirectConfigPreparedMutation {
+  const prepared = { status: "ready", plan } as IOSDirectConfigPreparedMutation;
+  Object.defineProperty(prepared, "mutation", { value: mutation, enumerable: false });
+  preparedValidators.set(prepared, validator);
+  return prepared;
+}
+
+async function exactPostcondition(
+  plan: IOSDirectConfigPlan,
+  publishableKey: string,
+  candidateHash: string,
+): Promise<boolean> {
+  const prepared = await prepareDirectConfig({
+    root: plan.root,
+    projectPath: plan.projectPath,
+    targetId: plan.targetId,
+    allowDirty: true,
+  });
+  return (
+    prepared.plan.status === "ready" &&
+    prepared.snapshot?.hash === candidateHash &&
+    prepared.structure?.existingPublishableKey === publishableKey &&
+    prepared.structure.hasClerkKitImport &&
+    prepared.structure.hasEnvironment &&
+    prepared.plan.changes?.configuration === "verify-existing" &&
+    prepared.plan.changes.clerkKitImport === "satisfied" &&
+    prepared.plan.changes.environment === "satisfied"
+  );
+}
+
+/**
+ * @internal Prepare one key-bearing Swift mutation without writing it. The
+ * returned plan/result remains redacted; only the non-enumerable mutation
+ * bytes are sensitive to accidental output.
+ */
+export async function prepareIOSDirectConfigMutation(
+  plan: IOSDirectConfigPlan,
+  publishableKey: string,
+): Promise<IOSDirectConfigPreparedMutation> {
+  if (plan.status === "blocked") return { status: "blocked", plan };
+  if (
+    plan.schemaVersion !== 1 ||
+    plan.kind !== "clerk-ios-direct-config" ||
+    !plan.sourcePath ||
+    !plan.expectedSourceHash ||
+    !plan.changes
+  ) {
+    return {
+      status: "blocked",
+      plan: redactedKeyBlocker(
+        plan,
+        "invalid-selection",
+        "The direct iOS configuration plan is incomplete or unsupported.",
+      ),
+    };
+  }
+  const normalizedKey = validatedDevelopmentKey(publishableKey);
+  if (!normalizedKey) {
+    let production = false;
+    try {
+      production = decodePublishableKey(publishableKey).instanceType === "production";
+    } catch {
+      // The redacted blocker below covers malformed values.
+    }
+    return {
+      status: "blocked",
+      plan: redactedKeyBlocker(
+        plan,
+        production ? "production-publishable-key" : "invalid-publishable-key",
+        production
+          ? "Automatic direct iOS configuration accepts a development publishable key only."
+          : "A valid Clerk development publishable key is required.",
+      ),
+    };
+  }
+
+  const current = await prepareDirectConfig({
+    root: plan.root,
+    projectPath: plan.projectPath,
+    targetId: plan.targetId,
+    allowDirty: plan.allowDirty,
+  });
+  if (
+    current.plan.status === "blocked" ||
+    !current.snapshot ||
+    !current.structure ||
+    !current.plan.expectedSourceHash
+  ) {
+    return { status: "blocked", plan: current.plan };
+  }
+  if (
+    current.plan.sourcePath !== plan.sourcePath ||
+    current.plan.expectedSourceHash !== plan.expectedSourceHash
+  ) {
+    return {
+      status: "stale",
+      plan,
+      message: "The selected Swift entry source changed after the plan was created.",
+    };
+  }
+  if (
+    current.structure.existingPublishableKey &&
+    current.structure.existingPublishableKey !== normalizedKey
+  ) {
+    return {
+      status: "blocked",
+      plan: redactedKeyBlocker(
+        plan,
+        "different-inline-publishable-key",
+        "The existing inline development publishable key belongs to a different Clerk application and was preserved.",
+      ),
+    };
+  }
+
+  const candidate = directConfigCandidate(current.structure, normalizedKey);
+  const candidateBytes = new TextEncoder().encode(candidate);
+  const candidateHash = sha256(candidateBytes);
+  if (candidateHash === current.snapshot.hash) {
+    return { status: "satisfied", plan };
+  }
+  const mutation = mutationWithHiddenBytes(current.snapshot, candidateBytes);
+  return readyPreparedMutation(plan, mutation, async () =>
+    exactPostcondition(plan, normalizedKey, candidateHash),
+  );
+}
+
+/** @internal Validate a committed prepared mutation with the same exact structural parser. */
+export async function validatePreparedIOSDirectConfig(
+  prepared: IOSDirectConfigPreparedMutation,
+): Promise<boolean> {
+  return (await preparedValidators.get(prepared)?.()) ?? false;
+}
+
+async function fileHash(path: string): Promise<string | undefined> {
+  try {
+    const info = await lstat(path);
+    if (!info.isFile() || info.isSymbolicLink() || info.size > MAX_SWIFT_FILE_BYTES) {
+      return undefined;
+    }
+    return sha256(await readFile(path));
+  } catch {
+    return undefined;
+  }
+}
+
+async function syncDirectory(path: string): Promise<void> {
+  try {
+    const directory = await open(path, "r");
+    try {
+      await directory.sync();
+    } finally {
+      await directory.close();
+    }
+  } catch {
+    // Same-directory rename remains atomic where directory fsync is unavailable.
+  }
+}
+
+async function cleanupTemporarySource(path: string): Promise<void> {
+  try {
+    await rm(path, { force: true });
+  } catch {
+    throw new Error(
+      "A temporary direct iOS source file could not be removed. Inspect the entry-source directory for a .clerk-*.tmp file before retrying.",
+    );
+  }
+}
+
+async function stageSource(mutation: IOSDirectConfigFileMutation): Promise<StagedSource> {
+  const temporaryPath = resolve(
+    dirname(mutation.absolutePath),
+    `.${basename(mutation.absolutePath)}.clerk-${process.pid}-${randomUUID()}.tmp`,
+  );
+  let created = false;
+  try {
+    const file = await open(temporaryPath, "wx", 0o600);
+    created = true;
+    try {
+      await file.writeFile(mutation.candidateBytes);
+      await file.sync();
+    } finally {
+      await file.close();
+    }
+    await chmod(temporaryPath, mutation.mode);
+    return { temporaryPath, mutation, committed: false };
+  } catch {
+    if (created) await cleanupTemporarySource(temporaryPath);
+    throw new Error("The direct iOS source update could not be staged safely.");
+  }
+}
+
+async function commitStagedSource(staged: StagedSource): Promise<"written" | "stale"> {
+  if ((await fileHash(staged.mutation.absolutePath)) !== staged.mutation.expectedHash) {
+    return "stale";
+  }
+  await rename(staged.temporaryPath, staged.mutation.absolutePath);
+  staged.committed = true;
+  await syncDirectory(dirname(staged.mutation.absolutePath));
+  return "written";
+}
+
+async function rollbackStagedSource(staged: StagedSource): Promise<boolean> {
+  if (!staged.committed) return true;
+  if ((await fileHash(staged.mutation.absolutePath)) !== staged.mutation.candidateHash) {
+    return false;
+  }
+  const rollbackMutation = mutationWithHiddenBytes(
+    {
+      absolutePath: staged.mutation.absolutePath,
+      relativePath: "",
+      bytes: staged.mutation.candidateBytes,
+      source: "",
+      hash: staged.mutation.candidateHash,
+      mode: staged.mutation.mode,
+    },
+    staged.mutation.originalBytes,
+  );
+  const rollback = await stageSource(rollbackMutation);
+  try {
+    if ((await commitStagedSource(rollback)) !== "written") return false;
+    staged.committed = false;
+    return (await fileHash(staged.mutation.absolutePath)) === staged.mutation.expectedHash;
+  } finally {
+    await cleanupTemporarySource(rollback.temporaryPath);
+  }
+}
+
+export async function applyIOSDirectConfig(
+  plan: IOSDirectConfigPlan,
+  publishableKey: string,
+  options: IOSDirectConfigApplyOptions = {},
+): Promise<IOSDirectConfigApplyResult> {
+  const prepared = await prepareIOSDirectConfigMutation(plan, publishableKey);
+  if (prepared.status !== "ready") return prepared;
+
+  const staged = await stageSource(prepared.mutation);
+  try {
+    await options.beforeCommit?.();
+    if ((await commitStagedSource(staged)) === "stale") {
+      return {
+        status: "stale",
+        plan,
+        message: "The selected Swift entry source changed while the update was being committed.",
+      };
+    }
+    await options.beforePostWriteValidation?.();
+    const valid =
+      options.forcePostWriteValidationFailure !== true &&
+      (await validatePreparedIOSDirectConfig(prepared));
+    if (valid) return { status: "applied", plan };
+
+    if (!(await rollbackStagedSource(staged))) {
+      throw new Error(
+        "The direct iOS source update failed validation, and a concurrent edit prevented safe rollback. Inspect the entry source before retrying.",
+      );
+    }
+    return {
+      status: "rolled-back",
+      plan,
+      message: "The direct iOS source update failed validation and the original file was restored.",
+    };
+  } catch (error) {
+    if (staged.committed && !(await rollbackStagedSource(staged))) {
+      throw new Error(
+        "The direct iOS source update failed, and a concurrent edit prevented safe rollback. Inspect the entry source before retrying.",
+      );
+    }
+    if (error instanceof Error && error.message.includes("concurrent edit")) throw error;
+    return {
+      status: "rolled-back",
+      plan,
+      message: "The direct iOS source update failed and the original file was restored.",
+    };
+  } finally {
+    await cleanupTemporarySource(staged.temporaryPath);
+  }
+}

--- a/packages/cli-core/src/commands/init/ios/discovery.ts
+++ b/packages/cli-core/src/commands/init/ios/discovery.ts
@@ -1,0 +1,330 @@
+import { readdir, realpath } from "node:fs/promises";
+import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import type { IOSWorkspaceInspection } from "./types.ts";
+
+const MAX_DISCOVERY_DEPTH = 3;
+const MAX_EXHAUSTIVE_DISCOVERY_DEPTH = 24;
+const MAX_DISCOVERY_DIRECTORIES = 10_000;
+const MAX_DISCOVERED_CONTAINERS = 1_000;
+const IGNORED_DIRECTORIES = new Set([
+  ".build",
+  ".git",
+  ".swiftpm",
+  "build",
+  "Carthage",
+  "DerivedData",
+  "node_modules",
+  "Pods",
+  "SourcePackages",
+]);
+
+export interface IOSContainerDiscovery {
+  projectPaths: string[];
+  workspacePaths: string[];
+  /** False when a bounded or unreadable traversal could have hidden another container. */
+  complete: boolean;
+}
+
+export interface IOSContainerDiscoveryOptions {
+  /**
+   * Traverse deeply enough for strict cross-target source-ownership proofs.
+   * Any traversal limit or read failure is returned as incomplete so callers
+   * can fail closed instead of treating a partial inventory as exhaustive.
+   */
+  exhaustive?: boolean;
+}
+
+interface ContainerWalkState {
+  complete: boolean;
+  directoriesVisited: number;
+  maxDepth: number;
+  includeHiddenDirectories: boolean;
+}
+
+function isWithinRoot(root: string, path: string): boolean {
+  const rel = relative(root, path);
+  return rel === "" || (!rel.startsWith(`..${sep}`) && rel !== ".." && !isAbsolute(rel));
+}
+
+export function relativeIOSPath(root: string, path: string): string {
+  const rel = relative(root, path);
+  return rel === "" ? "." : rel.split(sep).join("/");
+}
+
+/**
+ * Checks both the lexical path and every existing filesystem ancestor. This
+ * prevents an in-root symlink from turning a supposedly local read into a read
+ * somewhere else on disk. Non-existent leaf paths are allowed only when their
+ * nearest existing ancestor is still within the real root.
+ */
+export async function pathIsSafelyWithinIOSRoot(
+  rootInput: string,
+  candidateInput: string,
+): Promise<boolean> {
+  const root = resolve(rootInput);
+  const candidate = resolve(candidateInput);
+  if (!isWithinRoot(root, candidate)) return false;
+
+  let realRoot: string;
+  try {
+    realRoot = await realpath(root);
+  } catch {
+    return false;
+  }
+
+  let existingAncestor = candidate;
+  const missingSegments: string[] = [];
+  let realAncestor: string | undefined;
+  while (isWithinRoot(root, existingAncestor)) {
+    try {
+      realAncestor = await realpath(existingAncestor);
+      break;
+    } catch {
+      if (existingAncestor === root) break;
+      missingSegments.unshift(basename(existingAncestor));
+      const parent = dirname(existingAncestor);
+      if (parent === existingAncestor) break;
+      existingAncestor = parent;
+    }
+  }
+
+  if (!realAncestor) return false;
+  return isWithinRoot(realRoot, resolve(realAncestor, ...missingSegments));
+}
+
+async function walkContainers(
+  directory: string,
+  depth: number,
+  projects: Set<string>,
+  workspaces: Set<string>,
+  state: ContainerWalkState,
+): Promise<void> {
+  if (state.directoriesVisited >= MAX_DISCOVERY_DIRECTORIES) {
+    state.complete = false;
+    return;
+  }
+  state.directoriesVisited += 1;
+
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch {
+    state.complete = false;
+    return;
+  }
+
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const absolutePath = resolve(directory, entry.name);
+
+    if (entry.name.endsWith(".xcodeproj")) {
+      if (projects.size + workspaces.size >= MAX_DISCOVERED_CONTAINERS) {
+        state.complete = false;
+        continue;
+      }
+      projects.add(absolutePath);
+      continue;
+    }
+
+    if (entry.name.endsWith(".xcworkspace")) {
+      // Xcode creates a private workspace inside every .xcodeproj. It is an
+      // implementation detail, not a user-selectable workspace.
+      if (!directory.endsWith(".xcodeproj")) {
+        if (projects.size + workspaces.size >= MAX_DISCOVERED_CONTAINERS) {
+          state.complete = false;
+          continue;
+        }
+        workspaces.add(absolutePath);
+      }
+      continue;
+    }
+
+    if (IGNORED_DIRECTORIES.has(entry.name)) continue;
+    if (!state.includeHiddenDirectories && entry.name.startsWith(".")) continue;
+    if (depth >= state.maxDepth) {
+      state.complete = false;
+      continue;
+    }
+    await walkContainers(absolutePath, depth + 1, projects, workspaces, state);
+  }
+}
+
+export async function discoverIOSContainers(
+  rootInput: string,
+  options: IOSContainerDiscoveryOptions = {},
+): Promise<IOSContainerDiscovery> {
+  const root = resolve(rootInput);
+  const projects = new Set<string>();
+  const workspaces = new Set<string>();
+  const exhaustive = options.exhaustive === true;
+  const state: ContainerWalkState = {
+    complete: true,
+    directoriesVisited: 0,
+    maxDepth: exhaustive ? MAX_EXHAUSTIVE_DISCOVERY_DEPTH : MAX_DISCOVERY_DEPTH,
+    includeHiddenDirectories: exhaustive,
+  };
+
+  if (root.endsWith(".xcodeproj")) {
+    projects.add(root);
+  } else if (root.endsWith(".xcworkspace")) {
+    workspaces.add(root);
+  } else {
+    await walkContainers(root, 0, projects, workspaces, state);
+  }
+
+  return {
+    projectPaths: [...projects].sort(),
+    workspacePaths: [...workspaces].sort(),
+    complete: state.complete,
+  };
+}
+
+function decodeXMLAttribute(value: string): string {
+  return value
+    .replaceAll("&quot;", '"')
+    .replaceAll("&apos;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&amp;", "&");
+}
+
+export function xmlAttribute(source: string, name: string): string | undefined {
+  let cursor = 0;
+  while (cursor < source.length) {
+    while (/\s/.test(source[cursor] ?? "")) cursor += 1;
+    const attributeName = /^[A-Za-z_:][A-Za-z0-9_.:-]*/.exec(source.slice(cursor))?.[0];
+    if (!attributeName) {
+      cursor += 1;
+      continue;
+    }
+    cursor += attributeName.length;
+    while (/\s/.test(source[cursor] ?? "")) cursor += 1;
+    if (source[cursor] !== "=") continue;
+    cursor += 1;
+    while (/\s/.test(source[cursor] ?? "")) cursor += 1;
+    const quote = source[cursor];
+    if (quote !== '"' && quote !== "'") continue;
+    const valueStart = ++cursor;
+    const valueEnd = source.indexOf(quote, valueStart);
+    if (valueEnd === -1) return undefined;
+    if (attributeName === name) {
+      return decodeXMLAttribute(source.slice(valueStart, valueEnd));
+    }
+    cursor = valueEnd + 1;
+  }
+  return undefined;
+}
+
+function resolveWorkspaceLocation(
+  base: string,
+  location: string | undefined,
+  containerBase: string,
+): string {
+  if (!location) return base;
+  const separatorIndex = location.indexOf(":");
+  const scheme = separatorIndex === -1 ? "group" : location.slice(0, separatorIndex);
+  const rawPath = separatorIndex === -1 ? location : location.slice(separatorIndex + 1);
+  if (scheme === "absolute") return resolve(rawPath);
+  if (scheme === "container") return resolve(containerBase, rawPath);
+  return resolve(base, rawPath);
+}
+
+/**
+ * Masks XML comments without joining the bytes on either side. Removing a
+ * comment outright could synthesize markup from two otherwise inert fragments
+ * (for example, `<Fi<!-- -->leRef>`).
+ */
+function maskXMLComments(source: string): string {
+  const chunks: string[] = [];
+  let cursor = 0;
+  while (cursor < source.length) {
+    const start = source.indexOf("<!--", cursor);
+    if (start === -1) {
+      chunks.push(source.slice(cursor));
+      break;
+    }
+    chunks.push(source.slice(cursor, start));
+    const closing = source.indexOf("-->", start + 4);
+    const end = closing === -1 ? source.length : closing + 3;
+    chunks.push(" ".repeat(end - start));
+    cursor = end;
+  }
+  return chunks.join("");
+}
+
+/**
+ * Reads only project references from an Xcode workspace. We deliberately do
+ * not use Xcode or resolve packages. Unsupported/external references remain
+ * visible in the workspace inventory but are not traversed.
+ */
+export async function inspectWorkspace(
+  rootInput: string,
+  workspacePath: string,
+): Promise<{ inspection: IOSWorkspaceInspection; localProjectPaths: string[] }> {
+  const root = resolve(rootInput);
+  const contentsPath = resolve(workspacePath, "contents.xcworkspacedata");
+  let xml = "";
+  try {
+    if (!(await pathIsSafelyWithinIOSRoot(root, contentsPath))) {
+      throw new Error("external workspace");
+    }
+    const file = Bun.file(contentsPath);
+    if (!(await file.exists()) || file.size > 2_000_000) throw new Error("unreadable workspace");
+    xml = maskXMLComments(await file.text());
+  } catch {
+    return {
+      inspection: { path: relativeIOSPath(root, workspacePath), projectPaths: [] },
+      localProjectPaths: [],
+    };
+  }
+
+  const projectPaths = new Set<string>();
+  const localProjectPaths = new Set<string>();
+  const workspaceDirectory = dirname(workspacePath);
+  const groupBases = [workspaceDirectory];
+  const elementPattern = /<(\/)?(Workspace|Group|FileRef)\b([^>]*)>/g;
+  for (const match of xml.matchAll(elementPattern)) {
+    const closing = match[1] === "/";
+    const tag = match[2];
+    const attributes = match[3] ?? "";
+    if (tag === "Group") {
+      if (closing) {
+        if (groupBases.length > 1) groupBases.pop();
+      } else {
+        const base = groupBases.at(-1) ?? workspaceDirectory;
+        groupBases.push(
+          resolveWorkspaceLocation(base, xmlAttribute(attributes, "location"), workspaceDirectory),
+        );
+        if (attributes.trimEnd().endsWith("/")) groupBases.pop();
+      }
+      continue;
+    }
+    if (closing || tag !== "FileRef") continue;
+
+    const location = xmlAttribute(attributes, "location");
+    const base = groupBases.at(-1) ?? workspaceDirectory;
+    const embeddedProject =
+      location === "self:" && workspaceDirectory.endsWith(".xcodeproj")
+        ? workspaceDirectory
+        : undefined;
+    if (!embeddedProject && !location?.endsWith(".xcodeproj")) continue;
+    const absolutePath =
+      embeddedProject ?? resolveWorkspaceLocation(base, location, workspaceDirectory);
+    const safelyLocal = await pathIsSafelyWithinIOSRoot(root, absolutePath);
+    projectPaths.add(safelyLocal ? relativeIOSPath(root, absolutePath) : absolutePath);
+    if (safelyLocal) localProjectPaths.add(absolutePath);
+  }
+
+  return {
+    inspection: {
+      path: relativeIOSPath(root, workspacePath),
+      projectPaths: [...projectPaths].sort(),
+    },
+    localProjectPaths: [...localProjectPaths].sort(),
+  };
+}
+
+export function pathIsWithinIOSRoot(rootInput: string, candidate: string): boolean {
+  return isWithinRoot(resolve(rootInput), resolve(candidate));
+}

--- a/packages/cli-core/src/commands/init/ios/discovery.ts
+++ b/packages/cli-core/src/commands/init/ios/discovery.ts
@@ -235,7 +235,7 @@ function resolveWorkspaceLocation(
  * comment outright could synthesize markup from two otherwise inert fragments
  * (for example, `<Fi<!-- -->leRef>`).
  */
-function maskXMLComments(source: string): string {
+export function maskXMLComments(source: string): string {
   const chunks: string[] = [];
   let cursor = 0;
   while (cursor < source.length) {

--- a/packages/cli-core/src/commands/init/ios/entitlements-settings.test.ts
+++ b/packages/cli-core/src/commands/init/ios/entitlements-settings.test.ts
@@ -1,0 +1,488 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { build as buildPbxProject, parse as parsePbxProject } from "@bacons/xcode/json";
+import {
+  appendFile,
+  chmod,
+  link,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  applyIOSExistingFileTransaction,
+  hashIOSFileBytes,
+  type IOSExistingFileMutation,
+} from "./file-transaction.ts";
+import {
+  planIOSMissingEntitlementsSettings,
+  prepareIOSMissingEntitlementsSettingsMutation,
+  validateIOSMissingEntitlementsSettingsPostcondition,
+} from "./entitlements-settings.ts";
+import {
+  planIOSSDKInstall,
+  prepareIOSSDKInstallMutation,
+  validateIOSSDKInstallPostcondition,
+} from "./install-sdk.ts";
+import type { PbxObjects } from "./pbx.ts";
+import { createIOSFixture, IOS_FIXTURE_IDS } from "./test-helpers.ts";
+
+const SYNCHRONIZED_ROOT_ID = "515151515151515151515151";
+const ANCESTOR_SYNCHRONIZED_ROOT_ID = "525252525252525252525252";
+const DEVICE_SETTING = "CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]";
+const SIMULATOR_SETTING = "CODE_SIGN_ENTITLEMENTS[sdk=iphonesimulator*]";
+const MAC_SETTING = "CODE_SIGN_ENTITLEMENTS[sdk=macosx*]";
+const temporaryDirectories: string[] = [];
+
+interface MutableProject {
+  project: ReturnType<typeof parsePbxProject>;
+  objects: PbxObjects;
+}
+
+async function temporaryRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "clerk-ios-entitlements-settings-"));
+  temporaryDirectories.push(root);
+  return root;
+}
+
+function pbxprojPath(root: string): string {
+  return join(root, "MyApp.xcodeproj", "project.pbxproj");
+}
+
+function entitlementsPath(root: string): string {
+  return join(root, "MyApp", "MyApp.entitlements");
+}
+
+function mutableProject(source: string): MutableProject {
+  const project = parsePbxProject(source);
+  const archive = project as unknown as { objects: PbxObjects };
+  return { project, objects: archive.objects };
+}
+
+function settings(objects: PbxObjects, id: string): Record<string, unknown> {
+  return objects[id]!.buildSettings as Record<string, unknown>;
+}
+
+async function makeSynchronizedFixture(
+  options: {
+    secondTarget?: boolean;
+    clerkSDK?: boolean;
+    shareRoot?: boolean;
+    retainClassicReference?: boolean;
+  } = {},
+): Promise<string> {
+  const root = await temporaryRoot();
+  await createIOSFixture(root, {
+    secondTarget: options.secondTarget,
+    clerkSDK: options.clerkSDK,
+  });
+  const path = pbxprojPath(root);
+  const graph = mutableProject(await readFile(path, "utf8"));
+  const mainGroup = graph.objects[IOS_FIXTURE_IDS.mainGroup]!;
+  const children = mainGroup.children as string[];
+  mainGroup.children = [
+    ...children.filter((id) => id !== IOS_FIXTURE_IDS.entitlementsFile),
+    SYNCHRONIZED_ROOT_ID,
+  ];
+  graph.objects[SYNCHRONIZED_ROOT_ID] = {
+    isa: "PBXFileSystemSynchronizedRootGroup",
+    path: "MyApp",
+    sourceTree: "<group>",
+  };
+  graph.objects[IOS_FIXTURE_IDS.appTarget]!.fileSystemSynchronizedGroups = [SYNCHRONIZED_ROOT_ID];
+  if (options.shareRoot) {
+    graph.objects[IOS_FIXTURE_IDS.secondTarget]!.fileSystemSynchronizedGroups = [
+      SYNCHRONIZED_ROOT_ID,
+    ];
+  }
+  for (const id of [IOS_FIXTURE_IDS.targetDebug, IOS_FIXTURE_IDS.targetRelease]) {
+    const values = settings(graph.objects, id);
+    delete values.CODE_SIGN_ENTITLEMENTS;
+    values[MAC_SETTING] = "MyApp/MyApp.mac.entitlements";
+  }
+  if (!options.retainClassicReference) {
+    delete graph.objects[IOS_FIXTURE_IDS.entitlementsFile];
+  }
+  await writeFile(path, buildPbxProject(graph.project));
+  await rm(entitlementsPath(root));
+  return root;
+}
+
+function options(root: string) {
+  return {
+    root,
+    projectPath: "MyApp.xcodeproj",
+    targetId: IOS_FIXTURE_IDS.appTarget,
+  };
+}
+
+function blockerCodes(
+  plan: Awaited<ReturnType<typeof planIOSMissingEntitlementsSettings>>,
+): string[] {
+  return plan.blockers.map((item) => item.code);
+}
+
+async function createCrossProjectClassicReference(root: string): Promise<void> {
+  const projectPath = join(root, "Other.xcodeproj");
+  await mkdir(projectPath);
+  await writeFile(
+    join(projectPath, "project.pbxproj"),
+    `// !$*UTF8*$!
+{
+  archiveVersion = 1;
+  classes = { };
+  objectVersion = 56;
+  objects = {
+    616161616161616161616161 = {
+      isa = PBXProject;
+      mainGroup = 626262626262626262626262;
+      projectDirPath = "";
+      projectRoot = "";
+      targets = ( );
+    };
+    626262626262626262626262 = {
+      isa = PBXGroup;
+      children = ( 636363636363636363636363, );
+      sourceTree = "<group>";
+    };
+    636363636363636363636363 = {
+      isa = PBXFileReference;
+      lastKnownFileType = text.plist.entitlements;
+      path = MyApp/MyApp.entitlements;
+      sourceTree = "<group>";
+    };
+  };
+  rootObject = 616161616161616161616161;
+}
+`,
+  );
+}
+
+async function initializeGitRepository(root: string): Promise<void> {
+  const child = Bun.spawn(["git", "init", "--quiet", root], {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdout = new Response(child.stdout).arrayBuffer();
+  const stderr = new Response(child.stderr).arrayBuffer();
+  const [exitCode] = await Promise.all([child.exited, stdout, stderr]);
+  if (exitCode !== 0) throw new Error("Could not initialize the test Git repository.");
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+describe("missing iOS entitlements build settings", () => {
+  test("adds SDK-qualified settings to every selected configuration and is byte-idempotent", async () => {
+    const root = await makeSynchronizedFixture({ secondTarget: true });
+    await chmod(pbxprojPath(root), 0o640);
+    const before = await readFile(pbxprojPath(root));
+    const beforeGraph = mutableProject(before.toString());
+    const secondBefore = JSON.stringify({
+      debug: beforeGraph.objects[IOS_FIXTURE_IDS.secondDebug],
+      release: beforeGraph.objects[IOS_FIXTURE_IDS.secondRelease],
+    });
+
+    const plan = await planIOSMissingEntitlementsSettings(options(root));
+    expect(plan).toMatchObject({
+      status: "ready",
+      entitlementsPath: "MyApp/MyApp.entitlements",
+      buildSettingPath: "MyApp/MyApp.entitlements",
+      synchronizedRootPath: "MyApp",
+      configurationIds: [IOS_FIXTURE_IDS.targetDebug, IOS_FIXTURE_IDS.targetRelease],
+      blockers: [],
+    });
+    const prepared = await prepareIOSMissingEntitlementsSettingsMutation(plan);
+    expect(prepared.status).toBe("ready");
+    expect(JSON.stringify(prepared)).not.toContain("candidateBytes");
+    if (prepared.status !== "ready") throw new Error("Expected a prepared mutation.");
+    expect(prepared.mutation.originalBytes).toEqual(before);
+
+    const result = await applyIOSExistingFileTransaction(
+      [prepared.mutation],
+      [() => validateIOSMissingEntitlementsSettingsPostcondition(plan)],
+    );
+    expect(result.status).toBe("applied");
+    expect((await stat(pbxprojPath(root))).mode & 0o777).toBe(0o640);
+    const after = await readFile(pbxprojPath(root));
+    const afterGraph = mutableProject(after.toString());
+    for (const id of [IOS_FIXTURE_IDS.targetDebug, IOS_FIXTURE_IDS.targetRelease]) {
+      expect(settings(afterGraph.objects, id)).toMatchObject({
+        [DEVICE_SETTING]: "MyApp/MyApp.entitlements",
+        [SIMULATOR_SETTING]: "MyApp/MyApp.entitlements",
+        [MAC_SETTING]: "MyApp/MyApp.mac.entitlements",
+      });
+    }
+    expect(
+      JSON.stringify({
+        debug: afterGraph.objects[IOS_FIXTURE_IDS.secondDebug],
+        release: afterGraph.objects[IOS_FIXTURE_IDS.secondRelease],
+      }),
+    ).toBe(secondBefore);
+    expect(await Bun.file(entitlementsPath(root)).exists()).toBe(false);
+
+    const rerun = await planIOSMissingEntitlementsSettings(options(root));
+    expect(rerun.status).toBe("satisfied");
+    expect((await prepareIOSMissingEntitlementsSettingsMutation(rerun)).status).toBe("satisfied");
+    expect(await readFile(pbxprojPath(root))).toEqual(after);
+  });
+
+  test("composes with an SDK candidate into one project mutation", async () => {
+    const root = await makeSynchronizedFixture({ clerkSDK: false });
+    const entitlementsPlan = await planIOSMissingEntitlementsSettings(options(root));
+    const sdkPlan = await planIOSSDKInstall(options(root));
+    const sdk = await prepareIOSSDKInstallMutation(sdkPlan);
+    expect(sdk.status).toBe("ready");
+    if (sdk.status !== "ready") throw new Error("Expected an SDK mutation.");
+
+    const combined = await prepareIOSMissingEntitlementsSettingsMutation(
+      entitlementsPlan,
+      sdk.mutation,
+    );
+    expect(combined.status).toBe("ready");
+    if (combined.status !== "ready") throw new Error("Expected a combined mutation.");
+    expect(combined.mutation.path).toBe(sdk.mutation.path);
+    expect(combined.mutation.originalHash).toBe(sdk.mutation.originalHash);
+    expect(combined.mutation.candidateHash).not.toBe(sdk.mutation.candidateHash);
+
+    const result = await applyIOSExistingFileTransaction(
+      [combined.mutation],
+      [
+        () => validateIOSSDKInstallPostcondition(sdk.plan),
+        () => validateIOSMissingEntitlementsSettingsPostcondition(entitlementsPlan),
+      ],
+    );
+    expect(result.status).toBe("applied");
+    expect(await validateIOSSDKInstallPostcondition(sdk.plan)).toBe(true);
+    expect(await validateIOSMissingEntitlementsSettingsPostcondition(entitlementsPlan)).toBe(true);
+  });
+
+  test("produces deterministic candidate bytes", async () => {
+    const firstRoot = await makeSynchronizedFixture();
+    const secondRoot = await makeSynchronizedFixture();
+    const first = await prepareIOSMissingEntitlementsSettingsMutation(
+      await planIOSMissingEntitlementsSettings(options(firstRoot)),
+    );
+    const second = await prepareIOSMissingEntitlementsSettingsMutation(
+      await planIOSMissingEntitlementsSettings(options(secondRoot)),
+    );
+    expect(first.status).toBe("ready");
+    expect(second.status).toBe("ready");
+    if (first.status !== "ready" || second.status !== "ready") {
+      throw new Error("Expected deterministic mutations.");
+    }
+    expect(first.mutation.candidateBytes).toEqual(second.mutation.candidateBytes);
+  });
+
+  test("blocks missing, ambiguous, shared, and generated synchronized-root ownership", async () => {
+    const missingRoot = await temporaryRoot();
+    await createIOSFixture(missingRoot, { releaseEntitlements: false });
+    const missingGraph = mutableProject(await readFile(pbxprojPath(missingRoot), "utf8"));
+    delete settings(missingGraph.objects, IOS_FIXTURE_IDS.targetDebug).CODE_SIGN_ENTITLEMENTS;
+    delete missingGraph.objects[IOS_FIXTURE_IDS.entitlementsFile];
+    missingGraph.objects[IOS_FIXTURE_IDS.mainGroup]!.children = (
+      missingGraph.objects[IOS_FIXTURE_IDS.mainGroup]!.children as string[]
+    ).filter((id) => id !== IOS_FIXTURE_IDS.entitlementsFile);
+    await writeFile(pbxprojPath(missingRoot), buildPbxProject(missingGraph.project));
+    await rm(entitlementsPath(missingRoot));
+    expect(blockerCodes(await planIOSMissingEntitlementsSettings(options(missingRoot)))).toContain(
+      "missing-synchronized-root",
+    );
+
+    const ambiguousRoot = await makeSynchronizedFixture();
+    const ambiguousGraph = mutableProject(await readFile(pbxprojPath(ambiguousRoot), "utf8"));
+    const secondRootId = "525252525252525252525252";
+    ambiguousGraph.objects[secondRootId] = {
+      isa: "PBXFileSystemSynchronizedRootGroup",
+      path: "Other",
+      sourceTree: "<group>",
+    };
+    ambiguousGraph.objects[IOS_FIXTURE_IDS.mainGroup]!.children = [
+      ...(ambiguousGraph.objects[IOS_FIXTURE_IDS.mainGroup]!.children as string[]),
+      secondRootId,
+    ];
+    ambiguousGraph.objects[IOS_FIXTURE_IDS.appTarget]!.fileSystemSynchronizedGroups = [
+      SYNCHRONIZED_ROOT_ID,
+      secondRootId,
+    ];
+    await writeFile(pbxprojPath(ambiguousRoot), buildPbxProject(ambiguousGraph.project));
+    expect(
+      blockerCodes(await planIOSMissingEntitlementsSettings(options(ambiguousRoot))),
+    ).toContain("ambiguous-synchronized-root");
+
+    const sharedRoot = await makeSynchronizedFixture({ secondTarget: true, shareRoot: true });
+    expect(blockerCodes(await planIOSMissingEntitlementsSettings(options(sharedRoot)))).toContain(
+      "shared-synchronized-root",
+    );
+
+    const generatedRoot = await makeSynchronizedFixture();
+    await writeFile(join(generatedRoot, "project.yml"), "name: MyApp\n");
+    expect(
+      blockerCodes(await planIOSMissingEntitlementsSettings(options(generatedRoot))),
+    ).toContain("generated-project");
+  });
+
+  test.each(["regular", "directory", "symlink", "hardlink"] as const)(
+    "refuses an unreferenced %s destination collision",
+    async (kind) => {
+      const root = await makeSynchronizedFixture();
+      const destination = entitlementsPath(root);
+      if (kind === "regular") await writeFile(destination, "existing");
+      if (kind === "directory") await mkdir(destination);
+      if (kind === "symlink") {
+        const source = join(root, "MyApp", "Other.entitlements");
+        await writeFile(source, "existing");
+        await symlink(source, destination);
+      }
+      if (kind === "hardlink") {
+        const source = join(root, "MyApp", "Other.entitlements");
+        await writeFile(source, "existing");
+        await link(source, destination);
+      }
+      expect(blockerCodes(await planIOSMissingEntitlementsSettings(options(root)))).toContain(
+        "entitlements-destination-exists",
+      );
+    },
+  );
+
+  test("refuses a classic file reference and partial iOS settings", async () => {
+    const referenceRoot = await makeSynchronizedFixture({ retainClassicReference: true });
+    expect(
+      blockerCodes(await planIOSMissingEntitlementsSettings(options(referenceRoot))),
+    ).toContain("entitlements-destination-exists");
+
+    const partialRoot = await makeSynchronizedFixture();
+    const graph = mutableProject(await readFile(pbxprojPath(partialRoot), "utf8"));
+    settings(graph.objects, IOS_FIXTURE_IDS.targetDebug)[DEVICE_SETTING] =
+      "MyApp/MyApp.entitlements";
+    await writeFile(pbxprojPath(partialRoot), buildPbxProject(graph.project));
+    expect(blockerCodes(await planIOSMissingEntitlementsSettings(options(partialRoot)))).toContain(
+      "conflicting-entitlements-settings",
+    );
+  });
+
+  test("refuses an entitlements destination referenced by another target", async () => {
+    const root = await makeSynchronizedFixture({ secondTarget: true });
+    const graph = mutableProject(await readFile(pbxprojPath(root), "utf8"));
+    for (const id of [IOS_FIXTURE_IDS.secondDebug, IOS_FIXTURE_IDS.secondRelease]) {
+      settings(graph.objects, id).CODE_SIGN_ENTITLEMENTS = "MyApp/MyApp.entitlements";
+    }
+    await writeFile(pbxprojPath(root), buildPbxProject(graph.project));
+
+    expect(blockerCodes(await planIOSMissingEntitlementsSettings(options(root)))).toContain(
+      "shared-entitlements-destination",
+    );
+  });
+
+  test("refuses a destination represented by a classic reference in another project", async () => {
+    const root = await makeSynchronizedFixture();
+    await createCrossProjectClassicReference(root);
+
+    expect(blockerCodes(await planIOSMissingEntitlementsSettings(options(root)))).toContain(
+      "entitlements-destination-exists",
+    );
+  });
+
+  test("refuses a sibling synchronized root that is an ancestor of the destination", async () => {
+    const root = await makeSynchronizedFixture({ secondTarget: true });
+    const graph = mutableProject(await readFile(pbxprojPath(root), "utf8"));
+    graph.objects[ANCESTOR_SYNCHRONIZED_ROOT_ID] = {
+      isa: "PBXFileSystemSynchronizedRootGroup",
+      path: ".",
+      sourceTree: "<group>",
+    };
+    graph.objects[IOS_FIXTURE_IDS.mainGroup]!.children = [
+      ...(graph.objects[IOS_FIXTURE_IDS.mainGroup]!.children as string[]),
+      ANCESTOR_SYNCHRONIZED_ROOT_ID,
+    ];
+    graph.objects[IOS_FIXTURE_IDS.secondTarget]!.fileSystemSynchronizedGroups = [
+      ANCESTOR_SYNCHRONIZED_ROOT_ID,
+    ];
+    await writeFile(pbxprojPath(root), buildPbxProject(graph.project));
+
+    expect(blockerCodes(await planIOSMissingEntitlementsSettings(options(root)))).toContain(
+      "shared-synchronized-root",
+    );
+  });
+
+  test("blocks a Git-ignored destination and honors a targeted negation", async () => {
+    const ignoredRoot = await makeSynchronizedFixture();
+    await initializeGitRepository(ignoredRoot);
+    await writeFile(join(ignoredRoot, ".gitignore"), "*.entitlements\n");
+    expect(blockerCodes(await planIOSMissingEntitlementsSettings(options(ignoredRoot)))).toContain(
+      "ignored-entitlements-destination",
+    );
+
+    const includedRoot = await makeSynchronizedFixture();
+    await initializeGitRepository(includedRoot);
+    await writeFile(
+      join(includedRoot, ".gitignore"),
+      "*.entitlements\n!MyApp/MyApp.entitlements\n",
+    );
+    expect(await planIOSMissingEntitlementsSettings(options(includedRoot))).toMatchObject({
+      status: "ready",
+      blockers: [],
+    });
+  });
+
+  test("postcondition rejects replacement of the synchronized root directory", async () => {
+    const root = await makeSynchronizedFixture();
+    const plan = await planIOSMissingEntitlementsSettings(options(root));
+    const prepared = await prepareIOSMissingEntitlementsSettingsMutation(plan);
+    expect(prepared.status).toBe("ready");
+    if (prepared.status !== "ready") throw new Error("Expected a prepared mutation.");
+    expect((await applyIOSExistingFileTransaction([prepared.mutation], [() => true])).status).toBe(
+      "applied",
+    );
+
+    const sourcePath = join(root, "MyApp", "MyAppApp.swift");
+    const source = await readFile(sourcePath);
+    await rename(join(root, "MyApp"), join(root, "MyApp-replaced"));
+    await mkdir(join(root, "MyApp"));
+    await writeFile(sourcePath, source);
+
+    expect(await validateIOSMissingEntitlementsSettingsPostcondition(plan)).toBe(false);
+  });
+
+  test("treats project, destination, and base-mutation races as stale", async () => {
+    const projectRoot = await makeSynchronizedFixture();
+    const projectPlan = await planIOSMissingEntitlementsSettings(options(projectRoot));
+    const newerProject = await readFile(pbxprojPath(projectRoot));
+    await appendFile(pbxprojPath(projectRoot), "\n// newer\n");
+    expect((await prepareIOSMissingEntitlementsSettingsMutation(projectPlan)).status).toBe("stale");
+    expect(await readFile(pbxprojPath(projectRoot))).not.toEqual(newerProject);
+
+    const destinationRoot = await makeSynchronizedFixture();
+    const destinationPlan = await planIOSMissingEntitlementsSettings(options(destinationRoot));
+    await writeFile(entitlementsPath(destinationRoot), "newer");
+    expect((await prepareIOSMissingEntitlementsSettingsMutation(destinationPlan)).status).toBe(
+      "stale",
+    );
+    expect(await readFile(entitlementsPath(destinationRoot), "utf8")).toBe("newer");
+
+    const baseRoot = await makeSynchronizedFixture();
+    const basePlan = await planIOSMissingEntitlementsSettings(options(baseRoot));
+    const bytes = new Uint8Array(await readFile(pbxprojPath(baseRoot)));
+    const invalidBase: IOSExistingFileMutation = {
+      path: join(baseRoot, "Other.xcodeproj", "project.pbxproj"),
+      originalBytes: bytes,
+      originalHash: hashIOSFileBytes(bytes),
+      candidateBytes: bytes,
+      candidateHash: hashIOSFileBytes(bytes),
+      mode: 0o644,
+    };
+    expect(
+      (await prepareIOSMissingEntitlementsSettingsMutation(basePlan, invalidBase)).status,
+    ).toBe("stale");
+  });
+});

--- a/packages/cli-core/src/commands/init/ios/entitlements-settings.ts
+++ b/packages/cli-core/src/commands/init/ios/entitlements-settings.ts
@@ -1,0 +1,1498 @@
+import { lstat, readFile, readdir, realpath } from "node:fs/promises";
+import { isDeepStrictEqual } from "node:util";
+import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import { build as buildPbxProject, parse as parsePbxProject } from "@bacons/xcode/json";
+import { inspectTargetBuildConfigurations } from "./build-settings.ts";
+import {
+  discoverIOSContainers,
+  inspectWorkspace,
+  pathIsSafelyWithinIOSRoot,
+  relativeIOSPath,
+} from "./discovery.ts";
+import { hashIOSFileBytes, type IOSExistingFileMutation } from "./file-transaction.ts";
+import { inspectIOSProject } from "./inspect.ts";
+import {
+  asString,
+  buildPbxParentIndex,
+  isRecord,
+  resolvePbxFilePath,
+  type PbxObject,
+  type PbxObjects,
+} from "./pbx.ts";
+import type { IOSDiagnostic } from "./types.ts";
+
+const APP_PRODUCT_TYPE = "com.apple.product-type.application";
+const DEVICE_SETTING = "CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]";
+const SIMULATOR_SETTING = "CODE_SIGN_ENTITLEMENTS[sdk=iphonesimulator*]";
+const MAX_PBXPROJ_BYTES = 15_000_000;
+
+export interface IOSMissingEntitlementsSettingsOptions {
+  root: string;
+  /** Invocation-root-relative selected .xcodeproj path. */
+  projectPath: string;
+  targetId: string;
+}
+
+export type IOSMissingEntitlementsSettingsBlockerCode =
+  | "invalid-selection"
+  | "external-path"
+  | "generated-project"
+  | "unreadable-project"
+  | "malformed-project"
+  | "target-not-found"
+  | "incomplete-build-configurations"
+  | "missing-synchronized-root"
+  | "ambiguous-synchronized-root"
+  | "unsafe-synchronized-root"
+  | "shared-synchronized-root"
+  | "invalid-entitlements-destination"
+  | "entitlements-destination-exists"
+  | "ignored-entitlements-destination"
+  | "unresolved-git-ignore"
+  | "shared-entitlements-destination"
+  | "conflicting-entitlements-settings"
+  | "unsupported-project";
+
+export interface IOSMissingEntitlementsSettingsBlocker {
+  code: IOSMissingEntitlementsSettingsBlockerCode;
+  message: string;
+}
+
+interface IOSMissingEntitlementsSettingsPlanBase {
+  schemaVersion: 1;
+  kind: "clerk-ios-missing-entitlements-settings";
+  root: string;
+  projectPath: string;
+  targetId: string;
+  /** Exact target configuration IDs authorized by this plan, when inspectable. */
+  configurationIds: string[];
+  actions: string[];
+  blockers: IOSMissingEntitlementsSettingsBlocker[];
+}
+
+interface IOSMissingEntitlementsSettingsResolvedFields {
+  targetName: string;
+  /** Invocation-root-relative destination. */
+  entitlementsPath: string;
+  /** Value written to CODE_SIGN_ENTITLEMENTS, relative to the .xcodeproj directory. */
+  buildSettingPath: string;
+  /** Invocation-root-relative synchronized target root. */
+  synchronizedRootPath: string;
+  synchronizedRootObjectId: string;
+  expectedSynchronizedRootIdentity: { device: number; inode: number };
+  expectedPbxprojHash: string;
+  expectedPbxprojMode: number;
+}
+
+export type IOSMissingEntitlementsSettingsPlan =
+  | (IOSMissingEntitlementsSettingsPlanBase &
+      IOSMissingEntitlementsSettingsResolvedFields & { status: "ready" })
+  | (IOSMissingEntitlementsSettingsPlanBase &
+      IOSMissingEntitlementsSettingsResolvedFields & { status: "satisfied" })
+  | (IOSMissingEntitlementsSettingsPlanBase &
+      Partial<IOSMissingEntitlementsSettingsResolvedFields> & { status: "blocked" });
+
+interface IOSMissingEntitlementsSettingsPlanSource {
+  targetName?: string;
+  entitlementsPath?: string;
+  buildSettingPath?: string;
+  synchronizedRootPath?: string;
+  synchronizedRootObjectId?: string;
+  expectedSynchronizedRootIdentity?: { device: number; inode: number };
+  expectedPbxprojHash?: string;
+  expectedPbxprojMode?: number;
+}
+
+export type PreparedIOSMissingEntitlementsSettingsMutation =
+  | { status: "ready"; plan: IOSMissingEntitlementsSettingsPlan; mutation: IOSExistingFileMutation }
+  | { status: "satisfied"; plan: IOSMissingEntitlementsSettingsPlan }
+  | { status: "blocked"; plan: IOSMissingEntitlementsSettingsPlan }
+  | { status: "stale"; plan: IOSMissingEntitlementsSettingsPlan };
+
+interface ProjectGraph {
+  project: ReturnType<typeof parsePbxProject>;
+  objects: PbxObjects;
+  projectObjectId: string;
+  projectObject: PbxObject;
+  targetId: string;
+  targetObject: PbxObject;
+  configurationIds: string[];
+}
+
+interface ProjectSnapshot {
+  absoluteProjectPath: string;
+  pbxprojPath: string;
+  bytes: Uint8Array;
+  hash: string;
+  mode: number;
+  source: string;
+  graph: ProjectGraph;
+}
+
+interface SynchronizedRoot {
+  objectId: string;
+  absolutePath: string;
+  relativePath: string;
+  device: number;
+  inode: number;
+}
+
+function blocker(
+  code: IOSMissingEntitlementsSettingsBlockerCode,
+  message: string,
+): IOSMissingEntitlementsSettingsBlocker {
+  return { code, message };
+}
+
+function planBase(
+  options: IOSMissingEntitlementsSettingsOptions,
+): Pick<
+  IOSMissingEntitlementsSettingsPlanBase,
+  "schemaVersion" | "kind" | "root" | "projectPath" | "targetId"
+> {
+  return {
+    schemaVersion: 1,
+    kind: "clerk-ios-missing-entitlements-settings",
+    root: resolve(options.root),
+    projectPath: options.projectPath.replaceAll("\\", "/"),
+    targetId: options.targetId,
+  };
+}
+
+function blockedPlan(
+  options: IOSMissingEntitlementsSettingsOptions,
+  detail: IOSMissingEntitlementsSettingsBlocker,
+  source: IOSMissingEntitlementsSettingsPlanSource & { configurationIds?: string[] } = {},
+): IOSMissingEntitlementsSettingsPlan {
+  return {
+    ...planBase(options),
+    ...source,
+    status: "blocked",
+    configurationIds: source.configurationIds ?? [],
+    actions: [],
+    blockers: [detail],
+  };
+}
+
+function blockPrepared(
+  plan: IOSMissingEntitlementsSettingsPlan,
+  code: IOSMissingEntitlementsSettingsBlockerCode,
+  message: string,
+): PreparedIOSMissingEntitlementsSettingsMutation {
+  return {
+    status: "blocked",
+    plan: {
+      ...plan,
+      status: "blocked",
+      actions: [],
+      blockers: [blocker(code, message)],
+    },
+  };
+}
+
+function exactStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) return undefined;
+  const result = [...value];
+  return new Set(result).size === result.length ? result : undefined;
+}
+
+function optionalExactStringArray(value: unknown): string[] | undefined {
+  return value == null ? [] : exactStringArray(value);
+}
+
+function normalizedObjects(value: unknown): PbxObjects | undefined {
+  if (!isRecord(value)) return undefined;
+  const objects: PbxObjects = {};
+  for (const [id, object] of Object.entries(value)) {
+    if (!isRecord(object)) return undefined;
+    objects[id] = object as PbxObject;
+  }
+  return objects;
+}
+
+function projectGraph(
+  project: ReturnType<typeof parsePbxProject>,
+  targetId: string,
+): ProjectGraph | undefined {
+  const archive: unknown = project;
+  if (!isRecord(archive)) return undefined;
+  const objects = normalizedObjects(archive.objects);
+  const projectObjectId = asString(archive.rootObject);
+  const projectObject = projectObjectId ? objects?.[projectObjectId] : undefined;
+  const targetObject = objects?.[targetId];
+  if (
+    !objects ||
+    !projectObjectId ||
+    projectObject?.isa !== "PBXProject" ||
+    targetObject?.isa !== "PBXNativeTarget" ||
+    asString(targetObject.productType) !== APP_PRODUCT_TYPE
+  ) {
+    return undefined;
+  }
+  const configurationListId = asString(targetObject.buildConfigurationList);
+  const configurationList = configurationListId ? objects[configurationListId] : undefined;
+  if (configurationList?.isa !== "XCConfigurationList") return undefined;
+  const configurationIds = exactStringArray(configurationList.buildConfigurations);
+  if (
+    !configurationIds ||
+    configurationIds.length === 0 ||
+    configurationIds.some((id) => objects[id]?.isa !== "XCBuildConfiguration")
+  ) {
+    return undefined;
+  }
+  return {
+    project,
+    objects,
+    projectObjectId,
+    projectObject,
+    targetId,
+    targetObject,
+    configurationIds,
+  };
+}
+
+function validSuppliedSelection(options: IOSMissingEntitlementsSettingsOptions): boolean {
+  const projectPath = options.projectPath.replaceAll("\\", "/");
+  return (
+    options.targetId.trim().length > 0 &&
+    projectPath.length > 0 &&
+    !isAbsolute(options.projectPath) &&
+    projectPath.endsWith(".xcodeproj")
+  );
+}
+
+async function readProjectSnapshot(
+  root: string,
+  projectPath: string,
+  targetId: string,
+): Promise<ProjectSnapshot | undefined> {
+  const absoluteProjectPath = resolve(root, projectPath);
+  const pbxprojPath = resolve(absoluteProjectPath, "project.pbxproj");
+  if (
+    !(await pathIsSafelyWithinIOSRoot(root, absoluteProjectPath)) ||
+    !(await pathIsSafelyWithinIOSRoot(root, pbxprojPath))
+  ) {
+    return undefined;
+  }
+  try {
+    const [projectInfo, info] = await Promise.all([lstat(absoluteProjectPath), lstat(pbxprojPath)]);
+    if (
+      !projectInfo.isDirectory() ||
+      projectInfo.isSymbolicLink() ||
+      !info.isFile() ||
+      info.isSymbolicLink() ||
+      info.size > MAX_PBXPROJ_BYTES
+    ) {
+      return undefined;
+    }
+    const bytes = new Uint8Array(await readFile(pbxprojPath));
+    const source = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    const project = parsePbxProject(source);
+    const graph = projectGraph(project, targetId);
+    if (!graph) return undefined;
+    return {
+      absoluteProjectPath,
+      pbxprojPath,
+      bytes,
+      hash: hashIOSFileBytes(bytes),
+      mode: info.mode & 0o7777,
+      source,
+      graph,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+async function generatedProjectKind(
+  root: string,
+  absoluteProjectPath: string,
+): Promise<"xcodegen" | "tuist" | null> {
+  let directory = dirname(absoluteProjectPath);
+  while (await pathIsSafelyWithinIOSRoot(root, directory)) {
+    for (const [relativePath, kind] of [
+      ["project.yml", "xcodegen"],
+      ["Project.swift", "tuist"],
+      ["Workspace.swift", "tuist"],
+      ["Tuist/ProjectDescriptionHelpers", "tuist"],
+    ] as const) {
+      const marker = resolve(directory, relativePath);
+      if ((await pathIsSafelyWithinIOSRoot(root, marker)) && (await Bun.file(marker).exists())) {
+        return kind;
+      }
+    }
+    if (directory === root) break;
+    const parent = dirname(directory);
+    if (parent === directory) break;
+    directory = parent;
+  }
+  return null;
+}
+
+function parentReferenceCount(objects: PbxObjects, childId: string): number {
+  let count = 0;
+  for (const object of Object.values(objects)) {
+    const children = optionalExactStringArray(object.children);
+    if (children?.includes(childId)) count += 1;
+  }
+  return count;
+}
+
+async function selectedSynchronizedRoot(
+  root: string,
+  snapshot: ProjectSnapshot,
+): Promise<{ root?: SynchronizedRoot; blocker?: IOSMissingEntitlementsSettingsBlocker }> {
+  const groupIds = optionalExactStringArray(
+    snapshot.graph.targetObject.fileSystemSynchronizedGroups,
+  );
+  if (!groupIds) {
+    return {
+      blocker: blocker(
+        "ambiguous-synchronized-root",
+        "The selected target has a malformed synchronized-folder list.",
+      ),
+    };
+  }
+  if (groupIds.length === 0) {
+    return {
+      blocker: blocker(
+        "missing-synchronized-root",
+        "The selected target does not have a filesystem-synchronized source root.",
+      ),
+    };
+  }
+  if (groupIds.length !== 1) {
+    return {
+      blocker: blocker(
+        "ambiguous-synchronized-root",
+        "The selected target has more than one filesystem-synchronized source root.",
+      ),
+    };
+  }
+  const objectId = groupIds[0]!;
+  const group = snapshot.graph.objects[objectId];
+  if (
+    group?.isa !== "PBXFileSystemSynchronizedRootGroup" ||
+    !asString(group.path)?.trim() ||
+    parentReferenceCount(snapshot.graph.objects, objectId) !== 1
+  ) {
+    return {
+      blocker: blocker(
+        "unsafe-synchronized-root",
+        "The selected target's synchronized source root could not be resolved uniquely.",
+      ),
+    };
+  }
+  const parents = buildPbxParentIndex(snapshot.graph.objects);
+  const projectDirectory = dirname(snapshot.absoluteProjectPath);
+  const groupRootDirectory = resolve(
+    projectDirectory,
+    asString(snapshot.graph.projectObject.projectDirPath) ?? "",
+  );
+  const absolutePath = resolvePbxFilePath(
+    objectId,
+    snapshot.graph.objects,
+    parents,
+    projectDirectory,
+    groupRootDirectory,
+  );
+  if (!absolutePath || !(await pathIsSafelyWithinIOSRoot(root, absolutePath))) {
+    return {
+      blocker: blocker(
+        "unsafe-synchronized-root",
+        "The selected target's synchronized source root resolves outside the invocation root.",
+      ),
+    };
+  }
+  try {
+    const info = await lstat(absolutePath);
+    if (!info.isDirectory() || info.isSymbolicLink()) throw new Error("unsupported root");
+    await realpath(absolutePath);
+    return {
+      root: {
+        objectId,
+        absolutePath,
+        relativePath: relativeIOSPath(root, absolutePath),
+        device: info.dev,
+        inode: info.ino,
+      },
+    };
+  } catch {
+    return {
+      blocker: blocker(
+        "unsafe-synchronized-root",
+        "The selected target's synchronized source root must be a regular, non-symlink directory.",
+      ),
+    };
+  }
+}
+
+async function localProjectPaths(root: string, selectedProjectPath: string): Promise<string[]> {
+  const containers = await discoverIOSContainers(root);
+  const paths = new Set([...containers.projectPaths, selectedProjectPath]);
+  for (const workspacePath of containers.workspacePaths) {
+    const workspace = await inspectWorkspace(root, workspacePath);
+    for (const projectPath of workspace.localProjectPaths) paths.add(projectPath);
+  }
+  return [...paths].sort();
+}
+
+async function synchronizedRootIsExclusive(
+  root: string,
+  selectedProjectPath: string,
+  selectedTargetId: string,
+  selectedRoot: SynchronizedRoot,
+  destination: string,
+): Promise<boolean> {
+  let selectedCanonical: string;
+  let canonicalDestination: string;
+  try {
+    selectedCanonical = await realpath(selectedRoot.absolutePath);
+    canonicalDestination = await canonicalPathWithPossibleMissingLeaf(destination);
+  } catch {
+    return false;
+  }
+  for (const absoluteProjectPath of await localProjectPaths(root, selectedProjectPath)) {
+    const pbxprojPath = resolve(absoluteProjectPath, "project.pbxproj");
+    if (!(await pathIsSafelyWithinIOSRoot(root, pbxprojPath))) return false;
+    let archive: unknown;
+    try {
+      const info = await lstat(pbxprojPath);
+      if (!info.isFile() || info.isSymbolicLink() || info.size > MAX_PBXPROJ_BYTES) return false;
+      archive = parsePbxProject(await readFile(pbxprojPath, "utf8"));
+    } catch {
+      return false;
+    }
+    if (!isRecord(archive)) return false;
+    const objects = normalizedObjects(archive.objects);
+    const projectObjectId = asString(archive.rootObject);
+    const projectObject = projectObjectId ? objects?.[projectObjectId] : undefined;
+    if (!objects || projectObject?.isa !== "PBXProject") return false;
+    const targetIds = exactStringArray(projectObject.targets);
+    if (!targetIds) return false;
+    const parents = buildPbxParentIndex(objects);
+    const projectDirectory = dirname(absoluteProjectPath);
+    const groupRootDirectory = resolve(
+      projectDirectory,
+      asString(projectObject.projectDirPath) ?? "",
+    );
+    for (const targetId of targetIds) {
+      const target = objects[targetId];
+      if (target?.isa !== "PBXNativeTarget") continue;
+      const groupIds = optionalExactStringArray(target.fileSystemSynchronizedGroups);
+      if (!groupIds) return false;
+      for (const groupId of groupIds) {
+        if (
+          absoluteProjectPath === selectedProjectPath &&
+          targetId === selectedTargetId &&
+          groupId === selectedRoot.objectId
+        ) {
+          continue;
+        }
+        const group = objects[groupId];
+        if (group?.isa !== "PBXFileSystemSynchronizedRootGroup") return false;
+        const groupPath = resolvePbxFilePath(
+          groupId,
+          objects,
+          parents,
+          projectDirectory,
+          groupRootDirectory,
+        );
+        if (!groupPath || !(await pathIsSafelyWithinIOSRoot(root, groupPath))) return false;
+        try {
+          const info = await lstat(groupPath);
+          if (!info.isDirectory() || info.isSymbolicLink()) return false;
+          const canonical = await realpath(groupPath);
+          if (
+            canonical === selectedCanonical ||
+            (info.dev === selectedRoot.device && info.ino === selectedRoot.inode) ||
+            pathContains(canonical, canonicalDestination)
+          ) {
+            return false;
+          }
+        } catch (error) {
+          if (!isFileSystemError(error, "ENOENT")) return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+async function canonicalPathWithPossibleMissingLeaf(path: string): Promise<string> {
+  try {
+    return await realpath(path);
+  } catch (error) {
+    if (!isFileSystemError(error, "ENOENT")) throw error;
+    return resolve(await realpath(dirname(path)), basename(path));
+  }
+}
+
+function pathContains(directory: string, candidate: string): boolean {
+  const relativePath = relative(directory, candidate);
+  return (
+    relativePath === "" ||
+    (relativePath !== ".." && !relativePath.startsWith(`..${sep}`) && !isAbsolute(relativePath))
+  );
+}
+
+type GitIgnoreState = "not-repository" | "included" | "ignored" | "error";
+
+async function findGitMarker(
+  start: string,
+): Promise<{ state: "found"; directory: string } | { state: "none" | "error" }> {
+  let directory = resolve(start);
+  while (true) {
+    try {
+      await lstat(resolve(directory, ".git"));
+      return { state: "found", directory };
+    } catch (error) {
+      if (!isFileSystemError(error, "ENOENT")) return { state: "error" };
+    }
+    const parent = dirname(directory);
+    if (parent === directory) return { state: "none" };
+    directory = parent;
+  }
+}
+
+async function runGit(
+  cwd: string,
+  args: readonly string[],
+): Promise<{ exitCode: number; stdout: string } | undefined> {
+  try {
+    const child = Bun.spawn(["git", ...args], {
+      cwd,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stdout = new Response(child.stdout).text();
+    const stderr = new Response(child.stderr).arrayBuffer();
+    const [exitCode, output] = await Promise.all([child.exited, stdout, stderr]).then(
+      ([code, text]) => [code, text] as const,
+    );
+    return { exitCode, stdout: output };
+  } catch {
+    return undefined;
+  }
+}
+
+async function gitIgnoreState(destination: string): Promise<GitIgnoreState> {
+  const marker = await findGitMarker(dirname(destination));
+  if (marker.state === "none") return "not-repository";
+  if (marker.state === "error") return "error";
+
+  const repository = await runGit(dirname(destination), ["rev-parse", "--show-toplevel"]);
+  if (!repository || repository.exitCode !== 0) return "error";
+  const lines = repository.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length !== 1 || !isAbsolute(lines[0]!)) return "error";
+
+  try {
+    const canonicalRepository = await realpath(lines[0]!);
+    const canonicalDestination = await canonicalPathWithPossibleMissingLeaf(destination);
+    if (!pathContains(canonicalRepository, canonicalDestination)) return "error";
+    const repositoryRelativePath = relative(canonicalRepository, canonicalDestination)
+      .split(sep)
+      .join("/");
+    if (
+      !repositoryRelativePath ||
+      repositoryRelativePath === ".." ||
+      repositoryRelativePath.startsWith("../") ||
+      isAbsolute(repositoryRelativePath)
+    ) {
+      return "error";
+    }
+    const checked = await runGit(canonicalRepository, [
+      "check-ignore",
+      "--quiet",
+      "--no-index",
+      "--",
+      repositoryRelativePath,
+    ]);
+    if (!checked) return "error";
+    if (checked.exitCode === 0) return "ignored";
+    if (checked.exitCode === 1) return "included";
+    return "error";
+  } catch {
+    return "error";
+  }
+}
+
+async function classicDestinationIsUnreferenced(
+  root: string,
+  selectedProjectPath: string,
+  destination: string,
+): Promise<boolean> {
+  const normalizedDestination = resolve(destination).toLocaleLowerCase("en-US");
+  let canonicalDestination: string;
+  try {
+    canonicalDestination = (
+      await canonicalPathWithPossibleMissingLeaf(destination)
+    ).toLocaleLowerCase("en-US");
+  } catch {
+    return false;
+  }
+  for (const absoluteProjectPath of await localProjectPaths(root, selectedProjectPath)) {
+    const pbxprojPath = resolve(absoluteProjectPath, "project.pbxproj");
+    if (!(await pathIsSafelyWithinIOSRoot(root, pbxprojPath))) return false;
+    let archive: unknown;
+    try {
+      const info = await lstat(pbxprojPath);
+      if (!info.isFile() || info.isSymbolicLink() || info.size > MAX_PBXPROJ_BYTES) return false;
+      archive = parsePbxProject(await readFile(pbxprojPath, "utf8"));
+    } catch {
+      return false;
+    }
+    if (!isRecord(archive)) return false;
+    const objects = normalizedObjects(archive.objects);
+    const projectObjectId = asString(archive.rootObject);
+    const projectObject = projectObjectId ? objects?.[projectObjectId] : undefined;
+    if (!objects || projectObject?.isa !== "PBXProject") return false;
+    const parents = buildPbxParentIndex(objects);
+    const projectDirectory = dirname(absoluteProjectPath);
+    const groupRootDirectory = resolve(
+      projectDirectory,
+      asString(projectObject.projectDirPath) ?? "",
+    );
+    for (const [objectId, object] of Object.entries(objects)) {
+      if (object.isa !== "PBXFileReference") continue;
+      const referencedPath = resolvePbxFilePath(
+        objectId,
+        objects,
+        parents,
+        projectDirectory,
+        groupRootDirectory,
+      );
+      if (!referencedPath) continue;
+      if (referencedPath.toLocaleLowerCase("en-US") === normalizedDestination) return false;
+      try {
+        if (
+          (await canonicalPathWithPossibleMissingLeaf(referencedPath)).toLocaleLowerCase(
+            "en-US",
+          ) === canonicalDestination
+        ) {
+          return false;
+        }
+      } catch {
+        // An unrelated unresolved reference cannot alias the existing parent
+        // of this exact destination without first becoming inspectable.
+      }
+    }
+  }
+  return true;
+}
+
+async function entitlementsDestinationIsExclusive(
+  root: string,
+  selectedProjectPath: string,
+  selectedTargetId: string,
+  destination: string,
+): Promise<boolean> {
+  const normalizedDestination = resolve(destination).toLocaleLowerCase("en-US");
+  for (const absoluteProjectPath of await localProjectPaths(root, selectedProjectPath)) {
+    const pbxprojPath = resolve(absoluteProjectPath, "project.pbxproj");
+    if (!(await pathIsSafelyWithinIOSRoot(root, pbxprojPath))) return false;
+    let archive: unknown;
+    try {
+      const info = await lstat(pbxprojPath);
+      if (!info.isFile() || info.isSymbolicLink() || info.size > MAX_PBXPROJ_BYTES) return false;
+      archive = parsePbxProject(await readFile(pbxprojPath, "utf8"));
+    } catch {
+      return false;
+    }
+    if (!isRecord(archive)) return false;
+    const objects = normalizedObjects(archive.objects);
+    const projectObjectId = asString(archive.rootObject);
+    const projectObject = projectObjectId ? objects?.[projectObjectId] : undefined;
+    if (!objects || projectObject?.isa !== "PBXProject") return false;
+    const targetIds = exactStringArray(projectObject.targets);
+    if (!targetIds) return false;
+    const parents = buildPbxParentIndex(objects);
+    const groupRootDirectory = resolve(
+      dirname(absoluteProjectPath),
+      asString(projectObject.projectDirPath) ?? "",
+    );
+    for (const targetId of targetIds) {
+      if (absoluteProjectPath === selectedProjectPath && targetId === selectedTargetId) continue;
+      const targetObject = objects[targetId];
+      if (targetObject?.isa !== "PBXNativeTarget") continue;
+      const diagnostics: IOSDiagnostic[] = [];
+      const configurations = await inspectTargetBuildConfigurations({
+        root,
+        projectPath: absoluteProjectPath,
+        groupRootDirectory,
+        projectObject,
+        targetId,
+        targetObject,
+        objects,
+        parents,
+        diagnostics,
+      });
+      if (
+        configurations.length === 0 ||
+        diagnostics.some((diagnostic) => diagnostic.severity === "error")
+      ) {
+        return false;
+      }
+      for (const configuration of configurations) {
+        const resolution = configuration.model.entitlementsPath;
+        if (resolution.state === "unresolved") return false;
+        if (resolution.state !== "resolved") continue;
+        const siblingPath = resolve(dirname(absoluteProjectPath), resolution.value);
+        if (!(await pathIsSafelyWithinIOSRoot(root, siblingPath))) return false;
+        if (siblingPath.toLocaleLowerCase("en-US") === normalizedDestination) return false;
+      }
+    }
+  }
+  return true;
+}
+
+function isFileSystemError(error: unknown, code: string): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === code
+  );
+}
+
+function destinationForRoot(
+  root: string,
+  absoluteProjectPath: string,
+  synchronizedRoot: SynchronizedRoot,
+):
+  | { absolutePath: string; relativePath: string; buildSettingPath: string }
+  | { blocker: IOSMissingEntitlementsSettingsBlocker } {
+  const rootName = basename(synchronizedRoot.absolutePath);
+  if (
+    !rootName ||
+    rootName === "." ||
+    rootName === ".." ||
+    rootName.includes("\0") ||
+    rootName.length > 200
+  ) {
+    return {
+      blocker: blocker(
+        "invalid-entitlements-destination",
+        "A deterministic entitlements filename could not be derived from the synchronized root.",
+      ),
+    };
+  }
+  const absolutePath = resolve(synchronizedRoot.absolutePath, `${rootName}.entitlements`);
+  const projectDirectory = dirname(absoluteProjectPath);
+  const buildSettingPath = relative(projectDirectory, absolutePath).split(sep).join("/");
+  if (
+    dirname(absolutePath) !== synchronizedRoot.absolutePath ||
+    !buildSettingPath ||
+    buildSettingPath === ".." ||
+    buildSettingPath.startsWith("../") ||
+    isAbsolute(buildSettingPath)
+  ) {
+    return {
+      blocker: blocker(
+        "invalid-entitlements-destination",
+        "The derived entitlements destination is not safely inside the synchronized root.",
+      ),
+    };
+  }
+  return {
+    absolutePath,
+    relativePath: relativeIOSPath(root, absolutePath),
+    buildSettingPath,
+  };
+}
+
+async function destinationState(
+  synchronizedRoot: SynchronizedRoot,
+  absolutePath: string,
+): Promise<"absent" | "regular" | "unsupported" | "case-collision"> {
+  try {
+    const info = await lstat(absolutePath);
+    return info.isFile() && !info.isSymbolicLink() ? "regular" : "unsupported";
+  } catch (error) {
+    if (!isFileSystemError(error, "ENOENT")) return "unsupported";
+  }
+  try {
+    const expectedName = basename(absolutePath).toLocaleLowerCase("en-US");
+    const entries = await readdir(synchronizedRoot.absolutePath);
+    if (entries.some((entry) => entry.toLocaleLowerCase("en-US") === expectedName)) {
+      return "case-collision";
+    }
+    return "absent";
+  } catch {
+    return "unsupported";
+  }
+}
+
+function settingsDictionary(
+  graph: ProjectGraph,
+  configurationId: string,
+): Record<string, unknown> | undefined {
+  const settings = graph.objects[configurationId]?.buildSettings;
+  return isRecord(settings) ? settings : undefined;
+}
+
+function rawSettingsAreExact(graph: ProjectGraph, buildSettingPath: string): boolean {
+  return graph.configurationIds.every((id) => {
+    const settings = settingsDictionary(graph, id);
+    return (
+      settings?.[DEVICE_SETTING] === buildSettingPath &&
+      settings?.[SIMULATOR_SETTING] === buildSettingPath
+    );
+  });
+}
+
+async function buildSettingState(
+  root: string,
+  snapshot: ProjectSnapshot,
+  buildSettingPath: string,
+): Promise<"missing" | "exact" | "conflicting" | "incomplete"> {
+  const diagnostics: IOSDiagnostic[] = [];
+  const parents = buildPbxParentIndex(snapshot.graph.objects);
+  const groupRootDirectory = resolve(
+    dirname(snapshot.absoluteProjectPath),
+    asString(snapshot.graph.projectObject.projectDirPath) ?? "",
+  );
+  const inspected = await inspectTargetBuildConfigurations({
+    root,
+    projectPath: snapshot.absoluteProjectPath,
+    groupRootDirectory,
+    projectObject: snapshot.graph.projectObject,
+    targetId: snapshot.graph.targetId,
+    targetObject: snapshot.graph.targetObject,
+    objects: snapshot.graph.objects,
+    parents,
+    diagnostics,
+  });
+  if (
+    inspected.length !== snapshot.graph.configurationIds.length ||
+    inspected.length === 0 ||
+    !inspected.some((configuration) => configuration.isIOS) ||
+    diagnostics.some((diagnostic) => diagnostic.severity === "error")
+  ) {
+    return "incomplete";
+  }
+  if (
+    inspected.every((configuration) => configuration.model.entitlementsPath.state === "missing")
+  ) {
+    return "missing";
+  }
+  if (
+    rawSettingsAreExact(snapshot.graph, buildSettingPath) &&
+    inspected.every(
+      (configuration) =>
+        configuration.model.entitlementsPath.state === "resolved" &&
+        configuration.model.entitlementsPath.value === buildSettingPath,
+    )
+  ) {
+    return "exact";
+  }
+  return "conflicting";
+}
+
+async function inspectSelectedTarget(
+  root: string,
+  projectPath: string,
+  targetId: string,
+): Promise<string | undefined> {
+  const inspection = await inspectIOSProject(root, { target: targetId });
+  if (
+    inspection.selection.state !== "selected" ||
+    inspection.selection.targetId !== targetId ||
+    inspection.selection.projectPath !== projectPath
+  ) {
+    return undefined;
+  }
+  return inspection.appTargets.find(
+    (target) => target.id === targetId && target.projectPath === projectPath,
+  )?.name;
+}
+
+export async function planIOSMissingEntitlementsSettings(
+  options: IOSMissingEntitlementsSettingsOptions,
+): Promise<IOSMissingEntitlementsSettingsPlan> {
+  const root = resolve(options.root);
+  const normalizedProjectPath = options.projectPath.replaceAll("\\", "/");
+  const normalizedOptions = { ...options, root, projectPath: normalizedProjectPath };
+  if (!validSuppliedSelection(normalizedOptions)) {
+    return blockedPlan(
+      normalizedOptions,
+      blocker(
+        "invalid-selection",
+        "A selected root-relative .xcodeproj and target object ID are required.",
+      ),
+    );
+  }
+  const absoluteProjectPath = resolve(root, normalizedProjectPath);
+  const pbxprojPath = resolve(absoluteProjectPath, "project.pbxproj");
+  if (
+    !(await pathIsSafelyWithinIOSRoot(root, absoluteProjectPath)) ||
+    !(await pathIsSafelyWithinIOSRoot(root, pbxprojPath))
+  ) {
+    return blockedPlan(
+      normalizedOptions,
+      blocker("external-path", "The selected Xcode project resolves outside the invocation root."),
+    );
+  }
+  const snapshot = await readProjectSnapshot(root, normalizedProjectPath, options.targetId);
+  if (!snapshot) {
+    return blockedPlan(
+      normalizedOptions,
+      blocker(
+        "unreadable-project",
+        "The selected project.pbxproj is missing, malformed, symlinked, too large, or unreadable.",
+      ),
+    );
+  }
+  const targetName = await inspectSelectedTarget(root, normalizedProjectPath, options.targetId);
+  if (!targetName) {
+    return blockedPlan(
+      normalizedOptions,
+      blocker(
+        "target-not-found",
+        "The selected object is not the exact inspected native iOS application target.",
+      ),
+      {
+        expectedPbxprojHash: snapshot.hash,
+        expectedPbxprojMode: snapshot.mode,
+        configurationIds: snapshot.graph.configurationIds,
+      },
+    );
+  }
+  const synchronized = await selectedSynchronizedRoot(root, snapshot);
+  if (!synchronized.root) {
+    return blockedPlan(normalizedOptions, synchronized.blocker!, {
+      targetName,
+      expectedPbxprojHash: snapshot.hash,
+      expectedPbxprojMode: snapshot.mode,
+      configurationIds: snapshot.graph.configurationIds,
+    });
+  }
+  const destination = destinationForRoot(root, snapshot.absoluteProjectPath, synchronized.root);
+  if ("blocker" in destination) {
+    return blockedPlan(normalizedOptions, destination.blocker, {
+      targetName,
+      synchronizedRootPath: synchronized.root.relativePath,
+      synchronizedRootObjectId: synchronized.root.objectId,
+      expectedSynchronizedRootIdentity: {
+        device: synchronized.root.device,
+        inode: synchronized.root.inode,
+      },
+      expectedPbxprojHash: snapshot.hash,
+      expectedPbxprojMode: snapshot.mode,
+      configurationIds: snapshot.graph.configurationIds,
+    });
+  }
+  if (
+    !(await synchronizedRootIsExclusive(
+      root,
+      snapshot.absoluteProjectPath,
+      options.targetId,
+      synchronized.root,
+      destination.absolutePath,
+    ))
+  ) {
+    return blockedPlan(
+      normalizedOptions,
+      blocker(
+        "shared-synchronized-root",
+        "The synchronized source root is shared with another target, or exclusive ownership could not be proven.",
+      ),
+      {
+        targetName,
+        synchronizedRootPath: synchronized.root.relativePath,
+        synchronizedRootObjectId: synchronized.root.objectId,
+        expectedSynchronizedRootIdentity: {
+          device: synchronized.root.device,
+          inode: synchronized.root.inode,
+        },
+        expectedPbxprojHash: snapshot.hash,
+        expectedPbxprojMode: snapshot.mode,
+        configurationIds: snapshot.graph.configurationIds,
+      },
+    );
+  }
+  if (!(await pathIsSafelyWithinIOSRoot(root, destination.absolutePath))) {
+    return blockedPlan(
+      normalizedOptions,
+      blocker(
+        "invalid-entitlements-destination",
+        "The entitlements destination resolves outside the invocation root.",
+      ),
+      { targetName, configurationIds: snapshot.graph.configurationIds },
+    );
+  }
+  const ignoreState = await gitIgnoreState(destination.absolutePath);
+  if (ignoreState === "ignored" || ignoreState === "error") {
+    return blockedPlan(
+      normalizedOptions,
+      blocker(
+        ignoreState === "ignored" ? "ignored-entitlements-destination" : "unresolved-git-ignore",
+        ignoreState === "ignored"
+          ? `${destination.relativePath} is ignored by Git. Add a targeted .gitignore negation before automatic setup.`
+          : `Git ignore status for ${destination.relativePath} could not be verified safely.`,
+      ),
+      {
+        targetName,
+        entitlementsPath: destination.relativePath,
+        buildSettingPath: destination.buildSettingPath,
+        synchronizedRootPath: synchronized.root.relativePath,
+        synchronizedRootObjectId: synchronized.root.objectId,
+        expectedSynchronizedRootIdentity: {
+          device: synchronized.root.device,
+          inode: synchronized.root.inode,
+        },
+        expectedPbxprojHash: snapshot.hash,
+        expectedPbxprojMode: snapshot.mode,
+        configurationIds: snapshot.graph.configurationIds,
+      },
+    );
+  }
+  if (
+    !(await classicDestinationIsUnreferenced(
+      root,
+      snapshot.absoluteProjectPath,
+      destination.absolutePath,
+    ))
+  ) {
+    return blockedPlan(
+      normalizedOptions,
+      blocker(
+        "entitlements-destination-exists",
+        "The intended entitlements destination is already represented by an Xcode file reference; it will not be adopted or overwritten.",
+      ),
+      {
+        targetName,
+        entitlementsPath: destination.relativePath,
+        buildSettingPath: destination.buildSettingPath,
+        synchronizedRootPath: synchronized.root.relativePath,
+        synchronizedRootObjectId: synchronized.root.objectId,
+        expectedSynchronizedRootIdentity: {
+          device: synchronized.root.device,
+          inode: synchronized.root.inode,
+        },
+        expectedPbxprojHash: snapshot.hash,
+        expectedPbxprojMode: snapshot.mode,
+        configurationIds: snapshot.graph.configurationIds,
+      },
+    );
+  }
+  if (
+    !(await entitlementsDestinationIsExclusive(
+      root,
+      snapshot.absoluteProjectPath,
+      options.targetId,
+      destination.absolutePath,
+    ))
+  ) {
+    return blockedPlan(
+      normalizedOptions,
+      blocker(
+        "shared-entitlements-destination",
+        "The intended entitlements destination is referenced by another target, or exclusive use could not be proven.",
+      ),
+      {
+        targetName,
+        entitlementsPath: destination.relativePath,
+        buildSettingPath: destination.buildSettingPath,
+        synchronizedRootPath: synchronized.root.relativePath,
+        synchronizedRootObjectId: synchronized.root.objectId,
+        expectedSynchronizedRootIdentity: {
+          device: synchronized.root.device,
+          inode: synchronized.root.inode,
+        },
+        expectedPbxprojHash: snapshot.hash,
+        expectedPbxprojMode: snapshot.mode,
+        configurationIds: snapshot.graph.configurationIds,
+      },
+    );
+  }
+  const settingState = await buildSettingState(root, snapshot, destination.buildSettingPath);
+  const sharedPlanFields: IOSMissingEntitlementsSettingsResolvedFields & {
+    configurationIds: string[];
+  } = {
+    targetName,
+    entitlementsPath: destination.relativePath,
+    buildSettingPath: destination.buildSettingPath,
+    synchronizedRootPath: synchronized.root.relativePath,
+    synchronizedRootObjectId: synchronized.root.objectId,
+    expectedSynchronizedRootIdentity: {
+      device: synchronized.root.device,
+      inode: synchronized.root.inode,
+    },
+    expectedPbxprojHash: snapshot.hash,
+    expectedPbxprojMode: snapshot.mode,
+    configurationIds: snapshot.graph.configurationIds,
+  };
+  if (settingState === "incomplete") {
+    return blockedPlan(
+      normalizedOptions,
+      blocker(
+        "incomplete-build-configurations",
+        "Every selected-target build configuration and iOS build context must be inspectable before adding entitlements settings.",
+      ),
+      sharedPlanFields,
+    );
+  }
+  if (settingState === "conflicting") {
+    return blockedPlan(
+      normalizedOptions,
+      blocker(
+        "conflicting-entitlements-settings",
+        "The selected target already has partial, inherited, unresolved, or conflicting iOS entitlements settings.",
+      ),
+      sharedPlanFields,
+    );
+  }
+  const pathState = await destinationState(synchronized.root, destination.absolutePath);
+  if (settingState === "missing") {
+    if (pathState !== "absent") {
+      return blockedPlan(
+        normalizedOptions,
+        blocker(
+          "entitlements-destination-exists",
+          "The intended entitlements destination already exists or is represented by an incompatible Xcode file reference; it will not be adopted or overwritten.",
+        ),
+        sharedPlanFields,
+      );
+    }
+    const generator = await generatedProjectKind(root, snapshot.absoluteProjectPath);
+    if (generator) {
+      return blockedPlan(
+        normalizedOptions,
+        blocker(
+          "generated-project",
+          `This is a ${generator === "xcodegen" ? "XcodeGen" : "Tuist"} project; update its source manifest instead of generated project.pbxproj output.`,
+        ),
+        sharedPlanFields,
+      );
+    }
+  } else if (pathState === "unsupported" || pathState === "case-collision") {
+    return blockedPlan(
+      normalizedOptions,
+      blocker(
+        "invalid-entitlements-destination",
+        "The configured entitlements destination is a symlink, directory, case-colliding path, or unreadable entry.",
+      ),
+      sharedPlanFields,
+    );
+  }
+
+  return {
+    ...planBase(normalizedOptions),
+    ...sharedPlanFields,
+    status: settingState === "exact" ? "satisfied" : "ready",
+    configurationIds: snapshot.graph.configurationIds,
+    actions:
+      settingState === "exact"
+        ? []
+        : [
+            `Add iOS device and simulator CODE_SIGN_ENTITLEMENTS settings for ${destination.relativePath} to every selected-target build configuration.`,
+          ],
+    blockers: [],
+  };
+}
+
+function sameStringArray(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function sameResolvedPlanIdentity(
+  left: Extract<IOSMissingEntitlementsSettingsPlan, { status: "ready" | "satisfied" }>,
+  right: Extract<IOSMissingEntitlementsSettingsPlan, { status: "ready" | "satisfied" }>,
+): boolean {
+  return (
+    left.root === right.root &&
+    left.projectPath === right.projectPath &&
+    left.targetId === right.targetId &&
+    left.entitlementsPath === right.entitlementsPath &&
+    left.buildSettingPath === right.buildSettingPath &&
+    left.synchronizedRootPath === right.synchronizedRootPath &&
+    left.synchronizedRootObjectId === right.synchronizedRootObjectId &&
+    left.expectedSynchronizedRootIdentity.device ===
+      right.expectedSynchronizedRootIdentity.device &&
+    left.expectedSynchronizedRootIdentity.inode === right.expectedSynchronizedRootIdentity.inode &&
+    left.expectedPbxprojHash === right.expectedPbxprojHash &&
+    left.expectedPbxprojMode === right.expectedPbxprojMode &&
+    sameStringArray(left.configurationIds, right.configurationIds)
+  );
+}
+
+function synchronizedRootPathForGraph(
+  graph: ProjectGraph,
+  absoluteProjectPath: string,
+  synchronizedRootObjectId: string,
+): string | undefined {
+  const group = graph.objects[synchronizedRootObjectId];
+  if (group?.isa !== "PBXFileSystemSynchronizedRootGroup") return undefined;
+  const projectDirectory = dirname(absoluteProjectPath);
+  return resolvePbxFilePath(
+    synchronizedRootObjectId,
+    graph.objects,
+    buildPbxParentIndex(graph.objects),
+    projectDirectory,
+    resolve(projectDirectory, asString(graph.projectObject.projectDirPath) ?? ""),
+  );
+}
+
+function preparedWithHiddenMutation(
+  plan: IOSMissingEntitlementsSettingsPlan,
+  mutation: IOSExistingFileMutation,
+): Extract<PreparedIOSMissingEntitlementsSettingsMutation, { status: "ready" }> {
+  const result = { status: "ready" as const, plan } as Extract<
+    PreparedIOSMissingEntitlementsSettingsMutation,
+    { status: "ready" }
+  >;
+  Object.defineProperty(result, "mutation", {
+    value: mutation,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  return result;
+}
+
+function baseMutationIsValid(mutation: IOSExistingFileMutation): boolean {
+  return (
+    hashIOSFileBytes(mutation.originalBytes) === mutation.originalHash &&
+    hashIOSFileBytes(mutation.candidateBytes) === mutation.candidateHash &&
+    Number.isInteger(mutation.mode) &&
+    mutation.mode >= 0 &&
+    mutation.mode <= 0o7777
+  );
+}
+
+export async function prepareIOSMissingEntitlementsSettingsMutation(
+  plan: IOSMissingEntitlementsSettingsPlan,
+  baseMutation?: IOSExistingFileMutation,
+): Promise<PreparedIOSMissingEntitlementsSettingsMutation> {
+  if (plan.status === "blocked") return { status: "blocked", plan };
+  if (plan.status === "satisfied") {
+    const current = await planIOSMissingEntitlementsSettings({
+      root: plan.root,
+      projectPath: plan.projectPath,
+      targetId: plan.targetId,
+    });
+    if (current.status === "blocked") return { status: "blocked", plan: current };
+    return current.status === "satisfied" && sameResolvedPlanIdentity(plan, current)
+      ? { status: "satisfied", plan: current }
+      : { status: "stale", plan };
+  }
+  if (
+    !plan.expectedPbxprojHash ||
+    plan.expectedPbxprojMode == null ||
+    !plan.entitlementsPath ||
+    !plan.buildSettingPath ||
+    !plan.synchronizedRootPath ||
+    !plan.synchronizedRootObjectId ||
+    !plan.expectedSynchronizedRootIdentity ||
+    plan.configurationIds.length === 0
+  ) {
+    return blockPrepared(
+      plan,
+      "unsupported-project",
+      "The serialized entitlements-settings plan is incomplete.",
+    );
+  }
+  const pbxprojPath = resolve(plan.root, plan.projectPath, "project.pbxproj");
+  const entitlementsPath = resolve(plan.root, plan.entitlementsPath);
+  const synchronizedRootPath = resolve(plan.root, plan.synchronizedRootPath);
+  if (
+    !(await pathIsSafelyWithinIOSRoot(plan.root, pbxprojPath)) ||
+    !(await pathIsSafelyWithinIOSRoot(plan.root, entitlementsPath)) ||
+    !(await pathIsSafelyWithinIOSRoot(plan.root, synchronizedRootPath))
+  ) {
+    return blockPrepared(
+      plan,
+      "external-path",
+      "A planned Xcode or entitlements path no longer resolves safely inside the invocation root.",
+    );
+  }
+  let currentBytes: Uint8Array;
+  try {
+    const [projectInfo, rootInfo] = await Promise.all([
+      lstat(pbxprojPath),
+      lstat(synchronizedRootPath),
+    ]);
+    currentBytes = new Uint8Array(await readFile(pbxprojPath));
+    if (
+      !projectInfo.isFile() ||
+      projectInfo.isSymbolicLink() ||
+      (projectInfo.mode & 0o7777) !== plan.expectedPbxprojMode ||
+      hashIOSFileBytes(currentBytes) !== plan.expectedPbxprojHash ||
+      !rootInfo.isDirectory() ||
+      rootInfo.isSymbolicLink() ||
+      rootInfo.dev !== plan.expectedSynchronizedRootIdentity.device ||
+      rootInfo.ino !== plan.expectedSynchronizedRootIdentity.inode
+    ) {
+      return { status: "stale", plan };
+    }
+  } catch {
+    return { status: "stale", plan };
+  }
+  try {
+    await lstat(entitlementsPath);
+    return { status: "stale", plan };
+  } catch (error) {
+    if (!isFileSystemError(error, "ENOENT")) return { status: "stale", plan };
+  }
+
+  const replanned = await planIOSMissingEntitlementsSettings({
+    root: plan.root,
+    projectPath: plan.projectPath,
+    targetId: plan.targetId,
+  });
+  if (replanned.status === "blocked") return { status: "blocked", plan: replanned };
+  if (
+    replanned.status !== "ready" ||
+    replanned.expectedPbxprojHash !== plan.expectedPbxprojHash ||
+    replanned.entitlementsPath !== plan.entitlementsPath ||
+    replanned.buildSettingPath !== plan.buildSettingPath ||
+    replanned.synchronizedRootPath !== plan.synchronizedRootPath ||
+    replanned.synchronizedRootObjectId !== plan.synchronizedRootObjectId ||
+    !sameStringArray(replanned.configurationIds, plan.configurationIds)
+  ) {
+    return { status: "stale", plan };
+  }
+
+  if (baseMutation) {
+    if (
+      resolve(baseMutation.path) !== pbxprojPath ||
+      baseMutation.originalHash !== plan.expectedPbxprojHash ||
+      baseMutation.mode !== plan.expectedPbxprojMode
+    ) {
+      return { status: "stale", plan };
+    }
+    if (!baseMutationIsValid(baseMutation)) {
+      return blockPrepared(
+        plan,
+        "unsupported-project",
+        "The prepared base Xcode mutation is invalid.",
+      );
+    }
+  }
+
+  const sourceBytes = baseMutation?.candidateBytes ?? currentBytes;
+  let model: ReturnType<typeof parsePbxProject>;
+  let graph: ProjectGraph;
+  try {
+    model = parsePbxProject(new TextDecoder("utf-8", { fatal: true }).decode(sourceBytes));
+    const parsedGraph = projectGraph(model, plan.targetId);
+    if (!parsedGraph) throw new Error("missing target graph");
+    graph = parsedGraph;
+  } catch {
+    return blockPrepared(
+      plan,
+      "unsupported-project",
+      "The prepared Xcode candidate could not be parsed safely.",
+    );
+  }
+  const groupIds = optionalExactStringArray(graph.targetObject.fileSystemSynchronizedGroups);
+  if (
+    !groupIds ||
+    groupIds.length !== 1 ||
+    groupIds[0] !== plan.synchronizedRootObjectId ||
+    !sameStringArray(graph.configurationIds, plan.configurationIds) ||
+    synchronizedRootPathForGraph(
+      graph,
+      resolve(plan.root, plan.projectPath),
+      plan.synchronizedRootObjectId,
+    ) !== synchronizedRootPath
+  ) {
+    return blockPrepared(
+      plan,
+      "unsupported-project",
+      "The prepared Xcode candidate changed the selected target structure.",
+    );
+  }
+  for (const configurationId of graph.configurationIds) {
+    const settings = settingsDictionary(graph, configurationId);
+    if (!settings) {
+      return blockPrepared(
+        plan,
+        "malformed-project",
+        "A selected-target build configuration has no mutable build-settings dictionary.",
+      );
+    }
+    const device = settings[DEVICE_SETTING];
+    const simulator = settings[SIMULATOR_SETTING];
+    const absent = device == null && simulator == null;
+    const exact = device === plan.buildSettingPath && simulator === plan.buildSettingPath;
+    if (!absent && !exact) {
+      return blockPrepared(
+        plan,
+        "conflicting-entitlements-settings",
+        "The prepared Xcode candidate introduced partial or conflicting iOS entitlements settings.",
+      );
+    }
+    settings[DEVICE_SETTING] = plan.buildSettingPath;
+    settings[SIMULATOR_SETTING] = plan.buildSettingPath;
+  }
+
+  let candidate: string;
+  let reparsed: ReturnType<typeof parsePbxProject>;
+  try {
+    candidate = buildPbxProject(model);
+    reparsed = parsePbxProject(candidate);
+  } catch {
+    return blockPrepared(
+      plan,
+      "unsupported-project",
+      "The proposed Xcode project could not be serialized and reparsed safely.",
+    );
+  }
+  if (!isDeepStrictEqual(reparsed, model)) {
+    return blockPrepared(
+      plan,
+      "unsupported-project",
+      "Serializing the proposed Xcode project would change unsupported object-graph data.",
+    );
+  }
+  const candidateGraph = projectGraph(reparsed, plan.targetId);
+  if (
+    !candidateGraph ||
+    !sameStringArray(candidateGraph.configurationIds, plan.configurationIds) ||
+    !rawSettingsAreExact(candidateGraph, plan.buildSettingPath)
+  ) {
+    return blockPrepared(
+      plan,
+      "unsupported-project",
+      "The proposed Xcode project did not retain every required iOS entitlements setting.",
+    );
+  }
+  const candidateBytes = new TextEncoder().encode(candidate);
+  return preparedWithHiddenMutation(plan, {
+    path: pbxprojPath,
+    originalBytes: baseMutation?.originalBytes ?? currentBytes,
+    originalHash: baseMutation?.originalHash ?? plan.expectedPbxprojHash,
+    candidateBytes,
+    candidateHash: hashIOSFileBytes(candidateBytes),
+    mode: baseMutation?.mode ?? plan.expectedPbxprojMode,
+  });
+}
+
+export async function validateIOSMissingEntitlementsSettingsPostcondition(
+  plan: IOSMissingEntitlementsSettingsPlan,
+): Promise<boolean> {
+  if (plan.status === "blocked") return false;
+  const current = await planIOSMissingEntitlementsSettings({
+    root: plan.root,
+    projectPath: plan.projectPath,
+    targetId: plan.targetId,
+  });
+  return (
+    current.status === "satisfied" &&
+    current.entitlementsPath === plan.entitlementsPath &&
+    current.buildSettingPath === plan.buildSettingPath &&
+    current.synchronizedRootPath === plan.synchronizedRootPath &&
+    current.synchronizedRootObjectId === plan.synchronizedRootObjectId &&
+    current.expectedSynchronizedRootIdentity.device ===
+      plan.expectedSynchronizedRootIdentity.device &&
+    current.expectedSynchronizedRootIdentity.inode ===
+      plan.expectedSynchronizedRootIdentity.inode &&
+    sameStringArray(current.configurationIds, plan.configurationIds)
+  );
+}

--- a/packages/cli-core/src/commands/init/ios/file-transaction.test.ts
+++ b/packages/cli-core/src/commands/init/ios/file-transaction.test.ts
@@ -1,0 +1,925 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  open,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  applyIOSExistingFileTransaction,
+  applyIOSFileTransaction,
+  hashIOSFileBytes,
+  IOSFileTransactionError,
+  type IOSCreateFileMutation,
+  type IOSExistingFileMutation,
+} from "./file-transaction.ts";
+
+const temporaryDirectories: string[] = [];
+
+async function temporaryRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "clerk-ios-file-transaction-"));
+  temporaryDirectories.push(root);
+  return root;
+}
+
+async function mutation(path: string, candidate: string): Promise<IOSExistingFileMutation> {
+  const originalBytes = new Uint8Array(await readFile(path));
+  const candidateBytes = new TextEncoder().encode(candidate);
+  const info = await lstat(path);
+  return {
+    path,
+    originalBytes,
+    originalHash: hashIOSFileBytes(originalBytes),
+    candidateBytes,
+    candidateHash: hashIOSFileBytes(candidateBytes),
+    mode: info.mode & 0o7777,
+  };
+}
+
+async function createMutation(
+  path: string,
+  candidate: string,
+  mode = 0o644,
+): Promise<IOSCreateFileMutation> {
+  const candidateBytes = new TextEncoder().encode(candidate);
+  const parent = await lstat(dirname(path));
+  return {
+    kind: "create",
+    path,
+    expectedParentIdentity: { device: parent.dev, inode: parent.ino },
+    candidateBytes,
+    candidateHash: hashIOSFileBytes(candidateBytes),
+    mode,
+  };
+}
+
+async function expectNoTemporaryFiles(root: string): Promise<void> {
+  expect((await readdir(root)).filter((name) => name.includes(".clerk-"))).toEqual([]);
+}
+
+async function expectRecoverableClaimedOriginals(
+  root: string,
+  expectedContents: string[],
+): Promise<void> {
+  const transactionFiles = (await readdir(root)).filter((name) => name.includes(".clerk-"));
+  const claimedOriginals = transactionFiles.filter((name) => name.endsWith(".claimed"));
+  expect(transactionFiles.filter((name) => name.endsWith(".tmp"))).toEqual([]);
+  expect(
+    (await Promise.all(claimedOriginals.map((name) => readFile(join(root, name), "utf8")))).sort(),
+  ).toEqual([...expectedContents].sort());
+}
+
+async function waitForCondition(condition: () => boolean | Promise<boolean>): Promise<void> {
+  for (let attempt = 0; attempt < 5_000; attempt++) {
+    if (await condition()) return;
+    await Bun.sleep(1);
+  }
+  throw new Error("Timed out waiting for the file transaction test condition.");
+}
+
+async function waitForStagingFile(root: string): Promise<void> {
+  await waitForCondition(async () =>
+    (await readdir(root)).some((name) => name.includes(".clerk-")),
+  );
+}
+
+function errorText(value: unknown, seen = new Set<unknown>()): string {
+  if (value == null || seen.has(value)) return "";
+  if (typeof value !== "object") return String(value);
+  seen.add(value);
+  if (value instanceof AggregateError) {
+    return `${value.name}: ${value.message}\n${value.errors
+      .map((error) => errorText(error, seen))
+      .join("\n")}`;
+  }
+  if (value instanceof Error) {
+    return `${value.name}: ${value.message}\n${errorText(value.cause, seen)}`;
+  }
+  return "";
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+describe("iOS existing-file transaction", () => {
+  test("stages and commits every file sequentially while preserving modes", async () => {
+    const root = await temporaryRoot();
+    const firstPath = join(root, "project.pbxproj");
+    const secondPath = join(root, "App.swift");
+    await writeFile(firstPath, "original project\n");
+    await writeFile(secondPath, "original source\n");
+    await chmod(firstPath, 0o640);
+    await chmod(secondPath, 0o600);
+    const mutations = await Promise.all([
+      mutation(firstPath, "candidate project\n"),
+      mutation(secondPath, "candidate source\n"),
+    ]);
+    let firstValidated = false;
+    let secondValidated = false;
+
+    const result = await applyIOSExistingFileTransaction(mutations, [
+      async () => {
+        await Promise.resolve();
+        firstValidated = true;
+        return (await readFile(firstPath, "utf8")) === "candidate project\n";
+      },
+      async () => {
+        await Promise.resolve();
+        secondValidated = true;
+        return (await readFile(secondPath, "utf8")) === "candidate source\n";
+      },
+    ]);
+
+    expect(result).toEqual({ status: "applied" });
+    expect(firstValidated).toBe(true);
+    expect(secondValidated).toBe(true);
+    expect(await readFile(firstPath, "utf8")).toBe("candidate project\n");
+    expect(await readFile(secondPath, "utf8")).toBe("candidate source\n");
+    expect((await lstat(firstPath)).mode & 0o7777).toBe(0o640);
+    expect((await lstat(secondPath)).mode & 0o7777).toBe(0o600);
+    await expectNoTemporaryFiles(root);
+  });
+
+  test("keeps the public destination present and both crash states recoverable", async () => {
+    const root = await temporaryRoot();
+    const path = join(root, "App.swift");
+    await writeFile(path, "original source\n");
+    const prepared = await mutation(path, "candidate source\n");
+    let backupPath: string | undefined;
+    const observed: string[] = [];
+
+    const result = await applyIOSExistingFileTransaction([prepared], [async () => true], {
+      beforeExistingDestinationBackup: async (destinationPath) => {
+        expect(await readFile(destinationPath, "utf8")).toBe("original source\n");
+        observed.push("before-backup");
+      },
+      afterExistingDestinationBackup: async (destinationPath, createdBackupPath) => {
+        backupPath = createdBackupPath;
+        expect(await readFile(destinationPath, "utf8")).toBe("original source\n");
+        expect(await readFile(createdBackupPath, "utf8")).toBe("original source\n");
+        const stagedPath = (await readdir(root)).find((name) => name.endsWith(".tmp"));
+        if (!stagedPath) throw new Error("expected the staged candidate to remain recoverable");
+        expect(await readFile(join(root, stagedPath), "utf8")).toBe("candidate source\n");
+        observed.push("backup-before-rename");
+      },
+      beforeExistingDestinationReplace: async (destinationPath, createdBackupPath) => {
+        expect(await readFile(destinationPath, "utf8")).toBe("original source\n");
+        expect(await readFile(createdBackupPath, "utf8")).toBe("original source\n");
+        observed.push("immediately-before-rename");
+      },
+      afterExistingDestinationReplace: async (destinationPath, createdBackupPath) => {
+        expect(await readFile(destinationPath, "utf8")).toBe("candidate source\n");
+        expect(await readFile(createdBackupPath, "utf8")).toBe("original source\n");
+        expect((await readdir(root)).filter((name) => name.endsWith(".tmp"))).toEqual([]);
+        observed.push("candidate-and-backup-after-rename");
+      },
+    });
+
+    expect(result).toEqual({ status: "applied" });
+    expect(observed).toEqual([
+      "before-backup",
+      "backup-before-rename",
+      "immediately-before-rename",
+      "candidate-and-backup-after-rename",
+    ]);
+    expect(backupPath).toBeDefined();
+    await expect(lstat(backupPath!)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await readFile(path, "utf8")).toBe("candidate source\n");
+    await expectNoTemporaryFiles(root);
+  });
+
+  test("atomically restores the verified backup without an absent destination window", async () => {
+    const root = await temporaryRoot();
+    const path = join(root, "App.swift");
+    await writeFile(path, "original source\n");
+    const prepared = await mutation(path, "candidate source\n");
+    let backupPath: string | undefined;
+
+    const result = await applyIOSExistingFileTransaction([prepared], [async () => false], {
+      afterExistingDestinationBackup: (_destinationPath, createdBackupPath) => {
+        backupPath = createdBackupPath;
+      },
+      beforeRollbackDestinationReplace: async (destinationPath, originalSourcePath) => {
+        expect(await readFile(destinationPath, "utf8")).toBe("candidate source\n");
+        expect(backupPath).toBe(originalSourcePath);
+        expect(await readFile(originalSourcePath, "utf8")).toBe("original source\n");
+      },
+      afterRollbackDestinationReplace: async (destinationPath) => {
+        expect(await readFile(destinationPath, "utf8")).toBe("original source\n");
+        expect(backupPath).toBeDefined();
+        await expect(lstat(backupPath!)).rejects.toMatchObject({ code: "ENOENT" });
+      },
+    });
+
+    expect(result).toEqual({ status: "rolled-back" });
+    expect(await readFile(path, "utf8")).toBe("original source\n");
+    await expectNoTemporaryFiles(root);
+  });
+
+  test("rolls back an after-rename failure without exposing candidate source bytes", async () => {
+    const root = await temporaryRoot();
+    const path = join(root, "App.swift");
+    const sensitiveCandidate = "pk_test_candidate_must_not_escape";
+    await writeFile(path, "original source\n");
+    const prepared = await mutation(path, sensitiveCandidate);
+
+    let caught: unknown;
+    try {
+      await applyIOSExistingFileTransaction([prepared], [async () => true], {
+        afterExistingDestinationReplace: () => {
+          throw new Error("forced after-rename failure");
+        },
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(IOSFileTransactionError);
+    expect((caught as IOSFileTransactionError).code).toBe("commit-failed");
+    expect(errorText(caught)).not.toContain(sensitiveCandidate);
+    expect(await readFile(path, "utf8")).toBe("original source\n");
+    await expectNoTemporaryFiles(root);
+  });
+
+  test("runs every postcondition and rolls back every file byte-for-byte", async () => {
+    const root = await temporaryRoot();
+    const firstPath = join(root, "project.pbxproj");
+    const secondPath = join(root, "App.swift");
+    const originalProject = new Uint8Array([0, 1, 2, 255]);
+    const originalSource = new TextEncoder().encode("// original\r\n");
+    await writeFile(firstPath, originalProject);
+    await writeFile(secondPath, originalSource);
+    const sensitiveCandidate = "pk_test_candidate_must_not_escape";
+    const mutations = await Promise.all([
+      mutation(firstPath, `candidate ${sensitiveCandidate}`),
+      mutation(secondPath, `candidate ${sensitiveCandidate}`),
+    ]);
+    let throwingValidatorRan = false;
+    let falseValidatorRan = false;
+
+    const result = await applyIOSExistingFileTransaction(mutations, [
+      async () => {
+        throwingValidatorRan = true;
+        throw new Error(sensitiveCandidate);
+      },
+      async () => {
+        falseValidatorRan = true;
+        return false;
+      },
+    ]);
+
+    expect(result).toEqual({ status: "rolled-back" });
+    expect(JSON.stringify(result)).not.toContain(sensitiveCandidate);
+    expect(throwingValidatorRan).toBe(true);
+    expect(falseValidatorRan).toBe(true);
+    expect(new Uint8Array(await readFile(firstPath))).toEqual(originalProject);
+    expect(new Uint8Array(await readFile(secondPath))).toEqual(originalSource);
+    await expectNoTemporaryFiles(root);
+  });
+
+  test("rejects a candidate edit after an earlier postcondition validates it", async () => {
+    const root = await temporaryRoot();
+    const path = join(root, "App.swift");
+    await writeFile(path, "original source\n");
+    const prepared = await mutation(path, "candidate source\n");
+    let releaseValidated: (() => void) | undefined;
+    const validated = new Promise<void>((resolve) => {
+      releaseValidated = resolve;
+    });
+
+    let caught: unknown;
+    try {
+      await applyIOSExistingFileTransaction(
+        [prepared],
+        [
+          async () => {
+            const matches = (await readFile(path, "utf8")) === "candidate source\n";
+            releaseValidated?.();
+            return matches;
+          },
+          async () => {
+            await validated;
+            await writeFile(path, "newer user source\n");
+            return true;
+          },
+        ],
+      );
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(IOSFileTransactionError);
+    expect((caught as IOSFileTransactionError).code).toBe("rollback-failed");
+    expect(await readFile(path, "utf8")).toBe("newer user source\n");
+    await expectRecoverableClaimedOriginals(root, ["original source\n"]);
+  });
+
+  test("cleans every staged candidate and preserves newer bytes when stale", async () => {
+    const root = await temporaryRoot();
+    const firstPath = join(root, "project.pbxproj");
+    const secondPath = join(root, "App.swift");
+    await writeFile(firstPath, "original project\n");
+    await writeFile(secondPath, "original source\n");
+    const mutations = await Promise.all([
+      mutation(firstPath, "candidate project\n"),
+      mutation(secondPath, "candidate source\n"),
+    ]);
+    await writeFile(firstPath, "newer user project\n");
+
+    const result = await applyIOSExistingFileTransaction(mutations, [async () => true]);
+
+    expect(result).toEqual({ status: "stale" });
+    expect(await readFile(firstPath, "utf8")).toBe("newer user project\n");
+    expect(await readFile(secondPath, "utf8")).toBe("original source\n");
+    await expectNoTemporaryFiles(root);
+  });
+
+  test("returns stale when the original mode changed after preparation", async () => {
+    const root = await temporaryRoot();
+    const path = join(root, "App.swift");
+    await writeFile(path, "original\n");
+    await chmod(path, 0o640);
+    const prepared = await mutation(path, "candidate\n");
+    await chmod(path, 0o600);
+
+    const result = await applyIOSExistingFileTransaction([prepared], [async () => true]);
+
+    expect(result).toEqual({ status: "stale" });
+    expect(await readFile(path, "utf8")).toBe("original\n");
+    expect((await lstat(path)).mode & 0o7777).toBe(0o600);
+    await expectNoTemporaryFiles(root);
+  });
+
+  test("returns stale when the original mode changes during staging", async () => {
+    const root = await temporaryRoot();
+    const path = join(root, "App.swift");
+    await writeFile(path, "original\n");
+    await chmod(path, 0o640);
+    const prepared = await mutation(path, "x".repeat(16 * 1024 * 1024));
+    const changeMode = (async () => {
+      await waitForStagingFile(root);
+      await chmod(path, 0o600);
+    })();
+
+    const [result] = await Promise.all([
+      applyIOSExistingFileTransaction([prepared], [async () => true]),
+      changeMode,
+    ]);
+
+    expect(result).toEqual({ status: "stale" });
+    expect(await readFile(path, "utf8")).toBe("original\n");
+    expect((await lstat(path)).mode & 0o7777).toBe(0o600);
+    await expectNoTemporaryFiles(root);
+  });
+
+  test("returns stale when a same-byte file replaces the original during staging", async () => {
+    const root = await temporaryRoot();
+    const path = join(root, "App.swift");
+    const replacementPath = join(root, "external-replacement.tmp");
+    await writeFile(path, "original\n");
+    await chmod(path, 0o640);
+    const prepared = await mutation(path, "x".repeat(16 * 1024 * 1024));
+    await writeFile(replacementPath, "original\n");
+    await chmod(replacementPath, 0o640);
+    const replacementIdentity = await lstat(replacementPath);
+    const replaceOriginal = (async () => {
+      await waitForStagingFile(root);
+      await rename(replacementPath, path);
+    })();
+
+    const [result] = await Promise.all([
+      applyIOSExistingFileTransaction([prepared], [async () => true]),
+      replaceOriginal,
+    ]);
+
+    expect(result).toEqual({ status: "stale" });
+    expect(await readFile(path, "utf8")).toBe("original\n");
+    expect((await lstat(path)).ino).toBe(replacementIdentity.ino);
+    await expectNoTemporaryFiles(root);
+  });
+
+  test("rechecks identity immediately before each replacement commit", async () => {
+    const root = await temporaryRoot();
+    const firstPath = join(root, "First.swift");
+    const targetPath = join(root, "Target.swift");
+    const replacementPath = join(root, "external-target.tmp");
+    await writeFile(firstPath, "original first\n");
+    await writeFile(targetPath, "original target\n");
+    await chmod(targetPath, 0o640);
+    const intermediatePaths = Array.from({ length: 20 }, (_, index) =>
+      join(root, `Intermediate-${index}.swift`),
+    );
+    await Promise.all(intermediatePaths.map((path) => writeFile(path, "original middle\n")));
+    await writeFile(replacementPath, "original target\n");
+    await chmod(replacementPath, 0o640);
+    const replacementIdentity = await lstat(replacementPath);
+    const prepared = await Promise.all([
+      mutation(firstPath, "candidate first\n"),
+      ...intermediatePaths.map((path) => mutation(path, "candidate middle\n")),
+      mutation(targetPath, "candidate target\n"),
+    ]);
+    const replaceTarget = (async () => {
+      await waitForCondition(async () => {
+        try {
+          return (await readFile(firstPath, "utf8")) === "candidate first\n";
+        } catch {
+          return false;
+        }
+      });
+      await rename(replacementPath, targetPath);
+    })();
+
+    const [result] = await Promise.all([
+      applyIOSExistingFileTransaction(prepared, [async () => true]),
+      replaceTarget,
+    ]);
+
+    expect(result).toEqual({ status: "stale" });
+    expect(await readFile(firstPath, "utf8")).toBe("original first\n");
+    for (const path of intermediatePaths) {
+      expect(await readFile(path, "utf8")).toBe("original middle\n");
+    }
+    expect(await readFile(targetPath, "utf8")).toBe("original target\n");
+    expect((await lstat(targetPath)).ino).toBe(replacementIdentity.ino);
+    await expectNoTemporaryFiles(root);
+  });
+
+  test("preserves a replacement visible before the final atomic commit check", async () => {
+    const root = await temporaryRoot();
+    const path = join(root, "App.swift");
+    const replacementPath = join(root, "external-replacement.tmp");
+    await writeFile(path, "original\n");
+    await chmod(path, 0o640);
+    const prepared = await mutation(path, "candidate\n");
+    await writeFile(replacementPath, "newer user source\n");
+    await chmod(replacementPath, 0o600);
+    const replacementIdentity = await lstat(replacementPath);
+
+    const result = await applyIOSExistingFileTransaction([prepared], [async () => true], {
+      beforeExistingDestinationReplace: async (destinationPath) => {
+        await rename(replacementPath, destinationPath);
+      },
+    });
+
+    expect(result).toEqual({ status: "stale" });
+    expect(await readFile(path, "utf8")).toBe("newer user source\n");
+    expect((await lstat(path)).ino).toBe(replacementIdentity.ino);
+    expect((await lstat(path)).mode & 0o7777).toBe(0o600);
+    await expectNoTemporaryFiles(root);
+  });
+
+  test("preserves writes through an already-open original file descriptor", async () => {
+    const root = await temporaryRoot();
+    const path = join(root, "App.swift");
+    await writeFile(path, "original\n");
+    await chmod(path, 0o640);
+    const prepared = await mutation(path, "candidate\n");
+    const editor = await open(path, "r+");
+
+    let result;
+    try {
+      result = await applyIOSExistingFileTransaction(
+        [prepared],
+        [
+          async () => {
+            await editor.truncate(0);
+            await editor.write("newer user source through open fd\n", 0, "utf8");
+            await editor.chmod(0o600);
+            await editor.sync();
+            return true;
+          },
+        ],
+      );
+    } finally {
+      await editor.close();
+    }
+
+    expect(result).toEqual({ status: "stale" });
+    expect(await readFile(path, "utf8")).toBe("newer user source through open fd\n");
+    expect((await lstat(path)).mode & 0o7777).toBe(0o600);
+    await expectNoTemporaryFiles(root);
+  });
+
+  test("guards rollback with candidate hashes and reports an explicit failure", async () => {
+    const root = await temporaryRoot();
+    const firstPath = join(root, "project.pbxproj");
+    const secondPath = join(root, "App.swift");
+    await writeFile(firstPath, "original project\n");
+    await writeFile(secondPath, "original source\n");
+    const sensitiveCandidate = "pk_test_candidate_must_not_escape";
+    const mutations = await Promise.all([
+      mutation(firstPath, `candidate project ${sensitiveCandidate}\n`),
+      mutation(secondPath, `candidate source ${sensitiveCandidate}\n`),
+    ]);
+
+    let caught: unknown;
+    try {
+      await applyIOSExistingFileTransaction(mutations, [
+        async () => {
+          await writeFile(secondPath, "newer user source\n");
+          return false;
+        },
+      ]);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(IOSFileTransactionError);
+    expect((caught as IOSFileTransactionError).code).toBe("rollback-failed");
+    expect(errorText(caught)).not.toContain(sensitiveCandidate);
+    expect(await readFile(firstPath, "utf8")).toBe(`candidate project ${sensitiveCandidate}\n`);
+    expect(await readFile(secondPath, "utf8")).toBe("newer user source\n");
+    await expectRecoverableClaimedOriginals(root, ["original project\n", "original source\n"]);
+  });
+
+  test("preserves a candidate whose mode changed before rollback", async () => {
+    const root = await temporaryRoot();
+    const path = join(root, "App.swift");
+    await writeFile(path, "original\n");
+    await chmod(path, 0o640);
+    const prepared = await mutation(path, "candidate\n");
+
+    let caught: unknown;
+    try {
+      await applyIOSExistingFileTransaction(
+        [prepared],
+        [
+          async () => {
+            await chmod(path, 0o600);
+            return false;
+          },
+        ],
+      );
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(IOSFileTransactionError);
+    expect((caught as IOSFileTransactionError).code).toBe("rollback-failed");
+    expect(await readFile(path, "utf8")).toBe("candidate\n");
+    expect((await lstat(path)).mode & 0o7777).toBe(0o600);
+    await expectRecoverableClaimedOriginals(root, ["original\n"]);
+  });
+
+  test("preserves a same-byte file that replaced the committed candidate inode", async () => {
+    const root = await temporaryRoot();
+    const path = join(root, "App.swift");
+    const replacementPath = join(root, "external-replacement.tmp");
+    await writeFile(path, "original\n");
+    await chmod(path, 0o640);
+    const prepared = await mutation(path, "candidate\n");
+
+    let caught: unknown;
+    try {
+      await applyIOSExistingFileTransaction(
+        [prepared],
+        [
+          async () => {
+            await writeFile(replacementPath, "candidate\n");
+            await chmod(replacementPath, 0o640);
+            await rename(replacementPath, path);
+            return false;
+          },
+        ],
+      );
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(IOSFileTransactionError);
+    expect((caught as IOSFileTransactionError).code).toBe("rollback-failed");
+    expect(await readFile(path, "utf8")).toBe("candidate\n");
+    expect((await lstat(path)).mode & 0o7777).toBe(0o640);
+    await expectRecoverableClaimedOriginals(root, ["original\n"]);
+  });
+
+  test("preserves a replacement visible before the final atomic rollback check", async () => {
+    const root = await temporaryRoot();
+    const path = join(root, "App.swift");
+    const replacementPath = join(root, "external-replacement.tmp");
+    await writeFile(path, "original\n");
+    await chmod(path, 0o640);
+    const prepared = await mutation(path, "candidate\n");
+    await writeFile(replacementPath, "newer user source\n");
+    await chmod(replacementPath, 0o600);
+    const replacementIdentity = await lstat(replacementPath);
+
+    let caught: unknown;
+    try {
+      await applyIOSExistingFileTransaction([prepared], [async () => false], {
+        beforeRollbackDestinationReplace: async (destinationPath) => {
+          await rename(replacementPath, destinationPath);
+        },
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(IOSFileTransactionError);
+    expect((caught as IOSFileTransactionError).code).toBe("rollback-failed");
+    expect(await readFile(path, "utf8")).toBe("newer user source\n");
+    expect((await lstat(path)).ino).toBe(replacementIdentity.ino);
+    expect((await lstat(path)).mode & 0o7777).toBe(0o600);
+    await expectRecoverableClaimedOriginals(root, ["original\n"]);
+  });
+
+  test("rejects invalid prepared hashes without exposing candidate bytes", async () => {
+    const root = await temporaryRoot();
+    const path = join(root, "App.swift");
+    await writeFile(path, "original\n");
+    const prepared = await mutation(path, "pk_test_candidate_must_not_escape");
+    prepared.candidateHash = hashIOSFileBytes("different bytes");
+
+    let caught: unknown;
+    try {
+      await applyIOSExistingFileTransaction([prepared], []);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(IOSFileTransactionError);
+    expect((caught as IOSFileTransactionError).code).toBe("invalid-mutation");
+    expect(errorText(caught)).not.toContain("pk_test_candidate_must_not_escape");
+    expect(await readFile(path, "utf8")).toBe("original\n");
+    await expectNoTemporaryFiles(root);
+  });
+});
+
+describe("iOS create-file transaction", () => {
+  test("returns stale when the prepared parent directory was replaced", async () => {
+    const root = await temporaryRoot();
+    const synchronizedRoot = join(root, "CoolApp");
+    const displacedRoot = join(root, "CoolApp-before-replacement");
+    const createdPath = join(synchronizedRoot, "CoolApp.entitlements");
+    await mkdir(synchronizedRoot);
+    const prepared = await createMutation(createdPath, "candidate entitlements\n");
+    await rename(synchronizedRoot, displacedRoot);
+    await mkdir(synchronizedRoot);
+
+    const result = await applyIOSFileTransaction([prepared], [async () => true]);
+
+    expect(result).toEqual({ status: "stale" });
+    await expect(lstat(createdPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(lstat(join(displacedRoot, "CoolApp.entitlements"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expectNoTemporaryFiles(synchronizedRoot);
+    await expectNoTemporaryFiles(displacedRoot);
+  });
+
+  test("fails closed when the prepared parent identity changes after create staging", async () => {
+    const root = await temporaryRoot();
+    const synchronizedRoot = join(root, "CoolApp");
+    const displacedRoot = join(root, "CoolApp-before-replacement");
+    const createdPath = join(synchronizedRoot, "CoolApp.entitlements");
+    const sourcePath = join(root, "CoolApp.swift");
+    await mkdir(synchronizedRoot);
+    await writeFile(sourcePath, "original source\n");
+    const prepared = [
+      await createMutation(createdPath, "candidate entitlements\n"),
+      await mutation(sourcePath, "x".repeat(16 * 1024 * 1024)),
+    ];
+    const replaceParentAfterCreateStage = (async () => {
+      await waitForStagingFile(root);
+      await rename(synchronizedRoot, displacedRoot);
+      await symlink(displacedRoot, synchronizedRoot, "dir");
+    })();
+
+    const [result] = await Promise.all([
+      applyIOSFileTransaction(prepared, [async () => true]),
+      replaceParentAfterCreateStage,
+    ]);
+
+    expect(result).toEqual({ status: "stale" });
+    expect(await readFile(sourcePath, "utf8")).toBe("original source\n");
+    await expect(lstat(createdPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expectNoTemporaryFiles(displacedRoot);
+    await expectNoTemporaryFiles(root);
+  });
+
+  test("restores an existing file when a create parent moves after its candidate is linked", async () => {
+    const root = await temporaryRoot();
+    const synchronizedRoot = join(root, "CoolApp");
+    const displacedRoot = join(root, "CoolApp-before-replacement");
+    const createdPath = join(synchronizedRoot, "CoolApp.entitlements");
+    const projectPath = join(root, "project.pbxproj");
+    const concurrentPath = join(synchronizedRoot, "concurrent-user-file");
+    await mkdir(synchronizedRoot);
+    await writeFile(concurrentPath, "newer directory state\n");
+    await writeFile(projectPath, "original project\n");
+    const prepared = [
+      await mutation(projectPath, "candidate project\n"),
+      await createMutation(createdPath, "candidate entitlements\n"),
+    ];
+
+    let caught: unknown;
+    try {
+      await applyIOSFileTransaction(prepared, [async () => true], {
+        beforeExistingDestinationReplace: async () => {
+          await rename(synchronizedRoot, displacedRoot);
+          await mkdir(synchronizedRoot);
+        },
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(IOSFileTransactionError);
+    expect((caught as IOSFileTransactionError).code).toBe("rollback-failed");
+    expect(await readFile(projectPath, "utf8")).toBe("original project\n");
+    await expect(lstat(createdPath)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await readFile(join(displacedRoot, "concurrent-user-file"), "utf8")).toBe(
+      "newer directory state\n",
+    );
+  });
+
+  test("restores a committed project file if the create parent changes during postvalidation", async () => {
+    const root = await temporaryRoot();
+    const synchronizedRoot = join(root, "CoolApp");
+    const displacedRoot = join(root, "CoolApp-before-replacement");
+    const createdPath = join(synchronizedRoot, "CoolApp.entitlements");
+    const projectPath = join(root, "project.pbxproj");
+    await mkdir(synchronizedRoot);
+    await writeFile(projectPath, "original project\n");
+    const sensitiveCandidate = "pk_test_candidate_must_not_escape";
+    const prepared = [
+      await createMutation(createdPath, sensitiveCandidate),
+      await mutation(projectPath, "candidate project\n"),
+    ];
+
+    let caught: unknown;
+    try {
+      await applyIOSFileTransaction(prepared, [
+        async () => {
+          await rename(synchronizedRoot, displacedRoot);
+          await mkdir(synchronizedRoot);
+          return true;
+        },
+      ]);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(IOSFileTransactionError);
+    expect((caught as IOSFileTransactionError).code).toBe("rollback-failed");
+    expect(errorText(caught)).not.toContain(sensitiveCandidate);
+    expect(await readFile(projectPath, "utf8")).toBe("original project\n");
+    await expect(lstat(createdPath)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await readFile(join(displacedRoot, "CoolApp.entitlements"), "utf8")).toBe(
+      sensitiveCandidate,
+    );
+  });
+
+  test("creates an absent file alongside a replacement and preserves both modes", async () => {
+    const root = await temporaryRoot();
+    const existingPath = join(root, "project.pbxproj");
+    const createdPath = join(root, "CoolApp.entitlements");
+    await writeFile(existingPath, "original project\n");
+    await chmod(existingPath, 0o600);
+
+    const result = await applyIOSFileTransaction(
+      [
+        await createMutation(createdPath, "created entitlements\n", 0o640),
+        await mutation(existingPath, "candidate project\n"),
+      ],
+      [
+        async () => (await readFile(createdPath, "utf8")) === "created entitlements\n",
+        async () => (await readFile(existingPath, "utf8")) === "candidate project\n",
+      ],
+    );
+
+    expect(result).toEqual({ status: "applied" });
+    expect(await readFile(createdPath, "utf8")).toBe("created entitlements\n");
+    expect(await readFile(existingPath, "utf8")).toBe("candidate project\n");
+    expect((await lstat(createdPath)).mode & 0o7777).toBe(0o640);
+    expect((await lstat(createdPath)).nlink).toBe(1);
+    expect((await lstat(existingPath)).mode & 0o7777).toBe(0o600);
+    await expectNoTemporaryFiles(root);
+  });
+
+  test("treats a formerly absent path as stale without clobbering it", async () => {
+    const root = await temporaryRoot();
+    const existingPath = join(root, "project.pbxproj");
+    const createdPath = join(root, "CoolApp.entitlements");
+    await writeFile(existingPath, "original project\n");
+    const mutations = [
+      await mutation(existingPath, "candidate project\n"),
+      await createMutation(createdPath, "candidate entitlements\n"),
+    ];
+    await writeFile(createdPath, "newer user entitlements\n");
+
+    const result = await applyIOSFileTransaction(mutations, [async () => true]);
+
+    expect(result).toEqual({ status: "stale" });
+    expect(await readFile(existingPath, "utf8")).toBe("original project\n");
+    expect(await readFile(createdPath, "utf8")).toBe("newer user entitlements\n");
+    await expectNoTemporaryFiles(root);
+  });
+
+  test("removes a created file and restores replacements when validation fails", async () => {
+    const root = await temporaryRoot();
+    const existingPath = join(root, "project.pbxproj");
+    const createdPath = join(root, "CoolApp.entitlements");
+    await writeFile(existingPath, "original project\n");
+
+    const result = await applyIOSFileTransaction(
+      [
+        await mutation(existingPath, "candidate project\n"),
+        await createMutation(createdPath, "candidate entitlements\n"),
+      ],
+      [async () => false],
+    );
+
+    expect(result).toEqual({ status: "rolled-back" });
+    expect(await readFile(existingPath, "utf8")).toBe("original project\n");
+    await expect(lstat(createdPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expectNoTemporaryFiles(root);
+  });
+
+  test("preserves newer bytes at a created path when rollback is requested", async () => {
+    const root = await temporaryRoot();
+    const createdPath = join(root, "CoolApp.entitlements");
+    const sensitiveCandidate = "pk_test_candidate_must_not_escape";
+
+    let caught: unknown;
+    try {
+      await applyIOSFileTransaction(
+        [await createMutation(createdPath, sensitiveCandidate)],
+        [
+          async () => {
+            await writeFile(createdPath, "newer user entitlements\n");
+            return false;
+          },
+        ],
+      );
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(IOSFileTransactionError);
+    expect((caught as IOSFileTransactionError).code).toBe("rollback-failed");
+    expect(errorText(caught)).not.toContain(sensitiveCandidate);
+    expect(await readFile(createdPath, "utf8")).toBe("newer user entitlements\n");
+    await expectNoTemporaryFiles(root);
+  });
+
+  test("preserves a same-byte file that replaced the transaction's created inode", async () => {
+    const root = await temporaryRoot();
+    const createdPath = join(root, "CoolApp.entitlements");
+    const candidate = "candidate entitlements\n";
+
+    let caught: unknown;
+    try {
+      await applyIOSFileTransaction(
+        [await createMutation(createdPath, candidate)],
+        [
+          async () => {
+            await rm(createdPath);
+            await writeFile(createdPath, candidate);
+            return false;
+          },
+        ],
+      );
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(IOSFileTransactionError);
+    expect((caught as IOSFileTransactionError).code).toBe("rollback-failed");
+    expect(await readFile(createdPath, "utf8")).toBe(candidate);
+    await expectNoTemporaryFiles(root);
+  });
+
+  test("rejects an invalid create hash without exposing candidate bytes", async () => {
+    const root = await temporaryRoot();
+    const createdPath = join(root, "CoolApp.entitlements");
+    const sensitiveCandidate = "pk_test_candidate_must_not_escape";
+    const prepared = await createMutation(createdPath, sensitiveCandidate);
+    prepared.candidateHash = hashIOSFileBytes("different bytes");
+
+    let caught: unknown;
+    try {
+      await applyIOSFileTransaction([prepared], []);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(IOSFileTransactionError);
+    expect((caught as IOSFileTransactionError).code).toBe("invalid-mutation");
+    expect(errorText(caught)).not.toContain(sensitiveCandidate);
+    await expect(lstat(createdPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expectNoTemporaryFiles(root);
+  });
+});

--- a/packages/cli-core/src/commands/init/ios/file-transaction.ts
+++ b/packages/cli-core/src/commands/init/ios/file-transaction.ts
@@ -1,0 +1,1163 @@
+import { link, lstat, open, readFile, rename, rm } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { basename, dirname, isAbsolute, resolve } from "node:path";
+
+/**
+ * An already-inspected existing file and its validated replacement bytes.
+ *
+ * @internal This contains candidate bytes and must never be included in CLI
+ * output, telemetry, serialized plans, or public errors/results.
+ */
+export interface IOSExistingFileMutation {
+  path: string;
+  originalBytes: Uint8Array;
+  originalHash: string;
+  candidateBytes: Uint8Array;
+  candidateHash: string;
+  mode: number;
+}
+
+/**
+ * An already-inspected absent path and the validated bytes to create there.
+ *
+ * @internal This contains candidate bytes and must never be included in CLI
+ * output, telemetry, serialized plans, or public errors/results.
+ */
+export interface IOSCreateFileMutation {
+  kind: "create";
+  path: string;
+  /** Exact parent directory inspected while preparing this create. */
+  expectedParentIdentity: { device: number; inode: number };
+  candidateBytes: Uint8Array;
+  candidateHash: string;
+  mode: number;
+}
+
+export type IOSFileMutation = IOSExistingFileMutation | IOSCreateFileMutation;
+
+export type IOSFilePostcondition = () => boolean | Promise<boolean>;
+
+export type IOSFileTransactionResult =
+  | { status: "applied" }
+  | { status: "stale" }
+  | { status: "rolled-back" };
+
+export type IOSFileTransactionErrorCode =
+  | "invalid-mutation"
+  | "stage-failed"
+  | "cleanup-failed"
+  | "commit-failed"
+  | "rollback-failed";
+
+/** A fixed-message failure that never carries mutation contents. */
+export class IOSFileTransactionError extends Error {
+  constructor(
+    readonly code: IOSFileTransactionErrorCode,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "IOSFileTransactionError";
+  }
+}
+
+interface StagedMutation {
+  mutation: IOSFileMutation;
+  temporaryPath: string;
+  temporaryPresent: boolean;
+  stagedIdentity: FileIdentity;
+  committedIdentity?: FileIdentity;
+  claimedOriginal?: ClaimedDestination;
+}
+
+interface ClaimedDestination {
+  path: string;
+  present: boolean;
+  identity: FileIdentity;
+}
+
+interface FileIdentity {
+  dev: number;
+  ino: number;
+  mode: number;
+}
+
+interface DirectoryIdentity {
+  device: number;
+  inode: number;
+}
+
+class IOSFileTransactionStaleError extends Error {}
+
+class IOSFileTransactionOwnershipError extends Error {}
+
+/**
+ * Deterministic race hooks used only by the file-transaction regression tests.
+ *
+ * @internal
+ */
+export interface IOSFileTransactionTestHooks {
+  beforeExistingDestinationBackup?: (path: string) => void | Promise<void>;
+  afterExistingDestinationBackup?: (path: string, backupPath: string) => void | Promise<void>;
+  beforeExistingDestinationReplace?: (path: string, backupPath: string) => void | Promise<void>;
+  afterExistingDestinationReplace?: (path: string, backupPath: string) => void | Promise<void>;
+  beforeRollbackDestinationReplace?: (path: string, backupPath: string) => void | Promise<void>;
+  afterRollbackDestinationReplace?: (path: string) => void | Promise<void>;
+}
+
+export function hashIOSFileBytes(value: string | Uint8Array): string {
+  return new Bun.CryptoHasher("sha256").update(value).digest("hex");
+}
+
+function transactionError(
+  code: IOSFileTransactionErrorCode,
+  message: string,
+  cause?: unknown,
+): IOSFileTransactionError {
+  return new IOSFileTransactionError(code, message, cause === undefined ? undefined : { cause });
+}
+
+function aggregateCause(errors: unknown[]): unknown {
+  return errors.length === 1 ? errors[0] : new AggregateError(errors);
+}
+
+async function syncDirectory(path: string): Promise<void> {
+  try {
+    const directory = await open(path, "r");
+    try {
+      await directory.sync();
+    } finally {
+      await directory.close();
+    }
+  } catch {
+    // Same-directory rename remains atomic even when directory fsync is not
+    // available on the current filesystem.
+  }
+}
+
+async function fileMatchesHash(path: string, expectedHash: string): Promise<boolean> {
+  try {
+    const info = await lstat(path);
+    if (!info.isFile() || info.isSymbolicLink()) return false;
+    return hashIOSFileBytes(await readFile(path)) === expectedHash;
+  } catch {
+    return false;
+  }
+}
+
+async function readRegularFileIdentity(path: string): Promise<FileIdentity | undefined> {
+  try {
+    const info = await lstat(path);
+    if (!info.isFile() || info.isSymbolicLink()) return undefined;
+    return { dev: info.dev, ino: info.ino, mode: info.mode & 0o7777 };
+  } catch {
+    return undefined;
+  }
+}
+
+async function readPathIdentity(path: string): Promise<FileIdentity | undefined> {
+  try {
+    const info = await lstat(path);
+    return { dev: info.dev, ino: info.ino, mode: info.mode & 0o7777 };
+  } catch {
+    return undefined;
+  }
+}
+
+async function readDirectoryIdentity(path: string): Promise<DirectoryIdentity | undefined> {
+  try {
+    const info = await lstat(path);
+    if (!info.isDirectory() || info.isSymbolicLink()) return undefined;
+    return { device: info.dev, inode: info.ino };
+  } catch {
+    return undefined;
+  }
+}
+
+function identitiesMatch(left: FileIdentity, right: FileIdentity): boolean {
+  return left.dev === right.dev && left.ino === right.ino && left.mode === right.mode;
+}
+
+function sameFile(left: FileIdentity, right: FileIdentity): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+async function createParentStillMatches(mutation: IOSCreateFileMutation): Promise<boolean> {
+  const current = await readDirectoryIdentity(dirname(mutation.path));
+  return (
+    current !== undefined &&
+    current.device === mutation.expectedParentIdentity.device &&
+    current.inode === mutation.expectedParentIdentity.inode
+  );
+}
+
+async function createParentsStillMatch(mutations: readonly IOSFileMutation[]): Promise<boolean> {
+  const matches = await Promise.all(
+    mutations.filter(isCreateMutation).map(async (mutation) => createParentStillMatches(mutation)),
+  );
+  return matches.every(Boolean);
+}
+
+async function fileMatchesIdentityAndHash(
+  path: string,
+  expectedIdentity: FileIdentity,
+  expectedHash: string,
+): Promise<boolean> {
+  try {
+    const beforeRead = await readRegularFileIdentity(path);
+    if (!beforeRead || !identitiesMatch(beforeRead, expectedIdentity)) return false;
+    const matchesHash = hashIOSFileBytes(await readFile(path)) === expectedHash;
+    const afterRead = await readRegularFileIdentity(path);
+    return matchesHash && afterRead !== undefined && identitiesMatch(afterRead, expectedIdentity);
+  } catch {
+    return false;
+  }
+}
+
+async function pathIsAbsent(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return false;
+  } catch (error) {
+    return isFileSystemError(error, "ENOENT");
+  }
+}
+
+function isFileSystemError(error: unknown, code: string): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === code
+  );
+}
+
+function transactionSiblingPath(path: string, purpose: string): string {
+  return resolve(
+    dirname(path),
+    `.${basename(path)}.clerk-${process.pid}-${randomUUID()}.${purpose}`,
+  );
+}
+
+async function removeClaimedPath(
+  claim: ClaimedDestination,
+  options: { expectedHash?: string; expectedMode?: number } = {},
+): Promise<void> {
+  const currentIdentity = await readPathIdentity(claim.path);
+  if (
+    !claim.present ||
+    !currentIdentity ||
+    !sameFile(currentIdentity, claim.identity) ||
+    (options.expectedMode !== undefined && currentIdentity.mode !== options.expectedMode) ||
+    (options.expectedHash !== undefined &&
+      !(await fileMatchesIdentityAndHash(claim.path, currentIdentity, options.expectedHash)))
+  ) {
+    throw new IOSFileTransactionOwnershipError(
+      "a claimed path no longer identified the transaction's file",
+    );
+  }
+  await rm(claim.path);
+  claim.present = false;
+}
+
+async function restoreClaimWithoutClobber(
+  claim: ClaimedDestination,
+  destinationPath: string,
+): Promise<void> {
+  try {
+    await link(claim.path, destinationPath);
+  } catch (error) {
+    if (isFileSystemError(error, "EEXIST")) {
+      const destinationIdentity = await readPathIdentity(destinationPath);
+      if (destinationIdentity && sameFile(destinationIdentity, claim.identity)) {
+        await removeClaimedPath(claim);
+        await syncDirectory(dirname(destinationPath));
+        return;
+      }
+    }
+    throw new IOSFileTransactionOwnershipError(
+      "a claimed destination could not be restored without overwriting newer filesystem state",
+      { cause: error },
+    );
+  }
+
+  const destinationIdentity = await readPathIdentity(destinationPath);
+  const claimIdentity = await readPathIdentity(claim.path);
+  if (
+    !destinationIdentity ||
+    !claimIdentity ||
+    !sameFile(destinationIdentity, claim.identity) ||
+    !sameFile(claimIdentity, claim.identity)
+  ) {
+    throw new IOSFileTransactionOwnershipError(
+      "a restored destination no longer identified the transaction's claimed file",
+    );
+  }
+  await removeClaimedPath(claim);
+  await syncDirectory(dirname(destinationPath));
+}
+
+type ClaimDestinationResult =
+  | { status: "claimed"; claim: ClaimedDestination }
+  | { status: "stale" };
+
+/**
+ * Hard-links the authorized destination to a unique same-directory recovery
+ * path without ever removing the public destination. The backup remains until
+ * aggregate postvalidation succeeds or rollback atomically restores it.
+ */
+async function backupDestination(
+  destinationPath: string,
+  expectedIdentity: FileIdentity,
+  expectedHash: string,
+): Promise<ClaimDestinationResult> {
+  const backupPath = transactionSiblingPath(destinationPath, "claimed");
+  try {
+    await link(destinationPath, backupPath);
+  } catch (error) {
+    if (isFileSystemError(error, "ENOENT")) return { status: "stale" };
+    throw error;
+  }
+
+  const linkedIdentity = await readPathIdentity(backupPath);
+  if (!linkedIdentity) return { status: "stale" };
+  const backup: ClaimedDestination = {
+    path: backupPath,
+    present: true,
+    identity: linkedIdentity,
+  };
+  const backupIdentity = await readRegularFileIdentity(backupPath);
+  if (!backupIdentity) {
+    await removeClaimedPath(backup);
+    return { status: "stale" };
+  }
+  const backupMatches =
+    identitiesMatch(backupIdentity, expectedIdentity) &&
+    (await fileMatchesIdentityAndHash(backupPath, expectedIdentity, expectedHash));
+  const destinationMatches = await fileMatchesIdentityAndHash(
+    destinationPath,
+    expectedIdentity,
+    expectedHash,
+  );
+  if (backupMatches && destinationMatches) return { status: "claimed", claim: backup };
+
+  await removeClaimedPath(backup);
+  return { status: "stale" };
+}
+
+/**
+ * Moves an existing destination to a unique same-directory name, then proves
+ * which inode was moved. Unlike an overwriting rename, this never destroys a
+ * replacement that arrives after the caller's last stale-input check.
+ */
+async function claimDestination(
+  destinationPath: string,
+  expectedIdentity: FileIdentity,
+  expectedHash: string,
+): Promise<ClaimDestinationResult> {
+  const claimedPath = transactionSiblingPath(destinationPath, "claimed");
+  try {
+    await rename(destinationPath, claimedPath);
+  } catch (error) {
+    if (isFileSystemError(error, "ENOENT")) return { status: "stale" };
+    throw error;
+  }
+
+  const movedIdentity = await readPathIdentity(claimedPath);
+  if (!movedIdentity) {
+    throw new IOSFileTransactionOwnershipError(
+      "a claimed destination could not be identified after it was moved",
+    );
+  }
+  const claim: ClaimedDestination = {
+    path: claimedPath,
+    present: true,
+    identity: movedIdentity,
+  };
+  const movedExpectedFile =
+    identitiesMatch(movedIdentity, expectedIdentity) &&
+    (await fileMatchesIdentityAndHash(claimedPath, expectedIdentity, expectedHash));
+  if (movedExpectedFile) return { status: "claimed", claim };
+
+  await restoreClaimWithoutClobber(claim, destinationPath);
+  return { status: "stale" };
+}
+
+function isCreateMutation(mutation: IOSFileMutation): mutation is IOSCreateFileMutation {
+  return "kind" in mutation && mutation.kind === "create";
+}
+
+function validateMutations(mutations: readonly IOSFileMutation[]): void {
+  if (mutations.length === 0) {
+    throw transactionError(
+      "invalid-mutation",
+      "The iOS file transaction did not contain a file mutation.",
+    );
+  }
+
+  const paths = new Set<string>();
+  for (const mutation of mutations) {
+    if (
+      !mutation.path ||
+      paths.has(mutation.path) ||
+      !Number.isInteger(mutation.mode) ||
+      mutation.mode < 0 ||
+      mutation.mode > 0o7777 ||
+      hashIOSFileBytes(mutation.candidateBytes) !== mutation.candidateHash ||
+      (isCreateMutation(mutation) &&
+        (!Number.isSafeInteger(mutation.expectedParentIdentity?.device) ||
+          mutation.expectedParentIdentity.device < 0 ||
+          !Number.isSafeInteger(mutation.expectedParentIdentity.inode) ||
+          mutation.expectedParentIdentity.inode < 0)) ||
+      (!isCreateMutation(mutation) &&
+        hashIOSFileBytes(mutation.originalBytes) !== mutation.originalHash)
+    ) {
+      throw transactionError(
+        "invalid-mutation",
+        "The iOS file transaction contained an invalid or duplicate mutation.",
+      );
+    }
+    paths.add(mutation.path);
+  }
+}
+
+function snapshotMutations(mutations: readonly IOSFileMutation[]): IOSFileMutation[] {
+  try {
+    return mutations.map((mutation) => {
+      if (!mutation.path || !isAbsolute(mutation.path)) {
+        throw new Error("mutation path must be absolute");
+      }
+      if (isCreateMutation(mutation)) {
+        return {
+          kind: "create",
+          path: resolve(mutation.path),
+          expectedParentIdentity: { ...mutation.expectedParentIdentity },
+          candidateBytes: new Uint8Array(mutation.candidateBytes),
+          candidateHash: mutation.candidateHash,
+          mode: mutation.mode,
+        };
+      }
+      return {
+        path: resolve(mutation.path),
+        originalBytes: new Uint8Array(mutation.originalBytes),
+        originalHash: mutation.originalHash,
+        candidateBytes: new Uint8Array(mutation.candidateBytes),
+        candidateHash: mutation.candidateHash,
+        mode: mutation.mode,
+      };
+    });
+  } catch (error) {
+    throw transactionError(
+      "invalid-mutation",
+      "The iOS file transaction contained an invalid mutation.",
+      error,
+    );
+  }
+}
+
+async function stageBytes(
+  mutation: IOSFileMutation,
+  bytes: Uint8Array,
+  expectedHash: string,
+): Promise<StagedMutation> {
+  const temporaryPath = resolve(
+    dirname(mutation.path),
+    `.${basename(mutation.path)}.clerk-${process.pid}-${randomUUID()}.tmp`,
+  );
+  let created = false;
+  let openedIdentity: FileIdentity | undefined;
+  try {
+    if (isCreateMutation(mutation) && !(await createParentStillMatches(mutation))) {
+      throw new IOSFileTransactionStaleError();
+    }
+    const temporary = await open(temporaryPath, "wx", mutation.mode);
+    created = true;
+    try {
+      const info = await temporary.stat();
+      if (!info.isFile()) throw new Error("staged path was not a regular file");
+      openedIdentity = {
+        dev: info.dev,
+        ino: info.ino,
+        mode: info.mode & 0o7777,
+      };
+      await temporary.writeFile(bytes);
+      await temporary.chmod(mutation.mode);
+      await temporary.sync();
+    } finally {
+      await temporary.close();
+    }
+    if (!(await fileMatchesHash(temporaryPath, expectedHash))) {
+      throw new Error("staged bytes did not match their prepared hash");
+    }
+    const stagedIdentity = await readRegularFileIdentity(temporaryPath);
+    if (!stagedIdentity || stagedIdentity.mode !== mutation.mode) {
+      throw new Error("staged file identity did not match its prepared mode");
+    }
+    if (isCreateMutation(mutation) && !(await createParentStillMatches(mutation))) {
+      throw new IOSFileTransactionStaleError();
+    }
+    return { mutation, temporaryPath, temporaryPresent: true, stagedIdentity };
+  } catch (error) {
+    if (created) {
+      try {
+        const currentIdentity = await readRegularFileIdentity(temporaryPath);
+        if (!openedIdentity || !currentIdentity || !sameFile(currentIdentity, openedIdentity)) {
+          throw new Error("the staged path no longer identified the transaction's file");
+        }
+        await rm(temporaryPath);
+      } catch (cleanupError) {
+        throw transactionError(
+          "cleanup-failed",
+          "A staged iOS file could not be removed after staging failed.",
+          aggregateCause([error, cleanupError]),
+        );
+      }
+    }
+    if (error instanceof IOSFileTransactionStaleError) throw error;
+    throw transactionError(
+      "stage-failed",
+      "The iOS file transaction could not be staged safely.",
+      error,
+    );
+  }
+}
+
+async function cleanupStaged(staged: readonly StagedMutation[]): Promise<void> {
+  const results = await Promise.allSettled(
+    staged
+      .filter((item) => item.temporaryPresent)
+      .map(async (item) => {
+        const currentIdentity = await readRegularFileIdentity(item.temporaryPath);
+        if (!currentIdentity || !sameFile(currentIdentity, item.stagedIdentity)) {
+          throw new Error("the staged path no longer identified the transaction's file");
+        }
+        await rm(item.temporaryPath);
+        item.temporaryPresent = false;
+      }),
+  );
+  const failures = results
+    .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+    .map((result) => result.reason);
+  if (failures.length > 0) {
+    throw transactionError(
+      "cleanup-failed",
+      "One or more staged iOS files could not be removed.",
+      aggregateCause(failures),
+    );
+  }
+}
+
+async function stageAll(
+  mutations: readonly IOSFileMutation[],
+  content: (mutation: IOSFileMutation) => { bytes: Uint8Array; hash: string },
+): Promise<StagedMutation[]> {
+  const staged: StagedMutation[] = [];
+  try {
+    for (const mutation of mutations) {
+      const value = content(mutation);
+      staged.push(await stageBytes(mutation, value.bytes, value.hash));
+    }
+    return staged;
+  } catch (error) {
+    try {
+      await cleanupStaged(staged);
+    } catch (cleanupError) {
+      throw transactionError(
+        "cleanup-failed",
+        "The iOS file transaction failed to clean up after staging.",
+        aggregateCause([error, cleanupError]),
+      );
+    }
+    throw error;
+  }
+}
+
+async function captureInitialExistingFileIdentities(
+  mutations: readonly IOSFileMutation[],
+): Promise<Map<string, FileIdentity> | undefined> {
+  const identities = new Map<string, FileIdentity>();
+  const states = await Promise.all(
+    mutations.map(async (mutation) => {
+      if (isCreateMutation(mutation)) {
+        return (await createParentStillMatches(mutation)) && (await pathIsAbsent(mutation.path));
+      }
+      const identity = await readRegularFileIdentity(mutation.path);
+      if (
+        !identity ||
+        identity.mode !== mutation.mode ||
+        !(await fileMatchesIdentityAndHash(mutation.path, identity, mutation.originalHash))
+      ) {
+        return false;
+      }
+      identities.set(mutation.path, identity);
+      return true;
+    }),
+  );
+  return states.every(Boolean) ? identities : undefined;
+}
+
+async function originalStateStillMatches(
+  mutation: IOSFileMutation,
+  initialIdentities: ReadonlyMap<string, FileIdentity>,
+): Promise<boolean> {
+  if (isCreateMutation(mutation)) {
+    return (await createParentStillMatches(mutation)) && (await pathIsAbsent(mutation.path));
+  }
+  const identity = initialIdentities.get(mutation.path);
+  return (
+    identity !== undefined &&
+    fileMatchesIdentityAndHash(mutation.path, identity, mutation.originalHash)
+  );
+}
+
+async function originalStatesStillMatch(
+  mutations: readonly IOSFileMutation[],
+  initialIdentities: ReadonlyMap<string, FileIdentity>,
+): Promise<boolean> {
+  const matches = await Promise.all(
+    mutations.map(async (mutation) => originalStateStillMatches(mutation, initialIdentities)),
+  );
+  return matches.every(Boolean);
+}
+
+async function createdCandidateIsUntouched(item: StagedMutation): Promise<boolean> {
+  if (!isCreateMutation(item.mutation) || !(await createParentStillMatches(item.mutation))) {
+    return false;
+  }
+  try {
+    const destinationIdentity = await readRegularFileIdentity(item.mutation.path);
+    if (
+      !destinationIdentity ||
+      !identitiesMatch(destinationIdentity, item.stagedIdentity) ||
+      destinationIdentity.mode !== item.mutation.mode
+    ) {
+      return false;
+    }
+    if (item.temporaryPresent) {
+      const temporaryIdentity = await readRegularFileIdentity(item.temporaryPath);
+      if (!temporaryIdentity || !identitiesMatch(temporaryIdentity, item.stagedIdentity)) {
+        return false;
+      }
+    }
+    return (
+      (await fileMatchesIdentityAndHash(
+        item.mutation.path,
+        item.committedIdentity ?? item.stagedIdentity,
+        item.mutation.candidateHash,
+      )) && (await createParentStillMatches(item.mutation))
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function committedCandidateIsUntouched(item: StagedMutation): Promise<boolean> {
+  if (isCreateMutation(item.mutation)) return createdCandidateIsUntouched(item);
+  if (!item.committedIdentity) return false;
+  return fileMatchesIdentityAndHash(
+    item.mutation.path,
+    item.committedIdentity,
+    item.mutation.candidateHash,
+  );
+}
+
+async function committedCandidatesAreUntouched(
+  committed: readonly StagedMutation[],
+): Promise<boolean> {
+  const states = await Promise.all(committed.map(committedCandidateIsUntouched));
+  return states.every(Boolean);
+}
+
+async function claimedOriginalIsUntouched(item: StagedMutation): Promise<boolean> {
+  if (isCreateMutation(item.mutation)) return true;
+  const claim = item.claimedOriginal;
+  return (
+    claim !== undefined &&
+    claim.present &&
+    (await fileMatchesIdentityAndHash(claim.path, claim.identity, item.mutation.originalHash))
+  );
+}
+
+async function claimedOriginalsAreUntouched(
+  committed: readonly StagedMutation[],
+): Promise<boolean> {
+  const states = await Promise.all(committed.map(claimedOriginalIsUntouched));
+  return states.every(Boolean);
+}
+
+async function cleanupClaimedOriginals(committed: readonly StagedMutation[]): Promise<void> {
+  if (
+    !(await committedCandidatesAreUntouched(committed)) ||
+    !(await claimedOriginalsAreUntouched(committed))
+  ) {
+    throw new IOSFileTransactionOwnershipError(
+      "one or more committed candidates or claimed originals changed before the originals could be released",
+    );
+  }
+  const results = await Promise.allSettled(
+    committed.map(async (item) => {
+      if (isCreateMutation(item.mutation) || !item.claimedOriginal?.present) return;
+      if (
+        !(await committedCandidateIsUntouched(item)) ||
+        !(await claimedOriginalIsUntouched(item))
+      ) {
+        throw new IOSFileTransactionOwnershipError(
+          "a committed candidate or claimed original changed before the original could be released",
+        );
+      }
+      await removeClaimedPath(item.claimedOriginal, {
+        expectedHash: item.mutation.originalHash,
+        expectedMode: item.mutation.mode,
+      });
+    }),
+  );
+  const failures = results
+    .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+    .map((result) => result.reason);
+  if (failures.length > 0) {
+    const cause = aggregateCause(failures);
+    if (failures.every((failure) => failure instanceof IOSFileTransactionOwnershipError)) {
+      throw new IOSFileTransactionOwnershipError(
+        "one or more committed candidates or claimed originals changed before the originals could be released",
+        { cause },
+      );
+    }
+    throw cause;
+  }
+}
+
+async function rollbackCommitted(
+  committed: readonly StagedMutation[],
+  hooks: IOSFileTransactionTestHooks,
+): Promise<void> {
+  if (committed.length === 0) return;
+
+  const reversed = [...committed].reverse();
+  const rollbackClaims: Array<{
+    claim: ClaimedDestination;
+    mutation: IOSFileMutation;
+  }> = [];
+  const rollbackFiles = await stageAll(
+    reversed
+      .map((item) => item.mutation)
+      .filter((mutation): mutation is IOSExistingFileMutation => !isCreateMutation(mutation)),
+    (mutation) => {
+      if (isCreateMutation(mutation)) {
+        throw new Error("create mutations do not have original bytes");
+      }
+      return { bytes: mutation.originalBytes, hash: mutation.originalHash };
+    },
+  );
+
+  try {
+    // Restore every still-owned existing file before attempting to remove a
+    // created dependency. A replaced create parent must not leave a project
+    // file pointing at a destination the transaction can no longer prove.
+    const candidatesAreUntouched = await Promise.all(
+      reversed
+        .filter((item) => !isCreateMutation(item.mutation))
+        .map(committedCandidateIsUntouched),
+    );
+    if (!candidatesAreUntouched.every(Boolean)) {
+      throw transactionError(
+        "rollback-failed",
+        "The iOS file transaction changed again before rollback; newer bytes were preserved.",
+      );
+    }
+
+    let rollbackIndex = 0;
+    for (const item of reversed) {
+      if (!(await committedCandidateIsUntouched(item))) {
+        throw transactionError(
+          "rollback-failed",
+          "The iOS file transaction changed again during rollback; newer bytes were preserved.",
+        );
+      }
+      if (isCreateMutation(item.mutation)) {
+        const candidateIdentity = item.committedIdentity ?? item.stagedIdentity;
+        const claimResult = await claimDestination(
+          item.mutation.path,
+          candidateIdentity,
+          item.mutation.candidateHash,
+        );
+        if (claimResult.status === "stale") {
+          throw transactionError(
+            "rollback-failed",
+            "The iOS file transaction changed again during rollback; newer bytes were preserved.",
+          );
+        }
+        const candidateClaim = claimResult.claim;
+        rollbackClaims.push({ claim: candidateClaim, mutation: item.mutation });
+        await removeClaimedPath(candidateClaim, {
+          expectedHash: item.mutation.candidateHash,
+          expectedMode: item.mutation.mode,
+        });
+        await syncDirectory(dirname(item.mutation.path));
+        if (
+          !(await createParentStillMatches(item.mutation)) ||
+          !(await pathIsAbsent(item.mutation.path))
+        ) {
+          throw transactionError(
+            "rollback-failed",
+            "An iOS create destination changed while rollback removed its candidate; newer filesystem state was preserved.",
+          );
+        }
+        continue;
+      }
+      const rollback = rollbackFiles[rollbackIndex++];
+      if (!rollback) {
+        throw new Error("a prepared rollback file was missing");
+      }
+      const originalBackup = item.claimedOriginal?.present ? item.claimedOriginal : undefined;
+      const originalSourcePath = originalBackup?.path ?? rollback.temporaryPath;
+      const originalSourceIdentity = await readRegularFileIdentity(originalSourcePath);
+      if (
+        !originalSourceIdentity ||
+        (originalBackup && !sameFile(originalSourceIdentity, originalBackup.identity)) ||
+        (!originalBackup &&
+          !(await fileMatchesIdentityAndHash(
+            originalSourcePath,
+            rollback.stagedIdentity,
+            item.mutation.originalHash,
+          )))
+      ) {
+        throw new IOSFileTransactionOwnershipError(
+          "the original iOS file could not be identified during rollback",
+        );
+      }
+      await hooks.beforeRollbackDestinationReplace?.(rollback.mutation.path, originalSourcePath);
+      if (!(await committedCandidateIsUntouched(item))) {
+        throw transactionError(
+          "rollback-failed",
+          "The iOS file transaction changed again during rollback; newer bytes were preserved.",
+        );
+      }
+      const sourceIdentityBeforeRename = await readRegularFileIdentity(originalSourcePath);
+      if (
+        !sourceIdentityBeforeRename ||
+        !sameFile(sourceIdentityBeforeRename, originalSourceIdentity)
+      ) {
+        throw new IOSFileTransactionOwnershipError(
+          "the original iOS file changed before atomic rollback",
+        );
+      }
+      // This final ownership check and the atomic rename are the standard
+      // replacement linearization boundary. A writer that wins afterward is
+      // ordered before this rollback; portable Node APIs do not provide an
+      // inode-conditional rename primitive.
+      await rename(originalSourcePath, rollback.mutation.path);
+      if (originalBackup) originalBackup.present = false;
+      else rollback.temporaryPresent = false;
+      await hooks.afterRollbackDestinationReplace?.(rollback.mutation.path);
+      const restoredIdentity = await readRegularFileIdentity(rollback.mutation.path);
+      if (
+        !restoredIdentity ||
+        !sameFile(restoredIdentity, originalSourceIdentity) ||
+        (!originalBackup &&
+          !(await fileMatchesIdentityAndHash(
+            rollback.mutation.path,
+            originalSourceIdentity,
+            item.mutation.originalHash,
+          )))
+      ) {
+        throw new IOSFileTransactionOwnershipError(
+          "the restored iOS file did not match its rollback source",
+        );
+      }
+      await syncDirectory(dirname(rollback.mutation.path));
+    }
+    await cleanupStaged(rollbackFiles);
+  } catch (error) {
+    let candidateClaimCleanupError: unknown;
+    const candidateClaimCleanupResults = await Promise.allSettled(
+      rollbackClaims.map(async ({ claim, mutation }) => {
+        if (!claim.present) return;
+        await removeClaimedPath(claim, {
+          expectedHash: mutation.candidateHash,
+          expectedMode: mutation.mode,
+        });
+      }),
+    );
+    const candidateClaimCleanupFailures = candidateClaimCleanupResults
+      .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+      .map((result) => result.reason);
+    if (candidateClaimCleanupFailures.length > 0) {
+      candidateClaimCleanupError = aggregateCause(candidateClaimCleanupFailures);
+    }
+    try {
+      await cleanupStaged(rollbackFiles);
+    } catch (cleanupError) {
+      throw transactionError(
+        "rollback-failed",
+        "The iOS file transaction could not be rolled back or cleaned up completely.",
+        aggregateCause(
+          [error, candidateClaimCleanupError, cleanupError].filter((cause) => cause !== undefined),
+        ),
+      );
+    }
+    if (candidateClaimCleanupError) {
+      throw transactionError(
+        "rollback-failed",
+        "The iOS file transaction could not be rolled back or cleaned up completely.",
+        aggregateCause([error, candidateClaimCleanupError].filter((cause) => cause !== undefined)),
+      );
+    }
+    if (error instanceof IOSFileTransactionError && error.code === "rollback-failed") throw error;
+    throw transactionError(
+      "rollback-failed",
+      "The iOS file transaction could not be rolled back completely.",
+      error,
+    );
+  }
+}
+
+async function rollbackAfterFailure(
+  committed: readonly StagedMutation[],
+  staged: readonly StagedMutation[],
+  hooks: IOSFileTransactionTestHooks,
+): Promise<void> {
+  let rollbackError: unknown;
+  let cleanupError: unknown;
+  try {
+    await rollbackCommitted(committed, hooks);
+  } catch (error) {
+    rollbackError = error;
+  }
+  try {
+    await cleanupStaged(staged);
+  } catch (error) {
+    cleanupError = error;
+  }
+  if (!(await createParentsStillMatch(committed.map((item) => item.mutation)))) {
+    cleanupError ??= transactionError(
+      "rollback-failed",
+      "An iOS create destination changed while rollback was being finalized; newer filesystem state was preserved.",
+    );
+  }
+  if (rollbackError || cleanupError) {
+    throw transactionError(
+      "rollback-failed",
+      "The iOS file transaction could not be rolled back or cleaned up completely.",
+      aggregateCause([rollbackError, cleanupError].filter((error) => error !== undefined)),
+    );
+  }
+}
+
+async function postconditionsAreValid(
+  postconditions: readonly IOSFilePostcondition[],
+): Promise<boolean> {
+  const results = await Promise.allSettled(
+    postconditions.map(async (postcondition) => Promise.resolve().then(postcondition)),
+  );
+  return results.every((result) => result.status === "fulfilled" && result.value === true);
+}
+
+/**
+ * Atomically creates or replaces a set of files as far as the filesystem
+ * allows. Candidates are all staged first; any partial commit is restored in
+ * reverse order if a later commit or aggregate postcondition fails.
+ *
+ * @internal Prepared mutations contain sensitive-to-output candidate bytes.
+ */
+export async function applyIOSFileTransaction(
+  mutations: readonly IOSFileMutation[],
+  postconditions: readonly IOSFilePostcondition[],
+  hooks: IOSFileTransactionTestHooks = {},
+): Promise<IOSFileTransactionResult> {
+  const prepared = snapshotMutations(mutations);
+  validateMutations(prepared);
+  const initialIdentities = await captureInitialExistingFileIdentities(prepared);
+  if (!initialIdentities) return { status: "stale" };
+  let staged: StagedMutation[];
+  try {
+    staged = await stageAll(prepared, (mutation) => ({
+      bytes: mutation.candidateBytes,
+      hash: mutation.candidateHash,
+    }));
+  } catch (error) {
+    if (error instanceof IOSFileTransactionStaleError) return { status: "stale" };
+    throw error;
+  }
+  const committed: StagedMutation[] = [];
+
+  if (!(await originalStatesStillMatch(prepared, initialIdentities))) {
+    await cleanupStaged(staged);
+    return { status: "stale" };
+  }
+
+  let stale = false;
+  let commitError: unknown;
+  for (const item of staged) {
+    if (!(await createParentsStillMatch(prepared))) {
+      stale = true;
+      break;
+    }
+    const originalStillMatches = await originalStateStillMatches(item.mutation, initialIdentities);
+    if (!originalStillMatches) {
+      stale = true;
+      break;
+    }
+    let committedThisItem = false;
+    try {
+      if (isCreateMutation(item.mutation)) {
+        await link(item.temporaryPath, item.mutation.path);
+      } else {
+        const expectedIdentity = initialIdentities.get(item.mutation.path);
+        if (!expectedIdentity) {
+          throw new Error("an existing iOS file identity was missing during commit");
+        }
+        await hooks.beforeExistingDestinationBackup?.(item.mutation.path);
+        const backupResult = await backupDestination(
+          item.mutation.path,
+          expectedIdentity,
+          item.mutation.originalHash,
+        );
+        if (backupResult.status === "stale") {
+          stale = true;
+          break;
+        }
+        item.claimedOriginal = backupResult.claim;
+        await hooks.afterExistingDestinationBackup?.(item.mutation.path, item.claimedOriginal.path);
+        await hooks.beforeExistingDestinationReplace?.(
+          item.mutation.path,
+          item.claimedOriginal.path,
+        );
+        if (
+          !(await createParentsStillMatch(prepared)) ||
+          !(await originalStateStillMatches(item.mutation, initialIdentities)) ||
+          !(await fileMatchesIdentityAndHash(
+            item.temporaryPath,
+            item.stagedIdentity,
+            item.mutation.candidateHash,
+          ))
+        ) {
+          throw new IOSFileTransactionStaleError();
+        }
+        // The original remains available through the verified hard-link
+        // backup while this same-directory rename atomically replaces the
+        // public destination. There is no path-absence window. The final
+        // ownership check and rename form the standard replacement
+        // linearization boundary; portable Node APIs do not provide an
+        // inode-conditional rename primitive.
+        await rename(item.temporaryPath, item.mutation.path);
+        item.temporaryPresent = false;
+      }
+      // A successful create link or existing-file rename proves that the
+      // destination referred to the staged inode at the commit linearization
+      // point. Record ownership synchronously before exposing it to rollback.
+      item.committedIdentity = item.stagedIdentity;
+      committed.push(item);
+      committedThisItem = true;
+      if (!isCreateMutation(item.mutation) && item.claimedOriginal) {
+        await hooks.afterExistingDestinationReplace?.(
+          item.mutation.path,
+          item.claimedOriginal.path,
+        );
+      }
+      if (!(await createParentsStillMatch(prepared))) {
+        throw new IOSFileTransactionStaleError();
+      }
+      const committedIdentity = await readRegularFileIdentity(item.mutation.path);
+      if (!committedIdentity || !identitiesMatch(committedIdentity, item.stagedIdentity)) {
+        throw new Error("committed file identity did not match its staged candidate");
+      }
+      item.committedIdentity = committedIdentity;
+      await syncDirectory(dirname(item.mutation.path));
+      if (!(await createParentsStillMatch(prepared))) {
+        throw new IOSFileTransactionStaleError();
+      }
+    } catch (error) {
+      let effectiveError = error;
+      if (!committedThisItem && item.claimedOriginal?.present) {
+        try {
+          await removeClaimedPath(item.claimedOriginal);
+        } catch (cleanupError) {
+          effectiveError = new IOSFileTransactionOwnershipError(
+            "an original-file backup could not be released after commit stopped",
+            { cause: aggregateCause([error, cleanupError]) },
+          );
+        }
+      }
+      if (
+        effectiveError instanceof IOSFileTransactionStaleError ||
+        (isCreateMutation(item.mutation) && isFileSystemError(effectiveError, "EEXIST"))
+      ) {
+        stale = true;
+      } else {
+        commitError = effectiveError;
+      }
+      break;
+    }
+  }
+
+  if (stale || commitError) {
+    await rollbackAfterFailure(committed, staged, hooks);
+    if (stale) return { status: "stale" };
+    throw transactionError(
+      "commit-failed",
+      "The iOS file transaction could not be committed and was restored.",
+      commitError,
+    );
+  }
+
+  const parentsMatchedBeforePostvalidation = await createParentsStillMatch(prepared);
+  const candidatesMatchedBeforePostvalidation = await committedCandidatesAreUntouched(committed);
+  const originalsMatchedBeforePostvalidation = await claimedOriginalsAreUntouched(committed);
+  const postconditionsValid = await postconditionsAreValid(postconditions);
+  const parentsMatchedAfterPostvalidation = await createParentsStillMatch(prepared);
+  const candidatesMatchedAfterPostvalidation = await committedCandidatesAreUntouched(committed);
+  const originalsMatchedAfterPostvalidation = await claimedOriginalsAreUntouched(committed);
+  if (
+    parentsMatchedBeforePostvalidation &&
+    candidatesMatchedBeforePostvalidation &&
+    originalsMatchedBeforePostvalidation &&
+    postconditionsValid &&
+    parentsMatchedAfterPostvalidation &&
+    candidatesMatchedAfterPostvalidation &&
+    originalsMatchedAfterPostvalidation
+  ) {
+    try {
+      await cleanupClaimedOriginals(committed);
+    } catch (error) {
+      await rollbackAfterFailure(committed, staged, hooks);
+      if (error instanceof IOSFileTransactionOwnershipError) return { status: "stale" };
+      throw transactionError(
+        "cleanup-failed",
+        "The iOS file transaction could not release its claimed original files and was restored.",
+        error,
+      );
+    }
+    await cleanupStaged(staged);
+    if (
+      (await createParentsStillMatch(prepared)) &&
+      (await committedCandidatesAreUntouched(committed))
+    ) {
+      return { status: "applied" };
+    }
+    await rollbackAfterFailure(committed, staged, hooks);
+    return { status: "stale" };
+  }
+
+  await rollbackAfterFailure(committed, staged, hooks);
+  return parentsMatchedBeforePostvalidation &&
+    candidatesMatchedBeforePostvalidation &&
+    parentsMatchedAfterPostvalidation &&
+    candidatesMatchedAfterPostvalidation &&
+    originalsMatchedBeforePostvalidation &&
+    originalsMatchedAfterPostvalidation
+    ? { status: "rolled-back" }
+    : { status: "stale" };
+}
+
+/**
+ * Atomically replaces a set of existing files as far as the filesystem allows.
+ *
+ * @internal Prepared mutations contain sensitive-to-output candidate bytes.
+ */
+export async function applyIOSExistingFileTransaction(
+  mutations: readonly IOSExistingFileMutation[],
+  postconditions: readonly IOSFilePostcondition[],
+  hooks: IOSFileTransactionTestHooks = {},
+): Promise<IOSFileTransactionResult> {
+  return applyIOSFileTransaction(mutations, postconditions, hooks);
+}

--- a/packages/cli-core/src/commands/init/ios/inspect.test.ts
+++ b/packages/cli-core/src/commands/init/ios/inspect.test.ts
@@ -300,6 +300,27 @@ struct MyApp: App {
     expect(JSON.stringify(inspection)).not.toContain(schemeKey);
   });
 
+  test("does not synthesize Run scheme markup across XML comments", async () => {
+    const root = await fixture({ includeKey: false });
+    const schemeDirectory = join(root, "MyApp.xcodeproj", "xcshareddata", "xcschemes");
+    await mkdir(schemeDirectory, { recursive: true });
+    const schemeKey = `pk_test_${Buffer.from("comment.clerk.example$").toString("base64")}`;
+    await Bun.write(
+      join(schemeDirectory, "MyApp.xcscheme"),
+      `<Scheme><Launch<!-- -->Action><BuildableProductRunnable><BuildableReference BlueprintIdentifier="${IOS_FIXTURE_IDS.appTarget}" /></BuildableProductRunnable><EnvironmentVariables><EnvironmentVariable key="CLERK_PUBLISHABLE_KEY" value="${schemeKey}" isEnabled="YES" /></EnvironmentVariables></Launch<!-- -->Action></Scheme>`,
+    );
+
+    const inspection = await inspectIOSProject(root);
+
+    expect(inspection.localPublishableKey).toEqual({
+      found: false,
+      conflict: false,
+      candidateSources: [],
+      invalidSources: [],
+    });
+    expect(JSON.stringify(inspection)).not.toContain(schemeKey);
+  });
+
   test("ignores a workspace scheme that references a different same-named project container", async () => {
     const root = await fixture({ includeKey: false, workspace: true });
     const schemeDirectory = join(root, "MyApp.xcworkspace", "xcshareddata", "xcschemes");

--- a/packages/cli-core/src/commands/init/ios/inspect.test.ts
+++ b/packages/cli-core/src/commands/init/ios/inspect.test.ts
@@ -1,0 +1,589 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, mkdir, rm, symlink } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { inspectWorkspace } from "./discovery.ts";
+import { inspectIOSProject } from "./inspect.ts";
+import { createIOSFixture, IOS_FIXTURE_IDS, treeDigest } from "./test-helpers.ts";
+
+const temporaryDirectories: string[] = [];
+
+async function fixture(options: Parameters<typeof createIOSFixture>[1] = {}): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "clerk-ios-inspect-"));
+  temporaryDirectories.push(root);
+  await createIOSFixture(root, options);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true })));
+});
+
+describe("inspectIOSProject", () => {
+  test("inspects target settings, Clerk linkage, entitlements, and Swift setup", async () => {
+    const root = await fixture({ complete: true, workspace: true });
+    const inspection = await inspectIOSProject(root);
+
+    expect(inspection.selection).toEqual({
+      state: "selected",
+      targetId: IOS_FIXTURE_IDS.appTarget,
+      targetName: "MyApp",
+      projectPath: "MyApp.xcodeproj",
+    });
+    expect(inspection.workspaces).toEqual([
+      { path: "MyApp.xcworkspace", projectPaths: ["MyApp.xcodeproj"] },
+    ]);
+    expect(inspection.projects[0]?.packages[0]).toMatchObject({
+      kind: "remote",
+      repository: "https://github.com/clerk/clerk-ios",
+      isClerk: true,
+    });
+
+    const target = inspection.appTargets[0];
+    expect(target?.packages).toEqual({
+      package: "remote",
+      clerkKit: "linked",
+      clerkKitUI: "linked",
+    });
+    expect(target?.configurations.map((configuration) => configuration.name)).toEqual([
+      "Debug",
+      "Release",
+    ]);
+    expect(target?.configurations[0]?.bundleIdentifier).toMatchObject({
+      state: "resolved",
+      value: "com.example.MyApp",
+    });
+    expect(target?.configurations[0]?.entitlements).toMatchObject({
+      associatedDomains: ["webcredentials:clerk.example.test"],
+      literalAppIdentifierPrefix: "LEGACY1234",
+      teamIdentifier: "ABCDE12345",
+    });
+    expect(target?.swift).toMatchObject({
+      status: "complete",
+      sourceFilesScanned: 1,
+    });
+    expect(target?.runtimeKeySinks).toEqual([]);
+    expect(inspection.localPublishableKey).toEqual({
+      found: true,
+      source: ".env",
+      frontendApiHost: "clerk.example.test",
+      instanceType: "development",
+      conflict: false,
+      candidateSources: [".env"],
+      invalidSources: [],
+    });
+    const fixtureKey = `pk_test_${Buffer.from("clerk.example.test$").toString("base64")}`;
+    expect(JSON.stringify(inspection)).not.toContain(fixtureKey);
+
+    const fromWorkspaceBundle = await inspectIOSProject(join(root, "MyApp.xcworkspace"));
+    expect(fromWorkspaceBundle.selection).toMatchObject({
+      state: "selected",
+      targetName: "MyApp",
+    });
+
+    const embeddedWorkspace = join(root, "MyApp.xcodeproj", "project.xcworkspace");
+    await mkdir(embeddedWorkspace, { recursive: true });
+    await Bun.write(
+      join(embeddedWorkspace, "contents.xcworkspacedata"),
+      '<?xml version="1.0"?><Workspace version="1.0"><FileRef location="self:"></FileRef></Workspace>',
+    );
+    const fromEmbeddedWorkspace = await inspectIOSProject(embeddedWorkspace);
+    expect(fromEmbeddedWorkspace.selection).toMatchObject({
+      state: "selected",
+      targetName: "MyApp",
+      projectPath: "MyApp.xcodeproj",
+    });
+  });
+
+  test("does not synthesize workspace markup across XML comments", async () => {
+    const root = await fixture({ workspace: true });
+    const workspace = join(root, "MyApp.xcworkspace");
+    await Bun.write(
+      join(workspace, "contents.xcworkspacedata"),
+      `<Workspace version="1.0">
+        <Fi<!-- -->leRef location="group:Injected.xcodeproj"></FileRef>
+        <!-- <FileRef location="group:Commented.xcodeproj"></FileRef> -->
+        <FileRef location="group:MyApp.xcodeproj"></FileRef>
+      </Workspace>`,
+    );
+
+    const result = await inspectWorkspace(root, workspace);
+
+    expect(result.inspection.projectPaths).toEqual(["MyApp.xcodeproj"]);
+    expect(result.localProjectPaths).toEqual([join(root, "MyApp.xcodeproj")]);
+  });
+
+  test("does not parse a workspace location token from inside another quoted attribute", async () => {
+    const root = await fixture({ workspace: true });
+    const workspace = join(root, "MyApp.xcworkspace");
+    await Bun.write(
+      join(workspace, "contents.xcworkspacedata"),
+      `<Workspace version="1.0">
+        <FileRef note="location=&quot;group:Injected.xcodeproj&quot;" location="group:MyApp.xcodeproj"></FileRef>
+      </Workspace>`,
+    );
+
+    const result = await inspectWorkspace(root, workspace);
+
+    expect(result.inspection.projectPaths).toEqual(["MyApp.xcodeproj"]);
+    expect(result.localProjectPaths).toEqual([join(root, "MyApp.xcodeproj")]);
+  });
+
+  test("does not guess when multiple application targets exist", async () => {
+    const root = await fixture({ secondTarget: true });
+    const inspection = await inspectIOSProject(root);
+
+    expect(inspection.selection.state).toBe("ambiguous");
+    expect(
+      inspection.diagnostics.some((diagnostic) => diagnostic.code === "xcode.ambiguous-app-target"),
+    ).toBe(true);
+  });
+
+  test("selects an explicit target by name or object ID", async () => {
+    const root = await fixture({ secondTarget: true });
+
+    const byName = await inspectIOSProject(root, { target: "AdminApp" });
+    const byId = await inspectIOSProject(root, { target: IOS_FIXTURE_IDS.appTarget });
+
+    expect(byName.selection).toMatchObject({ state: "selected", targetName: "AdminApp" });
+    expect(byId.selection).toMatchObject({ state: "selected", targetName: "MyApp" });
+  });
+
+  test("reports usable target choices when an explicit target is not found", async () => {
+    const root = await fixture({ secondTarget: true });
+
+    const inspection = await inspectIOSProject(root, { target: "MissingApp" });
+
+    expect(inspection.selection).toEqual({
+      state: "not-found",
+      requested: "MissingApp",
+      candidates: [
+        `AdminApp (${IOS_FIXTURE_IDS.secondTarget})`,
+        `MyApp (${IOS_FIXTURE_IDS.appTarget})`,
+      ],
+    });
+    expect(inspection.projects[0]?.appTargetIds).toEqual([
+      IOS_FIXTURE_IDS.secondTarget,
+      IOS_FIXTURE_IDS.appTarget,
+    ]);
+  });
+
+  test("does not treat watchOS application products as iOS app candidates", async () => {
+    const root = await fixture({ secondTarget: "watchos" });
+    const inspection = await inspectIOSProject(root);
+
+    expect(inspection.appTargets.map((target) => target.name)).toEqual(["MyApp"]);
+    expect(inspection.selection).toMatchObject({ state: "selected", targetName: "MyApp" });
+  });
+
+  test("preserves conflicting configuration values instead of guessing", async () => {
+    const root = await fixture({ conflictingBundle: true });
+    const inspection = await inspectIOSProject(root);
+
+    expect(
+      inspection.appTargets[0]?.configurations.map((configuration) =>
+        configuration.bundleIdentifier.state === "resolved"
+          ? configuration.bundleIdentifier.value
+          : configuration.bundleIdentifier.state,
+      ),
+    ).toEqual(["com.example.MyApp", "com.example.MyApp.release"]);
+    expect(
+      inspection.diagnostics.some(
+        (diagnostic) => diagnostic.code === "xcode.conflicting-build-setting",
+      ),
+    ).toBe(true);
+  });
+
+  test("reports a setting present in only one build configuration", async () => {
+    const root = await fixture({ releaseEntitlements: false });
+    const inspection = await inspectIOSProject(root);
+
+    expect(
+      inspection.diagnostics.some(
+        (diagnostic) =>
+          diagnostic.code === "xcode.conflicting-build-setting" &&
+          diagnostic.message.includes("Release=<missing>"),
+      ),
+    ).toBe(true);
+  });
+
+  test("resolves checked-in xcconfig includes and variables without Xcode", async () => {
+    const root = await fixture({ xcconfig: true });
+    const inspection = await inspectIOSProject(root);
+    const configurations = inspection.appTargets[0]?.configurations;
+
+    expect(configurations?.map((configuration) => configuration.bundleIdentifier)).toEqual([
+      expect.objectContaining({ state: "resolved", value: "com.example.MyApp" }),
+      expect.objectContaining({ state: "resolved", value: "com.example.MyApp" }),
+    ]);
+    expect(configurations?.map((configuration) => configuration.developmentTeam)).toEqual([
+      expect.objectContaining({ state: "resolved", value: "ABCDE12345" }),
+      expect.objectContaining({ state: "resolved", value: "ABCDE12345" }),
+    ]);
+  });
+
+  test("reads a target-owned LocalSecrets.plist without exposing its key", async () => {
+    const root = await fixture({ includeKey: false, localSecrets: true });
+    const inspection = await inspectIOSProject(root);
+
+    expect(inspection.localPublishableKey).toEqual({
+      found: true,
+      source: "MyApp/LocalSecrets.plist",
+      frontendApiHost: "native.clerk.example",
+      instanceType: "production",
+      conflict: false,
+      candidateSources: ["MyApp/LocalSecrets.plist"],
+      invalidSources: [],
+    });
+    expect(inspection.appTargets[0]?.runtimeKeySinks).toEqual([
+      { kind: "local-secrets-plist", path: "MyApp/LocalSecrets.plist" },
+    ]);
+    expect(JSON.stringify(inspection)).not.toContain("pk_live_");
+  });
+
+  test("treats a direct @main literal as the selected target's runtime key without exposing it", async () => {
+    const root = await fixture({ includeKey: false });
+    const publishableKey = `pk_test_${Buffer.from("inline.clerk.example$").toString("base64")}`;
+    await Bun.write(
+      join(root, "MyApp", "MyAppApp.swift"),
+      `import ClerkKit
+import SwiftUI
+
+@main
+struct MyApp: App {
+  init() {
+    Clerk.configure(publishableKey: "${publishableKey}")
+  }
+
+  var body: some Scene {
+    WindowGroup {
+      Text("Hello")
+        .environment(Clerk.shared)
+    }
+  }
+}
+`,
+    );
+
+    const inspection = await inspectIOSProject(root, { target: "MyApp" });
+
+    expect(inspection.localPublishableKey).toEqual({
+      found: true,
+      conflict: false,
+      source: "MyApp/MyAppApp.swift",
+      frontendApiHost: "inline.clerk.example",
+      instanceType: "development",
+      candidateSources: ["MyApp/MyAppApp.swift"],
+      invalidSources: [],
+    });
+    expect(JSON.stringify(inspection)).not.toContain(publishableKey);
+  });
+
+  test("reads an enabled publishable key from the selected target's Run scheme", async () => {
+    const root = await fixture({ includeKey: false });
+    const schemeDirectory = join(root, "MyApp.xcodeproj", "xcshareddata", "xcschemes");
+    await mkdir(schemeDirectory, { recursive: true });
+    const schemeKey = `pk_test_${Buffer.from("scheme.clerk.example$").toString("base64")}`;
+    await Bun.write(
+      join(schemeDirectory, "MyApp.xcscheme"),
+      `<Scheme><LaunchAction><BuildableProductRunnable><BuildableReference BlueprintIdentifier="${IOS_FIXTURE_IDS.appTarget}" /></BuildableProductRunnable><EnvironmentVariables><EnvironmentVariable key="CLERK_PUBLISHABLE_KEY" value="${schemeKey}" isEnabled="YES" /></EnvironmentVariables></LaunchAction></Scheme>`,
+    );
+
+    const inspection = await inspectIOSProject(root);
+
+    expect(inspection.localPublishableKey).toMatchObject({
+      found: true,
+      source: "MyApp.xcodeproj/xcshareddata/xcschemes/MyApp.xcscheme",
+      frontendApiHost: "scheme.clerk.example",
+      conflict: false,
+    });
+    expect(JSON.stringify(inspection)).not.toContain(schemeKey);
+  });
+
+  test("ignores a workspace scheme that references a different same-named project container", async () => {
+    const root = await fixture({ includeKey: false, workspace: true });
+    const schemeDirectory = join(root, "MyApp.xcworkspace", "xcshareddata", "xcschemes");
+    await mkdir(schemeDirectory, { recursive: true });
+    const schemeKey = `pk_test_${Buffer.from("wrong-container.clerk.example$").toString("base64")}`;
+    await Bun.write(
+      join(schemeDirectory, "WrongContainer.xcscheme"),
+      `<Scheme><LaunchAction><BuildableProductRunnable><BuildableReference BlueprintIdentifier="${IOS_FIXTURE_IDS.appTarget}" ReferencedContainer="container:Other/MyApp.xcodeproj" /></BuildableProductRunnable><EnvironmentVariables><EnvironmentVariable key="CLERK_PUBLISHABLE_KEY" value="${schemeKey}" isEnabled="YES" /></EnvironmentVariables></LaunchAction></Scheme>`,
+    );
+
+    const inspection = await inspectIOSProject(root);
+
+    expect(inspection.localPublishableKey).toEqual({
+      found: false,
+      conflict: false,
+      candidateSources: [],
+      invalidSources: [],
+    });
+    expect(JSON.stringify(inspection)).not.toContain(schemeKey);
+  });
+
+  test("blocks derived advice when equally effective keys point to different instances", async () => {
+    const root = await fixture({ includeKey: false });
+    const schemeDirectory = join(root, "MyApp.xcodeproj", "xcshareddata", "xcschemes");
+    await mkdir(schemeDirectory, { recursive: true });
+    const firstKey = `pk_test_${Buffer.from("first.clerk.example$").toString("base64")}`;
+    const secondKey = `pk_live_${Buffer.from("second.clerk.example$").toString("base64")}`;
+    const scheme = (key: string) =>
+      `<Scheme><LaunchAction><BuildableProductRunnable><BuildableReference BlueprintIdentifier="${IOS_FIXTURE_IDS.appTarget}" /></BuildableProductRunnable><EnvironmentVariables><EnvironmentVariable key="CLERK_PUBLISHABLE_KEY" value="${key}" isEnabled="YES" /></EnvironmentVariables></LaunchAction></Scheme>`;
+    await Bun.write(join(schemeDirectory, "First.xcscheme"), scheme(firstKey));
+    await Bun.write(join(schemeDirectory, "Second.xcscheme"), scheme(secondKey));
+
+    const inspection = await inspectIOSProject(root);
+
+    expect(inspection.localPublishableKey).toEqual({
+      found: true,
+      source: "MyApp.xcodeproj/xcshareddata/xcschemes/First.xcscheme",
+      conflict: true,
+      candidateSources: [
+        "MyApp.xcodeproj/xcshareddata/xcschemes/First.xcscheme",
+        "MyApp.xcodeproj/xcshareddata/xcschemes/Second.xcscheme",
+      ],
+      invalidSources: [],
+    });
+    expect(
+      inspection.diagnostics.some(
+        (diagnostic) => diagnostic.code === "clerk.conflicting-publishable-keys",
+      ),
+    ).toBe(true);
+    expect(JSON.stringify(inspection)).not.toContain(firstKey);
+    expect(JSON.stringify(inspection)).not.toContain(secondKey);
+  });
+
+  test("does not conflict a selected-target runtime key with the CLI process environment", async () => {
+    const root = await fixture({ includeKey: false, localSecrets: true });
+    const ambientKey = `pk_test_${Buffer.from("ambient.clerk.example$").toString("base64")}`;
+    const previousAmbientKey = process.env.CLERK_PUBLISHABLE_KEY;
+    process.env.CLERK_PUBLISHABLE_KEY = ambientKey;
+
+    try {
+      const inspection = await inspectIOSProject(root);
+
+      expect(inspection.localPublishableKey).toMatchObject({
+        found: true,
+        conflict: false,
+        source: "MyApp/LocalSecrets.plist",
+        frontendApiHost: "native.clerk.example",
+      });
+      expect(inspection.localPublishableKey.candidateSources).toEqual([
+        "CLERK_PUBLISHABLE_KEY environment variable",
+        "MyApp/LocalSecrets.plist",
+      ]);
+      expect(
+        inspection.diagnostics.some(
+          (diagnostic) => diagnostic.code === "clerk.conflicting-publishable-keys",
+        ),
+      ).toBe(false);
+      expect(JSON.stringify(inspection)).not.toContain(ambientKey);
+    } finally {
+      if (previousAmbientKey == null) delete process.env.CLERK_PUBLISHABLE_KEY;
+      else process.env.CLERK_PUBLISHABLE_KEY = previousAmbientKey;
+    }
+  });
+
+  test("does not fall through when the highest-precedence key is malformed", async () => {
+    const root = await fixture({ includeKey: false, localSecrets: true });
+    const schemeDirectory = join(root, "MyApp.xcodeproj", "xcshareddata", "xcschemes");
+    await mkdir(schemeDirectory, { recursive: true });
+    const schemePath = join(schemeDirectory, "MyApp.xcscheme");
+    await Bun.write(
+      schemePath,
+      `<Scheme><LaunchAction><BuildableProductRunnable><BuildableReference BlueprintIdentifier="${IOS_FIXTURE_IDS.appTarget}" /></BuildableProductRunnable><EnvironmentVariables><EnvironmentVariable key="CLERK_PUBLISHABLE_KEY" value="not-a-key" isEnabled="YES" /></EnvironmentVariables></LaunchAction></Scheme>`,
+    );
+
+    const inspection = await inspectIOSProject(root);
+
+    expect(inspection.localPublishableKey).toEqual({
+      found: false,
+      source: "MyApp.xcodeproj/xcshareddata/xcschemes/MyApp.xcscheme",
+      conflict: false,
+      candidateSources: [
+        "MyApp.xcodeproj/xcshareddata/xcschemes/MyApp.xcscheme",
+        "MyApp/LocalSecrets.plist",
+      ],
+      invalidSources: ["MyApp.xcodeproj/xcshareddata/xcschemes/MyApp.xcscheme"],
+    });
+  });
+
+  test("does not treat web-framework key names as native iOS configuration", async () => {
+    const root = await fixture({ includeKey: false });
+    const webKey = `pk_test_${Buffer.from("web.clerk.example$").toString("base64")}`;
+    await Bun.write(join(root, ".env"), `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${webKey}\n`);
+
+    const inspection = await inspectIOSProject(root);
+
+    expect(inspection.localPublishableKey).toEqual({
+      found: false,
+      conflict: false,
+      candidateSources: [],
+      invalidSources: [],
+    });
+  });
+
+  test("does not follow an entitlements symlink outside the inspected root", async () => {
+    if (process.platform === "win32") return;
+    const root = await fixture();
+    const externalRoot = await mkdtemp(join(tmpdir(), "clerk-ios-external-"));
+    temporaryDirectories.push(externalRoot);
+    const externalEntitlements = join(externalRoot, "External.entitlements");
+    await Bun.write(externalEntitlements, "<plist><dict></dict></plist>");
+    await rm(join(root, "MyApp", "MyApp.entitlements"));
+    await symlink(externalEntitlements, join(root, "MyApp", "MyApp.entitlements"));
+
+    const inspection = await inspectIOSProject(root);
+
+    expect(inspection.appTargets[0]?.configurations[0]?.entitlements).toBeUndefined();
+    expect(
+      inspection.diagnostics.some((diagnostic) => diagnostic.code === "xcode.external-path"),
+    ).toBe(true);
+  });
+
+  test("honors synchronized-group membership exceptions and iOS platform filters", async () => {
+    const root = await fixture({ complete: false });
+    const projectFile = join(root, "MyApp.xcodeproj", "project.pbxproj");
+    const original = await Bun.file(projectFile).text();
+    const synchronizedObjects = `
+    404040404040404040404040 = { isa = PBXFileSystemSynchronizedRootGroup; exceptions = ( 414141414141414141414141, 424242424242424242424242, ); path = Synced; sourceTree = "<group>"; };
+    414141414141414141414141 = { isa = PBXFileSystemSynchronizedBuildFileExceptionSet; membershipExceptions = ( "Excluded/Auth.swift", ); platformFiltersByRelativePath = { MacOnly.swift = ( macos, ); }; target = ${IOS_FIXTURE_IDS.appTarget}; };
+    424242424242424242424242 = { isa = PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet; buildPhase = ${IOS_FIXTURE_IDS.sourcesPhase}; membershipExceptions = ( PhaseExcluded.swift, ); };
+    `;
+    await Bun.write(
+      projectFile,
+      original
+        .replace(
+          `productType = "com.apple.product-type.application";\n      packageProductDependencies`,
+          `productType = "com.apple.product-type.application";\n      fileSystemSynchronizedGroups = ( 404040404040404040404040, );\n      packageProductDependencies`,
+        )
+        .replace(
+          `${IOS_FIXTURE_IDS.projectConfigList} = { isa = XCConfigurationList;`,
+          `${synchronizedObjects}\n    ${IOS_FIXTURE_IDS.projectConfigList} = { isa = XCConfigurationList;`,
+        ),
+    );
+    await mkdir(join(root, "Synced", "Included"), { recursive: true });
+    await mkdir(join(root, "Synced", "Excluded"), { recursive: true });
+    await Bun.write(
+      join(root, "Synced", "Included", "Auth.swift"),
+      "import ClerkKitUI\nstruct Included { let view = AuthView() }\n",
+    );
+    await Bun.write(
+      join(root, "Synced", "Excluded", "Auth.swift"),
+      "import ClerkKitUI\nstruct Excluded { let view = AuthView() }\n",
+    );
+    await Bun.write(
+      join(root, "Synced", "PhaseExcluded.swift"),
+      "import ClerkKit\nfunc excluded() { Clerk.configure(publishableKey: key) }\n",
+    );
+    await Bun.write(
+      join(root, "Synced", "MacOnly.swift"),
+      "import ClerkKit\nfunc macOnly() { Clerk.configure(publishableKey: key) }\n",
+    );
+
+    const inspection = await inspectIOSProject(root);
+    const swift = inspection.appTargets[0]?.swift;
+
+    expect(swift?.sourceFilesScanned).toBe(2);
+    expect(swift?.authFlowReferences).toEqual([{ path: "Synced/Included/Auth.swift" }]);
+    expect(swift?.configureCalls).toEqual([]);
+  });
+
+  test("does not use Catalyst-only classic build-file membership as native iOS evidence", async () => {
+    const root = await fixture({ complete: true });
+    const projectFile = join(root, "MyApp.xcodeproj", "project.pbxproj");
+    const original = await Bun.file(projectFile).text();
+    await Bun.write(
+      projectFile,
+      original
+        .replace(
+          `${IOS_FIXTURE_IDS.sourceBuildFile} = { isa = PBXBuildFile; fileRef`,
+          `${IOS_FIXTURE_IDS.sourceBuildFile} = { isa = PBXBuildFile; platformFilters = ( maccatalyst, ); fileRef`,
+        )
+        .replace(
+          `${IOS_FIXTURE_IDS.clerkKitBuildFile} = { isa = PBXBuildFile; productRef`,
+          `${IOS_FIXTURE_IDS.clerkKitBuildFile} = { isa = PBXBuildFile; platformFilters = ( maccatalyst, ); productRef`,
+        ),
+    );
+
+    const inspection = await inspectIOSProject(root);
+    const target = inspection.appTargets[0];
+
+    expect(target?.swift.sourceFilesScanned).toBe(0);
+    expect(target?.swift.configureCalls).toEqual([]);
+    expect(target?.packages.clerkKit).toBe("declared");
+  });
+
+  test("does not use unknown classic build-file filters as authoritative iOS evidence", async () => {
+    const root = await fixture({ complete: true });
+    const projectFile = join(root, "MyApp.xcodeproj", "project.pbxproj");
+    const original = await Bun.file(projectFile).text();
+    await Bun.write(
+      projectFile,
+      original
+        .replace(
+          `${IOS_FIXTURE_IDS.sourceBuildFile} = { isa = PBXBuildFile; fileRef`,
+          `${IOS_FIXTURE_IDS.sourceBuildFile} = { isa = PBXBuildFile; platformFilter = futureos; fileRef`,
+        )
+        .replace(
+          `${IOS_FIXTURE_IDS.clerkKitBuildFile} = { isa = PBXBuildFile; productRef`,
+          `${IOS_FIXTURE_IDS.clerkKitBuildFile} = { isa = PBXBuildFile; platformFilter = futureos; productRef`,
+        ),
+    );
+
+    const inspection = await inspectIOSProject(root);
+    const target = inspection.appTargets[0];
+
+    expect(target?.swift.sourceFilesScanned).toBe(0);
+    expect(target?.swift.evidenceComplete).toBe(false);
+    expect(target?.packages.clerkKit).toBe("declared");
+  });
+
+  test("does not use non-iOS or unknown LocalSecrets resource membership as a native key", async () => {
+    for (const platformFilter of ["maccatalyst", "futureos"]) {
+      const root = await fixture({ includeKey: false, localSecrets: true });
+      const projectFile = join(root, "MyApp.xcodeproj", "project.pbxproj");
+      const original = await Bun.file(projectFile).text();
+      await Bun.write(
+        projectFile,
+        original.replace(
+          `${IOS_FIXTURE_IDS.localSecretsBuildFile} = { isa = PBXBuildFile; fileRef`,
+          `${IOS_FIXTURE_IDS.localSecretsBuildFile} = { isa = PBXBuildFile; platformFilter = ${platformFilter}; fileRef`,
+        ),
+      );
+
+      const inspection = await inspectIOSProject(root);
+
+      expect(inspection.localPublishableKey).toEqual({
+        found: false,
+        conflict: false,
+        candidateSources: [],
+        invalidSources: [],
+      });
+    }
+  });
+
+  test("reports malformed projects as blocked evidence", async () => {
+    const root = await mkdtemp(join(tmpdir(), "clerk-ios-inspect-"));
+    temporaryDirectories.push(root);
+    await mkdir(join(root, "Broken.xcodeproj"));
+    await Bun.write(join(root, "Broken.xcodeproj", "project.pbxproj"), "{ objects = (");
+
+    const inspection = await inspectIOSProject(root);
+
+    expect(inspection.selection.state).toBe("none");
+    expect(
+      inspection.diagnostics.some((diagnostic) => diagnostic.code === "xcode.malformed-project"),
+    ).toBe(true);
+  });
+
+  test("detects generated projects and never mutates the inspected tree", async () => {
+    const root = await fixture({ complete: true, generated: "xcodegen" });
+    const before = await treeDigest(root);
+
+    const inspection = await inspectIOSProject(root);
+
+    expect(inspection.generatedProject).toBe("xcodegen");
+    expect(await treeDigest(root)).toEqual(before);
+  });
+});

--- a/packages/cli-core/src/commands/init/ios/inspect.ts
+++ b/packages/cli-core/src/commands/init/ios/inspect.ts
@@ -12,6 +12,7 @@ import {
 import {
   discoverIOSContainers,
   inspectWorkspace,
+  maskXMLComments,
   pathIsSafelyWithinIOSRoot,
   relativeIOSPath,
   xmlAttribute,
@@ -216,7 +217,7 @@ async function schemePublishableKeyCandidates(
     if (!(await file.exists()) || file.size > 2_000_000) continue;
     let xml: string;
     try {
-      xml = (await file.text()).replace(/<!--[\s\S]*?-->/g, "");
+      xml = maskXMLComments(await file.text());
     } catch {
       continue;
     }

--- a/packages/cli-core/src/commands/init/ios/inspect.ts
+++ b/packages/cli-core/src/commands/init/ios/inspect.ts
@@ -1,0 +1,1662 @@
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, extname, relative, resolve, sep } from "node:path";
+import plist from "@expo/plist";
+import { parse as parsePbxProject } from "@bacons/xcode/json";
+import { parseEnvFile } from "../../../lib/dotenv.ts";
+import { decodePublishableKey } from "../../../lib/fapi.ts";
+import {
+  addBuildSettingConflictDiagnostics,
+  inspectTargetBuildConfigurations,
+  resolveEntitlementsAbsolutePath,
+} from "./build-settings.ts";
+import {
+  discoverIOSContainers,
+  inspectWorkspace,
+  pathIsSafelyWithinIOSRoot,
+  relativeIOSPath,
+  xmlAttribute,
+} from "./discovery.ts";
+import {
+  asString,
+  asStringArray,
+  asStringRecord,
+  buildPbxParentIndex,
+  isClerkIOSRepository,
+  isRecord,
+  resolvePbxFilePath,
+  sanitizeRepositoryURL,
+  type PbxObject,
+  type PbxObjects,
+} from "./pbx.ts";
+import { inspectSwiftSources } from "./swift.ts";
+import type {
+  IOSAppTarget,
+  IOSBuildConfiguration,
+  IOSClerkPackageState,
+  IOSDiagnostic,
+  IOSEntitlementsInspection,
+  IOSPackageReference,
+  IOSProductLinkState,
+  IOSProjectInspection,
+  IOSProjectInspectionResult,
+  IOSSourceEvidence,
+  IOSTargetSelection,
+} from "./types.ts";
+
+const APP_PRODUCT_TYPE = "com.apple.product-type.application";
+const MAX_PBXPROJ_BYTES = 15_000_000;
+const MAX_SOURCE_FILES = 2_500;
+const MAX_SOURCE_DEPTH = 24;
+const MAX_SECRET_DISCOVERY_DEPTH = 5;
+const MAX_SECRET_FILES = 20;
+const SOURCE_IGNORES = new Set([
+  ".build",
+  ".git",
+  ".swiftpm",
+  "build",
+  "Carthage",
+  "DerivedData",
+  "Pods",
+  "SourcePackages",
+]);
+
+interface ParsedProject {
+  inspection: IOSProjectInspection;
+  appTargets: IOSAppTarget[];
+  appTargetCandidates: Array<{ targetId: string; targetName: string; projectPath: string }>;
+  diagnostics: IOSDiagnostic[];
+  sourceMemberships?: IOSTargetSourceMembership[];
+}
+
+export interface IOSTargetSourceMembership {
+  targetId: string;
+  targetName: string;
+  projectPath: string;
+  files: Array<{ absolutePath: string; relativePath: string }>;
+  complete: boolean;
+}
+
+const sourceMembershipByInspection = new WeakMap<
+  IOSProjectInspectionResult,
+  IOSTargetSourceMembership[]
+>();
+
+function emptySwiftInspection() {
+  return {
+    sourceFilesScanned: 0,
+    evidenceComplete: false,
+    entryPoints: [],
+    importsClerkKit: [],
+    importsClerkKitUI: [],
+    configureCalls: [],
+    localSecretsRuntimeBindings: [],
+    environmentInjections: [],
+    environmentConsumers: [],
+    authFlowReferences: [],
+    openURLHandlers: [],
+    status: "absent" as const,
+  };
+}
+
+function normalizeObjects(value: unknown): PbxObjects | undefined {
+  if (!isRecord(value)) return undefined;
+  const objects: PbxObjects = {};
+  for (const [id, object] of Object.entries(value)) {
+    if (isRecord(object)) objects[id] = object;
+  }
+  return objects;
+}
+
+function canonicalRequirement(value: unknown): Record<string, string> | undefined {
+  const requirement = asStringRecord(value);
+  return Object.keys(requirement).length > 0 ? requirement : undefined;
+}
+
+function buildFileIOSApplicability(object: PbxObject): {
+  applies: boolean;
+  recognized: boolean;
+} {
+  const platformFilter = asString(object.platformFilter);
+  const filters = [
+    ...asStringArray(object.platformFilters),
+    ...(platformFilter ? [platformFilter] : []),
+  ];
+  if (filters.length === 0) return { applies: true, recognized: true };
+  if (filters.some((filter) => /(?:^|[^a-z])(?:ios|iphone)/i.test(filter))) {
+    return { applies: true, recognized: true };
+  }
+  const recognized = filters.every((filter) =>
+    /(?:maccatalyst|macos|tvos|watchos|xros|visionos|driverkit)/i.test(filter),
+  );
+  return { applies: false, recognized };
+}
+
+interface PublishableKeyCandidate {
+  value?: string;
+  decoded?: { frontendApiHost: string; instanceType: "development" | "production" };
+  invalid?: true;
+  source: string;
+  evidence: IOSSourceEvidence[];
+  priority: number;
+  ambient?: true;
+}
+
+async function collectSchemeFiles(
+  root: string,
+  directory: string,
+  output: string[],
+  depth = 0,
+): Promise<void> {
+  if (depth > 6 || output.length >= 100) return;
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+  for (const entry of entries) {
+    const path = resolve(directory, entry.name);
+    if (entry.isDirectory()) {
+      await collectSchemeFiles(root, path, output, depth + 1);
+    } else if (
+      entry.isFile() &&
+      entry.name.endsWith(".xcscheme") &&
+      (await pathIsSafelyWithinIOSRoot(root, path))
+    ) {
+      output.push(path);
+    }
+  }
+}
+
+function enclosingXcodeContainer(path: string): string | undefined {
+  let current = dirname(path);
+  while (true) {
+    if (current.endsWith(".xcodeproj") || current.endsWith(".xcworkspace")) return current;
+    const parent = dirname(current);
+    if (parent === current) return undefined;
+    current = parent;
+  }
+}
+
+function schemeReferencesSelectedProject(
+  root: string,
+  schemePath: string,
+  selectedProjectPath: string,
+  referencedContainer: string | undefined,
+): boolean {
+  const selectedProject = resolve(root, selectedProjectPath);
+  const enclosingContainer = enclosingXcodeContainer(schemePath);
+  if (!referencedContainer) {
+    return (
+      enclosingContainer?.endsWith(".xcodeproj") === true && enclosingContainer === selectedProject
+    );
+  }
+  const base = enclosingContainer ? dirname(enclosingContainer) : root;
+  const normalized = referencedContainer.replaceAll("\\", "/");
+  return resolve(base, ...normalized.split("/")) === selectedProject;
+}
+
+async function schemePublishableKeyCandidates(
+  root: string,
+  selection: IOSTargetSelection,
+  schemeRoots: string[],
+): Promise<PublishableKeyCandidate[]> {
+  if (selection.state !== "selected") return [];
+  const schemePaths: string[] = [];
+  for (const schemeRoot of [...new Set(schemeRoots)].sort()) {
+    if (await pathIsSafelyWithinIOSRoot(root, schemeRoot)) {
+      await collectSchemeFiles(root, schemeRoot, schemePaths);
+    }
+  }
+  const candidates: PublishableKeyCandidate[] = [];
+
+  for (const path of schemePaths.sort()) {
+    const file = Bun.file(path);
+    if (!(await file.exists()) || file.size > 2_000_000) continue;
+    let xml: string;
+    try {
+      xml = (await file.text()).replace(/<!--[\s\S]*?-->/g, "");
+    } catch {
+      continue;
+    }
+
+    for (const launchAction of xml.matchAll(/<LaunchAction\b[^>]*>([\s\S]*?)<\/LaunchAction>/g)) {
+      const body = launchAction[1] ?? "";
+      const referencesTarget = [...body.matchAll(/<BuildableReference\b([^>]*)>/g)].some(
+        (reference) => {
+          const attributes = reference[1] ?? "";
+          if (xmlAttribute(attributes, "BlueprintIdentifier") !== selection.targetId) {
+            return false;
+          }
+          const container = xmlAttribute(attributes, "ReferencedContainer")?.replace(
+            /^container:/,
+            "",
+          );
+          return schemeReferencesSelectedProject(root, path, selection.projectPath, container);
+        },
+      );
+      if (!referencesTarget) continue;
+
+      for (const variable of body.matchAll(/<EnvironmentVariable\b([^>]*)\/?\s*>/g)) {
+        const attributes = variable[1] ?? "";
+        if (xmlAttribute(attributes, "key") !== "CLERK_PUBLISHABLE_KEY") continue;
+        if ((xmlAttribute(attributes, "isEnabled") ?? "YES").toUpperCase() === "NO") continue;
+        const value = xmlAttribute(attributes, "value")?.trim();
+        if (!value) continue;
+        const source = relativeIOSPath(root, path);
+        candidates.push({
+          value,
+          source,
+          evidence: [{ path: source, keyPath: "LaunchAction.EnvironmentVariables" }],
+          priority: 5,
+        });
+      }
+    }
+  }
+  return candidates;
+}
+
+async function collectLocalSecretsPlists(
+  root: string,
+  directory: string,
+  output: string[],
+  depth = 0,
+): Promise<void> {
+  if (depth > MAX_SECRET_DISCOVERY_DEPTH || output.length >= MAX_SECRET_FILES) return;
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+  for (const entry of entries) {
+    if (output.length >= MAX_SECRET_FILES) return;
+    const absolutePath = resolve(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (!SOURCE_IGNORES.has(entry.name) && !entry.name.startsWith(".")) {
+        await collectLocalSecretsPlists(root, absolutePath, output, depth + 1);
+      }
+    } else if (
+      entry.isFile() &&
+      entry.name === "LocalSecrets.plist" &&
+      (await pathIsSafelyWithinIOSRoot(root, absolutePath))
+    ) {
+      output.push(absolutePath);
+    }
+  }
+}
+
+async function readPublishableKeyCandidates(
+  root: string,
+  selection: IOSTargetSelection,
+  targetLocalSecretsPaths: string[],
+  schemeRoots: string[],
+  inlineCandidates: PublishableKeyCandidate[],
+): Promise<PublishableKeyCandidate[]> {
+  const selectedProjectDirectory =
+    selection.state === "selected" ? dirname(resolve(root, selection.projectPath)) : root;
+  const projectDirectories = [...new Set([selectedProjectDirectory, root])];
+  const candidates: PublishableKeyCandidate[] = [
+    ...inlineCandidates,
+    ...(await schemePublishableKeyCandidates(root, selection, schemeRoots)),
+  ];
+
+  for (const directory of projectDirectories) {
+    for (const [fileName, priority] of [
+      [".env.local", 20],
+      [".env", 30],
+    ] as const) {
+      const path = resolve(directory, fileName);
+      if (!(await pathIsSafelyWithinIOSRoot(root, path))) continue;
+      const file = Bun.file(path);
+      if (!(await file.exists()) || file.size > 1_000_000) continue;
+      try {
+        for (const line of parseEnvFile(await file.text())) {
+          if (line.type === "entry" && line.key === "CLERK_PUBLISHABLE_KEY" && line.value) {
+            candidates.push({
+              value: line.value,
+              source: relativeIOSPath(root, path),
+              evidence: [{ path: relativeIOSPath(root, path), keyPath: line.key }],
+              priority,
+            });
+          }
+        }
+      } catch {
+        // A partially-written env file is not evidence of a usable key.
+      }
+    }
+  }
+
+  for (const path of targetLocalSecretsPaths) {
+    const file = Bun.file(path);
+    if (!(await file.exists()) || file.size > 1_000_000) continue;
+    try {
+      const parsed: unknown = plist.parse(await file.text());
+      const value = isRecord(parsed) ? asString(parsed.CLERK_PUBLISHABLE_KEY) : undefined;
+      if (value) {
+        candidates.push({
+          value,
+          source: relativeIOSPath(root, path),
+          evidence: [{ path: relativeIOSPath(root, path), keyPath: "CLERK_PUBLISHABLE_KEY" }],
+          priority: 10,
+        });
+      }
+    } catch {
+      // Binary/malformed secret files are ignored rather than printing parser data.
+    }
+  }
+
+  for (const directory of projectDirectories) {
+    const path = resolve(directory, ".clerk", ".tmp", "keyless.json");
+    if (!(await pathIsSafelyWithinIOSRoot(root, path))) continue;
+    const file = Bun.file(path);
+    if (!(await file.exists()) || file.size > 1_000_000) continue;
+    try {
+      const parsed: unknown = await file.json();
+      const value = isRecord(parsed) ? asString(parsed.publishableKey) : undefined;
+      if (value) {
+        candidates.push({
+          value,
+          source: relativeIOSPath(root, path),
+          evidence: [{ path: relativeIOSPath(root, path), keyPath: "publishableKey" }],
+          priority: 40,
+        });
+      }
+    } catch {
+      // A partially-written SDK keyless file is not evidence of a usable key.
+    }
+  }
+
+  const ambient = process.env.CLERK_PUBLISHABLE_KEY;
+  if (ambient) {
+    candidates.push({
+      value: ambient,
+      source: "CLERK_PUBLISHABLE_KEY environment variable",
+      evidence: [],
+      priority: 50,
+      ambient: true,
+    });
+  }
+
+  return candidates.sort((a, b) => a.priority - b.priority || a.source.localeCompare(b.source));
+}
+
+async function inspectLocalPublishableKeys(
+  root: string,
+  selection: IOSTargetSelection,
+  targetLocalSecretsPaths: string[],
+  schemeRoots: string[],
+  inlineCandidates: PublishableKeyCandidate[],
+  diagnostics: IOSDiagnostic[],
+): Promise<IOSProjectInspectionResult["localPublishableKey"]> {
+  const candidates = await readPublishableKeyCandidates(
+    root,
+    selection,
+    targetLocalSecretsPaths,
+    schemeRoots,
+    inlineCandidates,
+  );
+  const candidateSources = [...new Set(candidates.map((candidate) => candidate.source))].sort();
+  const decodedCandidates: Array<{
+    candidate: PublishableKeyCandidate;
+    decoded?: { frontendApiHost: string; instanceType: "development" | "production" };
+  }> = [];
+  const invalidSources = new Set<string>();
+  for (const candidate of candidates) {
+    if (candidate.decoded) {
+      decodedCandidates.push({ candidate, decoded: candidate.decoded });
+      continue;
+    }
+    try {
+      if (candidate.invalid || candidate.value == null) throw new Error("invalid candidate");
+      const value = decodePublishableKey(candidate.value);
+      decodedCandidates.push({
+        candidate,
+        decoded: { frontendApiHost: value.fapiHost, instanceType: value.instanceType },
+      });
+    } catch {
+      invalidSources.add(candidate.source);
+      decodedCandidates.push({ candidate });
+      diagnostics.push({
+        code: "clerk.invalid-publishable-key",
+        severity: "warning",
+        message: `A publishable key candidate from ${candidate.source} has an invalid format.`,
+        remedy: "Replace it with a valid pk_test_ or pk_live_ publishable key.",
+        evidence: candidate.evidence,
+      });
+    }
+  }
+
+  const localCandidates = decodedCandidates.filter((item) => !item.candidate.ambient);
+  const ambientCandidates = decodedCandidates.filter((item) => item.candidate.ambient);
+  const effectivePriority = localCandidates[0]?.candidate.priority;
+  const effectiveCandidates =
+    effectivePriority == null
+      ? ambientCandidates
+      : localCandidates.filter((item) => item.candidate.priority === effectivePriority);
+
+  // A non-empty higher-precedence source is what the app/CLI will consume.
+  // Never fall through to a lower-precedence valid key when that source is malformed.
+  if (effectiveCandidates.some((item) => !item.decoded)) {
+    return {
+      found: false,
+      source: effectiveCandidates[0]!.candidate.source,
+      conflict: false,
+      candidateSources,
+      invalidSources: [...invalidSources].sort(),
+    };
+  }
+
+  const effectiveValid = effectiveCandidates.filter(
+    (
+      item,
+    ): item is typeof item & {
+      decoded: { frontendApiHost: string; instanceType: "development" | "production" };
+    } => item.decoded != null,
+  );
+  const identities = new Set(
+    effectiveValid.map((item) => `${item.decoded.instanceType}:${item.decoded.frontendApiHost}`),
+  );
+  const effective = effectiveValid[0];
+
+  if (identities.size > 1) {
+    diagnostics.push({
+      code: "clerk.conflicting-publishable-keys",
+      severity: "error",
+      message: "Equally effective publishable-key sources point to different Clerk instances.",
+      remedy: "Remove the stale source or make the equally preferred values agree.",
+      evidence: effectiveValid.flatMap((item) => item.candidate.evidence),
+    });
+    return {
+      found: true,
+      source: effective!.candidate.source,
+      conflict: true,
+      candidateSources,
+      invalidSources: [...invalidSources].sort(),
+    };
+  }
+
+  if (!effective) {
+    return {
+      found: false,
+      conflict: false,
+      candidateSources,
+      invalidSources: [...invalidSources].sort(),
+    };
+  }
+  return {
+    found: true,
+    conflict: false,
+    source: effective.candidate.source,
+    frontendApiHost: effective.decoded.frontendApiHost,
+    instanceType: effective.decoded.instanceType,
+    candidateSources,
+    invalidSources: [...invalidSources].sort(),
+  };
+}
+
+async function localPackageIsClerk(root: string, packagePath: string): Promise<boolean> {
+  const manifestPath = resolve(packagePath, "Package.swift");
+  if (!(await pathIsSafelyWithinIOSRoot(root, manifestPath))) return false;
+  const manifest = Bun.file(manifestPath);
+  if (!(await manifest.exists()) || manifest.size > 1_000_000) return false;
+  try {
+    const source = await manifest.text();
+    return /\b(?:ClerkKit|ClerkKitUI)\b/.test(source);
+  } catch {
+    return false;
+  }
+}
+
+async function inspectPackageReferences(
+  root: string,
+  projectPath: string,
+  projectObject: PbxObject,
+  objects: PbxObjects,
+): Promise<IOSPackageReference[]> {
+  const packageIds = new Set(asStringArray(projectObject.packageReferences));
+  // Some modern/local project layouts leave the project-level list partial.
+  // Preserve any package object the target graph can still reference.
+  for (const [id, object] of Object.entries(objects)) {
+    if (
+      object.isa === "XCRemoteSwiftPackageReference" ||
+      object.isa === "XCLocalSwiftPackageReference"
+    ) {
+      packageIds.add(id);
+    }
+  }
+
+  const packages: IOSPackageReference[] = [];
+  for (const objectId of [...packageIds].sort()) {
+    const object = objects[objectId];
+    if (object?.isa === "XCRemoteSwiftPackageReference") {
+      const rawRepository = asString(object.repositoryURL);
+      if (!rawRepository) continue;
+      const repository = sanitizeRepositoryURL(rawRepository);
+      packages.push({
+        kind: "remote",
+        objectId,
+        repository,
+        requirement: canonicalRequirement(object.requirement),
+        isClerk: isClerkIOSRepository(repository),
+      });
+    } else if (object?.isa === "XCLocalSwiftPackageReference") {
+      const relativePath = asString(object.relativePath);
+      if (!relativePath) continue;
+      const absolutePath = resolve(dirname(projectPath), relativePath);
+      const safelyLocal = await pathIsSafelyWithinIOSRoot(root, absolutePath);
+      packages.push({
+        kind: "local",
+        objectId,
+        path: safelyLocal ? relativeIOSPath(root, absolutePath) : absolutePath,
+        isClerk: safelyLocal && (await localPackageIsClerk(root, absolutePath)),
+      });
+    }
+  }
+  return packages;
+}
+
+function targetProductState(
+  targetObject: PbxObject,
+  objects: PbxObjects,
+  productName: "ClerkKit" | "ClerkKitUI",
+): { state: IOSProductLinkState; productIds: string[]; packageIds: string[] } {
+  const targetProductIds = asStringArray(targetObject.packageProductDependencies);
+  const matchingProductIds = targetProductIds.filter((id) => {
+    const product = objects[id];
+    return (
+      product?.isa === "XCSwiftPackageProductDependency" && product.productName === productName
+    );
+  });
+  if (matchingProductIds.length === 0) {
+    return { state: "absent", productIds: [], packageIds: [] };
+  }
+
+  const linkedProductIds = new Set<string>();
+  for (const phaseId of asStringArray(targetObject.buildPhases)) {
+    const phase = objects[phaseId];
+    if (phase?.isa !== "PBXFrameworksBuildPhase") continue;
+    for (const buildFileId of asStringArray(phase.files)) {
+      const buildFile = objects[buildFileId];
+      if (!buildFile || !buildFileIOSApplicability(buildFile).applies) continue;
+      const productRef = asString(buildFile.productRef);
+      if (productRef) linkedProductIds.add(productRef);
+    }
+  }
+
+  const packageIds = matchingProductIds
+    .map((id) => asString(objects[id]?.package))
+    .filter((id): id is string => id != null);
+  return {
+    state: matchingProductIds.some((id) => linkedProductIds.has(id)) ? "linked" : "declared",
+    productIds: matchingProductIds,
+    packageIds,
+  };
+}
+
+function inspectTargetPackages(
+  root: string,
+  projectPath: string,
+  targetName: string,
+  targetObject: PbxObject,
+  objects: PbxObjects,
+  packages: IOSPackageReference[],
+  diagnostics: IOSDiagnostic[],
+): IOSClerkPackageState {
+  const clerkKit = targetProductState(targetObject, objects, "ClerkKit");
+  const clerkKitUI = targetProductState(targetObject, objects, "ClerkKitUI");
+  const packageById = new Map(packages.map((item) => [item.objectId, item]));
+  const productPackageIds = [...clerkKit.packageIds, ...clerkKitUI.packageIds];
+  const attributed = productPackageIds
+    .map((id) => packageById.get(id))
+    .filter((item): item is IOSPackageReference => item?.isClerk === true);
+  const declaredClerkPackage = packages.find((item) => item.isClerk);
+  const hasClerkProduct = clerkKit.state !== "absent" || clerkKitUI.state !== "absent";
+
+  let packageKind: IOSClerkPackageState["package"] = "absent";
+  if (attributed[0]) packageKind = attributed[0].kind;
+  else if (declaredClerkPackage) packageKind = declaredClerkPackage.kind;
+  else if (hasClerkProduct) {
+    packageKind = "unattributed";
+    diagnostics.push({
+      code: "clerk.package-unattributed",
+      severity: "warning",
+      message: `${targetName} declares a Clerk product without an attributable clerk-ios package reference. This can be valid for a workspace-local package, but should be reviewed.`,
+      evidence: [...clerkKit.productIds, ...clerkKitUI.productIds].map((objectId) => ({
+        path: relativeIOSPath(root, resolve(projectPath, "project.pbxproj")),
+        objectId,
+      })),
+    });
+  }
+
+  return { package: packageKind, clerkKit: clerkKit.state, clerkKitUI: clerkKitUI.state };
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+async function inspectEntitlements(
+  root: string,
+  absolutePath: string,
+  evidence: IOSSourceEvidence[],
+  diagnostics: IOSDiagnostic[],
+): Promise<IOSEntitlementsInspection | undefined> {
+  const relativePath = relativeIOSPath(root, absolutePath);
+  const file = Bun.file(absolutePath);
+  if (!(await file.exists())) {
+    diagnostics.push({
+      code: "xcode.missing-entitlements",
+      severity: "warning",
+      message: `The configured entitlements file does not exist: ${relativePath}`,
+      remedy: "Create the file in Xcode or update CODE_SIGN_ENTITLEMENTS.",
+      evidence,
+    });
+    return undefined;
+  }
+
+  try {
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    if (new TextDecoder().decode(bytes.slice(0, 8)).startsWith("bplist")) {
+      throw new Error("binary plist");
+    }
+    const parsed: unknown = plist.parse(new TextDecoder().decode(bytes));
+    if (!isRecord(parsed)) throw new Error("plist root is not a dictionary");
+
+    const applicationIdentifier = asString(parsed["application-identifier"]);
+    return {
+      path: relativePath,
+      associatedDomains: stringArray(parsed["com.apple.developer.associated-domains"]).sort(),
+      unresolvedAssociatedDomains: [],
+      applicationIdentifier,
+      teamIdentifier: asString(parsed["com.apple.developer.team-identifier"]),
+      signInWithApple: stringArray(parsed["com.apple.developer.applesignin"]).length > 0,
+    };
+  } catch {
+    diagnostics.push({
+      code: "xcode.unreadable-entitlements",
+      severity: "warning",
+      message: `Could not inspect entitlements at ${relativePath}. Only XML plist entitlements are read in portable mode.`,
+      remedy: "Open the file in Xcode and save it as XML, then rerun the inspector.",
+      evidence,
+    });
+    return undefined;
+  }
+}
+
+async function attachEntitlements(
+  root: string,
+  projectPath: string,
+  configurations: IOSBuildConfiguration[],
+  settingsByConfiguration: Map<string, Record<string, string>>,
+  diagnostics: IOSDiagnostic[],
+): Promise<void> {
+  const cache = new Map<string, IOSEntitlementsInspection | undefined>();
+  for (const configuration of configurations) {
+    if (configuration.entitlementsPath.state !== "resolved") continue;
+    const absolutePath = resolveEntitlementsAbsolutePath(
+      root,
+      projectPath,
+      configuration.entitlementsPath,
+    );
+    if (!absolutePath) {
+      diagnostics.push({
+        code: "xcode.external-path",
+        severity: "warning",
+        message: `${configuration.name} resolves CODE_SIGN_ENTITLEMENTS outside the inspected root.`,
+        evidence: configuration.entitlementsPath.evidence,
+      });
+      continue;
+    }
+    if (!(await pathIsSafelyWithinIOSRoot(root, absolutePath))) {
+      diagnostics.push({
+        code: "xcode.external-path",
+        severity: "warning",
+        message: `${configuration.name} resolves CODE_SIGN_ENTITLEMENTS through a path outside the inspected root.`,
+        evidence: configuration.entitlementsPath.evidence,
+      });
+      continue;
+    }
+    if (!cache.has(absolutePath)) {
+      cache.set(
+        absolutePath,
+        await inspectEntitlements(
+          root,
+          absolutePath,
+          configuration.entitlementsPath.evidence,
+          diagnostics,
+        ),
+      );
+    }
+    const entitlements = cache.get(absolutePath);
+    if (!entitlements) continue;
+
+    const settings = settingsByConfiguration.get(configuration.name) ?? {};
+    const resolvedAssociatedDomains: string[] = [];
+    const unresolvedAssociatedDomains: string[] = [];
+    for (const domain of entitlements.associatedDomains) {
+      const expanded = expandEntitlementDomain(
+        domain,
+        settings,
+        configuration.bundleIdentifier.state === "resolved"
+          ? configuration.bundleIdentifier.value
+          : undefined,
+      );
+      if (expanded) resolvedAssociatedDomains.push(expanded);
+      else unresolvedAssociatedDomains.push(domain);
+    }
+    if (unresolvedAssociatedDomains.length > 0) {
+      diagnostics.push({
+        code: "xcode.unresolved-build-setting",
+        severity: "warning",
+        message: `${configuration.name} has associated-domain values with unresolved build settings.`,
+        remedy:
+          "Resolve the variables in the entitlements configuration before relying on domain checks.",
+        evidence: configuration.entitlementsPath.evidence,
+      });
+    }
+
+    const applicationIdentifier = entitlements.applicationIdentifier;
+    const prefixMatch = /^([A-Z0-9]{10})\.(.+)$/.exec(applicationIdentifier ?? "");
+    const literalAppIdentifierPrefix =
+      prefixMatch &&
+      configuration.bundleIdentifier.state === "resolved" &&
+      prefixMatch[2] === configuration.bundleIdentifier.value
+        ? prefixMatch[1]
+        : undefined;
+    configuration.entitlements = {
+      ...entitlements,
+      associatedDomains: resolvedAssociatedDomains.sort(),
+      unresolvedAssociatedDomains: unresolvedAssociatedDomains.sort(),
+      ...(literalAppIdentifierPrefix ? { literalAppIdentifierPrefix } : {}),
+    };
+  }
+}
+
+function expandEntitlementDomain(
+  raw: string,
+  settings: Record<string, string>,
+  bundleIdentifier: string | undefined,
+): string | undefined {
+  const variable = /\$\(([^)]+)\)|\$\{([^}]+)\}/g;
+  const builtins: Record<string, string | undefined> = {
+    CFBundleIdentifier: bundleIdentifier,
+    PRODUCT_BUNDLE_IDENTIFIER: bundleIdentifier,
+  };
+  const resolving = new Set<string>();
+  const expand = (value: string, depth: number): string | undefined => {
+    if (depth > 20) return undefined;
+    let unresolved = false;
+    variable.lastIndex = 0;
+    const expanded = value.replace(variable, (_match, parenthesized, braced) => {
+      const name = String(parenthesized ?? braced);
+      if (name.includes(":") || resolving.has(name)) {
+        unresolved = true;
+        return "";
+      }
+      const replacement = settings[name] ?? builtins[name];
+      if (replacement == null) {
+        unresolved = true;
+        return "";
+      }
+      resolving.add(name);
+      const nested = expand(replacement, depth + 1);
+      resolving.delete(name);
+      if (nested == null) unresolved = true;
+      return nested ?? "";
+    });
+    variable.lastIndex = 0;
+    return unresolved || variable.test(expanded) ? undefined : expanded;
+  };
+
+  const expanded = expand(raw, 0)?.trim();
+  if (!expanded || /pk_(?:test|live)_/i.test(expanded)) return undefined;
+  return expanded;
+}
+
+function normalizeSynchronizedPath(path: string): string {
+  return path.replaceAll("\\", "/").replace(/^\.\//, "").replace(/\/$/, "");
+}
+
+function synchronizedExclusions(
+  group: PbxObject,
+  targetId: string,
+  relevantPhaseIds: Set<string>,
+  objects: PbxObjects,
+): Set<string> {
+  const excluded = new Set<string>();
+  for (const exceptionId of asStringArray(group.exceptions)) {
+    const exception = objects[exceptionId];
+    const appliesToTarget =
+      exception?.isa === "PBXFileSystemSynchronizedBuildFileExceptionSet" &&
+      asString(exception.target) === targetId;
+    const appliesToPhase =
+      exception?.isa === "PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet" &&
+      relevantPhaseIds.has(asString(exception.buildPhase) ?? "");
+    if (!appliesToTarget && !appliesToPhase) continue;
+
+    for (const path of asStringArray(exception.membershipExceptions)) {
+      excluded.add(normalizeSynchronizedPath(path));
+    }
+    if (isRecord(exception.platformFiltersByRelativePath)) {
+      for (const [path, filters] of Object.entries(exception.platformFiltersByRelativePath)) {
+        const platformFilters = stringArray(filters);
+        if (
+          platformFilters.length > 0 &&
+          !platformFilters.some((filter) => /(?:^|[^a-z])(?:ios|iphone)/i.test(filter))
+        ) {
+          excluded.add(normalizeSynchronizedPath(path));
+        }
+      }
+    }
+  }
+  return excluded;
+}
+
+function synchronizedPathIsExcluded(path: string, excluded: Set<string>): boolean {
+  return [...excluded].some(
+    (excludedPath) => path === excludedPath || path.startsWith(`${excludedPath}/`),
+  );
+}
+
+async function localSecretsForTarget(options: {
+  root: string;
+  projectPath: string;
+  groupRootDirectory: string;
+  targetId: string;
+  targetObject: PbxObject;
+  objects: PbxObjects;
+  parents: Map<string, string>;
+}): Promise<string[]> {
+  const { root, projectPath, groupRootDirectory, targetId, targetObject, objects, parents } =
+    options;
+  const projectDirectory = dirname(projectPath);
+  const paths = new Set<string>();
+  const resourcePhaseIds = new Set(
+    asStringArray(targetObject.buildPhases).filter(
+      (phaseId) => objects[phaseId]?.isa === "PBXResourcesBuildPhase",
+    ),
+  );
+
+  for (const phaseId of resourcePhaseIds) {
+    const phase = objects[phaseId];
+    if (phase?.isa !== "PBXResourcesBuildPhase") continue;
+    for (const buildFileId of asStringArray(phase.files)) {
+      const buildFile = objects[buildFileId];
+      if (!buildFile || !buildFileIOSApplicability(buildFile).applies) continue;
+      const fileReference = asString(buildFile.fileRef);
+      if (!fileReference) continue;
+      const absolutePath = resolvePbxFilePath(
+        fileReference,
+        objects,
+        parents,
+        projectDirectory,
+        groupRootDirectory,
+      );
+      if (
+        absolutePath?.endsWith(`${sep}LocalSecrets.plist`) &&
+        (await pathIsSafelyWithinIOSRoot(root, absolutePath))
+      ) {
+        paths.add(absolutePath);
+      }
+    }
+  }
+
+  for (const groupId of asStringArray(targetObject.fileSystemSynchronizedGroups)) {
+    const group = objects[groupId];
+    if (group?.isa !== "PBXFileSystemSynchronizedRootGroup") continue;
+    const groupPath = resolvePbxFilePath(
+      groupId,
+      objects,
+      parents,
+      projectDirectory,
+      groupRootDirectory,
+    );
+    if (!groupPath || !(await pathIsSafelyWithinIOSRoot(root, groupPath))) continue;
+
+    const discovered: string[] = [];
+    await collectLocalSecretsPlists(root, groupPath, discovered);
+    const excluded = synchronizedExclusions(group, targetId, resourcePhaseIds, objects);
+    for (const absolutePath of discovered) {
+      const relativePath = relative(groupPath, absolutePath).split(sep).join("/");
+      if (!synchronizedPathIsExcluded(relativePath, excluded)) paths.add(absolutePath);
+    }
+  }
+
+  return [...paths].sort();
+}
+
+async function collectSwiftFiles(
+  root: string,
+  directory: string,
+  groupRoot: string,
+  excluded: Set<string>,
+  files: Map<string, { absolutePath: string; relativePath: string }>,
+  state: { complete: boolean },
+  depth = 0,
+): Promise<void> {
+  if (depth > MAX_SOURCE_DEPTH || files.size >= MAX_SOURCE_FILES) {
+    state.complete = false;
+    return;
+  }
+  if (!(await pathIsSafelyWithinIOSRoot(root, directory))) {
+    state.complete = false;
+    return;
+  }
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch {
+    state.complete = false;
+    return;
+  }
+
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+  for (const entry of entries) {
+    if (files.size >= MAX_SOURCE_FILES) {
+      state.complete = false;
+      return;
+    }
+    const absolutePath = resolve(directory, entry.name);
+    const pathFromGroup = relative(groupRoot, absolutePath).split(sep).join("/");
+    if (synchronizedPathIsExcluded(pathFromGroup, excluded)) {
+      continue;
+    }
+    if (entry.isDirectory()) {
+      if (!SOURCE_IGNORES.has(entry.name) && !entry.name.startsWith(".")) {
+        await collectSwiftFiles(root, absolutePath, groupRoot, excluded, files, state, depth + 1);
+      }
+    } else if (entry.isFile() && extname(entry.name) === ".swift") {
+      files.set(absolutePath, { absolutePath, relativePath: relativeIOSPath(root, absolutePath) });
+    } else if (entry.isSymbolicLink() && extname(entry.name) === ".swift") {
+      state.complete = false;
+    }
+  }
+}
+
+async function sourceFilesForTarget(options: {
+  root: string;
+  projectPath: string;
+  groupRootDirectory: string;
+  targetId: string;
+  targetObject: PbxObject;
+  objects: PbxObjects;
+  parents: Map<string, string>;
+  diagnostics: IOSDiagnostic[];
+}): Promise<{
+  files: Array<{ absolutePath: string; relativePath: string }>;
+  complete: boolean;
+}> {
+  const {
+    root,
+    projectPath,
+    groupRootDirectory,
+    targetId,
+    targetObject,
+    objects,
+    parents,
+    diagnostics,
+  } = options;
+  const projectDirectory = dirname(projectPath);
+  const files = new Map<string, { absolutePath: string; relativePath: string }>();
+  const state = { complete: true };
+  const projectEvidencePath = relativeIOSPath(root, resolve(projectPath, "project.pbxproj"));
+  const reportDangling = (objectId: string, message: string): void => {
+    state.complete = false;
+    diagnostics.push({
+      code: "xcode.dangling-reference",
+      severity: "warning",
+      message,
+      evidence: [{ path: projectEvidencePath, objectId }],
+    });
+  };
+  for (const phaseId of asStringArray(targetObject.buildPhases)) {
+    if (!objects[phaseId]) {
+      reportDangling(phaseId, `Target ${targetId} contains a dangling build phase reference.`);
+    }
+  }
+  const sourcePhaseIds = new Set(
+    asStringArray(targetObject.buildPhases).filter(
+      (phaseId) => objects[phaseId]?.isa === "PBXSourcesBuildPhase",
+    ),
+  );
+
+  for (const phaseId of sourcePhaseIds) {
+    const phase = objects[phaseId];
+    if (phase?.isa !== "PBXSourcesBuildPhase") continue;
+    for (const buildFileId of asStringArray(phase.files)) {
+      const buildFile = objects[buildFileId];
+      if (!buildFile) {
+        reportDangling(
+          buildFileId,
+          `Sources phase ${phaseId} contains a dangling build-file reference.`,
+        );
+        continue;
+      }
+      const applicability = buildFileIOSApplicability(buildFile);
+      if (!applicability.applies) {
+        if (!applicability.recognized) state.complete = false;
+        continue;
+      }
+      const fileReference = asString(buildFile.fileRef);
+      if (!fileReference) {
+        reportDangling(
+          buildFileId,
+          `Sources phase ${phaseId} contains a build file with no file reference.`,
+        );
+        continue;
+      }
+      if (!objects[fileReference]) {
+        reportDangling(
+          fileReference,
+          `Sources phase ${phaseId} contains a dangling file reference.`,
+        );
+        continue;
+      }
+      const absolutePath = resolvePbxFilePath(
+        fileReference,
+        objects,
+        parents,
+        projectDirectory,
+        groupRootDirectory,
+      );
+      if (!absolutePath) {
+        if (extname(asString(objects[fileReference]?.path) ?? "") === ".swift") {
+          state.complete = false;
+        }
+        continue;
+      }
+      if (extname(absolutePath) !== ".swift") continue;
+      if (!(await pathIsSafelyWithinIOSRoot(root, absolutePath))) {
+        state.complete = false;
+        diagnostics.push({
+          code: "xcode.external-path",
+          severity: "warning",
+          message: `Skipped Swift source outside the inspected root: ${absolutePath}`,
+          evidence: [{ path: absolutePath, objectId: fileReference }],
+        });
+        continue;
+      }
+      files.set(absolutePath, { absolutePath, relativePath: relativeIOSPath(root, absolutePath) });
+    }
+  }
+
+  for (const groupId of asStringArray(targetObject.fileSystemSynchronizedGroups)) {
+    const group = objects[groupId];
+    if (group?.isa !== "PBXFileSystemSynchronizedRootGroup") {
+      reportDangling(
+        groupId,
+        `Target ${targetId} contains an invalid synchronized-group reference.`,
+      );
+      continue;
+    }
+    const groupPath = resolvePbxFilePath(
+      groupId,
+      objects,
+      parents,
+      projectDirectory,
+      groupRootDirectory,
+    );
+    if (!groupPath) {
+      state.complete = false;
+      continue;
+    }
+    if (!(await pathIsSafelyWithinIOSRoot(root, groupPath))) {
+      state.complete = false;
+      diagnostics.push({
+        code: "xcode.external-path",
+        severity: "warning",
+        message: `Skipped synchronized source group outside the inspected root: ${groupPath}`,
+        evidence: [{ path: groupPath, objectId: groupId }],
+      });
+      continue;
+    }
+
+    const excluded = synchronizedExclusions(group, targetId, sourcePhaseIds, objects);
+    await collectSwiftFiles(root, groupPath, groupPath, excluded, files, state);
+  }
+
+  if (files.size === 0 || !state.complete) {
+    diagnostics.push({
+      code: "xcode.incomplete-source-membership",
+      severity: "info",
+      message:
+        files.size === 0
+          ? `No Swift source membership could be resolved for ${asString(targetObject.name) ?? targetId}; source-level Clerk checks may be incomplete.`
+          : `Swift source membership for ${asString(targetObject.name) ?? targetId} was only partially inspected; absence checks are advisory.`,
+      evidence: [
+        {
+          path: relativeIOSPath(root, resolve(projectPath, "project.pbxproj")),
+          objectId: targetId,
+        },
+      ],
+    });
+  }
+
+  return {
+    files: [...files.values()].sort((a, b) => a.relativePath.localeCompare(b.relativePath)),
+    complete: state.complete,
+  };
+}
+
+async function parseProject(
+  root: string,
+  projectPath: string,
+  requestedTarget?: string,
+): Promise<ParsedProject> {
+  const projectRelativePath = relativeIOSPath(root, projectPath);
+  const pbxprojPath = resolve(projectPath, "project.pbxproj");
+  const pbxprojRelativePath = relativeIOSPath(root, pbxprojPath);
+  const diagnostics: IOSDiagnostic[] = [];
+  const emptyInspection = (objectVersion?: string): IOSProjectInspection => ({
+    path: projectRelativePath,
+    pbxprojPath: pbxprojRelativePath,
+    objectVersion,
+    packages: [],
+    appTargetIds: [],
+    diagnostics,
+  });
+  if (!(await pathIsSafelyWithinIOSRoot(root, pbxprojPath))) {
+    diagnostics.push({
+      code: "xcode.external-path",
+      severity: "error",
+      message: `${projectRelativePath} resolves project.pbxproj outside the inspected root.`,
+      evidence: [{ path: pbxprojRelativePath }],
+    });
+    return { inspection: emptyInspection(), appTargets: [], appTargetCandidates: [], diagnostics };
+  }
+  const file = Bun.file(pbxprojPath);
+  if (!(await file.exists())) {
+    diagnostics.push({
+      code: "xcode.missing-project-file",
+      severity: "error",
+      message: `${projectRelativePath} does not contain project.pbxproj.`,
+      evidence: [{ path: pbxprojRelativePath }],
+    });
+    return { inspection: emptyInspection(), appTargets: [], appTargetCandidates: [], diagnostics };
+  }
+  if (file.size > MAX_PBXPROJ_BYTES) {
+    diagnostics.push({
+      code: "xcode.malformed-project",
+      severity: "error",
+      message: `${pbxprojRelativePath} is too large to inspect safely.`,
+      evidence: [{ path: pbxprojRelativePath }],
+    });
+    return { inspection: emptyInspection(), appTargets: [], appTargetCandidates: [], diagnostics };
+  }
+
+  let archive: Record<string, unknown>;
+  try {
+    const parsed: unknown = parsePbxProject(await readFile(pbxprojPath, "utf8"));
+    if (!isRecord(parsed)) throw new Error("invalid project root");
+    archive = parsed;
+  } catch (error) {
+    const parserLocation =
+      error instanceof Error
+        ? error.message.match(/\b(?:line|column|position)\s+\d+(?::\d+)?/i)?.[0]
+        : undefined;
+    diagnostics.push({
+      code: "xcode.malformed-project",
+      severity: "error",
+      // Parser messages can quote the surrounding pbxproj token. Do not echo
+      // arbitrary project content because shell phases sometimes hold secrets.
+      message: `Could not parse ${pbxprojRelativePath}${parserLocation ? ` (${parserLocation})` : ""}.`,
+      evidence: [{ path: pbxprojRelativePath }],
+    });
+    return { inspection: emptyInspection(), appTargets: [], appTargetCandidates: [], diagnostics };
+  }
+
+  const objectVersion = asString(archive.objectVersion);
+  const objects = normalizeObjects(archive.objects);
+  if (!objects) {
+    diagnostics.push({
+      code: "xcode.malformed-project",
+      severity: "error",
+      message: `${pbxprojRelativePath} has no readable Xcode object graph.`,
+      evidence: [{ path: pbxprojRelativePath }],
+    });
+    return {
+      inspection: emptyInspection(objectVersion),
+      appTargets: [],
+      appTargetCandidates: [],
+      diagnostics,
+    };
+  }
+
+  const rootObjectId = asString(archive.rootObject);
+  const projectObject =
+    (rootObjectId ? objects[rootObjectId] : undefined) ??
+    Object.values(objects).find((object) => object.isa === "PBXProject");
+  if (projectObject?.isa !== "PBXProject") {
+    diagnostics.push({
+      code: "xcode.malformed-project",
+      severity: "error",
+      message: `${pbxprojRelativePath} has no PBXProject root object.`,
+      evidence: [{ path: pbxprojRelativePath }],
+    });
+    return {
+      inspection: emptyInspection(objectVersion),
+      appTargets: [],
+      appTargetCandidates: [],
+      diagnostics,
+    };
+  }
+
+  const parents = buildPbxParentIndex(objects);
+  const groupRootDirectory = resolve(
+    dirname(projectPath),
+    asString(projectObject.projectDirPath) ?? "",
+  );
+  const packages = await inspectPackageReferences(root, projectPath, projectObject, objects);
+  const appTargets: IOSAppTarget[] = [];
+  const appTargetCandidates: ParsedProject["appTargetCandidates"] = [];
+  const targetIds = asStringArray(projectObject.targets).sort();
+  const sourceMemberships: IOSTargetSourceMembership[] = [];
+  const sourceMembershipById = new Map<
+    string,
+    {
+      files: Array<{ absolutePath: string; relativePath: string }>;
+      complete: boolean;
+      diagnostics: IOSDiagnostic[];
+    }
+  >();
+
+  // Resolve every native target, not only application products. Source
+  // mutators use this hidden result to refuse files shared with extensions,
+  // tests, or another app target while the public inspection JSON stays
+  // semantic and compact.
+  for (const targetId of targetIds) {
+    const targetObject = objects[targetId];
+    if (targetObject?.isa !== "PBXNativeTarget") continue;
+    const membershipDiagnostics: IOSDiagnostic[] = [];
+    const membership = await sourceFilesForTarget({
+      root,
+      projectPath,
+      groupRootDirectory,
+      targetId,
+      targetObject,
+      objects,
+      parents,
+      diagnostics: membershipDiagnostics,
+    });
+    sourceMembershipById.set(targetId, { ...membership, diagnostics: membershipDiagnostics });
+    sourceMemberships.push({
+      targetId,
+      targetName: asString(targetObject.name) ?? targetId,
+      projectPath: projectRelativePath,
+      files: membership.files,
+      complete: membership.complete,
+    });
+  }
+
+  for (const targetId of targetIds) {
+    const targetObject = objects[targetId];
+    if (targetObject?.isa !== "PBXNativeTarget" || targetObject.productType !== APP_PRODUCT_TYPE) {
+      continue;
+    }
+    const targetName = asString(targetObject.name) ?? targetId;
+    const configurationDiagnostics: IOSDiagnostic[] = [];
+    const targetConfigurations = await inspectTargetBuildConfigurations({
+      root,
+      projectPath,
+      groupRootDirectory,
+      projectObject,
+      targetId,
+      targetObject,
+      objects,
+      parents,
+      diagnostics: configurationDiagnostics,
+    });
+    if (
+      targetConfigurations.length > 0 &&
+      !targetConfigurations.some((configuration) => configuration.isIOS)
+    ) {
+      continue;
+    }
+    appTargetCandidates.push({
+      targetId,
+      targetName,
+      projectPath: projectRelativePath,
+    });
+    if (requestedTarget && requestedTarget !== targetId && requestedTarget !== targetName) {
+      continue;
+    }
+    diagnostics.push(...configurationDiagnostics);
+
+    const configurations = targetConfigurations.map((configuration) => configuration.model);
+    await attachEntitlements(
+      root,
+      projectPath,
+      configurations,
+      new Map(
+        targetConfigurations.map((configuration) => [
+          configuration.model.name,
+          configuration.settings,
+        ]),
+      ),
+      diagnostics,
+    );
+    addBuildSettingConflictDiagnostics(targetName, configurations, diagnostics);
+    const targetSources = sourceMembershipById.get(targetId) ?? {
+      files: [],
+      complete: false,
+      diagnostics: [],
+    };
+    diagnostics.push(...targetSources.diagnostics);
+
+    const swiftInspection =
+      targetSources.files.length > 0
+        ? await inspectSwiftSources(targetSources.files, {
+            membershipComplete: targetSources.complete,
+          })
+        : emptySwiftInspection();
+    if (targetSources.complete && !swiftInspection.evidenceComplete) {
+      diagnostics.push({
+        code: "xcode.incomplete-source-membership",
+        severity: "warning",
+        message: `One or more Swift members of ${targetName} could not be read safely; absence checks are advisory.`,
+        evidence: [
+          {
+            path: relativeIOSPath(root, resolve(projectPath, "project.pbxproj")),
+            objectId: targetId,
+          },
+        ],
+      });
+    }
+
+    const targetLocalSecrets = await localSecretsForTarget({
+      root,
+      projectPath,
+      groupRootDirectory,
+      targetId,
+      targetObject,
+      objects,
+      parents,
+    });
+    const appTarget: IOSAppTarget = {
+      id: targetId,
+      name: targetName,
+      productName: asString(targetObject.productName),
+      projectPath: projectRelativePath,
+      configurations,
+      packages: inspectTargetPackages(
+        root,
+        projectPath,
+        targetName,
+        targetObject,
+        objects,
+        packages,
+        diagnostics,
+      ),
+      swift: swiftInspection,
+      runtimeKeySinks: targetLocalSecrets.map((path) => ({
+        kind: "local-secrets-plist" as const,
+        path: relativeIOSPath(root, path),
+      })),
+    };
+    appTargets.push(appTarget);
+  }
+
+  appTargets.sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id));
+  appTargetCandidates.sort(
+    (a, b) => a.targetName.localeCompare(b.targetName) || a.targetId.localeCompare(b.targetId),
+  );
+  return {
+    inspection: {
+      path: projectRelativePath,
+      pbxprojPath: pbxprojRelativePath,
+      objectVersion,
+      packages,
+      appTargetIds: appTargetCandidates.map((target) => target.targetId),
+      diagnostics,
+    },
+    appTargets,
+    appTargetCandidates,
+    diagnostics,
+    sourceMemberships,
+  };
+}
+
+function selectTarget(
+  candidates: ParsedProject["appTargetCandidates"],
+  requestedTarget: string | undefined,
+  diagnostics: IOSDiagnostic[],
+): IOSTargetSelection {
+  if (requestedTarget) {
+    const matches = candidates.filter(
+      (candidate) =>
+        candidate.targetId === requestedTarget || candidate.targetName === requestedTarget,
+    );
+    const match = matches[0];
+    if (matches.length === 1 && match) return { state: "selected", ...match };
+    if (matches.length > 1) {
+      const matchedByObjectId = matches.every(
+        (candidate) => candidate.targetId === requestedTarget,
+      );
+      diagnostics.push({
+        code: "xcode.ambiguous-app-target",
+        severity: "error",
+        message: matchedByObjectId
+          ? `Target object ID "${requestedTarget}" exists in more than one project.`
+          : `Target name "${requestedTarget}" exists in more than one project.`,
+        remedy: matchedByObjectId
+          ? "Run the inspector from the directory containing only the intended project."
+          : "Rerun with --target <target-id>.",
+        evidence: matches.map((candidate) => ({
+          path: candidate.projectPath,
+          objectId: candidate.targetId,
+        })),
+      });
+      return { state: "ambiguous", candidates: matches };
+    }
+
+    diagnostics.push({
+      code: "xcode.target-not-found",
+      severity: "error",
+      message: `No iOS application target matches "${requestedTarget}".`,
+      remedy: "Choose one of the reported target names or IDs.",
+      evidence: candidates.map((candidate) => ({
+        path: candidate.projectPath,
+        objectId: candidate.targetId,
+      })),
+    });
+    return {
+      state: "not-found",
+      requested: requestedTarget,
+      candidates: candidates.map((candidate) => `${candidate.targetName} (${candidate.targetId})`),
+    };
+  }
+
+  const onlyCandidate = candidates[0];
+  if (candidates.length === 1 && onlyCandidate) {
+    return { state: "selected", ...onlyCandidate };
+  }
+  if (candidates.length === 0) {
+    diagnostics.push({
+      code: "xcode.no-ios-app-target",
+      severity: "error",
+      message: "No iOS application target was found.",
+      remedy: "Run from an iOS app project, or pass --framework ios from its project root.",
+      evidence: [],
+    });
+    return { state: "none" };
+  }
+
+  diagnostics.push({
+    code: "xcode.ambiguous-app-target",
+    severity: "error",
+    message: `Found ${candidates.length} iOS application targets; none was selected automatically.`,
+    remedy: "Rerun with --target <target-name-or-id>.",
+    evidence: candidates.map((candidate) => ({
+      path: candidate.projectPath,
+      objectId: candidate.targetId,
+    })),
+  });
+  return { state: "ambiguous", candidates };
+}
+
+async function detectGeneratedProject(
+  root: string,
+): Promise<{ kind: "xcodegen" | "tuist"; path: string } | null> {
+  const xcodeGenPath = resolve(root, "project.yml");
+  if (
+    (await pathIsSafelyWithinIOSRoot(root, xcodeGenPath)) &&
+    (await Bun.file(xcodeGenPath).exists())
+  ) {
+    return { kind: "xcodegen", path: "project.yml" };
+  }
+  for (const path of ["Project.swift", "Workspace.swift", "Tuist/ProjectDescriptionHelpers"]) {
+    const absolutePath = resolve(root, path);
+    if (
+      (await pathIsSafelyWithinIOSRoot(root, absolutePath)) &&
+      (await Bun.file(absolutePath).exists())
+    ) {
+      return { kind: "tuist", path };
+    }
+  }
+  return null;
+}
+
+export async function inspectIOSProject(
+  rootInput: string,
+  options: { target?: string; exhaustiveContainerDiscovery?: boolean } = {},
+): Promise<IOSProjectInspectionResult> {
+  const invocationPath = resolve(rootInput);
+  const root = invocationPath.endsWith(".xcodeproj")
+    ? dirname(invocationPath)
+    : invocationPath.endsWith(".xcworkspace")
+      ? dirname(invocationPath).endsWith(".xcodeproj")
+        ? dirname(dirname(invocationPath))
+        : dirname(invocationPath)
+      : invocationPath;
+  const diagnostics: IOSDiagnostic[] = [];
+  const discovered = await discoverIOSContainers(invocationPath, {
+    exhaustive: options.exhaustiveContainerDiscovery === true,
+  });
+  const projectPaths = new Set(discovered.projectPaths);
+  const workspaces = [];
+
+  for (const workspacePath of discovered.workspacePaths) {
+    const workspace = await inspectWorkspace(root, workspacePath);
+    workspaces.push(workspace.inspection);
+    for (const projectPath of workspace.localProjectPaths) projectPaths.add(projectPath);
+  }
+
+  if (projectPaths.size === 0) {
+    diagnostics.push({
+      code: "xcode.no-project",
+      severity: "error",
+      message: "No .xcodeproj was found in the inspected root.",
+      remedy: "Run this command from the directory containing your iOS project.",
+      evidence: [],
+    });
+  }
+
+  const projects: IOSProjectInspection[] = [];
+  const appTargets: IOSAppTarget[] = [];
+  const appTargetCandidates: ParsedProject["appTargetCandidates"] = [];
+  const sourceMemberships: IOSTargetSourceMembership[] = [];
+  for (const projectPath of [...projectPaths].sort()) {
+    const parsed = await parseProject(root, projectPath, options.target);
+    projects.push(parsed.inspection);
+    appTargets.push(...parsed.appTargets);
+    appTargetCandidates.push(...parsed.appTargetCandidates);
+    sourceMemberships.push(...(parsed.sourceMemberships ?? []));
+    diagnostics.push(...parsed.diagnostics);
+  }
+  if (options.exhaustiveContainerDiscovery === true && !discovered.complete) {
+    for (const membership of sourceMemberships) membership.complete = false;
+  }
+  appTargets.sort(
+    (a, b) =>
+      a.projectPath.localeCompare(b.projectPath) ||
+      a.name.localeCompare(b.name) ||
+      a.id.localeCompare(b.id),
+  );
+  appTargetCandidates.sort(
+    (a, b) =>
+      a.projectPath.localeCompare(b.projectPath) ||
+      a.targetName.localeCompare(b.targetName) ||
+      a.targetId.localeCompare(b.targetId),
+  );
+
+  const generatedProjectMarker = await detectGeneratedProject(root);
+  if (generatedProjectMarker) {
+    diagnostics.push({
+      code: "xcode.generated-project",
+      severity: "warning",
+      message: `This appears to be a ${generatedProjectMarker.kind === "xcodegen" ? "XcodeGen" : "Tuist"} project. Future automated setup must update the source manifest, not generated project.pbxproj output.`,
+      evidence: [{ path: generatedProjectMarker.path }],
+    });
+  }
+
+  const selection = selectTarget(appTargetCandidates, options.target, diagnostics);
+  const selectedAppTarget =
+    selection.state === "selected"
+      ? appTargets.find(
+          (target) =>
+            target.id === selection.targetId && target.projectPath === selection.projectPath,
+        )
+      : undefined;
+  const inlinePublishableKeyCandidates: PublishableKeyCandidate[] =
+    selectedAppTarget?.swift.configureCalls
+      .filter((call) => call.publishableKeyWiring === "inline-literal")
+      .map((call) => ({
+        source: call.path,
+        evidence: [{ path: call.path, keyPath: "Clerk.configure(publishableKey:)" }],
+        priority: 0,
+        ...(call.inlinePublishableKey?.state === "valid"
+          ? {
+              decoded: {
+                frontendApiHost: call.inlinePublishableKey.frontendApiHost,
+                instanceType: call.inlinePublishableKey.instanceType,
+              },
+            }
+          : { invalid: true as const }),
+      })) ?? [];
+  const localPublishableKeyInspection = await inspectLocalPublishableKeys(
+    root,
+    selection,
+    selectedAppTarget?.runtimeKeySinks.map((sink) => resolve(root, sink.path)) ?? [],
+    [
+      ...(selection.state === "selected" ? [resolve(root, selection.projectPath)] : []),
+      ...discovered.workspacePaths,
+    ],
+    inlinePublishableKeyCandidates,
+    diagnostics,
+  );
+  const result: IOSProjectInspectionResult = {
+    schemaVersion: 1,
+    platform: "ios",
+    root,
+    workspaces: workspaces.sort((a, b) => a.path.localeCompare(b.path)),
+    projects: projects.sort((a, b) => a.path.localeCompare(b.path)),
+    appTargets,
+    selection,
+    localPublishableKey: localPublishableKeyInspection,
+    generatedProject: generatedProjectMarker?.kind ?? null,
+    diagnostics,
+  };
+  sourceMembershipByInspection.set(result, sourceMemberships);
+  return result;
+}
+
+/**
+ * Returns the exact source-membership result used by the iOS semantic
+ * inspector without adding source paths to the serializable inspection JSON.
+ * This is intended for strict source mutators that must prove a non-Clerk
+ * Swift file belongs to one selected application target.
+ */
+export async function inspectIOSSourceMembership(
+  rootInput: string,
+): Promise<IOSTargetSourceMembership[]> {
+  const inspection = await inspectIOSProject(rootInput, {
+    exhaustiveContainerDiscovery: true,
+  });
+  return sourceMembershipByInspection.get(inspection) ?? [];
+}

--- a/packages/cli-core/src/commands/init/ios/install-sdk.test.ts
+++ b/packages/cli-core/src/commands/init/ios/install-sdk.test.ts
@@ -1,0 +1,745 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { build as buildPbxProject, parse as parsePbxProject } from "@bacons/xcode/json";
+import {
+  appendFile,
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  symlink,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { inspectIOSProject } from "./inspect.ts";
+import {
+  applyIOSSDKInstall,
+  DEFAULT_CLERK_IOS_MINIMUM_VERSION,
+  planIOSSDKInstall,
+  PREBUILT_AUTH_CLERK_IOS_MINIMUM_VERSION,
+  prepareIOSSDKInstallMutation,
+  type IOSSDKInstallBlockerCode,
+  validateIOSSDKInstallPostcondition,
+} from "./install-sdk.ts";
+import { applyIOSExistingFileTransaction } from "./file-transaction.ts";
+import { type PbxObject, type PbxObjects } from "./pbx.ts";
+import { createIOSFixture, IOS_FIXTURE_IDS, treeDigest } from "./test-helpers.ts";
+
+const temporaryDirectories: string[] = [];
+
+interface MutableGraph {
+  project: ReturnType<typeof parsePbxProject>;
+  objects: PbxObjects;
+  root: PbxObject;
+  target: PbxObject;
+  frameworks: PbxObject;
+}
+
+async function temporaryRoot(prefix = "clerk-ios-install-"): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  temporaryDirectories.push(root);
+  return root;
+}
+
+async function fixture(options: Parameters<typeof createIOSFixture>[1] = {}): Promise<string> {
+  const root = await temporaryRoot();
+  await createIOSFixture(root, options);
+  return root;
+}
+
+async function writePackageResolution(root: string, version: string): Promise<void> {
+  const directory = join(root, "MyApp.xcodeproj", "project.xcworkspace", "xcshareddata", "swiftpm");
+  await mkdir(directory, { recursive: true });
+  await Bun.write(
+    join(directory, "Package.resolved"),
+    JSON.stringify({
+      pins: [
+        {
+          identity: "clerk-ios",
+          kind: "remoteSourceControl",
+          location: "https://github.com/clerk/clerk-ios",
+          state: { revision: "a".repeat(40), version },
+        },
+      ],
+      version: 3,
+    }),
+  );
+}
+
+async function writeLocalClerkPackageWithExcludedAuthAPIDecoys(root: string): Promise<void> {
+  const packageRoot = join(root, "LocalClerk");
+  const sources: Record<string, string> = {
+    "Sources/ClerkKit/Core/Auth.swift":
+      "public struct Auth { public var events: AsyncStream<AuthEvent> { fatalError() } }\n",
+    "Sources/ClerkKit/Core/Clerk.swift":
+      "public struct Clerk { public func handle(_ url: URL) async throws -> Bool { true } }\n",
+    "Sources/ClerkKit/Domains/Auth/Session/Session.swift":
+      "public struct Session { public var tasks: [Task]? }\n",
+    "Sources/ClerkKit/Events/AuthEvent.swift":
+      "public enum AuthEvent { case signInNeedsContinuation; case signUpNeedsContinuation }\n",
+    "Sources/ClerkKit/Mocks/Clerk+Preview.swift":
+      "extension Clerk { public static func preview(preview: ((PreviewBuilder) -> Void)? = nil) -> Clerk { fatalError() } }\n",
+    "Sources/ClerkKitUI/Components/Auth/AuthView.swift":
+      "public struct AuthView: View { public init(mode: Mode = .signInOrUp, isDismissible: Bool = true) {} }\n",
+    "Sources/ClerkKitUI/Components/UserButton/UserButton.swift":
+      "public struct UserButton<Content> { public init(@ViewBuilder signedOutContent: () -> Content) {} }\n",
+    "Sources/ClerkKit/Compiled.swift": "public struct CompiledClerkKit {}\n",
+    "Sources/ClerkKitUI/Compiled.swift": "public struct CompiledClerkKitUI {}\n",
+  };
+  for (const [relativePath, source] of Object.entries(sources)) {
+    const path = join(packageRoot, relativePath);
+    await mkdir(dirname(path), { recursive: true });
+    await Bun.write(path, source);
+  }
+  await Bun.write(
+    join(packageRoot, "Package.swift"),
+    `// swift-tools-version: 6.0
+import PackageDescription
+let package = Package(
+  name: "Clerk",
+  products: [
+    .library(name: "ClerkKit", targets: ["ClerkKit"]),
+    .library(name: "ClerkKitUI", targets: ["ClerkKitUI"]),
+  ],
+  targets: [
+    .target(name: "ClerkKit", path: "Sources/ClerkKit", sources: ["Compiled.swift"]),
+    .target(name: "ClerkKitUI", path: "Sources/ClerkKitUI", sources: ["Compiled.swift"]),
+  ]
+)
+`,
+  );
+}
+
+function pbxprojPath(root: string): string {
+  return join(root, "MyApp.xcodeproj", "project.pbxproj");
+}
+
+function mutableGraph(project: ReturnType<typeof parsePbxProject>): MutableGraph {
+  const archive = project as unknown as { rootObject: string; objects: PbxObjects };
+  return {
+    project,
+    objects: archive.objects,
+    root: archive.objects[archive.rootObject]!,
+    target: archive.objects[IOS_FIXTURE_IDS.appTarget]!,
+    frameworks: archive.objects[IOS_FIXTURE_IDS.frameworksPhase]!,
+  };
+}
+
+async function transformProject(
+  root: string,
+  mutate: (graph: MutableGraph) => void,
+): Promise<void> {
+  const path = pbxprojPath(root);
+  const graph = mutableGraph(parsePbxProject(await readFile(path, "utf8")));
+  mutate(graph);
+  await Bun.write(path, buildPbxProject(graph.project));
+}
+
+function removeClerkSDK(graph: MutableGraph): void {
+  graph.root.packageReferences = [];
+  graph.target.packageProductDependencies = [];
+  graph.frameworks.files = [];
+  for (const id of [
+    IOS_FIXTURE_IDS.clerkPackage,
+    IOS_FIXTURE_IDS.clerkKit,
+    IOS_FIXTURE_IDS.clerkKitUI,
+    IOS_FIXTURE_IDS.clerkKitBuildFile,
+    IOS_FIXTURE_IDS.clerkKitUIBuildFile,
+  ]) {
+    delete graph.objects[id];
+  }
+}
+
+function installOptions(root: string, includeClerkKitUI = false) {
+  return {
+    root,
+    projectPath: "MyApp.xcodeproj",
+    targetId: IOS_FIXTURE_IDS.appTarget,
+    includeClerkKitUI,
+  };
+}
+
+function targetArraySnapshot(objects: PbxObjects, targetId: string): string {
+  const target = objects[targetId]!;
+  const buildPhases = Array.isArray(target.buildPhases)
+    ? target.buildPhases.filter((item): item is string => typeof item === "string")
+    : [];
+  return JSON.stringify({
+    buildPhases: target.buildPhases,
+    buildRules: target.buildRules,
+    dependencies: target.dependencies,
+    packageProductDependencies: target.packageProductDependencies,
+    phaseFiles: Object.fromEntries(
+      buildPhases.map((phaseId) => [phaseId, objects[phaseId]?.files]),
+    ),
+  });
+}
+
+function installedObjectIds(root: string): Promise<{
+  packageId: string;
+  productId: string;
+  buildFileId: string;
+}> {
+  return readFile(pbxprojPath(root), "utf8").then((source) => {
+    const graph = mutableGraph(parsePbxProject(source));
+    const packageEntry = Object.entries(graph.objects).find(
+      ([, object]) =>
+        object.isa === "XCRemoteSwiftPackageReference" &&
+        String(object.repositoryURL).includes("clerk/clerk-ios"),
+    );
+    const productEntry = Object.entries(graph.objects).find(
+      ([, object]) =>
+        object.isa === "XCSwiftPackageProductDependency" && object.productName === "ClerkKit",
+    );
+    const buildFileEntry = Object.entries(graph.objects).find(
+      ([, object]) => object.isa === "PBXBuildFile" && object.productRef === productEntry?.[0],
+    );
+    if (!packageEntry || !productEntry || !buildFileEntry) {
+      throw new Error("Installed Clerk graph is incomplete.");
+    }
+    return {
+      packageId: packageEntry[0],
+      productId: productEntry[0],
+      buildFileId: buildFileEntry[0],
+    };
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+describe("iOS Clerk SDK installer", () => {
+  test("returns satisfied without serializing or changing a configured project", async () => {
+    const root = await fixture();
+    const before = await readFile(pbxprojPath(root));
+
+    const plan = await planIOSSDKInstall(installOptions(root, true));
+    expect(plan).toMatchObject({
+      status: "satisfied",
+      minimumVersion: DEFAULT_CLERK_IOS_MINIMUM_VERSION,
+      products: ["ClerkKit", "ClerkKitUI"],
+      actions: [],
+      blockers: [],
+    });
+    expect((await applyIOSSDKInstall(plan)).status).toBe("satisfied");
+    expect(await readFile(pbxprojPath(root))).toEqual(before);
+  });
+
+  test("installs ClerkKit with stable IDs, preserves mode, and is byte-idempotent", async () => {
+    const firstRoot = await fixture();
+    const secondRoot = await fixture();
+    await transformProject(firstRoot, removeClerkSDK);
+    await transformProject(secondRoot, removeClerkSDK);
+    await chmod(pbxprojPath(firstRoot), 0o640);
+
+    const firstPlan = await planIOSSDKInstall(installOptions(firstRoot));
+    const secondPlan = await planIOSSDKInstall(installOptions(secondRoot));
+    expect(firstPlan.status).toBe("ready");
+    expect(secondPlan.status).toBe("ready");
+    expect(firstPlan.actions).toEqual(secondPlan.actions);
+    expect((await applyIOSSDKInstall(firstPlan)).status).toBe("applied");
+    expect((await applyIOSSDKInstall(secondPlan)).status).toBe("applied");
+
+    const firstIds = await installedObjectIds(firstRoot);
+    expect(firstIds).toEqual(await installedObjectIds(secondRoot));
+    expect(Object.values(firstIds).every((id) => /^[A-F0-9]{24}$/.test(id))).toBe(true);
+    expect((await stat(pbxprojPath(firstRoot))).mode & 0o777).toBe(0o640);
+
+    const inspection = await inspectIOSProject(firstRoot, {
+      target: IOS_FIXTURE_IDS.appTarget,
+    });
+    expect(inspection.appTargets[0]?.packages).toEqual({
+      package: "remote",
+      clerkKit: "linked",
+      clerkKitUI: "absent",
+    });
+    expect(inspection.projects[0]?.packages[0]).toMatchObject({
+      requirement: { kind: "upToNextMajorVersion", minimumVersion: "1.0.0" },
+    });
+
+    const afterFirstApply = await readFile(pbxprojPath(firstRoot));
+    const satisfied = await planIOSSDKInstall(installOptions(firstRoot));
+    expect(satisfied.status).toBe("satisfied");
+    expect((await applyIOSSDKInstall(satisfied)).status).toBe("satisfied");
+    expect(await readFile(pbxprojPath(firstRoot))).toEqual(afterFirstApply);
+  });
+
+  test("uses the modern ClerkKitUI minimum for a new remote package", async () => {
+    const root = await fixture();
+    await transformProject(root, removeClerkSDK);
+
+    const plan = await planIOSSDKInstall({
+      ...installOptions(root, true),
+      requirePrebuiltAuthCompatibility: true,
+    });
+
+    expect(plan).toMatchObject({
+      status: "ready",
+      minimumVersion: PREBUILT_AUTH_CLERK_IOS_MINIMUM_VERSION,
+      requirePrebuiltAuthCompatibility: true,
+    });
+    expect(plan.actions[0]).toContain(PREBUILT_AUTH_CLERK_IOS_MINIMUM_VERSION);
+    expect((await applyIOSSDKInstall(plan)).status).toBe("applied");
+    const installedPackage = (await inspectIOSProject(root)).projects[0]?.packages[0];
+    expect(installedPackage?.kind).toBe("remote");
+    if (installedPackage?.kind !== "remote") throw new Error("Expected a remote Clerk package.");
+    expect(installedPackage.requirement).toMatchObject({
+      kind: "upToNextMajorVersion",
+      minimumVersion: PREBUILT_AUTH_CLERK_IOS_MINIMUM_VERSION,
+    });
+  });
+
+  test("raises an explicitly older requested version to the prebuilt AuthView floor", async () => {
+    const root = await fixture();
+    await transformProject(root, removeClerkSDK);
+
+    const plan = await planIOSSDKInstall({
+      ...installOptions(root, true),
+      minimumVersion: "0.70.0",
+      requirePrebuiltAuthCompatibility: true,
+    });
+
+    expect(plan.minimumVersion).toBe(PREBUILT_AUTH_CLERK_IOS_MINIMUM_VERSION);
+    expect(plan.minimumVersion).not.toBe("0.70.0");
+  });
+
+  test("blocks a remote package pinned before the modern ClerkKitUI products", async () => {
+    const root = await fixture();
+    await transformProject(root, (graph) => {
+      graph.objects[IOS_FIXTURE_IDS.clerkPackage]!.requirement = {
+        kind: "exactVersion",
+        version: "0.70.0",
+      };
+    });
+    const before = await treeDigest(root);
+
+    const ordinaryPlan = await planIOSSDKInstall(installOptions(root, true));
+    const prebuiltPlan = await planIOSSDKInstall({
+      ...installOptions(root, true),
+      requirePrebuiltAuthCompatibility: true,
+    });
+
+    expect(ordinaryPlan.status).toBe("satisfied");
+    expect(prebuiltPlan.status).toBe("blocked");
+    expect(prebuiltPlan.blockers[0]?.code).toBe("incompatible-sdk");
+    expect(prebuiltPlan.blockers[0]?.message).toContain(PREBUILT_AUTH_CLERK_IOS_MINIMUM_VERSION);
+    expect(await treeDigest(root)).toEqual(before);
+  });
+
+  test("requires a compatible resolved pin when a remote range permits older SDKs", async () => {
+    const oldRoot = await fixture();
+    await transformProject(oldRoot, (graph) => {
+      graph.objects[IOS_FIXTURE_IDS.clerkPackage]!.requirement = {
+        kind: "versionRange",
+        minimumVersion: "0.70.0",
+        maximumVersion: "2.0.0",
+      };
+    });
+    await writePackageResolution(oldRoot, "0.70.0");
+    const oldPlan = await planIOSSDKInstall({
+      ...installOptions(oldRoot, true),
+      requirePrebuiltAuthCompatibility: true,
+    });
+    expect(oldPlan.status).toBe("blocked");
+    expect(oldPlan.blockers[0]?.code).toBe("incompatible-sdk");
+
+    const compatibleRoot = await fixture();
+    await transformProject(compatibleRoot, (graph) => {
+      graph.objects[IOS_FIXTURE_IDS.clerkPackage]!.requirement = {
+        kind: "versionRange",
+        minimumVersion: "0.70.0",
+        maximumVersion: "2.0.0",
+      };
+    });
+    await writePackageResolution(compatibleRoot, PREBUILT_AUTH_CLERK_IOS_MINIMUM_VERSION);
+    const compatiblePlan = await planIOSSDKInstall({
+      ...installOptions(compatibleRoot, true),
+      requirePrebuiltAuthCompatibility: true,
+    });
+    expect(compatiblePlan.status).toBe("satisfied");
+    expect(await validateIOSSDKInstallPostcondition(compatiblePlan)).toBe(true);
+  });
+
+  test("does not trust API decoys excluded from a local package's compiled targets", async () => {
+    const root = await fixture();
+    await writeLocalClerkPackageWithExcludedAuthAPIDecoys(root);
+    await transformProject(root, (graph) => {
+      graph.objects[IOS_FIXTURE_IDS.clerkPackage] = {
+        isa: "XCLocalSwiftPackageReference",
+        relativePath: "LocalClerk",
+      };
+    });
+
+    const plan = await planIOSSDKInstall({
+      ...installOptions(root, true),
+      requirePrebuiltAuthCompatibility: true,
+    });
+
+    expect(plan.status).toBe("blocked");
+    expect(plan.blockers).toEqual([
+      expect.objectContaining({
+        code: "incompatible-sdk",
+        message: expect.stringContaining("compiled target membership cannot be proven"),
+      }),
+    ]);
+  });
+
+  test("prepares an internal SDK mutation for a combined transaction", async () => {
+    const root = await fixture();
+    await transformProject(root, removeClerkSDK);
+    const before = await readFile(pbxprojPath(root));
+    const plan = await planIOSSDKInstall(installOptions(root, true));
+
+    const prepared = await prepareIOSSDKInstallMutation(plan);
+
+    expect(prepared.status).toBe("ready");
+    expect(await readFile(pbxprojPath(root))).toEqual(before);
+    if (prepared.status !== "ready") throw new Error("Expected a prepared SDK mutation.");
+    expect(await validateIOSSDKInstallPostcondition(prepared.plan)).toBe(false);
+    expect(prepared.mutation.path).toBe(pbxprojPath(root));
+    expect(JSON.stringify(prepared.plan)).not.toContain("candidateBytes");
+
+    const result = await applyIOSExistingFileTransaction(
+      [prepared.mutation],
+      [() => validateIOSSDKInstallPostcondition(prepared.plan)],
+    );
+    expect(result.status).toBe("applied");
+    expect(await validateIOSSDKInstallPostcondition(prepared.plan)).toBe(true);
+    expect((await inspectIOSProject(root)).appTargets[0]?.packages).toEqual({
+      package: "remote",
+      clerkKit: "linked",
+      clerkKitUI: "linked",
+    });
+  });
+
+  test("links only the selected independent second application target", async () => {
+    const root = await fixture({ secondTarget: true, clerkSDK: false });
+    const before = mutableGraph(parsePbxProject(await readFile(pbxprojPath(root), "utf8")));
+    const primaryArrays = targetArraySnapshot(before.objects, IOS_FIXTURE_IDS.appTarget);
+    expect(before.objects[IOS_FIXTURE_IDS.secondTarget]?.buildPhases).toEqual([
+      IOS_FIXTURE_IDS.secondSourcesPhase,
+      IOS_FIXTURE_IDS.secondFrameworksPhase,
+    ]);
+    expect(before.objects[IOS_FIXTURE_IDS.secondSourcesPhase]?.files).toEqual([
+      IOS_FIXTURE_IDS.secondSourceBuildFile,
+    ]);
+    expect(before.objects[IOS_FIXTURE_IDS.secondFrameworksPhase]?.files).toEqual([]);
+
+    const plan = await planIOSSDKInstall({
+      root,
+      projectPath: "MyApp.xcodeproj",
+      targetId: IOS_FIXTURE_IDS.secondTarget,
+    });
+    expect(plan.status).toBe("ready");
+    expect((await applyIOSSDKInstall(plan)).status).toBe("applied");
+
+    const after = mutableGraph(parsePbxProject(await readFile(pbxprojPath(root), "utf8")));
+    expect(targetArraySnapshot(after.objects, IOS_FIXTURE_IDS.appTarget)).toBe(primaryArrays);
+
+    const secondProductIds = after.objects[IOS_FIXTURE_IDS.secondTarget]
+      ?.packageProductDependencies as string[];
+    expect(secondProductIds).toHaveLength(1);
+    expect(after.objects[secondProductIds[0]!]).toMatchObject({
+      isa: "XCSwiftPackageProductDependency",
+      productName: "ClerkKit",
+    });
+    const secondFrameworkFiles = after.objects[IOS_FIXTURE_IDS.secondFrameworksPhase]
+      ?.files as string[];
+    expect(secondFrameworkFiles).toHaveLength(1);
+    expect(after.objects[secondFrameworkFiles[0]!]).toMatchObject({
+      isa: "PBXBuildFile",
+      productRef: secondProductIds[0],
+    });
+
+    const primaryInspection = await inspectIOSProject(root, {
+      target: IOS_FIXTURE_IDS.appTarget,
+    });
+    const secondInspection = await inspectIOSProject(root, {
+      target: IOS_FIXTURE_IDS.secondTarget,
+    });
+    expect(primaryInspection.appTargets[0]?.packages.clerkKit).toBe("absent");
+    expect(secondInspection.appTargets[0]?.packages.clerkKit).toBe("linked");
+  });
+
+  test("optionally installs ClerkKitUI and repairs a declared but unlinked product", async () => {
+    const cleanRoot = await fixture();
+    await transformProject(cleanRoot, removeClerkSDK);
+    const uiPlan = await planIOSSDKInstall(installOptions(cleanRoot, true));
+    expect(uiPlan.status).toBe("ready");
+    expect((await applyIOSSDKInstall(uiPlan)).status).toBe("applied");
+    expect((await inspectIOSProject(cleanRoot)).appTargets[0]?.packages).toEqual({
+      package: "remote",
+      clerkKit: "linked",
+      clerkKitUI: "linked",
+    });
+
+    const repairRoot = await fixture();
+    await transformProject(repairRoot, (graph) => {
+      graph.frameworks.files = [IOS_FIXTURE_IDS.clerkKitUIBuildFile];
+      delete graph.objects[IOS_FIXTURE_IDS.clerkKitBuildFile];
+    });
+    const repairPlan = await planIOSSDKInstall(installOptions(repairRoot));
+    expect(repairPlan.status).toBe("ready");
+    expect(repairPlan.actions).toEqual([
+      "Link ClerkKit in the selected target's Frameworks phase.",
+    ]);
+    expect((await applyIOSSDKInstall(repairPlan)).status).toBe("applied");
+    expect((await inspectIOSProject(repairRoot)).appTargets[0]?.packages.clerkKit).toBe("linked");
+
+    const missingPhaseRoot = await fixture();
+    await transformProject(missingPhaseRoot, (graph) => {
+      removeClerkSDK(graph);
+      graph.target.buildPhases = [IOS_FIXTURE_IDS.sourcesPhase];
+      delete graph.objects[IOS_FIXTURE_IDS.frameworksPhase];
+    });
+    const missingPhasePlan = await planIOSSDKInstall(installOptions(missingPhaseRoot));
+    expect(missingPhasePlan.actions).toContain(
+      "Create a Frameworks build phase for the selected target.",
+    );
+    expect((await applyIOSSDKInstall(missingPhasePlan)).status).toBe("applied");
+    expect((await inspectIOSProject(missingPhaseRoot)).appTargets[0]?.packages.clerkKit).toBe(
+      "linked",
+    );
+  });
+
+  test("reuses a verified local package and canonical remote URL variants", async () => {
+    const localRoot = await fixture();
+    await mkdir(join(localRoot, "LocalClerk", "Sources", "ClerkKit"), { recursive: true });
+    await mkdir(join(localRoot, "LocalClerk", "Sources", "ClerkKitUI"), { recursive: true });
+    await Bun.write(
+      join(localRoot, "LocalClerk", "Package.swift"),
+      `// swift-tools-version: 6.0
+import PackageDescription
+let package = Package(
+  name: "Clerk",
+  products: [
+    .library(name: "ClerkKit", targets: ["ClerkKit"]),
+    .library(name: "ClerkKitUI", targets: ["ClerkKitUI"]),
+  ],
+  targets: [
+    .target(name: "ClerkKit", path: "Sources/ClerkKit"),
+    .target(name: "ClerkKitUI", path: "Sources/ClerkKitUI"),
+  ]
+)
+`,
+    );
+    await transformProject(localRoot, (graph) => {
+      graph.objects[IOS_FIXTURE_IDS.clerkPackage] = {
+        isa: "XCLocalSwiftPackageReference",
+        relativePath: "LocalClerk",
+      };
+      graph.root.packageReferences = [];
+    });
+    const localPlan = await planIOSSDKInstall(installOptions(localRoot));
+    expect(localPlan).toMatchObject({ status: "ready" });
+    expect(localPlan.actions).toEqual([
+      "Attach the verified clerk-ios package reference to the Xcode project.",
+    ]);
+    expect((await applyIOSSDKInstall(localPlan)).status).toBe("applied");
+    expect((await inspectIOSProject(localRoot)).appTargets[0]?.packages.package).toBe("local");
+
+    const remoteRoot = await fixture();
+    await transformProject(remoteRoot, (graph) => {
+      graph.objects[IOS_FIXTURE_IDS.clerkPackage]!.repositoryURL =
+        "git@github.com:clerk/clerk-ios.git";
+    });
+    const before = await readFile(pbxprojPath(remoteRoot));
+    const remotePlan = await planIOSSDKInstall(installOptions(remoteRoot, true));
+    expect(remotePlan.status).toBe("satisfied");
+    expect((await applyIOSSDKInstall(remotePlan)).status).toBe("satisfied");
+    expect(await readFile(pbxprojPath(remoteRoot))).toEqual(before);
+  });
+
+  test("does not trust Clerk product names mentioned only in a local manifest comment", async () => {
+    const root = await fixture();
+    await mkdir(join(root, "UnrelatedPackage"));
+    await Bun.write(
+      join(root, "UnrelatedPackage", "Package.swift"),
+      '// swift-tools-version: 6.0\n// Package(name: "Clerk", products: [.library(name: "ClerkKit", targets: ["ClerkKit"])])\n',
+    );
+    await transformProject(root, (graph) => {
+      graph.objects[IOS_FIXTURE_IDS.clerkPackage] = {
+        isa: "XCLocalSwiftPackageReference",
+        relativePath: "UnrelatedPackage",
+      };
+    });
+
+    const before = await readFile(pbxprojPath(root));
+    const plan = await planIOSSDKInstall(installOptions(root));
+
+    expect(plan.status).toBe("blocked");
+    expect(plan.blockers[0]?.code).toBe("wrong-package");
+    expect(await readFile(pbxprojPath(root))).toEqual(before);
+  });
+
+  test("blocks unsafe or ambiguous selected-target graphs without writing", async () => {
+    const cases: Array<{
+      code: IOSSDKInstallBlockerCode;
+      mutate: (graph: MutableGraph) => void;
+    }> = [
+      {
+        code: "unattributed-product",
+        mutate: (graph) => {
+          delete graph.objects[IOS_FIXTURE_IDS.clerkKit]!.package;
+        },
+      },
+      {
+        code: "wrong-package",
+        mutate: (graph) => {
+          const wrongPackage = "919191919191919191919191";
+          graph.objects[wrongPackage] = {
+            isa: "XCRemoteSwiftPackageReference",
+            repositoryURL: "https://github.com/example/not-clerk",
+            requirement: { kind: "upToNextMajorVersion", minimumVersion: "1.0.0" },
+          };
+          graph.root.packageReferences = [IOS_FIXTURE_IDS.clerkPackage, wrongPackage];
+          graph.objects[IOS_FIXTURE_IDS.clerkKit]!.package = wrongPackage;
+        },
+      },
+      {
+        code: "ambiguous-package",
+        mutate: (graph) => {
+          const secondPackage = "929292929292929292929292";
+          graph.objects[secondPackage] = {
+            ...graph.objects[IOS_FIXTURE_IDS.clerkPackage]!,
+          };
+          graph.root.packageReferences = [IOS_FIXTURE_IDS.clerkPackage, secondPackage];
+        },
+      },
+      {
+        code: "duplicate-package",
+        mutate: (graph) => {
+          graph.root.packageReferences = [
+            IOS_FIXTURE_IDS.clerkPackage,
+            IOS_FIXTURE_IDS.clerkPackage,
+          ];
+        },
+      },
+      {
+        code: "duplicate-product",
+        mutate: (graph) => {
+          graph.target.packageProductDependencies = [
+            IOS_FIXTURE_IDS.clerkKit,
+            IOS_FIXTURE_IDS.clerkKit,
+          ];
+        },
+      },
+      {
+        code: "duplicate-build-file",
+        mutate: (graph) => {
+          graph.frameworks.files = [
+            IOS_FIXTURE_IDS.clerkKitBuildFile,
+            IOS_FIXTURE_IDS.clerkKitBuildFile,
+          ];
+        },
+      },
+      {
+        code: "ambiguous-frameworks-phase",
+        mutate: (graph) => {
+          const secondPhase = "939393939393939393939393";
+          graph.objects[secondPhase] = { ...graph.frameworks, files: [] };
+          graph.target.buildPhases = [
+            IOS_FIXTURE_IDS.sourcesPhase,
+            IOS_FIXTURE_IDS.frameworksPhase,
+            secondPhase,
+          ];
+        },
+      },
+      {
+        code: "unsupported-project",
+        mutate: (graph) => {
+          graph.objects[IOS_FIXTURE_IDS.clerkKitBuildFile]!.platformFilter = "futureOS";
+        },
+      },
+      {
+        code: "unsupported-project",
+        mutate: (graph) => {
+          graph.objects[IOS_FIXTURE_IDS.clerkPackage]!.requirement = {
+            kind: "upToNextMajorVersion",
+          };
+        },
+      },
+    ];
+
+    for (const item of cases) {
+      const root = await fixture();
+      await transformProject(root, item.mutate);
+      const before = await treeDigest(root);
+      const plan = await planIOSSDKInstall(installOptions(root));
+      expect(plan.status).toBe("blocked");
+      expect(plan.blockers[0]?.code).toBe(item.code);
+      expect(await treeDigest(root)).toEqual(before);
+    }
+  });
+
+  test("allows generated no-ops but blocks generated writes and project symlink escapes", async () => {
+    const satisfiedGeneratedRoot = await fixture();
+    await Bun.write(join(satisfiedGeneratedRoot, "project.yml"), "name: MyApp\n");
+    expect((await planIOSSDKInstall(installOptions(satisfiedGeneratedRoot))).status).toBe(
+      "satisfied",
+    );
+
+    const generatedRoot = await fixture();
+    await transformProject(generatedRoot, removeClerkSDK);
+    await Bun.write(join(generatedRoot, "project.yml"), "name: MyApp\n");
+    const generatedBefore = await treeDigest(generatedRoot);
+    const generatedPlan = await planIOSSDKInstall(installOptions(generatedRoot));
+    expect(generatedPlan.blockers[0]?.code).toBe("generated-project");
+    expect(await treeDigest(generatedRoot)).toEqual(generatedBefore);
+
+    const nestedRoot = await temporaryRoot();
+    await mkdir(join(nestedRoot, "ios"));
+    await createIOSFixture(join(nestedRoot, "ios"));
+    await transformProject(join(nestedRoot, "ios"), removeClerkSDK);
+    await Bun.write(join(nestedRoot, "ios", "project.yml"), "name: MyApp\n");
+    const nestedPlan = await planIOSSDKInstall({
+      ...installOptions(nestedRoot),
+      projectPath: "ios/MyApp.xcodeproj",
+    });
+    expect(nestedPlan.blockers[0]?.code).toBe("generated-project");
+
+    const outside = await temporaryRoot("clerk-ios-install-outside-");
+    await createIOSFixture(outside);
+    const symlinkRoot = await temporaryRoot();
+    await symlink(join(outside, "MyApp.xcodeproj"), join(symlinkRoot, "MyApp.xcodeproj"));
+    const escapedBefore = await treeDigest(symlinkRoot);
+    const escapedPlan = await planIOSSDKInstall(installOptions(symlinkRoot));
+    expect(escapedPlan.blockers[0]?.code).toBe("external-path");
+    expect(await treeDigest(symlinkRoot)).toEqual(escapedBefore);
+
+    const leafRoot = await fixture();
+    const leaf = pbxprojPath(leafRoot);
+    const realLeaf = join(leafRoot, "MyApp.xcodeproj", "actual.pbxproj");
+    await rename(leaf, realLeaf);
+    await symlink("actual.pbxproj", leaf);
+    const leafBefore = await treeDigest(leafRoot);
+    const leafPlan = await planIOSSDKInstall(installOptions(leafRoot));
+    expect(leafPlan.blockers[0]?.code).toBe("unreadable-project");
+    expect(await treeDigest(leafRoot)).toEqual(leafBefore);
+  });
+
+  test("rejects a stale plan and preserves the newer bytes", async () => {
+    const root = await fixture();
+    await transformProject(root, removeClerkSDK);
+    const plan = await planIOSSDKInstall(installOptions(root));
+    expect(plan.status).toBe("ready");
+
+    await appendFile(pbxprojPath(root), "\n// newer user edit\n");
+    const newerBytes = await readFile(pbxprojPath(root));
+    const prepared = await prepareIOSSDKInstallMutation(plan);
+    expect(prepared.status).toBe("stale");
+    expect("mutation" in prepared).toBe(false);
+    const result = await applyIOSSDKInstall(plan);
+    expect(result.status).toBe("stale");
+    expect(await readFile(pbxprojPath(root))).toEqual(newerBytes);
+    expect(
+      (await readdir(join(root, "MyApp.xcodeproj"))).some((name) => name.includes(".clerk-")),
+    ).toBe(false);
+  });
+});

--- a/packages/cli-core/src/commands/init/ios/install-sdk.ts
+++ b/packages/cli-core/src/commands/init/ios/install-sdk.ts
@@ -1,0 +1,1508 @@
+import { lstat, readFile } from "node:fs/promises";
+import { isDeepStrictEqual } from "node:util";
+import { dirname, isAbsolute, resolve } from "node:path";
+import { build as buildPbxProject, parse as parsePbxProject } from "@bacons/xcode/json";
+import semver from "semver";
+import { inspectIOSProject } from "./inspect.ts";
+import { pathIsSafelyWithinIOSRoot, relativeIOSPath } from "./discovery.ts";
+import {
+  applyIOSExistingFileTransaction,
+  hashIOSFileBytes,
+  type IOSExistingFileMutation,
+} from "./file-transaction.ts";
+import {
+  asString,
+  asStringArray,
+  isClerkIOSRepository,
+  isRecord,
+  type PbxObject,
+  type PbxObjects,
+} from "./pbx.ts";
+
+const APP_PRODUCT_TYPE = "com.apple.product-type.application";
+const CLERK_REPOSITORY = "https://github.com/clerk/clerk-ios";
+const MAX_PBXPROJ_BYTES = 15_000_000;
+const MAX_PACKAGE_METADATA_BYTES = 2_000_000;
+const PRODUCT_NAMES = ["ClerkKit", "ClerkKitUI"] as const;
+
+export const DEFAULT_CLERK_IOS_MINIMUM_VERSION = "1.0.0";
+// These floors are equal today, but remain separate so AuthView can raise its
+// minimum without changing the core-only ClerkKit installation policy.
+export const PREBUILT_AUTH_CLERK_IOS_MINIMUM_VERSION = DEFAULT_CLERK_IOS_MINIMUM_VERSION;
+
+export type IOSSDKProduct = (typeof PRODUCT_NAMES)[number];
+
+export interface IOSSDKInstallOptions {
+  root: string;
+  /** Project-root-relative path selected by the iOS inspector. */
+  projectPath: string;
+  targetId: string;
+  includeClerkKitUI?: boolean;
+  /** Used only when a new clerk-ios remote reference must be created. */
+  minimumVersion?: string;
+  /** Require proof that the selected package supports the documented ClerkKitUI products. */
+  requirePrebuiltAuthCompatibility?: boolean;
+}
+
+export type IOSSDKInstallBlockerCode =
+  | "invalid-selection"
+  | "external-path"
+  | "generated-project"
+  | "unreadable-project"
+  | "malformed-project"
+  | "target-not-found"
+  | "ambiguous-target"
+  | "ambiguous-package"
+  | "duplicate-package"
+  | "unattributed-product"
+  | "wrong-package"
+  | "duplicate-product"
+  | "ambiguous-frameworks-phase"
+  | "duplicate-build-file"
+  | "incompatible-sdk"
+  | "unsupported-project";
+
+export interface IOSSDKInstallBlocker {
+  code: IOSSDKInstallBlockerCode;
+  message: string;
+}
+
+export interface IOSSDKInstallPlan {
+  schemaVersion: 1;
+  kind: "clerk-ios-sdk-install";
+  status: "ready" | "satisfied" | "blocked";
+  root: string;
+  projectPath: string;
+  targetId: string;
+  products: IOSSDKProduct[];
+  minimumVersion: string;
+  requirePrebuiltAuthCompatibility?: true;
+  /** SHA-256 of the exact project.pbxproj bytes this plan was made from. */
+  expectedPbxprojHash?: string;
+  actions: string[];
+  blockers: IOSSDKInstallBlocker[];
+}
+
+export interface IOSSDKInstallApplyResult {
+  status: "applied" | "satisfied" | "blocked" | "stale" | "rolled-back";
+  plan: IOSSDKInstallPlan;
+  message?: string;
+}
+
+interface ProjectParts {
+  project: ReturnType<typeof parsePbxProject>;
+  objects: PbxObjects;
+  projectObjectId: string;
+  projectObject: PbxObject;
+  targetObject: PbxObject;
+}
+
+interface VerifiedPackage {
+  id: string;
+  kind: "remote" | "local";
+}
+
+interface ProductGraph {
+  productId?: string;
+  inTarget: boolean;
+  buildFileId?: string;
+}
+
+interface PreparedInstall {
+  plan: IOSSDKInstallPlan;
+  pbxprojPath?: string;
+  originalBytes?: Uint8Array;
+  originalHash?: string;
+  candidateBytes?: Uint8Array;
+  candidateHash?: string;
+  mode?: number;
+}
+
+function requestedProducts(includeClerkKitUI: boolean | undefined): IOSSDKProduct[] {
+  return includeClerkKitUI ? ["ClerkKit", "ClerkKitUI"] : ["ClerkKit"];
+}
+
+function validMinimumVersion(value: string): boolean {
+  return /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(value);
+}
+
+function effectiveMinimumVersion(options: IOSSDKInstallOptions): string {
+  const requested = options.minimumVersion ?? DEFAULT_CLERK_IOS_MINIMUM_VERSION;
+  if (
+    !options.requirePrebuiltAuthCompatibility ||
+    semver.valid(requested) == null ||
+    semver.gte(requested, PREBUILT_AUTH_CLERK_IOS_MINIMUM_VERSION)
+  ) {
+    return requested;
+  }
+  return PREBUILT_AUTH_CLERK_IOS_MINIMUM_VERSION;
+}
+
+function supportedRemoteRequirement(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  const kind = asString(value.kind);
+  if (kind === "upToNextMajorVersion" || kind === "upToNextMinorVersion") {
+    const minimumVersion = asString(value.minimumVersion);
+    return minimumVersion != null && validMinimumVersion(minimumVersion);
+  }
+  if (kind === "versionRange") {
+    const minimumVersion = asString(value.minimumVersion);
+    const maximumVersion = asString(value.maximumVersion);
+    return (
+      minimumVersion != null &&
+      maximumVersion != null &&
+      validMinimumVersion(minimumVersion) &&
+      validMinimumVersion(maximumVersion)
+    );
+  }
+  if (kind === "exactVersion") {
+    const version = asString(value.version);
+    return version != null && validMinimumVersion(version);
+  }
+  if (kind === "branch") return (asString(value.branch)?.trim().length ?? 0) > 0;
+  if (kind === "revision") return (asString(value.revision)?.trim().length ?? 0) > 0;
+  return false;
+}
+
+async function generatedProjectKind(
+  root: string,
+  absoluteProjectPath: string,
+): Promise<"xcodegen" | "tuist" | null> {
+  let directory = dirname(absoluteProjectPath);
+  while (await pathIsSafelyWithinIOSRoot(root, directory)) {
+    for (const [relativePath, kind] of [
+      ["project.yml", "xcodegen"],
+      ["Project.swift", "tuist"],
+      ["Workspace.swift", "tuist"],
+      ["Tuist/ProjectDescriptionHelpers", "tuist"],
+    ] as const) {
+      const marker = resolve(directory, relativePath);
+      if ((await pathIsSafelyWithinIOSRoot(root, marker)) && (await Bun.file(marker).exists())) {
+        return kind;
+      }
+    }
+    if (directory === root) break;
+    const parent = dirname(directory);
+    if (parent === directory) break;
+    directory = parent;
+  }
+  return null;
+}
+
+function makePlan(
+  options: IOSSDKInstallOptions,
+  root: string,
+  projectPath: string,
+  status: IOSSDKInstallPlan["status"],
+  details: {
+    actions?: string[];
+    blockers?: IOSSDKInstallBlocker[];
+    expectedPbxprojHash?: string;
+  } = {},
+): IOSSDKInstallPlan {
+  return {
+    schemaVersion: 1,
+    kind: "clerk-ios-sdk-install",
+    status,
+    root,
+    projectPath,
+    targetId: options.targetId,
+    products: requestedProducts(options.includeClerkKitUI),
+    minimumVersion: effectiveMinimumVersion(options),
+    ...(options.requirePrebuiltAuthCompatibility ? { requirePrebuiltAuthCompatibility: true } : {}),
+    expectedPbxprojHash: details.expectedPbxprojHash,
+    actions: details.actions ?? [],
+    blockers: details.blockers ?? [],
+  };
+}
+
+function blocked(
+  options: IOSSDKInstallOptions,
+  root: string,
+  projectPath: string,
+  code: IOSSDKInstallBlockerCode,
+  message: string,
+  source: Partial<PreparedInstall> = {},
+): PreparedInstall {
+  return {
+    ...source,
+    plan: makePlan(options, root, projectPath, "blocked", {
+      blockers: [{ code, message }],
+    }),
+  };
+}
+
+function strictStringArray(object: PbxObject, key: string): string[] | undefined {
+  const value = object[key];
+  if (value == null) return [];
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    return undefined;
+  }
+  return [...value];
+}
+
+function projectParts(
+  project: ReturnType<typeof parsePbxProject>,
+  targetId: string,
+): ProjectParts | undefined {
+  const archive: unknown = project;
+  if (!isRecord(archive) || !isRecord(archive.objects)) return undefined;
+  for (const object of Object.values(archive.objects)) {
+    if (!isRecord(object)) return undefined;
+  }
+  // Retain the parsed dictionary itself. Newly allocated object IDs must land
+  // in the model that the writer serializes, not a detached index copy.
+  const objects = archive.objects as PbxObjects;
+  const projectObjectId = asString(archive.rootObject);
+  const projectObject = projectObjectId ? objects[projectObjectId] : undefined;
+  const targetObject = objects[targetId];
+  if (!projectObjectId || projectObject?.isa !== "PBXProject" || !targetObject) {
+    return undefined;
+  }
+  return { project, objects, projectObjectId, projectObject, targetObject };
+}
+
+function swiftManifestWithoutComments(source: string): string {
+  const chars = source.split("");
+  const blank = (start: number, end: number) => {
+    for (let index = start; index < end; index += 1) {
+      if (chars[index] !== "\n" && chars[index] !== "\r") chars[index] = " ";
+    }
+  };
+  let index = 0;
+  while (index < chars.length) {
+    if (chars[index] === "/" && chars[index + 1] === "/") {
+      const start = index;
+      index += 2;
+      while (index < chars.length && chars[index] !== "\n") index += 1;
+      blank(start, index);
+      continue;
+    }
+    if (chars[index] === "/" && chars[index + 1] === "*") {
+      const start = index;
+      let depth = 1;
+      index += 2;
+      while (index < chars.length && depth > 0) {
+        if (chars[index] === "/" && chars[index + 1] === "*") {
+          depth += 1;
+          index += 2;
+        } else if (chars[index] === "*" && chars[index + 1] === "/") {
+          depth -= 1;
+          index += 2;
+        } else {
+          index += 1;
+        }
+      }
+      blank(start, index);
+      continue;
+    }
+
+    let hashCount = 0;
+    while (chars[index + hashCount] === "#") hashCount += 1;
+    const quoteIndex = index + hashCount;
+    if (chars[quoteIndex] !== '"') {
+      index += 1;
+      continue;
+    }
+    const multiline = chars[quoteIndex + 1] === '"' && chars[quoteIndex + 2] === '"';
+    index = quoteIndex + (multiline ? 3 : 1);
+    while (index < chars.length) {
+      const closesQuote = multiline
+        ? chars[index] === '"' && chars[index + 1] === '"' && chars[index + 2] === '"'
+        : chars[index] === '"';
+      if (closesQuote) {
+        const quoteLength = multiline ? 3 : 1;
+        let closesHashes = true;
+        for (let hash = 0; hash < hashCount; hash += 1) {
+          if (chars[index + quoteLength + hash] !== "#") closesHashes = false;
+        }
+        if (closesHashes) {
+          index += quoteLength + hashCount;
+          break;
+        }
+      }
+      if (chars[index] === "\\") {
+        let escapeHashes = 0;
+        while (chars[index + 1 + escapeHashes] === "#") escapeHashes += 1;
+        if (escapeHashes === hashCount) {
+          index += 2 + escapeHashes;
+          continue;
+        }
+      }
+      index += 1;
+    }
+  }
+  return chars.join("");
+}
+
+async function safeDirectory(root: string, path: string): Promise<boolean> {
+  if (!(await pathIsSafelyWithinIOSRoot(root, path))) return false;
+  try {
+    const info = await lstat(path);
+    return info.isDirectory() && !info.isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+async function localReferenceIsClerk(
+  root: string,
+  projectPath: string,
+  object: PbxObject,
+): Promise<boolean> {
+  const relativePath = asString(object.relativePath);
+  if (!relativePath) return false;
+  const packagePath = resolve(dirname(projectPath), relativePath);
+  const manifestPath = resolve(packagePath, "Package.swift");
+  if (!(await pathIsSafelyWithinIOSRoot(root, manifestPath))) return false;
+  const manifest = Bun.file(manifestPath);
+  if (!(await manifest.exists()) || manifest.size > 1_000_000) return false;
+  try {
+    const source = swiftManifestWithoutComments(await manifest.text());
+    const declaresClerkPackage = /\bPackage\s*\(\s*name\s*:\s*"Clerk"\s*,/s.test(source);
+    const declaresProduct = (name: IOSSDKProduct) =>
+      new RegExp(
+        `\\.library\\s*\\(\\s*name\\s*:\\s*"${name}"\\s*,\\s*targets\\s*:\\s*\\[\\s*"${name}"\\s*\\]\\s*\\)`,
+        "s",
+      ).test(source);
+    return (
+      declaresClerkPackage &&
+      declaresProduct("ClerkKit") &&
+      declaresProduct("ClerkKitUI") &&
+      (await safeDirectory(root, resolve(packagePath, "Sources", "ClerkKit"))) &&
+      (await safeDirectory(root, resolve(packagePath, "Sources", "ClerkKitUI")))
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function verifiedPackages(
+  root: string,
+  projectPath: string,
+  objects: PbxObjects,
+): Promise<VerifiedPackage[]> {
+  const result: VerifiedPackage[] = [];
+  for (const [id, object] of Object.entries(objects)) {
+    if (object.isa === "XCRemoteSwiftPackageReference") {
+      const repository = asString(object.repositoryURL);
+      if (repository && isClerkIOSRepository(repository)) {
+        result.push({ id, kind: "remote" });
+      }
+    } else if (
+      object.isa === "XCLocalSwiftPackageReference" &&
+      (await localReferenceIsClerk(root, projectPath, object))
+    ) {
+      result.push({ id, kind: "local" });
+    }
+  }
+  return result.sort((left, right) => left.id.localeCompare(right.id));
+}
+
+type RemoteRequirementProof = "compatible" | "incompatible" | "needs-resolution";
+
+function requirementBounds(requirement: PbxObject): {
+  minimum?: string;
+  maximum?: string;
+  exact?: string;
+} {
+  const kind = asString(requirement.kind);
+  if (kind === "exactVersion") return { exact: asString(requirement.version) };
+  if (kind === "versionRange") {
+    return {
+      minimum: asString(requirement.minimumVersion),
+      maximum: asString(requirement.maximumVersion),
+    };
+  }
+  if (kind === "upToNextMajorVersion" || kind === "upToNextMinorVersion") {
+    const minimum = asString(requirement.minimumVersion);
+    const parsed = minimum == null ? null : semver.parse(minimum);
+    if (!minimum || !parsed) return {};
+    return {
+      minimum,
+      maximum:
+        kind === "upToNextMajorVersion"
+          ? `${parsed.major + 1}.0.0`
+          : `${parsed.major}.${parsed.minor + 1}.0`,
+    };
+  }
+  return {};
+}
+
+function remoteRequirementProof(
+  requirement: PbxObject,
+  requiredVersion: string,
+): RemoteRequirementProof {
+  const bounds = requirementBounds(requirement);
+  if (bounds.exact) {
+    return semver.valid(bounds.exact) && semver.gte(bounds.exact, requiredVersion)
+      ? "compatible"
+      : "incompatible";
+  }
+  if (!bounds.minimum || semver.valid(bounds.minimum) == null) return "needs-resolution";
+  if (
+    bounds.maximum &&
+    (semver.valid(bounds.maximum) == null || !semver.gt(bounds.maximum, bounds.minimum))
+  ) {
+    return "incompatible";
+  }
+  if (semver.gte(bounds.minimum, requiredVersion)) return "compatible";
+  if (
+    bounds.maximum &&
+    semver.valid(bounds.maximum) != null &&
+    !semver.lt(requiredVersion, bounds.maximum)
+  ) {
+    return "incompatible";
+  }
+  return "needs-resolution";
+}
+
+function requirementAllowsVersion(requirement: PbxObject, version: string): boolean {
+  if (semver.valid(version) == null) return false;
+  const bounds = requirementBounds(requirement);
+  if (bounds.exact) return semver.valid(bounds.exact) != null && semver.eq(version, bounds.exact);
+  if (!bounds.minimum || semver.valid(bounds.minimum) == null) return false;
+  if (semver.lt(version, bounds.minimum)) return false;
+  return (
+    !bounds.maximum || (semver.valid(bounds.maximum) != null && semver.lt(version, bounds.maximum))
+  );
+}
+
+function packageResolvedPaths(
+  root: string,
+  projectPath: string,
+  inspection: Awaited<ReturnType<typeof inspectIOSProject>>,
+): string[] {
+  const paths = new Set<string>([
+    resolve(
+      root,
+      projectPath,
+      "project.xcworkspace",
+      "xcshareddata",
+      "swiftpm",
+      "Package.resolved",
+    ),
+  ]);
+  for (const workspace of inspection.workspaces) {
+    if (workspace.projectPaths.includes(projectPath)) {
+      paths.add(resolve(root, workspace.path, "xcshareddata", "swiftpm", "Package.resolved"));
+    }
+  }
+  return [...paths].sort();
+}
+
+async function resolvedClerkVersions(
+  root: string,
+  projectPath: string,
+  inspection: Awaited<ReturnType<typeof inspectIOSProject>>,
+): Promise<{ versions: string[]; unreadable: boolean }> {
+  const versions: string[] = [];
+  let unreadable = false;
+  for (const path of packageResolvedPaths(root, projectPath, inspection)) {
+    if (!(await pathIsSafelyWithinIOSRoot(root, path))) {
+      unreadable = true;
+      continue;
+    }
+    let info: Awaited<ReturnType<typeof lstat>>;
+    try {
+      info = await lstat(path);
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") continue;
+      unreadable = true;
+      continue;
+    }
+    if (!info.isFile() || info.isSymbolicLink() || info.size > MAX_PACKAGE_METADATA_BYTES) {
+      unreadable = true;
+      continue;
+    }
+    try {
+      const document: unknown = JSON.parse(await readFile(path, "utf8"));
+      if (!isRecord(document)) throw new Error("invalid Package.resolved root");
+      const legacyObject = isRecord(document.object) ? document.object : undefined;
+      const pins = Array.isArray(document.pins)
+        ? document.pins
+        : Array.isArray(legacyObject?.pins)
+          ? legacyObject.pins
+          : undefined;
+      if (!pins) throw new Error("invalid Package.resolved pins");
+      for (const pin of pins) {
+        if (!isRecord(pin)) {
+          unreadable = true;
+          continue;
+        }
+        const location = asString(pin.location) ?? asString(pin.repositoryURL);
+        const identity = (asString(pin.identity) ?? asString(pin.package))?.toLowerCase();
+        const isClerkPin = location
+          ? isClerkIOSRepository(location)
+          : identity === "clerk-ios" || identity === "clerk";
+        if (!isClerkPin) continue;
+        const state = isRecord(pin.state) ? pin.state : undefined;
+        const version = state ? asString(state.version) : undefined;
+        if (!version || semver.valid(version) == null) unreadable = true;
+        else versions.push(version);
+      }
+    } catch {
+      unreadable = true;
+    }
+  }
+  return { versions: [...new Set(versions)].sort(semver.compare), unreadable };
+}
+
+async function prebuiltAuthCompatibilityBlocker(
+  root: string,
+  projectPath: string,
+  inspection: Awaited<ReturnType<typeof inspectIOSProject>>,
+  selectedPackage: VerifiedPackage,
+  objects: PbxObjects,
+): Promise<IOSSDKInstallBlocker | undefined> {
+  const requiredVersion = PREBUILT_AUTH_CLERK_IOS_MINIMUM_VERSION;
+  const prefix = `ClerkKitUI's documented native components require clerk-ios ${requiredVersion} or newer.`;
+  if (selectedPackage.kind === "local") {
+    return {
+      code: "incompatible-sdk",
+      message: `${prefix} A local package's compiled target membership cannot be proven without executing its Package.swift manifest, so no source was changed. Use a compatible remote clerk-ios package or integrate AuthView manually.`,
+    };
+  }
+
+  const requirement = objects[selectedPackage.id]?.requirement;
+  if (!isRecord(requirement)) {
+    return {
+      code: "incompatible-sdk",
+      message: `${prefix} The existing remote package requirement could not prove that version, so no source was changed.`,
+    };
+  }
+  const proof = remoteRequirementProof(requirement, requiredVersion);
+  if (proof === "compatible") return undefined;
+  if (proof === "incompatible") {
+    return {
+      code: "incompatible-sdk",
+      message: `${prefix} The existing remote package requirement excludes that version, so no source was changed. Update the package requirement and rerun clerk init.`,
+    };
+  }
+
+  const resolved = await resolvedClerkVersions(root, projectPath, inspection);
+  if (
+    !resolved.unreadable &&
+    resolved.versions.length > 0 &&
+    resolved.versions.every(
+      (version) =>
+        semver.gte(version, requiredVersion) && requirementAllowsVersion(requirement, version),
+    )
+  ) {
+    return undefined;
+  }
+  return {
+    code: "incompatible-sdk",
+    message: `${prefix} Neither the existing remote requirement nor a canonical Package.resolved file proves a compatible version, so no source was changed. Require or resolve clerk-ios ${requiredVersion} or newer, then rerun clerk init.`,
+  };
+}
+
+function duplicateValue(values: string[]): string | undefined {
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) return value;
+    seen.add(value);
+  }
+  return undefined;
+}
+
+function stableObjectId(objects: PbxObjects, seed: string): string {
+  for (let attempt = 0; attempt < 10_000; attempt += 1) {
+    const id = new Bun.CryptoHasher("sha256")
+      .update(`clerk-ios-sdk:${seed}:${attempt}`)
+      .digest("hex")
+      .slice(0, 24)
+      .toUpperCase();
+    if (!objects[id]) return id;
+  }
+  throw new Error("Could not allocate a deterministic Xcode object ID.");
+}
+
+function clerkProductName(object: PbxObject | undefined): IOSSDKProduct | undefined {
+  if (object?.isa !== "XCSwiftPackageProductDependency") return undefined;
+  const name = asString(object.productName);
+  return PRODUCT_NAMES.find((productName) => productName === name);
+}
+
+function buildFileIOSApplicability(object: PbxObject): {
+  applies: boolean;
+  recognized: boolean;
+} {
+  const rawFilters = object.platformFilters;
+  if (
+    rawFilters != null &&
+    (!Array.isArray(rawFilters) || rawFilters.some((item) => typeof item !== "string"))
+  ) {
+    return { applies: false, recognized: false };
+  }
+  const platformFilter = asString(object.platformFilter);
+  const filters = [...asStringArray(rawFilters), ...(platformFilter ? [platformFilter] : [])];
+  if (filters.length === 0) return { applies: true, recognized: true };
+  if (filters.some((filter) => /(?:^|[^a-z])(?:ios|iphone)/i.test(filter))) {
+    return { applies: true, recognized: true };
+  }
+  const recognized = filters.every((filter) =>
+    /(?:maccatalyst|macos|tvos|watchos|xros|visionos|driverkit)/i.test(filter),
+  );
+  return { applies: false, recognized };
+}
+
+function validateProductPackage(
+  productId: string,
+  objects: PbxObjects,
+  verifiedPackageIds: Set<string>,
+  unsafeLocalPackageIds: Set<string>,
+): IOSSDKInstallBlocker | undefined {
+  const product = objects[productId];
+  const productName = clerkProductName(product);
+  if (!productName) {
+    return {
+      code: "malformed-project",
+      message: `The selected target contains an unreadable Swift package product dependency (${productId}).`,
+    };
+  }
+  const packageId = asString(product?.package);
+  if (!packageId) {
+    return {
+      code: "unattributed-product",
+      message: `${productName} is not attributed to a Swift package reference, so it cannot be repaired automatically.`,
+    };
+  }
+  if (!verifiedPackageIds.has(packageId)) {
+    if (unsafeLocalPackageIds.has(packageId)) {
+      return {
+        code: "external-path",
+        message: `${productName} points to a local package that cannot be verified safely inside the project root.`,
+      };
+    }
+    return {
+      code: "wrong-package",
+      message: `${productName} points to a package other than a verified clerk-ios reference.`,
+    };
+  }
+  return undefined;
+}
+
+function scanProductGraph(
+  productName: IOSSDKProduct,
+  targetProductIds: string[],
+  frameworkFiles: string[],
+  objects: PbxObjects,
+  verifiedPackageIds: Set<string>,
+  unsafeLocalPackageIds: Set<string>,
+): { graph?: ProductGraph; blocker?: IOSSDKInstallBlocker } {
+  const targetMatches = targetProductIds.filter(
+    (id) => clerkProductName(objects[id]) === productName,
+  );
+  if (targetMatches.length > 1) {
+    return {
+      blocker: {
+        code: "duplicate-product",
+        message: `The selected target contains more than one ${productName} product dependency.`,
+      },
+    };
+  }
+
+  const phaseMatches: Array<{ buildFileId: string; productId: string }> = [];
+  for (const buildFileId of frameworkFiles) {
+    const buildFile = objects[buildFileId];
+    if (!buildFile || buildFile.isa !== "PBXBuildFile") {
+      return {
+        blocker: {
+          code: "malformed-project",
+          message: `The selected target's Frameworks phase contains a dangling build file (${buildFileId}).`,
+        },
+      };
+    }
+    const productId = asString(buildFile.productRef);
+    if (productId && clerkProductName(objects[productId]) === productName) {
+      const applicability = buildFileIOSApplicability(buildFile);
+      if (!applicability.recognized) {
+        return {
+          blocker: {
+            code: "unsupported-project",
+            message: `${productName} has an unrecognized platform filter in the selected target's Frameworks phase.`,
+          },
+        };
+      }
+      if (applicability.applies) phaseMatches.push({ buildFileId, productId });
+    }
+  }
+  if (phaseMatches.length > 1) {
+    return {
+      blocker: {
+        code: "duplicate-build-file",
+        message: `The selected target links ${productName} more than once in its Frameworks phase.`,
+      },
+    };
+  }
+
+  const targetProductId = targetMatches[0];
+  const phaseMatch = phaseMatches[0];
+  if (targetProductId && phaseMatch && targetProductId !== phaseMatch.productId) {
+    return {
+      blocker: {
+        code: "duplicate-product",
+        message: `The selected target declares and links different ${productName} dependencies.`,
+      },
+    };
+  }
+  const productId = targetProductId ?? phaseMatch?.productId;
+  if (productId) {
+    const blocker = validateProductPackage(
+      productId,
+      objects,
+      verifiedPackageIds,
+      unsafeLocalPackageIds,
+    );
+    if (blocker) return { blocker };
+  }
+  return {
+    graph: {
+      productId,
+      inTarget: targetProductId != null,
+      buildFileId: phaseMatch?.buildFileId,
+    },
+  };
+}
+
+function validateCandidateGraph(
+  parts: ProjectParts,
+  packageId: string,
+  products: IOSSDKProduct[],
+): boolean {
+  const packageReferences = strictStringArray(parts.projectObject, "packageReferences");
+  const targetProducts = strictStringArray(parts.targetObject, "packageProductDependencies");
+  const buildPhases = strictStringArray(parts.targetObject, "buildPhases");
+  if (!packageReferences || !targetProducts || !buildPhases) return false;
+  if (packageReferences.filter((id) => id === packageId).length !== 1) return false;
+
+  const frameworkPhaseIds = buildPhases.filter(
+    (id) => parts.objects[id]?.isa === "PBXFrameworksBuildPhase",
+  );
+  if (frameworkPhaseIds.length !== 1) return false;
+  const frameworkFiles = strictStringArray(parts.objects[frameworkPhaseIds[0]!]!, "files");
+  if (!frameworkFiles) return false;
+
+  for (const productName of products) {
+    const productIds: string[] = targetProducts.filter(
+      (id) => clerkProductName(parts.objects[id]) === productName,
+    );
+    const productId = productIds[0];
+    if (productIds.length !== 1 || !productId) return false;
+    if (asString(parts.objects[productId]?.package) !== packageId) return false;
+    const linked = frameworkFiles.filter((buildFileId) => {
+      const buildFile = parts.objects[buildFileId];
+      return (
+        buildFile?.isa === "PBXBuildFile" &&
+        asString(buildFile?.productRef) === productId &&
+        buildFileIOSApplicability(buildFile).recognized &&
+        buildFileIOSApplicability(buildFile).applies
+      );
+    });
+    if (linked.length !== 1) return false;
+    const allLinkedProducts = frameworkFiles.filter((buildFileId) => {
+      const buildFile = parts.objects[buildFileId];
+      if (!buildFile || buildFile.isa !== "PBXBuildFile") return false;
+      const linkedProduct = parts.objects[asString(buildFile.productRef) ?? ""];
+      return (
+        clerkProductName(linkedProduct) === productName &&
+        buildFileIOSApplicability(buildFile).applies
+      );
+    });
+    if (allLinkedProducts.length !== 1) return false;
+  }
+  return true;
+}
+
+async function prepareInstall(options: IOSSDKInstallOptions): Promise<PreparedInstall> {
+  const root = resolve(options.root);
+  const suppliedProjectPath = options.projectPath.replaceAll("\\", "/");
+  const minimumVersion = effectiveMinimumVersion(options);
+  if (
+    !options.targetId ||
+    !suppliedProjectPath ||
+    isAbsolute(options.projectPath) ||
+    !suppliedProjectPath.endsWith(".xcodeproj") ||
+    !validMinimumVersion(minimumVersion)
+  ) {
+    return blocked(
+      options,
+      root,
+      suppliedProjectPath,
+      "invalid-selection",
+      "A selected root-relative .xcodeproj, target object ID, and valid minimum version are required.",
+    );
+  }
+
+  const absoluteProjectPath = resolve(root, suppliedProjectPath);
+  const projectPath = relativeIOSPath(root, absoluteProjectPath);
+  const pbxprojPath = resolve(absoluteProjectPath, "project.pbxproj");
+  if (
+    !(await pathIsSafelyWithinIOSRoot(root, absoluteProjectPath)) ||
+    !(await pathIsSafelyWithinIOSRoot(root, pbxprojPath))
+  ) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "external-path",
+      `${projectPath}/project.pbxproj resolves outside the project root.`,
+      { pbxprojPath },
+    );
+  }
+
+  let info: Awaited<ReturnType<typeof lstat>>;
+  let originalBuffer: Buffer;
+  try {
+    info = await lstat(pbxprojPath);
+    if (!info.isFile() || info.isSymbolicLink() || info.size > MAX_PBXPROJ_BYTES) {
+      throw new Error("unsupported project file");
+    }
+    originalBuffer = await readFile(pbxprojPath);
+  } catch {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "unreadable-project",
+      `${projectPath}/project.pbxproj is missing, too large, symlinked, or unreadable.`,
+      { pbxprojPath },
+    );
+  }
+  const originalBytes = new Uint8Array(originalBuffer);
+  const originalHash = hashIOSFileBytes(originalBytes);
+  const source = {
+    pbxprojPath,
+    originalBytes,
+    originalHash,
+    mode: info.mode & 0o7777,
+  };
+
+  let originalText: string;
+  let parsed: ReturnType<typeof parsePbxProject>;
+  try {
+    originalText = new TextDecoder("utf-8", { fatal: true }).decode(originalBuffer);
+    parsed = parsePbxProject(originalText);
+  } catch {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "malformed-project",
+      `${projectPath}/project.pbxproj could not be parsed safely.`,
+      source,
+    );
+  }
+  const parsedParts = projectParts(parsed, options.targetId);
+  if (!parsedParts) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "target-not-found",
+      `The selected target ${options.targetId} does not exist in ${projectPath}.`,
+      source,
+    );
+  }
+  if (
+    parsedParts.targetObject.isa !== "PBXNativeTarget" ||
+    asString(parsedParts.targetObject.productType) !== APP_PRODUCT_TYPE
+  ) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "target-not-found",
+      `The selected object ${options.targetId} is not an application target.`,
+      source,
+    );
+  }
+
+  const inspection = await inspectIOSProject(root, { target: options.targetId });
+  const generator =
+    inspection.generatedProject ?? (await generatedProjectKind(root, absoluteProjectPath));
+  if (inspection.selection.state === "ambiguous") {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "ambiguous-target",
+      `Target object ID ${options.targetId} is ambiguous in this project root.`,
+      source,
+    );
+  }
+  if (
+    inspection.selection.state !== "selected" ||
+    inspection.selection.targetId !== options.targetId ||
+    inspection.selection.projectPath !== projectPath
+  ) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "target-not-found",
+      `The selected target ${options.targetId} is not a verified iOS application target in ${projectPath}.`,
+      source,
+    );
+  }
+
+  // Parse a second model instead of structured-cloning. pbxproj data literals
+  // can be Buffers, which structuredClone turns into writer-incompatible
+  // Uint8Arrays under Bun.
+  let model: ReturnType<typeof parsePbxProject>;
+  try {
+    model = parsePbxProject(originalText);
+  } catch {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "malformed-project",
+      "The Xcode project could not be parsed into an isolated mutation model.",
+      source,
+    );
+  }
+  const parts = projectParts(model, options.targetId);
+  if (!parts) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "malformed-project",
+      "The Xcode project object graph could not be cloned safely.",
+      source,
+    );
+  }
+  const projectPackageIds = strictStringArray(parts.projectObject, "packageReferences");
+  const targetProductIds = strictStringArray(parts.targetObject, "packageProductDependencies");
+  const targetBuildPhases = strictStringArray(parts.targetObject, "buildPhases");
+  if (!projectPackageIds || !targetProductIds || !targetBuildPhases) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "malformed-project",
+      "The selected target has malformed package or build-phase reference lists.",
+      source,
+    );
+  }
+  if (duplicateValue(projectPackageIds)) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "duplicate-package",
+      "The project packageReferences list contains a duplicate object ID.",
+      source,
+    );
+  }
+  if (duplicateValue(targetProductIds)) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "duplicate-product",
+      "The selected target packageProductDependencies list contains a duplicate object ID.",
+      source,
+    );
+  }
+  if (duplicateValue(targetBuildPhases)) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "ambiguous-frameworks-phase",
+      "The selected target buildPhases list contains a duplicate object ID.",
+      source,
+    );
+  }
+  if (
+    projectPackageIds.some(
+      (id) =>
+        !parts.objects[id] ||
+        !["XCRemoteSwiftPackageReference", "XCLocalSwiftPackageReference"].includes(
+          parts.objects[id]!.isa ?? "",
+        ),
+    ) ||
+    targetProductIds.some((id) => parts.objects[id]?.isa !== "XCSwiftPackageProductDependency") ||
+    targetBuildPhases.some(
+      (id) =>
+        !parts.objects[id] || !(asString(parts.objects[id]!.isa) ?? "").endsWith("BuildPhase"),
+    )
+  ) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "malformed-project",
+      "The selected target contains a dangling or invalid package, product, or build-phase reference.",
+      source,
+    );
+  }
+
+  const packages = await verifiedPackages(root, absoluteProjectPath, parts.objects);
+  if (packages.length > 1) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "ambiguous-package",
+      "More than one verified clerk-ios package reference exists in this Xcode project.",
+      source,
+    );
+  }
+  const verifiedPackageIds = new Set(packages.map((item) => item.id));
+  const unsafeLocalPackageIds = new Set<string>();
+  for (const [id, object] of Object.entries(parts.objects)) {
+    if (object.isa !== "XCLocalSwiftPackageReference") continue;
+    const relativePath = asString(object.relativePath);
+    if (
+      !relativePath ||
+      !(await pathIsSafelyWithinIOSRoot(
+        root,
+        resolve(dirname(absoluteProjectPath), relativePath, "Package.swift"),
+      ))
+    ) {
+      unsafeLocalPackageIds.add(id);
+    }
+  }
+
+  const frameworkPhaseIds = targetBuildPhases.filter(
+    (id) => parts.objects[id]?.isa === "PBXFrameworksBuildPhase",
+  );
+  if (frameworkPhaseIds.length > 1) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "ambiguous-frameworks-phase",
+      "The selected target contains more than one Frameworks build phase.",
+      source,
+    );
+  }
+  let frameworkPhaseId = frameworkPhaseIds[0];
+  let frameworkFiles: string[] = [];
+  if (frameworkPhaseId) {
+    const files = strictStringArray(parts.objects[frameworkPhaseId]!, "files");
+    if (!files) {
+      return blocked(
+        options,
+        root,
+        projectPath,
+        "malformed-project",
+        "The selected target's Frameworks build phase has a malformed files list.",
+        source,
+      );
+    }
+    if (duplicateValue(files)) {
+      return blocked(
+        options,
+        root,
+        projectPath,
+        "duplicate-build-file",
+        "The selected target's Frameworks build phase contains a duplicate build file.",
+        source,
+      );
+    }
+    frameworkFiles = files;
+  }
+
+  const graphs = new Map<IOSSDKProduct, ProductGraph>();
+  const productBlockers: IOSSDKInstallBlocker[] = [];
+  for (const productName of PRODUCT_NAMES) {
+    const result = scanProductGraph(
+      productName,
+      targetProductIds,
+      frameworkFiles,
+      parts.objects,
+      verifiedPackageIds,
+      unsafeLocalPackageIds,
+    );
+    if (result.blocker) {
+      productBlockers.push(result.blocker);
+    } else {
+      graphs.set(productName, result.graph!);
+    }
+  }
+  if (productBlockers.length > 0) {
+    return {
+      ...source,
+      plan: makePlan(options, root, projectPath, "blocked", {
+        blockers: productBlockers,
+      }),
+    };
+  }
+
+  const actions: string[] = [];
+  let selectedPackage = packages[0];
+  const packageWasPresent = selectedPackage != null;
+  if (!selectedPackage) {
+    const packageId = stableObjectId(
+      parts.objects,
+      `${parts.projectObjectId}:${options.targetId}:remote-package:${CLERK_REPOSITORY}`,
+    );
+    parts.objects[packageId] = {
+      isa: "XCRemoteSwiftPackageReference",
+      repositoryURL: CLERK_REPOSITORY,
+      requirement: { kind: "upToNextMajorVersion", minimumVersion },
+    };
+    selectedPackage = { id: packageId, kind: "remote" };
+    verifiedPackageIds.add(packageId);
+    actions.push(`Add clerk-ios ${minimumVersion} or newer as a Swift package reference.`);
+  } else if (selectedPackage.kind === "remote") {
+    const packageObject = parts.objects[selectedPackage.id];
+    if (!supportedRemoteRequirement(packageObject?.requirement)) {
+      return blocked(
+        options,
+        root,
+        projectPath,
+        "unsupported-project",
+        "The existing clerk-ios remote reference has no readable package requirement.",
+        source,
+      );
+    }
+  }
+
+  if (options.requirePrebuiltAuthCompatibility && packageWasPresent) {
+    const compatibilityBlocker = await prebuiltAuthCompatibilityBlocker(
+      root,
+      projectPath,
+      inspection,
+      selectedPackage,
+      parts.objects,
+    );
+    if (compatibilityBlocker) {
+      return {
+        ...source,
+        plan: makePlan(options, root, projectPath, "blocked", {
+          blockers: [compatibilityBlocker],
+        }),
+      };
+    }
+  }
+
+  if (!projectPackageIds.includes(selectedPackage.id)) {
+    parts.projectObject.packageReferences = [...projectPackageIds, selectedPackage.id];
+    projectPackageIds.push(selectedPackage.id);
+    actions.push("Attach the verified clerk-ios package reference to the Xcode project.");
+  }
+
+  const products = requestedProducts(options.includeClerkKitUI);
+  const requiresFrameworkPhase = products.some(
+    (productName) => !graphs.get(productName)?.buildFileId,
+  );
+  if (!frameworkPhaseId && requiresFrameworkPhase) {
+    frameworkPhaseId = stableObjectId(
+      parts.objects,
+      `${parts.projectObjectId}:${options.targetId}:frameworks-phase`,
+    );
+    parts.objects[frameworkPhaseId] = {
+      isa: "PBXFrameworksBuildPhase",
+      buildActionMask: 2147483647,
+      files: [],
+      runOnlyForDeploymentPostprocessing: 0,
+    };
+    parts.targetObject.buildPhases = [...targetBuildPhases, frameworkPhaseId];
+    frameworkFiles = [];
+    actions.push("Create a Frameworks build phase for the selected target.");
+  }
+
+  for (const productName of products) {
+    const graph = graphs.get(productName)!;
+    let productId = graph.productId;
+    if (!productId) {
+      productId = stableObjectId(
+        parts.objects,
+        `${parts.projectObjectId}:${options.targetId}:product:${selectedPackage.id}:${productName}`,
+      );
+      parts.objects[productId] = {
+        isa: "XCSwiftPackageProductDependency",
+        package: selectedPackage.id,
+        productName,
+      };
+    }
+    if (!graph.inTarget) {
+      const currentProducts = strictStringArray(parts.targetObject, "packageProductDependencies")!;
+      parts.targetObject.packageProductDependencies = [...currentProducts, productId];
+      actions.push(`Add ${productName} to the selected target's package products.`);
+    }
+    if (!graph.buildFileId) {
+      if (!frameworkPhaseId) {
+        return blocked(
+          options,
+          root,
+          projectPath,
+          "unsupported-project",
+          `A Frameworks phase could not be created for ${productName}.`,
+          source,
+        );
+      }
+      const buildFileId = stableObjectId(
+        parts.objects,
+        `${parts.projectObjectId}:${options.targetId}:build-file:${productId}`,
+      );
+      parts.objects[buildFileId] = { isa: "PBXBuildFile", productRef: productId };
+      const phase = parts.objects[frameworkPhaseId]!;
+      const currentFiles = strictStringArray(phase, "files")!;
+      phase.files = [...currentFiles, buildFileId];
+      actions.push(`Link ${productName} in the selected target's Frameworks phase.`);
+    }
+  }
+
+  if (actions.length === 0) {
+    return {
+      ...source,
+      plan: makePlan(options, root, projectPath, "satisfied", {
+        expectedPbxprojHash: originalHash,
+      }),
+    };
+  }
+  if (generator) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "generated-project",
+      `This is a ${generator === "xcodegen" ? "XcodeGen" : "Tuist"} project; update its source manifest instead of generated project.pbxproj output.`,
+      source,
+    );
+  }
+
+  let candidate: string;
+  let reparsed: ReturnType<typeof parsePbxProject>;
+  try {
+    candidate = buildPbxProject(model);
+    reparsed = parsePbxProject(candidate);
+  } catch {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "unsupported-project",
+      "The proposed Xcode project could not be serialized and reparsed safely.",
+      source,
+    );
+  }
+  if (!isDeepStrictEqual(reparsed, model)) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "unsupported-project",
+      "Serializing this Xcode project would change unsupported object-graph data.",
+      source,
+    );
+  }
+  const candidateParts = projectParts(reparsed, options.targetId);
+  if (!candidateParts || !validateCandidateGraph(candidateParts, selectedPackage.id, products)) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "unsupported-project",
+      "The proposed Xcode project did not pass package-linkage validation.",
+      source,
+    );
+  }
+
+  const candidateBytes = new TextEncoder().encode(candidate);
+  return {
+    ...source,
+    candidateBytes,
+    candidateHash: hashIOSFileBytes(candidateBytes),
+    plan: makePlan(options, root, projectPath, "ready", {
+      actions,
+      expectedPbxprojHash: originalHash,
+    }),
+  };
+}
+
+/** @internal Postcondition for a combined PBX project and Swift source transaction. */
+export async function validateIOSSDKInstallPostcondition(
+  plan: IOSSDKInstallPlan,
+): Promise<boolean> {
+  const absoluteProjectPath = resolve(plan.root, plan.projectPath);
+  const pbxprojPath = resolve(absoluteProjectPath, "project.pbxproj");
+  if (!(await pathIsSafelyWithinIOSRoot(plan.root, pbxprojPath))) return false;
+  let parsed: ReturnType<typeof parsePbxProject>;
+  try {
+    parsed = parsePbxProject(await readFile(pbxprojPath, "utf8"));
+  } catch {
+    return false;
+  }
+  const parts = projectParts(parsed, plan.targetId);
+  if (!parts) return false;
+  const packages = await verifiedPackages(plan.root, absoluteProjectPath, parts.objects);
+  const selectedPackage = packages[0];
+  if (
+    packages.length !== 1 ||
+    !selectedPackage ||
+    !validateCandidateGraph(parts, selectedPackage.id, plan.products)
+  ) {
+    return false;
+  }
+
+  const inspection = await inspectIOSProject(plan.root, { target: plan.targetId });
+  if (inspection.generatedProject || (await generatedProjectKind(plan.root, absoluteProjectPath))) {
+    return false;
+  }
+  if (
+    inspection.selection.state !== "selected" ||
+    inspection.selection.targetId !== plan.targetId ||
+    inspection.selection.projectPath !== plan.projectPath
+  ) {
+    return false;
+  }
+  if (
+    plan.requirePrebuiltAuthCompatibility &&
+    (await prebuiltAuthCompatibilityBlocker(
+      plan.root,
+      plan.projectPath,
+      inspection,
+      selectedPackage,
+      parts.objects,
+    )) != null
+  ) {
+    return false;
+  }
+  const target = inspection.appTargets.find(
+    (item) => item.id === plan.targetId && item.projectPath === plan.projectPath,
+  );
+  if (!target || !["remote", "local"].includes(target.packages.package)) return false;
+  return plan.products.every((productName) =>
+    productName === "ClerkKit"
+      ? target.packages.clerkKit === "linked"
+      : target.packages.clerkKitUI === "linked",
+  );
+}
+
+export async function planIOSSDKInstall(options: IOSSDKInstallOptions): Promise<IOSSDKInstallPlan> {
+  return (await prepareInstall(options)).plan;
+}
+
+/**
+ * An internal SDK preparation result for a larger iOS file transaction. The
+ * ready case contains candidate PBX bytes and must not be logged or serialized.
+ *
+ * @internal
+ */
+export type PreparedIOSSDKInstallMutation =
+  | { status: "blocked"; plan: IOSSDKInstallPlan }
+  | { status: "stale"; plan: IOSSDKInstallPlan }
+  | { status: "satisfied"; plan: IOSSDKInstallPlan }
+  | { status: "ready"; plan: IOSSDKInstallPlan; mutation: IOSExistingFileMutation };
+
+/**
+ * Reprepares a serialized SDK plan and exposes its PBX mutation without writing
+ * it so a caller can combine it with Swift source mutations.
+ *
+ * @internal The ready result contains candidate bytes.
+ */
+export async function prepareIOSSDKInstallMutation(
+  plan: IOSSDKInstallPlan,
+): Promise<PreparedIOSSDKInstallMutation> {
+  if (plan.status === "blocked") return { status: "blocked", plan };
+
+  const prepared = await prepareInstall({
+    root: plan.root,
+    projectPath: plan.projectPath,
+    targetId: plan.targetId,
+    includeClerkKitUI: plan.products.includes("ClerkKitUI"),
+    minimumVersion: plan.minimumVersion,
+    requirePrebuiltAuthCompatibility: plan.requirePrebuiltAuthCompatibility,
+  });
+  if (!plan.expectedPbxprojHash || prepared.originalHash !== plan.expectedPbxprojHash) {
+    return { status: "stale", plan };
+  }
+  if (prepared.plan.status === "blocked") {
+    return { status: "blocked", plan: prepared.plan };
+  }
+  if (prepared.plan.status === "satisfied") {
+    return { status: "satisfied", plan: prepared.plan };
+  }
+  if (
+    !prepared.pbxprojPath ||
+    !prepared.originalBytes ||
+    !prepared.candidateBytes ||
+    !prepared.candidateHash ||
+    prepared.mode == null
+  ) {
+    return {
+      status: "blocked",
+      plan: makePlan(
+        {
+          root: plan.root,
+          projectPath: plan.projectPath,
+          targetId: plan.targetId,
+          includeClerkKitUI: plan.products.includes("ClerkKitUI"),
+          minimumVersion: plan.minimumVersion,
+          requirePrebuiltAuthCompatibility: plan.requirePrebuiltAuthCompatibility,
+        },
+        plan.root,
+        plan.projectPath,
+        "blocked",
+        {
+          blockers: [
+            {
+              code: "unsupported-project",
+              message: "The prepared install did not contain a validated candidate project.",
+            },
+          ],
+        },
+      ),
+    };
+  }
+
+  return {
+    status: "ready",
+    plan: prepared.plan,
+    mutation: {
+      path: prepared.pbxprojPath,
+      originalBytes: prepared.originalBytes,
+      originalHash: prepared.originalHash,
+      candidateBytes: prepared.candidateBytes,
+      candidateHash: prepared.candidateHash,
+      mode: prepared.mode,
+    },
+  };
+}
+
+export async function applyIOSSDKInstall(
+  plan: IOSSDKInstallPlan,
+): Promise<IOSSDKInstallApplyResult> {
+  const prepared = await prepareIOSSDKInstallMutation(plan);
+  if (prepared.status === "stale") {
+    return {
+      status: "stale",
+      plan,
+      message: "The Xcode project changed after the install plan was created.",
+    };
+  }
+  if (prepared.status === "blocked") {
+    return { status: "blocked", plan: prepared.plan };
+  }
+  if (prepared.status === "satisfied") {
+    return { status: "satisfied", plan: prepared.plan };
+  }
+
+  const writeResult = await applyIOSExistingFileTransaction(
+    [prepared.mutation],
+    [async () => validateIOSSDKInstallPostcondition(prepared.plan)],
+  );
+  if (writeResult.status === "stale") {
+    return {
+      status: "stale",
+      plan,
+      message: "The Xcode project changed while the install was being applied.",
+    };
+  }
+  return writeResult.status === "applied"
+    ? { status: "applied", plan: prepared.plan }
+    : {
+        status: "rolled-back",
+        plan: prepared.plan,
+        message:
+          "The proposed Xcode change failed post-write validation and was restored byte-for-byte.",
+      };
+}

--- a/packages/cli-core/src/commands/init/ios/pbx.test.ts
+++ b/packages/cli-core/src/commands/init/ios/pbx.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import {
+  buildPbxParentIndex,
+  isClerkIOSRepository,
+  resolvePbxFilePath,
+  sanitizeRepositoryURL,
+  type PbxObjects,
+} from "./pbx.ts";
+
+describe("resolvePbxFilePath", () => {
+  test("does not treat a pathless group's display name as a directory", () => {
+    const objects: PbxObjects = {
+      root: {
+        isa: "PBXGroup",
+        children: ["logical"],
+        sourceTree: "<group>",
+      },
+      logical: {
+        isa: "PBXGroup",
+        children: ["file"],
+        name: "Navigator Label",
+        sourceTree: "<group>",
+      },
+      file: {
+        isa: "PBXFileReference",
+        name: "Display Name.swift",
+        path: "Sources/App.swift",
+        sourceTree: "<group>",
+      },
+    };
+    const projectDirectory = join("/", "tmp", "Example");
+
+    expect(
+      resolvePbxFilePath("file", objects, buildPbxParentIndex(objects), projectDirectory),
+    ).toBe(join(projectDirectory, "Sources", "App.swift"));
+  });
+
+  test("does not guess a path from a pathless file reference's display name", () => {
+    const objects: PbxObjects = {
+      root: {
+        isa: "PBXGroup",
+        children: ["file"],
+        sourceTree: "<group>",
+      },
+      file: {
+        isa: "PBXFileReference",
+        name: "Display Name.swift",
+        sourceTree: "<group>",
+      },
+    };
+
+    expect(
+      resolvePbxFilePath("file", objects, buildPbxParentIndex(objects), "/tmp/Example"),
+    ).toBeUndefined();
+  });
+
+  test("uses projectDirPath only for group-relative paths, not SOURCE_ROOT", () => {
+    const objects: PbxObjects = {
+      main: { isa: "PBXGroup", children: ["group", "sourceRootFile"], sourceTree: "<group>" },
+      group: {
+        isa: "PBXGroup",
+        children: ["groupFile"],
+        path: "Sources",
+        sourceTree: "<group>",
+      },
+      groupFile: { isa: "PBXFileReference", path: "App.swift", sourceTree: "<group>" },
+      sourceRootFile: {
+        isa: "PBXFileReference",
+        path: "Root.swift",
+        sourceTree: "SOURCE_ROOT",
+      },
+    };
+    const parents = buildPbxParentIndex(objects);
+
+    expect(
+      resolvePbxFilePath(
+        "groupFile",
+        objects,
+        parents,
+        "/tmp/Example",
+        "/tmp/Example/ActualProjectRoot",
+      ),
+    ).toBe("/tmp/Example/ActualProjectRoot/Sources/App.swift");
+    expect(
+      resolvePbxFilePath(
+        "sourceRootFile",
+        objects,
+        parents,
+        "/tmp/Example",
+        "/tmp/Example/ActualProjectRoot",
+      ),
+    ).toBe("/tmp/Example/Root.swift");
+  });
+});
+
+describe("sanitizeRepositoryURL", () => {
+  test("canonicalizes Clerk HTTPS and SCP-style repository URLs", () => {
+    expect(sanitizeRepositoryURL("https://token@example.com/clerk/clerk-ios.git?key=secret")).toBe(
+      "https://example.com/clerk/clerk-ios",
+    );
+    expect(sanitizeRepositoryURL("git@github.com:clerk/clerk-ios.git")).toBe(
+      "ssh://github.com/clerk/clerk-ios",
+    );
+    expect(isClerkIOSRepository("git@github.com:clerk/clerk-ios.git")).toBe(true);
+  });
+
+  test("does not expose unsupported local or malformed repository values", () => {
+    expect(sanitizeRepositoryURL("file:///Users/alice/private/clerk-ios")).toBe(
+      "file://<redacted>",
+    );
+    expect(sanitizeRepositoryURL("not valid token@example.com/path")).toBe(
+      "<invalid-repository-url>",
+    );
+  });
+});

--- a/packages/cli-core/src/commands/init/ios/pbx.ts
+++ b/packages/cli-core/src/commands/init/ios/pbx.ts
@@ -1,0 +1,129 @@
+import { isAbsolute, resolve } from "node:path";
+
+export type PbxObject = Record<string, unknown> & { isa?: string };
+export type PbxObjects = Record<string, PbxObject>;
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function asString(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (typeof value === "number") return String(value);
+  return undefined;
+}
+
+export function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+export function asStringRecord(value: unknown): Record<string, string> {
+  if (!isRecord(value)) return {};
+  const result: Record<string, string> = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (typeof item === "string" || typeof item === "number") {
+      result[key] = String(item);
+    } else if (Array.isArray(item)) {
+      result[key] = item.map(String).join(" ");
+    }
+  }
+  return result;
+}
+
+export function buildPbxParentIndex(objects: PbxObjects): Map<string, string> {
+  const parents = new Map<string, string>();
+  for (const [id, object] of Object.entries(objects)) {
+    for (const child of asStringArray(object.children)) {
+      if (!parents.has(child)) parents.set(child, id);
+    }
+  }
+  return parents;
+}
+
+/** Resolve a group/file reference without invoking Xcode. */
+export function resolvePbxFilePath(
+  objectId: string,
+  objects: PbxObjects,
+  parents: Map<string, string>,
+  projectDirectory: string,
+  groupRootDirectory: string = projectDirectory,
+  seen: Set<string> = new Set(),
+): string | undefined {
+  if (seen.has(objectId)) return undefined;
+  seen.add(objectId);
+
+  const object = objects[objectId];
+  if (!object) return undefined;
+
+  const objectPath = asString(object.path);
+  // `name` is only an Xcode navigator display label. A pathless group is a
+  // logical group and contributes no filesystem component; a pathless file
+  // reference cannot be resolved without guessing.
+  if (objectPath == null && object.isa === "PBXFileReference") return undefined;
+  const rawPath = objectPath ?? "";
+  const sourceTree = asString(object.sourceTree) ?? "<group>";
+
+  if (sourceTree === "<absolute>") {
+    return rawPath ? resolve(rawPath) : undefined;
+  }
+  if (isAbsolute(rawPath)) {
+    return resolve(rawPath);
+  }
+  if (sourceTree === "SOURCE_ROOT" || sourceTree === "<sourceRoot>") {
+    return resolve(projectDirectory, rawPath);
+  }
+  if (sourceTree !== "<group>") return undefined;
+
+  const parentId = parents.get(objectId);
+  if (!parentId) return resolve(groupRootDirectory, rawPath);
+  const parentPath = resolvePbxFilePath(
+    parentId,
+    objects,
+    parents,
+    projectDirectory,
+    groupRootDirectory,
+    seen,
+  );
+  return parentPath ? resolve(parentPath, rawPath) : undefined;
+}
+
+export function sanitizeRepositoryURL(repository: string): string {
+  const trimmed = repository.trim();
+  const scpMatch = trimmed.match(/^(?:[^@]+@)?([^:]+):(.+)$/);
+  const scpHost = scpMatch?.[1];
+  const scpPath = scpMatch?.[2];
+  if (scpHost && scpPath && !trimmed.includes("://")) {
+    return `ssh://${scpHost.toLowerCase()}/${scpPath.replace(/^\/+/, "")}`
+      .replace(/\.git\/?$/i, "")
+      .replace(/\/$/, "");
+  }
+
+  try {
+    const url = new URL(trimmed);
+    if (!["https:", "http:", "ssh:", "git:"].includes(url.protocol)) {
+      return `${url.protocol}//<redacted>`;
+    }
+    url.username = "";
+    url.password = "";
+    url.search = "";
+    url.hash = "";
+    return `${url.protocol}//${url.host.toLowerCase()}${url.pathname}`
+      .replace(/\.git\/?$/i, "")
+      .replace(/\/$/, "");
+  } catch {
+    const sanitized = trimmed
+      .replace(/[?#].*$/, "")
+      .replace(/\.git\/?$/i, "")
+      .replace(/\/$/, "");
+    return /^[a-zA-Z0-9._/-]+$/.test(sanitized) ? sanitized : "<invalid-repository-url>";
+  }
+}
+
+export function isClerkIOSRepository(repository: string): boolean {
+  const canonical = sanitizeRepositoryURL(repository).toLowerCase();
+  return (
+    canonical === "https://github.com/clerk/clerk-ios" ||
+    canonical === "ssh://github.com/clerk/clerk-ios"
+  );
+}

--- a/packages/cli-core/src/commands/init/ios/products.test.ts
+++ b/packages/cli-core/src/commands/init/ios/products.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+import {
+  clerkKitUIInstallDecision,
+  hasIOSDirectConfigCompatibility,
+  shouldInstallClerkKitUI,
+  shouldPlanIOSDirectConfig,
+} from "./products.ts";
+import type { IOSAppTarget, IOSProjectInspectionResult } from "./types.ts";
+
+function target(): IOSAppTarget {
+  return {
+    id: "TARGET",
+    name: "MyApp",
+    projectPath: "MyApp.xcodeproj",
+    configurations: [],
+    packages: { package: "absent", clerkKit: "absent", clerkKitUI: "absent" },
+    runtimeKeySinks: [],
+    swift: {
+      sourceFilesScanned: 1,
+      evidenceComplete: true,
+      entryPoints: [{ path: "MyApp/MyAppApp.swift" }],
+      importsClerkKit: [],
+      importsClerkKitUI: [],
+      configureCalls: [],
+      localSecretsRuntimeBindings: [],
+      environmentInjections: [],
+      environmentConsumers: [],
+      authFlowReferences: [],
+      openURLHandlers: [],
+      status: "absent",
+    },
+  };
+}
+
+function inspection(selected: IOSAppTarget): IOSProjectInspectionResult {
+  return {
+    schemaVersion: 1,
+    platform: "ios",
+    root: "/tmp/test",
+    workspaces: [],
+    projects: [],
+    appTargets: [selected],
+    selection: {
+      state: "selected",
+      targetId: selected.id,
+      targetName: selected.name,
+      projectPath: selected.projectPath,
+    },
+    localPublishableKey: {
+      found: false,
+      conflict: false,
+      candidateSources: [],
+      invalidSources: [],
+    },
+    generatedProject: null,
+    diagnostics: [],
+  };
+}
+
+describe("shouldInstallClerkKitUI", () => {
+  test("defaults an untouched, fully inspected target to the prebuilt UI path", () => {
+    expect(shouldInstallClerkKitUI(target())).toBe(true);
+  });
+
+  test("upgrades a source-blank ClerkKit-only graph created by an earlier setup", () => {
+    const coreOnly = target();
+    coreOnly.packages = { package: "remote", clerkKit: "linked", clerkKitUI: "absent" };
+    expect(shouldInstallClerkKitUI(coreOnly)).toBe(true);
+  });
+
+  test("preserves a source-proven custom-flow target", () => {
+    const customSource = target();
+    customSource.swift.importsClerkKit = [{ path: "MyApp/Auth.swift" }];
+    customSource.swift.status = "partial";
+    expect(shouldInstallClerkKitUI(customSource)).toBe(false);
+  });
+
+  test("honors existing ClerkKitUI source or product evidence", () => {
+    const imported = target();
+    imported.swift.importsClerkKitUI = [{ path: "MyApp/Auth.swift" }];
+    imported.swift.status = "partial";
+    expect(shouldInstallClerkKitUI(imported)).toBe(true);
+
+    const declared = target();
+    declared.packages.clerkKitUI = "declared";
+    expect(shouldInstallClerkKitUI(declared)).toBe(true);
+  });
+
+  test("does not infer a prebuilt default from incomplete source evidence", () => {
+    const incomplete = target();
+    incomplete.swift.evidenceComplete = false;
+    incomplete.packages = { package: "remote", clerkKit: "linked", clerkKitUI: "absent" };
+    expect(clerkKitUIInstallDecision(incomplete)).toBe("unknown");
+    expect(shouldInstallClerkKitUI(incomplete)).toBe(false);
+
+    incomplete.swift.importsClerkKit = [{ path: "MyApp/Visible.swift" }];
+    expect(clerkKitUIInstallDecision(incomplete)).toBe("unknown");
+    expect(shouldInstallClerkKitUI(incomplete)).toBe(false);
+  });
+});
+
+describe("direct configuration compatibility", () => {
+  test.each(["local-secrets-loader", "process-info-environment"] as const)(
+    "preserves an existing %s configure route",
+    (publishableKeyWiring) => {
+      const selected = target();
+      selected.swift.configureCalls = [
+        {
+          path: "MyApp/MyAppApp.swift",
+          publishableKeyWiring,
+          startupBinding: "app-init",
+          ...(publishableKeyWiring === "local-secrets-loader"
+            ? { localSecretsRuntimeBinding: "proven" as const }
+            : {}),
+        },
+      ];
+      const result = inspection(selected);
+
+      expect(hasIOSDirectConfigCompatibility(result, selected)).toBe(true);
+      expect(shouldPlanIOSDirectConfig(result, selected)).toBe(false);
+    },
+  );
+
+  test("preserves an enabled selected-target scheme key route", () => {
+    const selected = target();
+    const result = inspection(selected);
+    result.localPublishableKey.candidateSources = [
+      "MyApp.xcodeproj/xcshareddata/xcschemes/MyApp.xcscheme",
+    ];
+
+    expect(hasIOSDirectConfigCompatibility(result, selected)).toBe(true);
+    expect(shouldPlanIOSDirectConfig(result, selected)).toBe(false);
+  });
+
+  test("preserves a target-owned runtime key sink", () => {
+    const selected = target();
+    selected.runtimeKeySinks = [{ kind: "local-secrets-plist", path: "MyApp/LocalSecrets.plist" }];
+    const result = inspection(selected);
+
+    expect(hasIOSDirectConfigCompatibility(result, selected)).toBe(true);
+    expect(shouldPlanIOSDirectConfig(result, selected)).toBe(false);
+  });
+
+  test("plans direct configuration for a fresh compatible target", () => {
+    const selected = target();
+    const result = inspection(selected);
+
+    expect(hasIOSDirectConfigCompatibility(result, selected)).toBe(false);
+    expect(shouldPlanIOSDirectConfig(result, selected)).toBe(true);
+  });
+});

--- a/packages/cli-core/src/commands/init/ios/products.ts
+++ b/packages/cli-core/src/commands/init/ios/products.ts
@@ -1,0 +1,59 @@
+import type { IOSAppTarget, IOSProjectInspectionResult } from "./types.ts";
+
+export type ClerkKitUIInstallDecision = "prebuilt" | "core-only" | "unknown";
+
+/**
+ * Chooses the prebuilt UI product for an explicitly UI-backed target or for a
+ * fully inspected target that has not begun a custom Clerk integration. A
+ * source-blank ClerkKit-only graph is upgraded because an earlier CLI release
+ * may have created it; source-proven custom targets remain core-only.
+ */
+export function clerkKitUIInstallDecision(target: IOSAppTarget): ClerkKitUIInstallDecision {
+  const hasUIIntent =
+    target.swift.importsClerkKitUI.length > 0 || target.packages.clerkKitUI !== "absent";
+  if (hasUIIntent) return "prebuilt";
+
+  const hasCustomSourceIntent = target.swift.importsClerkKit.length > 0;
+  if (!target.swift.evidenceComplete) return "unknown";
+  return hasCustomSourceIntent ? "core-only" : "prebuilt";
+}
+
+export function shouldInstallClerkKitUI(target: IOSAppTarget): boolean {
+  return clerkKitUIInstallDecision(target) === "prebuilt";
+}
+
+/** Existing runtime-key routes that direct source configuration must preserve. */
+export function hasIOSDirectConfigCompatibility(
+  inspection: IOSProjectInspectionResult,
+  target: IOSAppTarget,
+): boolean {
+  const hasCompatibleConfigure = target.swift.configureCalls.some(
+    (call) =>
+      call.publishableKeyWiring === "local-secrets-loader" ||
+      call.publishableKeyWiring === "process-info-environment",
+  );
+  const hasEnabledSchemeKey = inspection.localPublishableKey.candidateSources.some((source) =>
+    source.endsWith(".xcscheme"),
+  );
+  return hasCompatibleConfigure || hasEnabledSchemeKey || target.runtimeKeySinks.length > 0;
+}
+
+/**
+ * Routes only the fresh/direct-literal Swift path to the source mutator.
+ * Existing LocalSecrets and ProcessInfo integrations remain compatibility
+ * paths and are never rewritten into a literal automatically.
+ */
+export function shouldPlanIOSDirectConfig(
+  inspection: IOSProjectInspectionResult,
+  target: IOSAppTarget,
+  productDecision: ClerkKitUIInstallDecision = clerkKitUIInstallDecision(target),
+): boolean {
+  if (hasIOSDirectConfigCompatibility(inspection, target)) return false;
+
+  const hasInlineConfigure = target.swift.configureCalls.some(
+    (call) => call.publishableKeyWiring === "inline-literal",
+  );
+  return (
+    hasInlineConfigure || target.swift.configureCalls.length > 0 || productDecision === "prebuilt"
+  );
+}

--- a/packages/cli-core/src/commands/init/ios/runtime-key.test.ts
+++ b/packages/cli-core/src/commands/init/ios/runtime-key.test.ts
@@ -1,0 +1,1053 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { appendFile, mkdir, mkdtemp, readdir, rename, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+import plist from "@expo/plist";
+import {
+  applyIOSRuntimeKey,
+  planIOSRuntimeKey,
+  planIOSRuntimeKeyVerification,
+  type IOSRuntimeKeyBlockerCode,
+  verifyIOSRuntimeKey,
+} from "./runtime-key.ts";
+import { createIOSFixture, IOS_FIXTURE_IDS, treeDigest } from "./test-helpers.ts";
+
+const temporaryDirectories: string[] = [];
+const LOADER_FILE = "474747474747474747474747";
+const LOADER_BUILD_FILE = "484848484848484848484848";
+const TARGET_IGNORE_RULE = "/MyApp/LocalSecrets.plist\n";
+const TEMPORARY_IGNORE_RULE = "/MyApp/.LocalSecrets.plist.clerk-*.tmp\n";
+
+function publishableKey(host: string, live = false): string {
+  return `pk_${live ? "live" : "test"}_${Buffer.from(`${host}$`).toString("base64")}`;
+}
+
+function plistSource(key?: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- unrelated data must survive byte-for-byte -->
+  <key>ANALYTICS_ENABLED</key>
+  <true/>
+${key == null ? "" : `  <key>CLERK_PUBLISHABLE_KEY</key>\n  <string>${key}</string>\n`}</dict>
+</plist>
+`;
+}
+
+const APP_SOURCE = `import ClerkKit
+import SwiftUI
+
+@main
+struct MyApp: App {
+  init() {
+    Clerk.configure(publishableKey: ClerkLocalSecrets.load().publishableKey ?? "")
+  }
+
+  var body: some Scene {
+    WindowGroup { Text("Hello") }
+      .environment(Clerk.shared)
+  }
+}
+`;
+
+const LOADER_SOURCE = `import Foundation
+
+struct ClerkLocalSecrets {
+  let publishableKey: String?
+
+  static func load(
+    bundle: Bundle = .main,
+    processInfo: ProcessInfo = .processInfo
+  ) -> ClerkLocalSecrets {
+    let plistValues = localSecretsPlistValues(bundle: bundle)
+    return .init(
+      publishableKey: resolveValue(
+        for: "CLERK_PUBLISHABLE_KEY",
+        processInfo: processInfo,
+        plistValues: plistValues
+      )
+    )
+  }
+
+  private static func resolveValue(
+    for key: String,
+    processInfo: ProcessInfo,
+    plistValues: [String: Any]
+  ) -> String? {
+    if let environmentValue = normalized(processInfo.environment[key]) {
+      return environmentValue
+    }
+    return normalized(plistValues[key] as? String)
+  }
+
+  private static func normalized(_ value: String?) -> String? {
+    guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+      return nil
+    }
+    return value
+  }
+
+  private static func localSecretsPlistValues(bundle: Bundle) -> [String: Any] {
+    guard
+      let url = bundle.url(forResource: "LocalSecrets", withExtension: "plist"),
+      let data = try? Data(contentsOf: url),
+      let propertyList = try? PropertyListSerialization.propertyList(from: data, format: nil),
+      let values = propertyList as? [String: Any]
+    else {
+      return [:]
+    }
+    return values
+  }
+}
+`;
+
+async function fixture(key?: string, secondTarget = false): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "clerk-ios-runtime-key-"));
+  temporaryDirectories.push(root);
+  await createIOSFixture(root, {
+    complete: false,
+    includeKey: false,
+    localSecrets: true,
+    secondTarget,
+  });
+  await Bun.write(join(root, "MyApp", "MyAppApp.swift"), APP_SOURCE);
+  await Bun.write(join(root, "MyApp", "ClerkLocalSecrets.swift"), LOADER_SOURCE);
+  await Bun.write(join(root, "MyApp", "LocalSecrets.plist"), plistSource(key));
+
+  const projectPath = join(root, "MyApp.xcodeproj", "project.pbxproj");
+  const project = await Bun.file(projectPath).text();
+  await Bun.write(
+    projectPath,
+    project
+      .replace(
+        `children = ( ${IOS_FIXTURE_IDS.appFile}, ${IOS_FIXTURE_IDS.localSecretsFile}, );`,
+        `children = ( ${IOS_FIXTURE_IDS.appFile}, ${LOADER_FILE}, ${IOS_FIXTURE_IDS.localSecretsFile}, );`,
+      )
+      .replace(
+        `${IOS_FIXTURE_IDS.appFile} = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAppApp.swift; sourceTree = "<group>"; };`,
+        `${IOS_FIXTURE_IDS.appFile} = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAppApp.swift; sourceTree = "<group>"; };\n    ${LOADER_FILE} = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClerkLocalSecrets.swift; sourceTree = "<group>"; };`,
+      )
+      .replace(
+        `files = ( ${IOS_FIXTURE_IDS.sourceBuildFile}, );`,
+        `files = ( ${IOS_FIXTURE_IDS.sourceBuildFile}, ${LOADER_BUILD_FILE}, );`,
+      )
+      .replace(
+        `${IOS_FIXTURE_IDS.sourceBuildFile} = { isa = PBXBuildFile; fileRef = ${IOS_FIXTURE_IDS.appFile}; };`,
+        `${IOS_FIXTURE_IDS.sourceBuildFile} = { isa = PBXBuildFile; fileRef = ${IOS_FIXTURE_IDS.appFile}; };\n    ${LOADER_BUILD_FILE} = { isa = PBXBuildFile; fileRef = ${LOADER_FILE}; };`,
+      ),
+  );
+  return root;
+}
+
+function options(root: string) {
+  return {
+    root,
+    projectPath: "MyApp.xcodeproj",
+    targetId: IOS_FIXTURE_IDS.appTarget,
+  };
+}
+
+async function run(root: string, key: string) {
+  const plan = await planIOSRuntimeKey(options(root));
+  const result = await applyIOSRuntimeKey(plan, key);
+  return { plan, result };
+}
+
+async function initGit(root: string): Promise<void> {
+  const child = Bun.spawn(["git", "init", "--quiet"], {
+    cwd: root,
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+  if ((await child.exited) !== 0) {
+    throw new Error(await new Response(child.stderr).text());
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+describe("iOS runtime publishable-key transaction", () => {
+  test("verifies an existing runtime key without retaining either compared value", async () => {
+    const localKey = publishableKey("verify-local.clerk.example");
+    const linkedKey = publishableKey("verify-linked.clerk.example");
+    const root = await fixture(localKey);
+    const plan = await planIOSRuntimeKeyVerification(options(root));
+
+    const matched = await verifyIOSRuntimeKey(plan, localKey);
+    const mismatched = await verifyIOSRuntimeKey(plan, linkedKey);
+
+    expect(plan.status).toBe("ready");
+    expect(matched.status).toBe("matched");
+    expect(mismatched.status).toBe("mismatched");
+    expect(JSON.stringify({ plan, matched, mismatched })).not.toContain(localKey);
+    expect(JSON.stringify({ plan, matched, mismatched })).not.toContain(linkedKey);
+  });
+
+  test("treats the same valid key in an ignored target sink as a byte-for-byte no-op", async () => {
+    const key = publishableKey("same.clerk.example");
+    const root = await fixture(key);
+    await Bun.write(join(root, ".gitignore"), "/MyApp/LocalSecrets.plist\n");
+    const before = await treeDigest(root);
+
+    const { plan, result } = await run(root, key);
+
+    expect(plan.status).toBe("ready");
+    expect(result.status).toBe("satisfied");
+    expect(await treeDigest(root)).toEqual(before);
+    expect(JSON.stringify({ plan, result })).not.toContain(key);
+  });
+
+  test("replaces an invalid placeholder while preserving unrelated XML bytes", async () => {
+    const root = await fixture("pk_test_...");
+    const key = publishableKey("replacement.clerk.example");
+    const path = join(root, "MyApp", "LocalSecrets.plist");
+    const before = await Bun.file(path).text();
+
+    const { plan, result } = await run(root, key);
+    const after = await Bun.file(path).text();
+
+    expect(result.status).toBe("applied");
+    expect(after).toBe(before.replace("pk_test_...", key));
+    expect(await Bun.file(join(root, ".gitignore")).text()).toBe(
+      TEMPORARY_IGNORE_RULE + TARGET_IGNORE_RULE,
+    );
+    expect(JSON.stringify({ plan, result })).not.toContain(key);
+  });
+
+  test("plans a gitignore change for crash-safe staging even when the target rule exists", async () => {
+    const root = await fixture("pk_test_...");
+    await Bun.write(join(root, ".gitignore"), TARGET_IGNORE_RULE);
+
+    const plan = await planIOSRuntimeKey(options(root));
+
+    expect(plan.status).toBe("ready");
+    expect(plan.changesGitignore).toBe(true);
+    expect(plan.actions.some((action) => action.includes("atomic-write staging file"))).toBe(true);
+  });
+
+  test("inserts a missing key without changing unrelated plist values", async () => {
+    const root = await fixture();
+    const key = publishableKey("insert.clerk.example");
+    const path = join(root, "MyApp", "LocalSecrets.plist");
+
+    const { result } = await run(root, key);
+    const source = await Bun.file(path).text();
+    const parsed = plist.parse(source) as Record<string, unknown>;
+
+    expect(result.status).toBe("applied");
+    expect(parsed.ANALYTICS_ENABLED).toBe(true);
+    expect(parsed.CLERK_PUBLISHABLE_KEY).toBe(key);
+    expect(source).toContain("<!-- unrelated data must survive byte-for-byte -->");
+  });
+
+  test("does not insert a duplicate semantic key when its XML spelling is encoded", async () => {
+    const root = await fixture("pk_test_...");
+    const path = join(root, "MyApp", "LocalSecrets.plist");
+    await Bun.write(
+      path,
+      plistSource("pk_test_...").replace("CLERK_PUBLISHABLE_KEY", "CLERK_PUBLISHABLE_&#75;EY"),
+    );
+    const before = await treeDigest(root);
+    const plan = await planIOSRuntimeKey(options(root));
+
+    const result = await applyIOSRuntimeKey(plan, publishableKey("encoded-key.clerk.example"));
+
+    expect(result.status).toBe("blocked");
+    expect(result.plan.blockers[0]?.code).toBe("unsupported-local-secrets");
+    expect(await treeDigest(root)).toEqual(before);
+  });
+
+  test("blocks a different valid key without writing any file", async () => {
+    const existingKey = publishableKey("existing.clerk.example");
+    const replacementKey = publishableKey("different.clerk.example");
+    const root = await fixture(existingKey);
+    const before = await treeDigest(root);
+
+    const { plan, result } = await run(root, replacementKey);
+
+    expect(result.status).toBe("blocked");
+    expect(result.plan.blockers[0]?.code).toBe("different-publishable-key");
+    expect(await treeDigest(root)).toEqual(before);
+    const serialized = JSON.stringify({ plan, result });
+    expect(serialized).not.toContain(existingKey);
+    expect(serialized).not.toContain(replacementKey);
+  });
+
+  test("blocks invalid apply input without exposing it", async () => {
+    const root = await fixture("pk_test_...");
+    const plan = await planIOSRuntimeKey(options(root));
+    const invalid = "pk_test_not-a-real-key";
+
+    const result = await applyIOSRuntimeKey(plan, invalid);
+
+    expect(result.status).toBe("blocked");
+    expect(result.plan.blockers[0]?.code).toBe("invalid-publishable-key");
+    expect(JSON.stringify(result)).not.toContain(invalid);
+  });
+
+  test("blocks a production publishable key without exposing it", async () => {
+    const root = await fixture("pk_test_...");
+    const plan = await planIOSRuntimeKey(options(root));
+    const productionKey = publishableKey("production.clerk.example", true);
+
+    const result = await applyIOSRuntimeKey(plan, productionKey);
+
+    expect(result.status).toBe("blocked");
+    expect(result.plan.blockers[0]?.code).toBe("production-publishable-key");
+    expect(JSON.stringify(result)).not.toContain(productionKey);
+  });
+
+  test("adds only the ignore rule when an existing valid key is not ignored", async () => {
+    const key = publishableKey("ignore-only.clerk.example");
+    const root = await fixture(key);
+    const plistBefore = await Bun.file(join(root, "MyApp", "LocalSecrets.plist")).text();
+
+    const { result } = await run(root, key);
+
+    expect(result.status).toBe("applied");
+    expect(await Bun.file(join(root, "MyApp", "LocalSecrets.plist")).text()).toBe(plistBefore);
+    expect(await Bun.file(join(root, ".gitignore")).text()).toBe("/MyApp/LocalSecrets.plist\n");
+  });
+
+  test("normalizes surrounding whitespace in an otherwise matching key", async () => {
+    const key = publishableKey("normalized.clerk.example");
+    const root = await fixture(`  ${key}\n`);
+
+    const { result } = await run(root, key);
+
+    expect(result.status).toBe("applied");
+    expect(await Bun.file(join(root, "MyApp", "LocalSecrets.plist")).text()).toContain(
+      `<string>${key}</string>`,
+    );
+  });
+
+  test("adds a portable exact rule even when a broader Git pattern already ignores the sink", async () => {
+    const root = await fixture("pk_test_...");
+    await initGit(root);
+    await Bun.write(join(root, ".gitignore"), "**/LocalSecrets.plist\n");
+    const key = publishableKey("broad-ignore.clerk.example");
+
+    const { result } = await run(root, key);
+
+    expect(result.status).toBe("applied");
+    expect(await Bun.file(join(root, ".gitignore")).text()).toBe(
+      `**/LocalSecrets.plist\n${TEMPORARY_IGNORE_RULE}${TARGET_IGNORE_RULE}`,
+    );
+  });
+
+  test("does not treat whitespace around a rule as the exact portable rule", async () => {
+    const root = await fixture("pk_test_...");
+    await Bun.write(join(root, ".gitignore"), " /MyApp/LocalSecrets.plist\n");
+    const key = publishableKey("whitespace-rule.clerk.example");
+
+    const { result } = await run(root, key);
+
+    expect(result.status).toBe("applied");
+    expect(await Bun.file(join(root, ".gitignore")).text()).toBe(
+      ` /MyApp/LocalSecrets.plist\n${TEMPORARY_IGNORE_RULE}${TARGET_IGNORE_RULE}`,
+    );
+  });
+
+  test("appends the exact rule after a later negation before reporting satisfaction", async () => {
+    for (const repository of [false, true]) {
+      const key = publishableKey(`${repository ? "git" : "plain"}-negated.clerk.example`);
+      const root = await fixture(key);
+      if (repository) await initGit(root);
+      await Bun.write(
+        join(root, ".gitignore"),
+        "/MyApp/LocalSecrets.plist\n!/MyApp/LocalSecrets.plist\n",
+      );
+
+      const { result } = await run(root, key);
+
+      expect(result.status).toBe("applied");
+      expect(await Bun.file(join(root, ".gitignore")).text()).toBe(
+        "/MyApp/LocalSecrets.plist\n!/MyApp/LocalSecrets.plist\n/MyApp/LocalSecrets.plist\n",
+      );
+      if (repository) {
+        const check = Bun.spawn(
+          ["git", "check-ignore", "--quiet", "--no-index", "--", "MyApp/LocalSecrets.plist"],
+          { cwd: root, stdout: "ignore", stderr: "ignore" },
+        );
+        expect(await check.exited).toBe(0);
+      }
+    }
+  });
+
+  test("blocks nested gitignore files that can override the root protection", async () => {
+    for (const repository of [false, true]) {
+      const root = await fixture("pk_test_...");
+      if (repository) await initGit(root);
+      await Bun.write(
+        join(root, "MyApp", ".gitignore"),
+        "!LocalSecrets.plist\n!.LocalSecrets.plist.clerk-*.tmp\n",
+      );
+      const before = await treeDigest(root);
+
+      const plan = await planIOSRuntimeKey(options(root));
+
+      expect(plan.status).toBe("blocked");
+      expect(plan.blockers[0]?.code).toBe("unsafe-gitignore");
+      expect(await treeDigest(root)).toEqual(before);
+    }
+  });
+
+  test("blocks a LocalSecrets.plist already tracked by Git", async () => {
+    const root = await fixture("pk_test_...");
+    await initGit(root);
+    const add = Bun.spawn(["git", "add", "--", "MyApp/LocalSecrets.plist"], {
+      cwd: root,
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    expect(await add.exited).toBe(0);
+    const before = await treeDigest(root);
+
+    const plan = await planIOSRuntimeKey(options(root));
+
+    expect(plan.status).toBe("blocked");
+    expect(plan.blockers[0]?.code).toBe("tracked-local-secrets");
+    expect(await treeDigest(root)).toEqual(before);
+  });
+
+  test("blocks every enabled selected-target Run-scheme override", async () => {
+    for (const schemeKey of [
+      publishableKey("same-scheme.clerk.example"),
+      publishableKey("other-scheme.clerk.example"),
+    ]) {
+      const root = await fixture("pk_test_...");
+      const directory = join(root, "MyApp.xcodeproj", "xcshareddata", "xcschemes");
+      await mkdir(directory, { recursive: true });
+      await Bun.write(
+        join(directory, "MyApp.xcscheme"),
+        `<Scheme><LaunchAction><BuildableProductRunnable><BuildableReference BlueprintIdentifier="${IOS_FIXTURE_IDS.appTarget}" ReferencedContainer="container:MyApp.xcodeproj" /></BuildableProductRunnable><EnvironmentVariables><EnvironmentVariable key="CLERK_PUBLISHABLE_KEY" value="${schemeKey}" isEnabled="YES" /></EnvironmentVariables></LaunchAction></Scheme>`,
+      );
+
+      const plan = await planIOSRuntimeKey(options(root));
+
+      expect(plan.status).toBe("blocked");
+      expect(plan.blockers[0]?.code).toBe("scheme-override");
+      expect(JSON.stringify(plan)).not.toContain(schemeKey);
+    }
+  });
+
+  test("blocks malformed, binary, oversized, and symlinked sinks", async () => {
+    const cases: Array<{
+      expected: IOSRuntimeKeyBlockerCode;
+      mutate(root: string): Promise<void>;
+    }> = [
+      {
+        expected: "malformed-local-secrets",
+        mutate: async (root) => {
+          await Bun.write(join(root, "MyApp", "LocalSecrets.plist"), "<plist><dict>");
+        },
+      },
+      {
+        expected: "malformed-local-secrets",
+        mutate: async (root) => {
+          await Bun.write(
+            join(root, "MyApp", "LocalSecrets.plist"),
+            new Uint8Array([0x62, 0x70, 0x6c, 0x69, 0x73, 0x74, 0x30, 0x30]),
+          );
+        },
+      },
+      {
+        expected: "unreadable-local-secrets",
+        mutate: async (root) => {
+          await Bun.write(join(root, "MyApp", "LocalSecrets.plist"), "x".repeat(1_000_001));
+        },
+      },
+      {
+        expected: "unreadable-local-secrets",
+        mutate: async (root) => {
+          const path = join(root, "MyApp", "LocalSecrets.plist");
+          const outside = join(root, "outside.plist");
+          await Bun.write(outside, plistSource("pk_test_..."));
+          await rm(path);
+          await symlink(outside, path);
+        },
+      },
+    ];
+
+    for (const item of cases) {
+      const root = await fixture("pk_test_...");
+      await item.mutate(root);
+      const before = await treeDigest(root);
+
+      const plan = await planIOSRuntimeKey(options(root));
+
+      expect(plan.status).toBe("blocked");
+      expect(plan.blockers[0]?.code).toBe(item.expected);
+      expect(await treeDigest(root)).toEqual(before);
+    }
+  });
+
+  test("blocks a generated project and an explicitly selected non-target resource", async () => {
+    const generatedRoot = await fixture("pk_test_...");
+    await Bun.write(join(generatedRoot, "project.yml"), "name: MyApp\n");
+    const generatedPlan = await planIOSRuntimeKey(options(generatedRoot));
+    expect(generatedPlan.blockers[0]?.code).toBe("generated-project");
+
+    const root = await fixture("pk_test_...");
+    await mkdir(join(root, "NotTarget"));
+    await Bun.write(join(root, "NotTarget", "LocalSecrets.plist"), plistSource("pk_test_..."));
+    const plan = await planIOSRuntimeKey({
+      ...options(root),
+      localSecretsPath: "NotTarget/LocalSecrets.plist",
+    });
+    expect(plan.blockers[0]?.code).toBe("not-target-resource");
+  });
+
+  test("blocks a generator marker beside a nested selected project", async () => {
+    const root = await fixture("pk_test_...");
+    await mkdir(join(root, "ios"));
+    await rename(join(root, "MyApp.xcodeproj"), join(root, "ios", "MyApp.xcodeproj"));
+    await rename(join(root, "MyApp"), join(root, "ios", "MyApp"));
+    await Bun.write(join(root, "ios", "project.yml"), "name: MyApp\n");
+
+    const plan = await planIOSRuntimeKey({
+      root,
+      projectPath: "ios/MyApp.xcodeproj",
+      targetId: IOS_FIXTURE_IDS.appTarget,
+    });
+
+    expect(plan.status).toBe("blocked");
+    expect(plan.blockers[0]?.code).toBe("generated-project");
+  });
+
+  test("blocks an invocation root above the selected project's nested Git repository", async () => {
+    const root = await fixture("pk_test_...");
+    const nested = join(root, "Nested");
+    await mkdir(nested);
+    await rename(join(root, "MyApp.xcodeproj"), join(nested, "MyApp.xcodeproj"));
+    await rename(join(root, "MyApp"), join(nested, "MyApp"));
+    await initGit(nested);
+
+    const plan = await planIOSRuntimeKey({
+      root,
+      projectPath: "Nested/MyApp.xcodeproj",
+      targetId: IOS_FIXTURE_IDS.appTarget,
+    });
+
+    expect(plan.status).toBe("blocked");
+    expect(plan.blockers[0]?.code).toBe("git-repository-mismatch");
+    expect(await Bun.file(join(root, ".gitignore")).exists()).toBe(false);
+  });
+
+  test("requires exact entrypoint, configure, loader, and sink proof", async () => {
+    const root = await fixture("pk_test_...");
+    await Bun.write(join(root, "MyApp", "ClerkLocalSecrets.swift"), "import Foundation\n");
+
+    const plan = await planIOSRuntimeKey(options(root));
+
+    expect(plan.status).toBe("blocked");
+    expect(plan.blockers[0]?.code).toBe("unproven-runtime-wiring");
+  });
+
+  test("does not treat a same-file unused configure helper as app-startup wiring", async () => {
+    const root = await fixture("pk_test_...");
+    await Bun.write(
+      join(root, "MyApp", "MyAppApp.swift"),
+      APP_SOURCE.replace(
+        `  init() {
+    Clerk.configure(publishableKey: ClerkLocalSecrets.load().publishableKey ?? "")
+  }`,
+        `  init() {}
+
+  func unusedConfigureHelper() {
+    Clerk.configure(publishableKey: ClerkLocalSecrets.load().publishableKey ?? "")
+  }`,
+      ),
+    );
+
+    const plan = await planIOSRuntimeKey(options(root));
+
+    expect(plan.status).toBe("blocked");
+    expect(plan.blockers[0]?.code).toBe("unproven-runtime-wiring");
+  });
+
+  test("blocks a LocalSecrets resource shared by another iOS application target", async () => {
+    const root = await fixture("pk_test_...", true);
+    const projectPath = join(root, "MyApp.xcodeproj", "project.pbxproj");
+    const project = await Bun.file(projectPath).text();
+    await Bun.write(
+      projectPath,
+      project.replace(
+        `buildPhases = ( ${IOS_FIXTURE_IDS.secondSourcesPhase}, ${IOS_FIXTURE_IDS.secondFrameworksPhase}, );`,
+        `buildPhases = ( ${IOS_FIXTURE_IDS.secondSourcesPhase}, ${IOS_FIXTURE_IDS.secondFrameworksPhase}, ${IOS_FIXTURE_IDS.resourcesPhase}, );`,
+      ),
+    );
+    const before = await treeDigest(root);
+
+    const plan = await planIOSRuntimeKey(options(root));
+
+    expect(plan.status).toBe("blocked");
+    expect(plan.blockers[0]?.code).toBe("shared-local-secrets");
+    expect(await treeDigest(root)).toEqual(before);
+  });
+
+  test("allows a sibling target's proven-disjoint external synchronized group", async () => {
+    const root = await fixture("pk_test_...", true);
+    const externalGroup = await mkdtemp(join(tmpdir(), "clerk-ios-external-group-"));
+    temporaryDirectories.push(externalGroup);
+    await Bun.write(join(externalGroup, "ExternalApp.swift"), "import SwiftUI\n");
+
+    const synchronizedGroupId = "515151515151515151515151";
+    const projectPath = join(root, "MyApp.xcodeproj", "project.pbxproj");
+    const project = await Bun.file(projectPath).text();
+    await Bun.write(
+      projectPath,
+      project
+        .replace(
+          `productType = "com.apple.product-type.application";\n      packageProductDependencies = ( );`,
+          `productType = "com.apple.product-type.application";\n      fileSystemSynchronizedGroups = ( ${synchronizedGroupId}, );\n      packageProductDependencies = ( );`,
+        )
+        .replace(
+          `${IOS_FIXTURE_IDS.projectConfigList} = { isa = XCConfigurationList;`,
+          `${synchronizedGroupId} = { isa = PBXFileSystemSynchronizedRootGroup; path = "${externalGroup}"; sourceTree = "<absolute>"; };\n    ${IOS_FIXTURE_IDS.projectConfigList} = { isa = XCConfigurationList;`,
+        ),
+    );
+
+    const plan = await planIOSRuntimeKey(options(root));
+
+    expect(plan.status).toBe("ready");
+    expect(plan.blockers).toEqual([]);
+  });
+
+  test("ignores a missing unrelated project while proving selected-project ownership", async () => {
+    const root = await fixture("pk_test_...");
+    await mkdir(join(root, "Unrelated.xcodeproj"));
+
+    const plan = await planIOSRuntimeKey(options(root));
+
+    expect(plan.status).toBe("ready");
+    expect(plan.blockers).toEqual([]);
+  });
+
+  test("blocks an external symlinked resource that aliases the selected sink", async () => {
+    const root = await fixture("pk_test_...", true);
+    const externalGroup = await mkdtemp(join(tmpdir(), "clerk-ios-external-alias-"));
+    temporaryDirectories.push(externalGroup);
+    const externalAlias = join(externalGroup, "LocalSecrets.plist");
+    await symlink(join(root, "MyApp", "LocalSecrets.plist"), externalAlias);
+
+    const externalReferenceId = "525252525252525252525252";
+    const externalBuildFileId = "535353535353535353535353";
+    const externalResourcesPhaseId = "545454545454545454545454";
+    const projectPath = join(root, "MyApp.xcodeproj", "project.pbxproj");
+    const project = await Bun.file(projectPath).text();
+    await Bun.write(
+      projectPath,
+      project
+        .replace(
+          `buildPhases = ( ${IOS_FIXTURE_IDS.secondSourcesPhase}, ${IOS_FIXTURE_IDS.secondFrameworksPhase}, );`,
+          `buildPhases = ( ${IOS_FIXTURE_IDS.secondSourcesPhase}, ${IOS_FIXTURE_IDS.secondFrameworksPhase}, ${externalResourcesPhaseId}, );`,
+        )
+        .replace(
+          `${IOS_FIXTURE_IDS.projectConfigList} = { isa = XCConfigurationList;`,
+          `${externalReferenceId} = { isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "${externalAlias}"; sourceTree = "<absolute>"; };\n    ${externalBuildFileId} = { isa = PBXBuildFile; fileRef = ${externalReferenceId}; };\n    ${externalResourcesPhaseId} = { isa = PBXResourcesBuildPhase; files = ( ${externalBuildFileId}, ); };\n    ${IOS_FIXTURE_IDS.projectConfigList} = { isa = XCConfigurationList;`,
+        ),
+    );
+    const before = await treeDigest(root);
+
+    const plan = await planIOSRuntimeKey(options(root));
+
+    expect(plan.status).toBe("blocked");
+    expect(plan.blockers[0]?.code).toBe("shared-local-secrets");
+    expect(await treeDigest(root)).toEqual(before);
+  });
+
+  test("fails closed when selected-project resource membership is dangling", async () => {
+    const root = await fixture("pk_test_...", true);
+    const danglingResourcesPhaseId = "555555555555555555555555";
+    const danglingBuildFileId = "565656565656565656565656";
+    const projectPath = join(root, "MyApp.xcodeproj", "project.pbxproj");
+    const project = await Bun.file(projectPath).text();
+    await Bun.write(
+      projectPath,
+      project
+        .replace(
+          `buildPhases = ( ${IOS_FIXTURE_IDS.secondSourcesPhase}, ${IOS_FIXTURE_IDS.secondFrameworksPhase}, );`,
+          `buildPhases = ( ${IOS_FIXTURE_IDS.secondSourcesPhase}, ${IOS_FIXTURE_IDS.secondFrameworksPhase}, ${danglingResourcesPhaseId}, );`,
+        )
+        .replace(
+          `${IOS_FIXTURE_IDS.projectConfigList} = { isa = XCConfigurationList;`,
+          `${danglingResourcesPhaseId} = { isa = PBXResourcesBuildPhase; files = ( ${danglingBuildFileId}, ); };\n    ${IOS_FIXTURE_IDS.projectConfigList} = { isa = XCConfigurationList;`,
+        ),
+    );
+    const before = await treeDigest(root);
+
+    const plan = await planIOSRuntimeKey(options(root));
+
+    expect(plan.status).toBe("blocked");
+    expect(plan.blockers[0]?.code).toBe("shared-local-secrets");
+    expect(await treeDigest(root)).toEqual(before);
+  });
+
+  test("rejects stale plist and gitignore plans without overwriting newer bytes", async () => {
+    const plistRoot = await fixture("pk_test_...");
+    const plistPlan = await planIOSRuntimeKey(options(plistRoot));
+    const plistPath = join(plistRoot, "MyApp", "LocalSecrets.plist");
+    await appendFile(plistPath, "\n<!-- newer plist edit -->\n");
+    const newerPlist = await Bun.file(plistPath).text();
+
+    const plistResult = await applyIOSRuntimeKey(
+      plistPlan,
+      publishableKey("stale-plist.clerk.example"),
+    );
+    expect(plistResult.status).toBe("stale");
+    expect(await Bun.file(plistPath).text()).toBe(newerPlist);
+
+    const ignoreRoot = await fixture("pk_test_...");
+    await Bun.write(join(ignoreRoot, ".gitignore"), "build/\n");
+    const ignorePlan = await planIOSRuntimeKey(options(ignoreRoot));
+    await appendFile(join(ignoreRoot, ".gitignore"), "DerivedData/\n");
+    const newerIgnore = await Bun.file(join(ignoreRoot, ".gitignore")).text();
+
+    const ignoreResult = await applyIOSRuntimeKey(
+      ignorePlan,
+      publishableKey("stale-ignore.clerk.example"),
+    );
+    expect(ignoreResult.status).toBe("stale");
+    expect(await Bun.file(join(ignoreRoot, ".gitignore")).text()).toBe(newerIgnore);
+  });
+
+  test("rolls back every committed file byte-for-byte after validation failure", async () => {
+    const root = await fixture("pk_test_...");
+    const before = await treeDigest(root);
+    const plan = await planIOSRuntimeKey(options(root));
+
+    const result = await applyIOSRuntimeKey(plan, publishableKey("rollback.clerk.example"), {
+      forcePostWriteValidationFailure: true,
+    });
+
+    expect(result.status).toBe("rolled-back");
+    expect(await treeDigest(root)).toEqual(before);
+  });
+
+  test("rolls back when concurrent Swift edits invalidate the proven runtime wiring", async () => {
+    const root = await fixture("pk_test_...");
+    const plistPath = join(root, "MyApp", "LocalSecrets.plist");
+    const plistBefore = await Bun.file(plistPath).text();
+    const plan = await planIOSRuntimeKey(options(root));
+
+    const result = await applyIOSRuntimeKey(
+      plan,
+      publishableKey("concurrent-swift.clerk.example"),
+      {
+        beforePostWriteValidation: async () => {
+          await Bun.write(
+            join(root, "MyApp", "MyAppApp.swift"),
+            APP_SOURCE.replace("Clerk.configure", "Clerk.notConfigure"),
+          );
+        },
+      },
+    );
+
+    expect(result.status).toBe("rolled-back");
+    expect(await Bun.file(plistPath).text()).toBe(plistBefore);
+    expect(await Bun.file(join(root, ".gitignore")).exists()).toBe(false);
+  });
+
+  test("rolls back when a nested gitignore appears before post-write validation", async () => {
+    const root = await fixture("pk_test_...");
+    const plistPath = join(root, "MyApp", "LocalSecrets.plist");
+    const plistBefore = await Bun.file(plistPath).text();
+    const plan = await planIOSRuntimeKey(options(root));
+
+    const result = await applyIOSRuntimeKey(
+      plan,
+      publishableKey("concurrent-nested-ignore.clerk.example"),
+      {
+        beforePostWriteValidation: async () => {
+          await Bun.write(
+            join(root, "MyApp", ".gitignore"),
+            "!LocalSecrets.plist\n!.LocalSecrets.plist.clerk-*.tmp\n",
+          );
+        },
+      },
+    );
+
+    expect(result.status).toBe("rolled-back");
+    expect(await Bun.file(plistPath).text()).toBe(plistBefore);
+    expect(await Bun.file(join(root, ".gitignore")).exists()).toBe(false);
+    expect(await Bun.file(join(root, "MyApp", ".gitignore")).text()).toContain(
+      "!LocalSecrets.plist",
+    );
+  });
+
+  test("rolls back when a sibling target concurrently begins owning the runtime sink", async () => {
+    const root = await fixture("pk_test_...", true);
+    const plistPath = join(root, "MyApp", "LocalSecrets.plist");
+    const projectPath = join(root, "MyApp.xcodeproj", "project.pbxproj");
+    const plistBefore = await Bun.file(plistPath).text();
+    const plan = await planIOSRuntimeKey(options(root));
+
+    const result = await applyIOSRuntimeKey(
+      plan,
+      publishableKey("concurrent-owner.clerk.example"),
+      {
+        beforePostWriteValidation: async () => {
+          const project = await Bun.file(projectPath).text();
+          await Bun.write(
+            projectPath,
+            project.replace(
+              `buildPhases = ( ${IOS_FIXTURE_IDS.secondSourcesPhase}, ${IOS_FIXTURE_IDS.secondFrameworksPhase}, );`,
+              `buildPhases = ( ${IOS_FIXTURE_IDS.secondSourcesPhase}, ${IOS_FIXTURE_IDS.secondFrameworksPhase}, ${IOS_FIXTURE_IDS.resourcesPhase}, );`,
+            ),
+          );
+        },
+      },
+    );
+
+    expect(result.status).toBe("rolled-back");
+    expect(await Bun.file(plistPath).text()).toBe(plistBefore);
+    expect(await Bun.file(join(root, ".gitignore")).exists()).toBe(false);
+  });
+
+  test("cleans every temporary file when plist staging fails after creation", async () => {
+    const root = await fixture("pk_test_...");
+    const before = await treeDigest(root);
+    const plan = await planIOSRuntimeKey(options(root));
+
+    const result = await applyIOSRuntimeKey(plan, publishableKey("stage-fail.clerk.example"), {
+      forcePlistStageFailureAfterCreate: true,
+    });
+
+    expect(result.status).toBe("rolled-back");
+    expect(await treeDigest(root)).toEqual(before);
+    for (const directory of [root, join(root, "MyApp")]) {
+      expect((await readdir(directory)).some((name) => name.includes(".clerk-"))).toBe(false);
+    }
+  });
+
+  test("retains the ignore guard when a staged key temp cannot be cleaned before rollback", async () => {
+    const root = await fixture("pk_test_...");
+    const plan = await planIOSRuntimeKey(options(root));
+    const key = publishableKey("stale-temp-cleanup.clerk.example");
+    const plistPath = join(root, "MyApp", "LocalSecrets.plist");
+
+    const apply = applyIOSRuntimeKey(plan, key, {
+      forcePlistCleanupFailureBeforeCommit: true,
+      afterPlistStage: async () => {
+        await appendFile(plistPath, "\n<!-- concurrent edit -->\n");
+      },
+    });
+
+    await expect(apply).rejects.toThrow("temporary runtime-key file could not be removed");
+    expect(await Bun.file(join(root, ".gitignore")).text()).toBe(
+      TEMPORARY_IGNORE_RULE + TARGET_IGNORE_RULE,
+    );
+    expect(await Bun.file(plistPath).text()).not.toContain(key);
+    for (const directory of [root, join(root, "MyApp")]) {
+      expect((await readdir(directory)).some((name) => name.includes(".clerk-"))).toBe(false);
+    }
+  });
+
+  test("commits and verifies the temporary-file guard before writing key bytes", async () => {
+    const root = await fixture("pk_test_...");
+    await initGit(root);
+    const plan = await planIOSRuntimeKey(options(root));
+    let guardObserved = false;
+
+    const result = await applyIOSRuntimeKey(plan, publishableKey("guard-first.clerk.example"), {
+      beforePlistWrite: async (temporaryPath) => {
+        expect(await Bun.file(temporaryPath).text()).toBe("");
+        expect(await Bun.file(join(root, ".gitignore")).text()).toBe(
+          TEMPORARY_IGNORE_RULE + TARGET_IGNORE_RULE,
+        );
+        const check = Bun.spawn(
+          ["git", "check-ignore", "--quiet", "--no-index", "--", relative(root, temporaryPath)],
+          { cwd: root, stdout: "ignore", stderr: "ignore" },
+        );
+        expect(await check.exited).toBe(0);
+        guardObserved = true;
+      },
+    });
+
+    expect(result.status).toBe("applied");
+    expect(guardObserved).toBe(true);
+  });
+
+  test("never writes key bytes when the committed guard is negated before plist staging", async () => {
+    const root = await fixture("pk_test_...");
+    const key = publishableKey("guard-negated-before-write.clerk.example");
+    const plan = await planIOSRuntimeKey(options(root));
+    const result = await applyIOSRuntimeKey(plan, key, {
+      beforePlistWrite: async (temporaryPath) => {
+        const relativeTemporaryPath = relative(root, temporaryPath).split("\\").join("/");
+        await appendFile(
+          join(root, ".gitignore"),
+          `!/${relativeTemporaryPath}\n!/MyApp/LocalSecrets.plist\n`,
+        );
+      },
+    });
+
+    expect(["stale", "rolled-back"]).toContain(result.status);
+    expect(await Bun.file(join(root, "MyApp", "LocalSecrets.plist")).text()).not.toContain(key);
+    for (const name of await readdir(join(root, "MyApp"))) {
+      if (name.includes(".clerk-") && (await Bun.file(join(root, "MyApp", name)).exists())) {
+        expect(await Bun.file(join(root, "MyApp", name)).text()).not.toContain(key);
+      }
+    }
+  });
+
+  test("rolls back when the committed guard is negated after plist staging", async () => {
+    const root = await fixture("pk_test_...");
+    const key = publishableKey("guard-negated-after-stage.clerk.example");
+    const plan = await planIOSRuntimeKey(options(root));
+    const result = await applyIOSRuntimeKey(plan, key, {
+      afterPlistStage: async () => {
+        const temporaryName = (await readdir(join(root, "MyApp"))).find((name) =>
+          name.includes(".clerk-"),
+        );
+        expect(temporaryName).toBeDefined();
+        await appendFile(
+          join(root, ".gitignore"),
+          `!/MyApp/${temporaryName}\n!/MyApp/LocalSecrets.plist\n`,
+        );
+      },
+    });
+
+    expect(["stale", "rolled-back"]).toContain(result.status);
+    expect(await Bun.file(join(root, "MyApp", "LocalSecrets.plist")).text()).not.toContain(key);
+    for (const name of await readdir(join(root, "MyApp"))) {
+      if (name.includes(".clerk-") && (await Bun.file(join(root, "MyApp", name)).exists())) {
+        expect(await Bun.file(join(root, "MyApp", name)).text()).not.toContain(key);
+      }
+    }
+  });
+
+  test("rolls back when the committed guard is negated after plist commit", async () => {
+    const root = await fixture("pk_test_...");
+    const key = publishableKey("guard-negated-after-commit.clerk.example");
+    const plan = await planIOSRuntimeKey(options(root));
+    const result = await applyIOSRuntimeKey(plan, key, {
+      afterPlistCommit: async () => {
+        await appendFile(
+          join(root, ".gitignore"),
+          "!/MyApp/.LocalSecrets.plist.clerk-*.tmp\n!/MyApp/LocalSecrets.plist\n",
+        );
+      },
+    });
+
+    expect(["stale", "rolled-back"]).toContain(result.status);
+    expect(await Bun.file(join(root, "MyApp", "LocalSecrets.plist")).text()).not.toContain(key);
+    for (const name of await readdir(join(root, "MyApp"))) {
+      if (name.includes(".clerk-") && (await Bun.file(join(root, "MyApp", name)).exists())) {
+        expect(await Bun.file(join(root, "MyApp", name)).text()).not.toContain(key);
+      }
+    }
+  });
+
+  test("rolls back a linked target when its staged temporary cleanup fails", async () => {
+    const root = await fixture("pk_test_...");
+    const before = await treeDigest(root);
+    const plan = await planIOSRuntimeKey(options(root));
+
+    const apply = applyIOSRuntimeKey(plan, publishableKey("commit-cleanup.clerk.example"), {
+      forceGitignoreCommitCleanupFailure: true,
+    });
+
+    await expect(apply).rejects.toThrow("temporary runtime-key file could not be removed");
+    expect(await treeDigest(root)).toEqual(before);
+    for (const directory of [root, join(root, "MyApp")]) {
+      expect((await readdir(directory)).some((name) => name.includes(".clerk-"))).toBe(false);
+    }
+  });
+
+  test("retains the exact ignore rule when a newer key-bearing plist prevents rollback", async () => {
+    const root = await fixture("pk_test_...");
+    const plan = await planIOSRuntimeKey(options(root));
+    const key = publishableKey("partial-rollback.clerk.example");
+    const plistPath = join(root, "MyApp", "LocalSecrets.plist");
+
+    const apply = applyIOSRuntimeKey(plan, key, {
+      forcePostWriteValidationFailure: true,
+      beforePostWriteValidation: async () => {
+        await appendFile(plistPath, "\n<!-- concurrent user edit -->\n");
+      },
+    });
+
+    await expect(apply).rejects.toThrow("Git-ignore protection was retained");
+    expect(await Bun.file(join(root, ".gitignore")).text()).toBe(
+      TEMPORARY_IGNORE_RULE + TARGET_IGNORE_RULE,
+    );
+    expect(await Bun.file(plistPath).text()).toContain("concurrent user edit");
+    expect(await Bun.file(plistPath).text()).toContain(key);
+  });
+
+  test("re-establishes ignore protection when concurrent edits prevent payload rollback", async () => {
+    const root = await fixture("pk_test_...");
+    const plan = await planIOSRuntimeKey(options(root));
+    const key = publishableKey("protected-partial-rollback.clerk.example");
+    const plistPath = join(root, "MyApp", "LocalSecrets.plist");
+
+    const apply = applyIOSRuntimeKey(plan, key, {
+      afterPlistCommit: async () => {
+        await appendFile(plistPath, "\n<!-- concurrent user edit -->\n");
+        await appendFile(
+          join(root, ".gitignore"),
+          "!/MyApp/.LocalSecrets.plist.clerk-*.tmp\n!/MyApp/LocalSecrets.plist\n",
+        );
+      },
+    });
+
+    await expect(apply).rejects.toThrow("Git-ignore protection was retained");
+    const gitignore = await Bun.file(join(root, ".gitignore")).text();
+    expect(gitignore.endsWith(TEMPORARY_IGNORE_RULE + TARGET_IGNORE_RULE)).toBe(true);
+    expect(gitignore.lastIndexOf("!/MyApp/LocalSecrets.plist")).toBeLessThan(
+      gitignore.lastIndexOf("/MyApp/LocalSecrets.plist"),
+    );
+    expect(await Bun.file(plistPath).text()).toContain("concurrent user edit");
+    expect(await Bun.file(plistPath).text()).toContain(key);
+  });
+
+  test("is idempotent after apply and removes every temporary file", async () => {
+    const root = await fixture("pk_test_...");
+    const key = publishableKey("idempotent.clerk.example");
+
+    const first = await run(root, key);
+    expect(first.result.status).toBe("applied");
+    const afterFirst = await treeDigest(root);
+
+    const second = await run(root, key);
+    expect(second.result.status).toBe("satisfied");
+    expect(await treeDigest(root)).toEqual(afterFirst);
+    for (const directory of [root, join(root, "MyApp")]) {
+      expect((await readdir(directory)).some((name) => name.includes(".clerk-"))).toBe(false);
+    }
+  });
+
+  test("blocks a symlinked .gitignore without touching either target", async () => {
+    const root = await fixture("pk_test_...");
+    const external = join(root, "external-ignore");
+    await Bun.write(external, "build/\n");
+    await symlink(external, join(root, ".gitignore"));
+    const before = await treeDigest(root);
+
+    const plan = await planIOSRuntimeKey(options(root));
+
+    expect(plan.status).toBe("blocked");
+    expect(plan.blockers[0]?.code).toBe("unsafe-gitignore");
+    expect(await treeDigest(root)).toEqual(before);
+  });
+
+  test("blocks a LocalSecrets symlink after a path swap", async () => {
+    const root = await fixture("pk_test_...");
+    const path = join(root, "MyApp", "LocalSecrets.plist");
+    const original = join(root, "MyApp", "OriginalLocalSecrets.plist");
+    await rename(path, original);
+    await symlink("OriginalLocalSecrets.plist", path);
+
+    const plan = await planIOSRuntimeKey(options(root));
+
+    expect(plan.status).toBe("blocked");
+    expect(plan.blockers[0]?.code).toBe("unreadable-local-secrets");
+  });
+});

--- a/packages/cli-core/src/commands/init/ios/runtime-key.ts
+++ b/packages/cli-core/src/commands/init/ios/runtime-key.ts
@@ -1,0 +1,2753 @@
+import {
+  chmod,
+  link,
+  lstat,
+  open,
+  readFile,
+  readdir,
+  realpath,
+  rename,
+  rm,
+} from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
+import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import { parse as parsePbxProject } from "@bacons/xcode/json";
+import plist from "@expo/plist";
+import { decodePublishableKey } from "../../../lib/fapi.ts";
+import { inspectIOSProject } from "./inspect.ts";
+import { pathIsSafelyWithinIOSRoot, relativeIOSPath } from "./discovery.ts";
+import type { IOSAppTarget } from "./types.ts";
+import {
+  asString,
+  asStringArray,
+  buildPbxParentIndex,
+  isRecord,
+  resolvePbxFilePath,
+  type PbxObject,
+  type PbxObjects,
+} from "./pbx.ts";
+
+const APP_PRODUCT_TYPE = "com.apple.product-type.application";
+const MAX_PBXPROJ_BYTES = 15_000_000;
+const MAX_LOCAL_SECRETS_BYTES = 1_000_000;
+const MAX_GITIGNORE_BYTES = 1_000_000;
+const MAX_DISCOVERY_DEPTH = 24;
+const MAX_DISCOVERED_SECRETS = 20;
+const MAX_OWNERSHIP_SCAN_ENTRIES = 20_000;
+const SECRET_KEY = "CLERK_PUBLISHABLE_KEY";
+const DISCOVERY_IGNORES = new Set([
+  ".build",
+  ".git",
+  ".swiftpm",
+  "build",
+  "Carthage",
+  "DerivedData",
+  "node_modules",
+  "Pods",
+  "SourcePackages",
+]);
+
+export interface IOSRuntimeKeyPlanOptions {
+  root: string;
+  /** Project-root-relative path selected by the iOS inspector. */
+  projectPath: string;
+  targetId: string;
+  /** Optional project-root-relative disambiguation when the target owns more than one sink. */
+  localSecretsPath?: string;
+}
+
+export type IOSRuntimeKeyBlockerCode =
+  | "invalid-selection"
+  | "external-path"
+  | "unreadable-project"
+  | "malformed-project"
+  | "target-not-found"
+  | "generated-project"
+  | "missing-local-secrets"
+  | "ambiguous-local-secrets"
+  | "not-target-resource"
+  | "shared-local-secrets"
+  | "unreadable-local-secrets"
+  | "malformed-local-secrets"
+  | "unsupported-local-secrets"
+  | "unproven-runtime-wiring"
+  | "scheme-override"
+  | "tracked-local-secrets"
+  | "git-state-unknown"
+  | "git-repository-mismatch"
+  | "unsafe-gitignore"
+  | "invalid-publishable-key"
+  | "production-publishable-key"
+  | "different-publishable-key";
+
+export interface IOSRuntimeKeyBlocker {
+  code: IOSRuntimeKeyBlockerCode;
+  message: string;
+}
+
+/**
+ * A structural, serializable plan. It intentionally contains neither the
+ * publishable key nor candidate plist bytes. The raw key is accepted only by
+ * applyIOSRuntimeKey.
+ */
+export interface IOSRuntimeKeyPlan {
+  schemaVersion: 1;
+  kind: "clerk-ios-runtime-key";
+  status: "ready" | "blocked";
+  root: string;
+  projectPath: string;
+  targetId: string;
+  localSecretsPath?: string;
+  gitignorePath?: string;
+  gitignoreRule?: string;
+  /** SHA-256 of the exact existing sink bytes inspected by this plan. */
+  expectedLocalSecretsHash?: string;
+  /** Null means the .gitignore did not exist when the plan was created. */
+  expectedGitignoreHash?: string | null;
+  /** True when apply may update .gitignore, including its crash-safe staging guard. */
+  changesGitignore: boolean;
+  actions: string[];
+  blockers: IOSRuntimeKeyBlocker[];
+}
+
+export interface IOSRuntimeKeyApplyResult {
+  status: "applied" | "satisfied" | "blocked" | "stale" | "rolled-back";
+  plan: IOSRuntimeKeyPlan;
+  message?: string;
+}
+
+/**
+ * A read-only, serializable proof of which runtime sink should be compared
+ * after Clerk application linking. It never contains the locally stored key.
+ */
+export interface IOSRuntimeKeyVerificationPlan {
+  schemaVersion: 1;
+  kind: "clerk-ios-runtime-key-verification";
+  status: "ready" | "blocked";
+  root: string;
+  projectPath: string;
+  targetId: string;
+  localSecretsPath?: string;
+  expectedLocalSecretsHash?: string;
+  blockers: IOSRuntimeKeyBlocker[];
+}
+
+export interface IOSRuntimeKeyVerificationResult {
+  status: "matched" | "mismatched" | "stale" | "blocked";
+  plan: IOSRuntimeKeyVerificationPlan;
+}
+
+/** @internal Test-only fault injection used to prove rollback. */
+export interface IOSRuntimeKeyApplyOptions {
+  forcePostWriteValidationFailure?: boolean;
+  forcePlistStageFailureAfterCreate?: boolean;
+  forcePlistCleanupFailureBeforeCommit?: boolean;
+  forceGitignoreCommitCleanupFailure?: boolean;
+  beforePlistWrite?: (temporaryPath: string) => void | Promise<void>;
+  afterPlistStage?: () => void | Promise<void>;
+  afterPlistCommit?: () => void | Promise<void>;
+  beforePostWriteValidation?: () => void | Promise<void>;
+}
+
+type GitContext =
+  | { state: "repository"; root: string }
+  | { state: "not-repository" }
+  | { state: "unknown" }
+  | { state: "mismatch" };
+
+interface FileSnapshot {
+  path: string;
+  exists: boolean;
+  hash?: string;
+  mode: number;
+  bytes?: Uint8Array;
+}
+
+interface PreparedRuntimeKeyPlan {
+  plan: IOSRuntimeKeyPlan;
+  plist?: Record<string, unknown>;
+  localSecretsSnapshot?: FileSnapshot;
+  gitignoreSnapshot?: FileSnapshot;
+  gitContext?: GitContext;
+  gitignoreNeeded?: boolean;
+}
+
+interface PreparedRuntimeKeyVerification {
+  plan: IOSRuntimeKeyVerificationPlan;
+  localSecretsSnapshot?: FileSnapshot;
+  /** Kept only inside the verification call and never copied into a public result. */
+  existingPublishableKey?: string;
+}
+
+interface StagedFile {
+  targetPath: string;
+  temporaryPath: string;
+  candidateHash: string;
+  original: FileSnapshot;
+  committed: boolean;
+  cleanupFailuresRemaining: number;
+  keyBearing: boolean;
+}
+
+interface RollbackDependency {
+  root: string;
+  /** The key-bearing file that must be made safe before its protection can be removed. */
+  payloadPath: string;
+  /** The ignore file whose committed candidate protects the payload. */
+  protectionPath: string;
+  /** Rules that protect both the final payload and its crash-safe staging file. */
+  protectionRules: string[];
+}
+
+class RuntimeKeyTemporaryFileCleanupError extends Error {
+  constructor(
+    message: string,
+    readonly keyBearing: boolean,
+  ) {
+    super(message);
+  }
+}
+
+interface StageFileOptions {
+  forceFailureAfterCreate?: boolean;
+  cleanupFailures?: number;
+  keyBearing?: boolean;
+  beforeWrite?: (temporaryPath: string) => boolean | Promise<boolean>;
+}
+
+function sha256(value: string | Uint8Array): string {
+  return new Bun.CryptoHasher("sha256").update(value).digest("hex");
+}
+
+function makePlan(
+  options: IOSRuntimeKeyPlanOptions,
+  root: string,
+  projectPath: string,
+  status: IOSRuntimeKeyPlan["status"],
+  details: Partial<
+    Pick<
+      IOSRuntimeKeyPlan,
+      | "localSecretsPath"
+      | "gitignorePath"
+      | "gitignoreRule"
+      | "expectedLocalSecretsHash"
+      | "expectedGitignoreHash"
+      | "changesGitignore"
+      | "actions"
+      | "blockers"
+    >
+  > = {},
+): IOSRuntimeKeyPlan {
+  return {
+    schemaVersion: 1,
+    kind: "clerk-ios-runtime-key",
+    status,
+    root,
+    projectPath,
+    targetId: options.targetId,
+    localSecretsPath: details.localSecretsPath,
+    gitignorePath: details.gitignorePath,
+    gitignoreRule: details.gitignoreRule,
+    expectedLocalSecretsHash: details.expectedLocalSecretsHash,
+    expectedGitignoreHash: details.expectedGitignoreHash,
+    changesGitignore: details.changesGitignore ?? false,
+    actions: details.actions ?? [],
+    blockers: details.blockers ?? [],
+  };
+}
+
+function blocked(
+  options: IOSRuntimeKeyPlanOptions,
+  root: string,
+  projectPath: string,
+  code: IOSRuntimeKeyBlockerCode,
+  message: string,
+  source: Partial<PreparedRuntimeKeyPlan> = {},
+): PreparedRuntimeKeyPlan {
+  return {
+    ...source,
+    plan: makePlan(options, root, projectPath, "blocked", {
+      localSecretsPath: source.plan?.localSecretsPath,
+      gitignorePath: source.plan?.gitignorePath,
+      gitignoreRule: source.plan?.gitignoreRule,
+      expectedLocalSecretsHash: source.plan?.expectedLocalSecretsHash,
+      expectedGitignoreHash: source.plan?.expectedGitignoreHash,
+      changesGitignore: source.plan?.changesGitignore,
+      blockers: [{ code, message }],
+    }),
+  };
+}
+
+function makeVerificationPlan(
+  options: IOSRuntimeKeyPlanOptions,
+  root: string,
+  projectPath: string,
+  status: IOSRuntimeKeyVerificationPlan["status"],
+  details: Partial<
+    Pick<
+      IOSRuntimeKeyVerificationPlan,
+      "localSecretsPath" | "expectedLocalSecretsHash" | "blockers"
+    >
+  > = {},
+): IOSRuntimeKeyVerificationPlan {
+  return {
+    schemaVersion: 1,
+    kind: "clerk-ios-runtime-key-verification",
+    status,
+    root,
+    projectPath,
+    targetId: options.targetId,
+    localSecretsPath: details.localSecretsPath,
+    expectedLocalSecretsHash: details.expectedLocalSecretsHash,
+    blockers: details.blockers ?? [],
+  };
+}
+
+function verificationBlocked(
+  options: IOSRuntimeKeyPlanOptions,
+  root: string,
+  projectPath: string,
+  code: IOSRuntimeKeyBlockerCode,
+  message: string,
+  source: Partial<PreparedRuntimeKeyVerification> = {},
+): PreparedRuntimeKeyVerification {
+  return {
+    plan: makeVerificationPlan(options, root, projectPath, "blocked", {
+      localSecretsPath: source.plan?.localSecretsPath,
+      expectedLocalSecretsHash: source.plan?.expectedLocalSecretsHash,
+      blockers: [{ code, message }],
+    }),
+  };
+}
+
+function normalizedObjects(value: unknown): PbxObjects | undefined {
+  if (!isRecord(value)) return undefined;
+  const objects: PbxObjects = {};
+  for (const [id, object] of Object.entries(value)) {
+    if (!isRecord(object)) return undefined;
+    objects[id] = object;
+  }
+  return objects;
+}
+
+function buildFileIOSApplicability(object: PbxObject): {
+  applies: boolean;
+  recognized: boolean;
+} {
+  const platformFilter = asString(object.platformFilter);
+  const filters = [
+    ...asStringArray(object.platformFilters),
+    ...(platformFilter ? [platformFilter] : []),
+  ];
+  if (filters.length === 0) return { applies: true, recognized: true };
+  if (filters.some((filter) => /(?:^|[^a-z])(?:ios|iphone)/i.test(filter))) {
+    return { applies: true, recognized: true };
+  }
+  const recognized = filters.every((filter) =>
+    /(?:maccatalyst|macos|tvos|watchos|xros|visionos|driverkit)/i.test(filter),
+  );
+  return { applies: false, recognized };
+}
+
+function normalizeSynchronizedPath(path: string): string {
+  return path.replaceAll("\\", "/").replace(/^\.\//, "").replace(/\/$/, "");
+}
+
+function containsControlCharacter(value: string): boolean {
+  return [...value].some((character) => {
+    const codePoint = character.codePointAt(0)!;
+    return codePoint <= 0x1f || codePoint === 0x7f;
+  });
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+function synchronizedExclusions(
+  group: PbxObject,
+  targetId: string,
+  resourcePhaseIds: Set<string>,
+  objects: PbxObjects,
+): Set<string> {
+  const excluded = new Set<string>();
+  for (const exceptionId of asStringArray(group.exceptions)) {
+    const exception = objects[exceptionId];
+    const appliesToTarget =
+      exception?.isa === "PBXFileSystemSynchronizedBuildFileExceptionSet" &&
+      asString(exception.target) === targetId;
+    const appliesToPhase =
+      exception?.isa === "PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet" &&
+      resourcePhaseIds.has(asString(exception.buildPhase) ?? "");
+    if (!appliesToTarget && !appliesToPhase) continue;
+
+    for (const path of asStringArray(exception.membershipExceptions)) {
+      excluded.add(normalizeSynchronizedPath(path));
+    }
+    if (!isRecord(exception.platformFiltersByRelativePath)) continue;
+    for (const [path, filters] of Object.entries(exception.platformFiltersByRelativePath)) {
+      const platformFilters = stringArray(filters);
+      if (
+        platformFilters.length > 0 &&
+        !platformFilters.some((filter) => /(?:^|[^a-z])(?:ios|iphone)/i.test(filter))
+      ) {
+        excluded.add(normalizeSynchronizedPath(path));
+      }
+    }
+  }
+  return excluded;
+}
+
+function synchronizedPathIsExcluded(path: string, excluded: Set<string>): boolean {
+  return [...excluded].some(
+    (excludedPath) => path === excludedPath || path.startsWith(`${excludedPath}/`),
+  );
+}
+
+async function collectLocalSecrets(
+  root: string,
+  directory: string,
+  output: string[],
+  depth = 0,
+): Promise<void> {
+  if (depth > MAX_DISCOVERY_DEPTH || output.length >= MAX_DISCOVERED_SECRETS) return;
+  if (!(await pathIsSafelyWithinIOSRoot(root, directory))) return;
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  entries.sort((left, right) => left.name.localeCompare(right.name));
+  for (const entry of entries) {
+    if (output.length >= MAX_DISCOVERED_SECRETS) return;
+    const path = resolve(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (!entry.name.startsWith(".") && !DISCOVERY_IGNORES.has(entry.name)) {
+        await collectLocalSecrets(root, path, output, depth + 1);
+      }
+    } else if (entry.isFile() && entry.name === "LocalSecrets.plist") {
+      output.push(path);
+    }
+  }
+}
+
+async function generatedProjectKind(
+  root: string,
+  absoluteProjectPath: string,
+): Promise<"xcodegen" | "tuist" | null> {
+  let directory = dirname(absoluteProjectPath);
+  while (await pathIsSafelyWithinIOSRoot(root, directory)) {
+    for (const [relativePath, kind] of [
+      ["project.yml", "xcodegen"],
+      ["Project.swift", "tuist"],
+      ["Workspace.swift", "tuist"],
+      ["Tuist/ProjectDescriptionHelpers", "tuist"],
+    ] as const) {
+      const marker = resolve(directory, relativePath);
+      if ((await pathIsSafelyWithinIOSRoot(root, marker)) && (await Bun.file(marker).exists())) {
+        return kind;
+      }
+    }
+    if (directory === root) break;
+    const parent = dirname(directory);
+    if (parent === directory) break;
+    directory = parent;
+  }
+  return null;
+}
+
+async function targetLocalSecretsPaths(
+  root: string,
+  absoluteProjectPath: string,
+  targetId: string,
+): Promise<{ paths?: string[]; blocker?: IOSRuntimeKeyBlocker }> {
+  const pbxprojPath = resolve(absoluteProjectPath, "project.pbxproj");
+  if (!(await pathIsSafelyWithinIOSRoot(root, pbxprojPath))) {
+    return {
+      blocker: {
+        code: "external-path",
+        message: "The selected Xcode project resolves outside the project root.",
+      },
+    };
+  }
+
+  let info;
+  let archive: unknown;
+  try {
+    info = await lstat(pbxprojPath);
+    if (!info.isFile() || info.isSymbolicLink() || info.size > MAX_PBXPROJ_BYTES) {
+      throw new Error("unsupported project file");
+    }
+    archive = parsePbxProject(await readFile(pbxprojPath, "utf8"));
+  } catch {
+    return {
+      blocker: {
+        code: "unreadable-project",
+        message: "The selected Xcode project is missing, too large, symlinked, or unreadable.",
+      },
+    };
+  }
+  if (!isRecord(archive)) {
+    return {
+      blocker: {
+        code: "malformed-project",
+        message: "The selected Xcode project has no readable object graph.",
+      },
+    };
+  }
+  const objects = normalizedObjects(archive.objects);
+  const projectObjectId = asString(archive.rootObject);
+  const projectObject = projectObjectId ? objects?.[projectObjectId] : undefined;
+  const targetObject = objects?.[targetId];
+  if (!objects || projectObject?.isa !== "PBXProject") {
+    return {
+      blocker: {
+        code: "malformed-project",
+        message: "The selected Xcode project has no readable PBXProject root.",
+      },
+    };
+  }
+  if (
+    targetObject?.isa !== "PBXNativeTarget" ||
+    asString(targetObject.productType) !== APP_PRODUCT_TYPE
+  ) {
+    return {
+      blocker: {
+        code: "target-not-found",
+        message: "The selected object is not an iOS application target.",
+      },
+    };
+  }
+
+  const parents = buildPbxParentIndex(objects);
+  const projectDirectory = dirname(absoluteProjectPath);
+  const groupRootDirectory = resolve(
+    projectDirectory,
+    asString(projectObject.projectDirPath) ?? "",
+  );
+  const resourcePhaseIds = new Set(
+    asStringArray(targetObject.buildPhases).filter(
+      (phaseId) => objects[phaseId]?.isa === "PBXResourcesBuildPhase",
+    ),
+  );
+  const paths = new Set<string>();
+
+  for (const phaseId of resourcePhaseIds) {
+    const phase = objects[phaseId];
+    if (phase?.isa !== "PBXResourcesBuildPhase") continue;
+    for (const buildFileId of asStringArray(phase.files)) {
+      const buildFile = objects[buildFileId];
+      if (!buildFile || !buildFileIOSApplicability(buildFile).applies) continue;
+      const fileReferenceId = asString(buildFile.fileRef);
+      if (!fileReferenceId) continue;
+      const path = resolvePbxFilePath(
+        fileReferenceId,
+        objects,
+        parents,
+        projectDirectory,
+        groupRootDirectory,
+      );
+      if (
+        path?.endsWith(`${sep}LocalSecrets.plist`) &&
+        (await pathIsSafelyWithinIOSRoot(root, path))
+      ) {
+        paths.add(path);
+      }
+    }
+  }
+
+  for (const groupId of asStringArray(targetObject.fileSystemSynchronizedGroups)) {
+    const group = objects[groupId];
+    if (group?.isa !== "PBXFileSystemSynchronizedRootGroup") continue;
+    const groupPath = resolvePbxFilePath(
+      groupId,
+      objects,
+      parents,
+      projectDirectory,
+      groupRootDirectory,
+    );
+    if (!groupPath || !(await pathIsSafelyWithinIOSRoot(root, groupPath))) continue;
+    const discovered: string[] = [];
+    await collectLocalSecrets(root, groupPath, discovered);
+    const excluded = synchronizedExclusions(group, targetId, resourcePhaseIds, objects);
+    for (const path of discovered) {
+      const pathFromGroup = relative(groupPath, path).split(sep).join("/");
+      if (!synchronizedPathIsExcluded(pathFromGroup, excluded)) paths.add(path);
+    }
+  }
+
+  return { paths: [...paths].sort() };
+}
+
+async function snapshotExistingFile(
+  path: string,
+  maximumBytes: number,
+): Promise<FileSnapshot | undefined> {
+  try {
+    const info = await lstat(path);
+    if (!info.isFile() || info.isSymbolicLink() || info.size > maximumBytes) return undefined;
+    const bytes = new Uint8Array(await readFile(path));
+    return {
+      path,
+      exists: true,
+      hash: sha256(bytes),
+      mode: info.mode & 0o7777,
+      bytes,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+async function snapshotOptionalFile(
+  root: string,
+  path: string,
+  maximumBytes: number,
+  missingMode: number,
+): Promise<FileSnapshot | undefined> {
+  if (!(await pathIsSafelyWithinIOSRoot(root, path))) return undefined;
+  try {
+    const info = await lstat(path);
+    if (!info.isFile() || info.isSymbolicLink() || info.size > maximumBytes) return undefined;
+    const bytes = new Uint8Array(await readFile(path));
+    return {
+      path,
+      exists: true,
+      hash: sha256(bytes),
+      mode: info.mode & 0o7777,
+      bytes,
+    };
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return { path, exists: false, mode: missingMode };
+    }
+    return undefined;
+  }
+}
+
+function decodeUTF8(bytes: Uint8Array): string | undefined {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return undefined;
+  }
+}
+
+function parseXMLPlist(bytes: Uint8Array): Record<string, unknown> | undefined {
+  if (new TextDecoder().decode(bytes.slice(0, 8)).startsWith("bplist")) return undefined;
+  const source = decodeUTF8(bytes);
+  if (!source) return undefined;
+  try {
+    const parsed: unknown = plist.parse(source);
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function hasGitMarkerInAncestors(start: string): Promise<boolean> {
+  let directory = resolve(start);
+  while (true) {
+    try {
+      await lstat(resolve(directory, ".git"));
+      return true;
+    } catch {
+      // Walk to the filesystem root.
+    }
+    const parent = dirname(directory);
+    if (parent === directory) return false;
+    directory = parent;
+  }
+}
+
+async function gitContext(root: string): Promise<GitContext> {
+  try {
+    const child = Bun.spawn(["git", "rev-parse", "--show-toplevel"], {
+      cwd: root,
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    const output = (await new Response(child.stdout).text()).trim();
+    if ((await child.exited) !== 0 || output === "") {
+      return (await hasGitMarkerInAncestors(root))
+        ? { state: "unknown" }
+        : { state: "not-repository" };
+    }
+    const [canonicalRepositoryRoot, canonicalRoot] = await Promise.all([
+      realpath(output),
+      realpath(root),
+    ]);
+    const rootFromRepository = relative(canonicalRepositoryRoot, canonicalRoot);
+    if (
+      rootFromRepository === ".." ||
+      rootFromRepository.startsWith(`..${sep}`) ||
+      isAbsolute(rootFromRepository)
+    ) {
+      return { state: "unknown" };
+    }
+    return { state: "repository", root: canonicalRepositoryRoot };
+  } catch {
+    return (await hasGitMarkerInAncestors(root))
+      ? { state: "unknown" }
+      : { state: "not-repository" };
+  }
+}
+
+async function coherentGitContext(root: string, locations: string[]): Promise<GitContext> {
+  const contexts = await Promise.all([gitContext(root), ...locations.map(gitContext)]);
+  if (contexts.some((context) => context.state === "unknown")) return { state: "unknown" };
+  const repositories = contexts.filter(
+    (context): context is Extract<GitContext, { state: "repository" }> =>
+      context.state === "repository",
+  );
+  if (repositories.length === 0) return { state: "not-repository" };
+  if (
+    repositories.length !== contexts.length ||
+    new Set(repositories.map((context) => context.root)).size !== 1
+  ) {
+    return { state: "mismatch" };
+  }
+  return repositories[0]!;
+}
+
+async function hasDescendantGitignore(
+  rootInput: string,
+  localSecretsPath: string,
+): Promise<boolean> {
+  const root = resolve(rootInput);
+  let directory = dirname(resolve(localSecretsPath));
+  const pathFromRoot = relative(root, directory);
+  if (pathFromRoot === ".." || pathFromRoot.startsWith(`..${sep}`) || isAbsolute(pathFromRoot)) {
+    return true;
+  }
+
+  while (directory !== root) {
+    try {
+      // A lower-level ignore file takes precedence over root rules. Treat every
+      // filesystem object here conservatively, including symlinks and directories.
+      await lstat(resolve(directory, ".gitignore"));
+      return true;
+    } catch (error) {
+      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) return true;
+    }
+
+    const parent = dirname(directory);
+    if (parent === directory) return true;
+    directory = parent;
+  }
+
+  return false;
+}
+
+async function gitPathExitCode(
+  repositoryRoot: string,
+  args: string[],
+  absolutePath: string,
+): Promise<number | undefined> {
+  let canonicalPath: string;
+  try {
+    canonicalPath = await realpath(absolutePath);
+  } catch {
+    return undefined;
+  }
+  const path = relative(repositoryRoot, canonicalPath);
+  if (path === ".." || path.startsWith(`..${sep}`) || isAbsolute(path)) return undefined;
+  try {
+    const child = Bun.spawn(["git", ...args, "--", path], {
+      cwd: repositoryRoot,
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    return await child.exited;
+  } catch {
+    return undefined;
+  }
+}
+
+function escapeGitignorePath(path: string): string {
+  return path
+    .split("/")
+    .map((component) => {
+      let escaped = component.replaceAll("\\", "\\\\").replaceAll(" ", "\\ ");
+      for (const character of ["[", "]", "*", "?", "!", "#"]) {
+        escaped = escaped.replaceAll(character, `\\${character}`);
+      }
+      return escaped;
+    })
+    .join("/");
+}
+
+function gitignoreRule(root: string, localSecretsPath: string): string {
+  return `/${escapeGitignorePath(relativeIOSPath(root, localSecretsPath))}`;
+}
+
+function gitignoreTemporaryRule(root: string, localSecretsPath: string): string {
+  const components = relativeIOSPath(root, localSecretsPath).split("/");
+  const fileName = components.pop()!;
+  const directory = components.length > 0 ? `${escapeGitignorePath(components.join("/"))}/` : "";
+  return `/${directory}.${escapeGitignorePath(fileName)}.clerk-*.tmp`;
+}
+
+function gitignoreContainsRule(content: string, rule: string): boolean {
+  return content.split(/\r?\n/).some((line) => line === rule);
+}
+
+function gitignoreEndsWithRule(content: string, rule: string): boolean {
+  for (const line of content.split(/\r?\n/).reverse()) {
+    if (line.trim() === "" || line.startsWith("#")) continue;
+    return line === rule;
+  }
+  return false;
+}
+
+function gitignoreRuleIsEffectiveWithoutRepository(content: string, rule: string): boolean {
+  const lines = content.split(/\r?\n/);
+  const ruleIndex = lines.lastIndexOf(rule);
+  if (ruleIndex < 0) return false;
+
+  // Without Git there is no authoritative matcher available. A later negation
+  // could re-include this path (or its parent), so fail closed rather than
+  // inferring safety from the presence of a positive rule alone.
+  return !lines.slice(ruleIndex + 1).some((line) => line.startsWith("!"));
+}
+
+function appendGitignoreRule(content: string, rule: string): string {
+  const lineEnding = content.includes("\r\n") ? "\r\n" : "\n";
+  const separator = content.length > 0 && !content.endsWith("\n") ? lineEnding : "";
+  return `${content}${separator}${rule}${lineEnding}`;
+}
+
+function hasProvenRuntimeKeyWiring(target: IOSAppTarget | undefined): target is IOSAppTarget {
+  if (!target || !target.swift.evidenceComplete) return false;
+  const entryPoint = target.swift.entryPoints[0];
+  const configureCall = target.swift.configureCalls[0];
+  return (
+    target.swift.entryPoints.length === 1 &&
+    target.swift.configureCalls.length === 1 &&
+    configureCall?.publishableKeyWiring === "local-secrets-loader" &&
+    configureCall.localSecretsRuntimeBinding === "proven" &&
+    configureCall.startupBinding === "app-init" &&
+    configureCall.path === entryPoint?.path &&
+    target.swift.localSecretsRuntimeBindings.length === 1 &&
+    target.runtimeKeySinks.length === 1
+  );
+}
+
+function exactStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) return undefined;
+  return value;
+}
+
+function optionalExactStringArray(value: unknown): string[] | undefined {
+  return value == null ? [] : exactStringArray(value);
+}
+
+function isSameOrDescendant(parent: string, candidate: string): boolean {
+  const pathFromParent = relative(parent, candidate);
+  return (
+    pathFromParent === "" ||
+    (!pathFromParent.startsWith(`..${sep}`) &&
+      pathFromParent !== ".." &&
+      !isAbsolute(pathFromParent))
+  );
+}
+
+function sameFileIdentity(
+  left: { dev: number | bigint; ino: number | bigint },
+  right: { dev: number | bigint; ino: number | bigint },
+): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function normalizedSynchronizedExceptionPath(path: string): string | undefined {
+  const normalized = normalizeSynchronizedPath(path);
+  if (
+    normalized === "" ||
+    normalized === ".." ||
+    normalized.startsWith("../") ||
+    normalized.startsWith("/") ||
+    containsControlCharacter(normalized)
+  ) {
+    return undefined;
+  }
+  return normalized;
+}
+
+function provenSynchronizedExclusions(
+  group: PbxObject,
+  targetId: string,
+  resourcePhaseIds: Set<string>,
+  objects: PbxObjects,
+): Set<string> | undefined {
+  const exceptionIds = optionalExactStringArray(group.exceptions);
+  if (!exceptionIds) return undefined;
+
+  const excluded = new Set<string>();
+  for (const exceptionId of exceptionIds) {
+    const exception = objects[exceptionId];
+    if (!exception) return undefined;
+
+    let applies = false;
+    if (exception.isa === "PBXFileSystemSynchronizedBuildFileExceptionSet") {
+      const exceptionTargetId = asString(exception.target);
+      if (!exceptionTargetId || objects[exceptionTargetId]?.isa !== "PBXNativeTarget") {
+        return undefined;
+      }
+      applies = exceptionTargetId === targetId;
+    } else if (exception.isa === "PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet") {
+      const exceptionPhaseId = asString(exception.buildPhase);
+      const exceptionPhase = exceptionPhaseId ? objects[exceptionPhaseId] : undefined;
+      if (
+        !exceptionPhaseId ||
+        typeof exceptionPhase?.isa !== "string" ||
+        !exceptionPhase.isa.endsWith("BuildPhase")
+      ) {
+        return undefined;
+      }
+      applies = resourcePhaseIds.has(exceptionPhaseId);
+    } else {
+      return undefined;
+    }
+
+    if (!applies) continue;
+    const membershipExceptions = optionalExactStringArray(exception.membershipExceptions);
+    if (!membershipExceptions) return undefined;
+    for (const path of membershipExceptions) {
+      const normalized = normalizedSynchronizedExceptionPath(path);
+      if (!normalized) return undefined;
+      excluded.add(normalized);
+    }
+
+    if (exception.platformFiltersByRelativePath == null) continue;
+    if (!isRecord(exception.platformFiltersByRelativePath)) return undefined;
+    for (const [path, rawFilters] of Object.entries(exception.platformFiltersByRelativePath)) {
+      const filters = exactStringArray(rawFilters);
+      const normalized = normalizedSynchronizedExceptionPath(path);
+      if (!filters || !normalized) return undefined;
+      const applicability = buildFileIOSApplicability({ platformFilters: filters });
+      if (!applicability.recognized) return undefined;
+      if (!applicability.applies) excluded.add(normalized);
+    }
+  }
+  return excluded;
+}
+
+interface RuntimeSinkIdentity {
+  dev: number | bigint;
+  ino: number | bigint;
+}
+
+interface OwnershipScanState {
+  entries: number;
+  visitedDirectories: Set<string>;
+}
+
+async function synchronizedDirectoryOwnsCanonicalSink(options: {
+  canonicalDirectory: string;
+  canonicalSink: string;
+  excluded: Set<string>;
+  logicalPrefix: string;
+  sinkIdentity: RuntimeSinkIdentity;
+  state: OwnershipScanState;
+  depth?: number;
+}): Promise<boolean | undefined> {
+  const {
+    canonicalDirectory,
+    canonicalSink,
+    excluded,
+    logicalPrefix,
+    sinkIdentity,
+    state,
+    depth = 0,
+  } = options;
+  if (depth > MAX_DISCOVERY_DEPTH) return undefined;
+
+  if (isSameOrDescendant(canonicalDirectory, canonicalSink)) {
+    const pathFromDirectory = relative(canonicalDirectory, canonicalSink).split(sep).join("/");
+    const logicalSinkPath = normalizeSynchronizedPath(
+      logicalPrefix ? `${logicalPrefix}/${pathFromDirectory}` : pathFromDirectory,
+    );
+    if (!synchronizedPathIsExcluded(logicalSinkPath, excluded)) return true;
+  }
+
+  const visitKey = `${canonicalDirectory}\0${logicalPrefix}`;
+  if (state.visitedDirectories.has(visitKey)) return false;
+  state.visitedDirectories.add(visitKey);
+
+  let entries;
+  try {
+    entries = await readdir(canonicalDirectory, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+  state.entries += entries.length;
+  if (state.entries > MAX_OWNERSHIP_SCAN_ENTRIES) return undefined;
+
+  entries.sort((left, right) => left.name.localeCompare(right.name));
+  for (const entry of entries) {
+    const logicalPath = normalizeSynchronizedPath(
+      logicalPrefix ? `${logicalPrefix}/${entry.name}` : entry.name,
+    );
+    if (synchronizedPathIsExcluded(logicalPath, excluded)) continue;
+
+    const entryPath = resolve(canonicalDirectory, entry.name);
+    let entryInfo;
+    try {
+      entryInfo = await lstat(entryPath);
+    } catch {
+      return undefined;
+    }
+
+    if (entryInfo.isFile()) {
+      if (sameFileIdentity(entryInfo, sinkIdentity)) return true;
+      continue;
+    }
+
+    if (!entryInfo.isDirectory() && !entryInfo.isSymbolicLink()) continue;
+    let canonicalEntry: string;
+    let canonicalEntryInfo;
+    try {
+      canonicalEntry = await realpath(entryPath);
+      canonicalEntryInfo = await lstat(canonicalEntry);
+    } catch {
+      // A dangling or unreadable alias could conceal a second path to the sink.
+      return undefined;
+    }
+
+    if (canonicalEntryInfo.isFile()) {
+      if (sameFileIdentity(canonicalEntryInfo, sinkIdentity)) return true;
+      continue;
+    }
+    if (!canonicalEntryInfo.isDirectory()) continue;
+
+    const nestedOwnership = await synchronizedDirectoryOwnsCanonicalSink({
+      canonicalDirectory: canonicalEntry,
+      canonicalSink,
+      excluded,
+      logicalPrefix: logicalPath,
+      sinkIdentity,
+      state,
+      depth: depth + 1,
+    });
+    if (nestedOwnership == null || nestedOwnership) return nestedOwnership;
+  }
+  return false;
+}
+
+async function synchronizedGroupOwnsCanonicalSink(options: {
+  groupPath: string;
+  canonicalSink: string;
+  excluded: Set<string>;
+  sinkIdentity: RuntimeSinkIdentity;
+}): Promise<boolean | undefined> {
+  let canonicalGroup: string;
+  let groupInfo;
+  try {
+    canonicalGroup = await realpath(options.groupPath);
+    groupInfo = await lstat(canonicalGroup);
+  } catch {
+    return undefined;
+  }
+  if (!groupInfo.isDirectory()) return undefined;
+
+  return synchronizedDirectoryOwnsCanonicalSink({
+    canonicalDirectory: canonicalGroup,
+    canonicalSink: options.canonicalSink,
+    excluded: options.excluded,
+    logicalPrefix: "",
+    sinkIdentity: options.sinkIdentity,
+    state: { entries: 0, visitedDirectories: new Set() },
+  });
+}
+
+async function classicReferenceOwnsCanonicalSink(options: {
+  referenceId: string;
+  canonicalSink: string;
+  sinkIdentity: RuntimeSinkIdentity;
+  objects: PbxObjects;
+  parents: Map<string, string>;
+  projectDirectory: string;
+  groupRootDirectory: string;
+  seen?: Set<string>;
+}): Promise<boolean | undefined> {
+  const {
+    referenceId,
+    canonicalSink,
+    sinkIdentity,
+    objects,
+    parents,
+    projectDirectory,
+    groupRootDirectory,
+    seen = new Set<string>(),
+  } = options;
+  if (seen.has(referenceId)) return undefined;
+  seen.add(referenceId);
+
+  const reference = objects[referenceId];
+  if (!reference) return undefined;
+  if (["PBXVariantGroup", "XCVersionGroup", "PBXGroup"].includes(reference.isa ?? "")) {
+    const children = exactStringArray(reference.children);
+    if (!children) return undefined;
+    let ownsSink = false;
+    for (const child of children) {
+      const childOwnership = await classicReferenceOwnsCanonicalSink({
+        referenceId: child,
+        canonicalSink,
+        sinkIdentity,
+        objects,
+        parents,
+        projectDirectory,
+        groupRootDirectory,
+        seen: new Set(seen),
+      });
+      if (childOwnership == null) return undefined;
+      ownsSink ||= childOwnership;
+    }
+    return ownsSink;
+  }
+  if (reference.isa !== "PBXFileReference") return undefined;
+
+  const path = resolvePbxFilePath(
+    referenceId,
+    objects,
+    parents,
+    projectDirectory,
+    groupRootDirectory,
+  );
+  if (!path) return undefined;
+
+  let info;
+  try {
+    info = await lstat(path);
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "ENOENT" &&
+      basename(path) !== "LocalSecrets.plist"
+    ) {
+      return false;
+    }
+    return undefined;
+  }
+
+  if (info.isFile() && !info.isSymbolicLink()) {
+    return sameFileIdentity(info, sinkIdentity);
+  }
+
+  let canonicalReference: string;
+  let canonicalInfo;
+  try {
+    canonicalReference = await realpath(path);
+    canonicalInfo = await lstat(canonicalReference);
+  } catch {
+    return undefined;
+  }
+  if (canonicalInfo.isFile()) return sameFileIdentity(canonicalInfo, sinkIdentity);
+  if (!canonicalInfo.isDirectory()) return false;
+
+  return synchronizedDirectoryOwnsCanonicalSink({
+    canonicalDirectory: canonicalReference,
+    canonicalSink,
+    excluded: new Set(),
+    logicalPrefix: "",
+    sinkIdentity,
+    state: { entries: 0, visitedDirectories: new Set() },
+  });
+}
+
+async function targetOwnsCanonicalRuntimeSink(options: {
+  canonicalSink: string;
+  groupRootDirectory: string;
+  objects: PbxObjects;
+  parents: Map<string, string>;
+  projectDirectory: string;
+  sinkIdentity: RuntimeSinkIdentity;
+  target: PbxObject;
+  targetId: string;
+}): Promise<boolean | undefined> {
+  const {
+    canonicalSink,
+    groupRootDirectory,
+    objects,
+    parents,
+    projectDirectory,
+    sinkIdentity,
+    target,
+    targetId,
+  } = options;
+  const buildPhaseIds = exactStringArray(target.buildPhases);
+  if (!buildPhaseIds) return undefined;
+
+  const resourcePhaseIds = new Set<string>();
+  for (const phaseId of buildPhaseIds) {
+    const phase = objects[phaseId];
+    if (typeof phase?.isa !== "string" || !phase.isa.endsWith("BuildPhase")) return undefined;
+    if (phase.isa === "PBXResourcesBuildPhase") resourcePhaseIds.add(phaseId);
+  }
+
+  let ownsSink = false;
+  for (const phaseId of resourcePhaseIds) {
+    const phase = objects[phaseId]!;
+    const buildFileIds = exactStringArray(phase.files);
+    if (!buildFileIds) return undefined;
+    for (const buildFileId of buildFileIds) {
+      const buildFile = objects[buildFileId];
+      if (buildFile?.isa !== "PBXBuildFile") return undefined;
+      const applicability = buildFileIOSApplicability(buildFile);
+      if (!applicability.recognized) return undefined;
+      if (!applicability.applies) continue;
+      const referenceId = asString(buildFile.fileRef);
+      if (!referenceId) return undefined;
+      const referenceOwnership = await classicReferenceOwnsCanonicalSink({
+        referenceId,
+        canonicalSink,
+        sinkIdentity,
+        objects,
+        parents,
+        projectDirectory,
+        groupRootDirectory,
+      });
+      if (referenceOwnership == null) return undefined;
+      ownsSink ||= referenceOwnership;
+    }
+  }
+
+  const synchronizedGroupIds = optionalExactStringArray(target.fileSystemSynchronizedGroups);
+  if (!synchronizedGroupIds) return undefined;
+  for (const groupId of synchronizedGroupIds) {
+    const group = objects[groupId];
+    if (group?.isa !== "PBXFileSystemSynchronizedRootGroup") return undefined;
+    const groupPath = resolvePbxFilePath(
+      groupId,
+      objects,
+      parents,
+      projectDirectory,
+      groupRootDirectory,
+    );
+    if (!groupPath) return undefined;
+    const excluded = provenSynchronizedExclusions(group, targetId, resourcePhaseIds, objects);
+    if (!excluded) return undefined;
+    const synchronizedOwnership = await synchronizedGroupOwnsCanonicalSink({
+      groupPath,
+      canonicalSink,
+      excluded,
+      sinkIdentity,
+    });
+    if (synchronizedOwnership == null) return undefined;
+    ownsSink ||= synchronizedOwnership;
+  }
+
+  return ownsSink;
+}
+
+async function hasExclusiveRuntimeSinkOwnership(
+  root: string,
+  projectPath: string,
+  targetId: string,
+  localSecretsPath: string,
+): Promise<boolean> {
+  let canonicalSink: string;
+  let sinkIdentity: RuntimeSinkIdentity;
+  try {
+    canonicalSink = await realpath(localSecretsPath);
+    const sinkInfo = await lstat(canonicalSink);
+    if (!sinkInfo.isFile()) return false;
+    sinkIdentity = { dev: sinkInfo.dev, ino: sinkInfo.ino };
+  } catch {
+    return false;
+  }
+
+  const absoluteProjectPath = resolve(root, projectPath);
+  const pbxprojPath = resolve(absoluteProjectPath, "project.pbxproj");
+  if (!(await pathIsSafelyWithinIOSRoot(root, pbxprojPath))) return false;
+
+  let archive: unknown;
+  try {
+    const info = await lstat(pbxprojPath);
+    if (!info.isFile() || info.isSymbolicLink() || info.size > MAX_PBXPROJ_BYTES) return false;
+    archive = parsePbxProject(await readFile(pbxprojPath, "utf8"));
+  } catch {
+    return false;
+  }
+
+  if (!isRecord(archive)) return false;
+  const objects = normalizedObjects(archive.objects);
+  const projectObjectId = asString(archive.rootObject);
+  const projectObject = projectObjectId ? objects?.[projectObjectId] : undefined;
+  if (!objects || projectObject?.isa !== "PBXProject") return false;
+
+  const projectTargetIds = exactStringArray(projectObject.targets);
+  if (!projectTargetIds || !projectTargetIds.includes(targetId)) return false;
+  const parents = buildPbxParentIndex(objects);
+  const projectDirectory = dirname(absoluteProjectPath);
+  const groupRootDirectory = resolve(
+    projectDirectory,
+    asString(projectObject.projectDirPath) ?? "",
+  );
+
+  const owners = new Set<string>();
+  for (const candidateTargetId of projectTargetIds) {
+    const target = objects[candidateTargetId];
+    if (!target) return false;
+    if (target.isa !== "PBXNativeTarget" || asString(target.productType) !== APP_PRODUCT_TYPE) {
+      continue;
+    }
+
+    const ownership = await targetOwnsCanonicalRuntimeSink({
+      canonicalSink,
+      groupRootDirectory,
+      objects,
+      parents,
+      projectDirectory,
+      sinkIdentity,
+      target,
+      targetId: candidateTargetId,
+    });
+    if (ownership == null) return false;
+    if (ownership) owners.add(candidateTargetId);
+  }
+  return owners.size === 1 && owners.has(targetId);
+}
+
+async function prepareRuntimeKeyVerification(
+  options: IOSRuntimeKeyPlanOptions,
+): Promise<PreparedRuntimeKeyVerification> {
+  const root = resolve(options.root);
+  const suppliedProjectPath = options.projectPath.replaceAll("\\", "/");
+  if (
+    !options.targetId ||
+    !suppliedProjectPath ||
+    isAbsolute(options.projectPath) ||
+    !suppliedProjectPath.endsWith(".xcodeproj") ||
+    (options.localSecretsPath != null && isAbsolute(options.localSecretsPath))
+  ) {
+    return verificationBlocked(
+      options,
+      root,
+      suppliedProjectPath,
+      "invalid-selection",
+      "A root-relative Xcode project, application target, and optional root-relative LocalSecrets path are required.",
+    );
+  }
+
+  const absoluteProjectPath = resolve(root, suppliedProjectPath);
+  const projectPath = relativeIOSPath(root, absoluteProjectPath);
+  if (!(await pathIsSafelyWithinIOSRoot(root, absoluteProjectPath))) {
+    return verificationBlocked(
+      options,
+      root,
+      projectPath,
+      "external-path",
+      "The selected Xcode project resolves outside the project root.",
+    );
+  }
+
+  const inspection = await inspectIOSProject(root, { target: options.targetId });
+  if (
+    inspection.selection.state !== "selected" ||
+    inspection.selection.targetId !== options.targetId ||
+    inspection.selection.projectPath !== projectPath
+  ) {
+    return verificationBlocked(
+      options,
+      root,
+      projectPath,
+      "target-not-found",
+      "The selected application target could not be verified in the selected Xcode project.",
+    );
+  }
+  const selectedTarget = inspection.appTargets.find(
+    (target) => target.id === options.targetId && target.projectPath === projectPath,
+  );
+  if (!hasProvenRuntimeKeyWiring(selectedTarget)) {
+    return verificationBlocked(
+      options,
+      root,
+      projectPath,
+      "unproven-runtime-wiring",
+      "The selected target must have exactly one proven app entry point, LocalSecrets configure call, LocalSecrets runtime loader, and target-owned LocalSecrets.plist sink.",
+    );
+  }
+  if (
+    inspection.localPublishableKey.candidateSources.some((source) => source.endsWith(".xcscheme"))
+  ) {
+    return verificationBlocked(
+      options,
+      root,
+      projectPath,
+      "scheme-override",
+      "The selected target has an enabled CLERK_PUBLISHABLE_KEY Run-scheme override, so LocalSecrets.plist is not the exclusive runtime key source.",
+    );
+  }
+
+  const membership = await targetLocalSecretsPaths(root, absoluteProjectPath, options.targetId);
+  if (membership.blocker) {
+    return verificationBlocked(
+      options,
+      root,
+      projectPath,
+      membership.blocker.code,
+      membership.blocker.message,
+    );
+  }
+  const memberPaths = membership.paths ?? [];
+  let localSecretsPath: string | undefined;
+  if (options.localSecretsPath != null) {
+    const requestedPath = resolve(root, options.localSecretsPath);
+    if (!(await pathIsSafelyWithinIOSRoot(root, requestedPath))) {
+      return verificationBlocked(
+        options,
+        root,
+        projectPath,
+        "external-path",
+        "The requested LocalSecrets.plist resolves outside the project root.",
+      );
+    }
+    localSecretsPath = memberPaths.find((path) => resolve(path) === requestedPath);
+    if (!localSecretsPath) {
+      return verificationBlocked(
+        options,
+        root,
+        projectPath,
+        "not-target-resource",
+        "The requested LocalSecrets.plist is not a proven resource of the selected target.",
+      );
+    }
+  } else if (memberPaths.length === 0) {
+    return verificationBlocked(
+      options,
+      root,
+      projectPath,
+      "missing-local-secrets",
+      "The selected target does not already own a LocalSecrets.plist resource.",
+    );
+  } else if (memberPaths.length > 1) {
+    return verificationBlocked(
+      options,
+      root,
+      projectPath,
+      "ambiguous-local-secrets",
+      "The selected target owns more than one LocalSecrets.plist resource; select one explicitly.",
+    );
+  } else {
+    localSecretsPath = memberPaths[0];
+  }
+
+  if (
+    !localSecretsPath ||
+    basename(localSecretsPath) !== "LocalSecrets.plist" ||
+    resolve(root, selectedTarget.runtimeKeySinks[0]!.path) !== resolve(localSecretsPath)
+  ) {
+    return verificationBlocked(
+      options,
+      root,
+      projectPath,
+      "not-target-resource",
+      "A unique target-owned LocalSecrets.plist resource could not be resolved.",
+    );
+  }
+  if (
+    !(await hasExclusiveRuntimeSinkOwnership(root, projectPath, options.targetId, localSecretsPath))
+  ) {
+    return verificationBlocked(
+      options,
+      root,
+      projectPath,
+      "shared-local-secrets",
+      "LocalSecrets.plist must be owned exclusively by the selected iOS application target before its runtime key can be verified.",
+    );
+  }
+
+  const localSecretsRelativePath = relativeIOSPath(root, localSecretsPath);
+  const redactedSource = {
+    plan: makeVerificationPlan(options, root, projectPath, "ready", {
+      localSecretsPath: localSecretsRelativePath,
+    }),
+  };
+  const localSecretsSnapshot = await snapshotExistingFile(
+    localSecretsPath,
+    MAX_LOCAL_SECRETS_BYTES,
+  );
+  if (!localSecretsSnapshot) {
+    return verificationBlocked(
+      options,
+      root,
+      projectPath,
+      "unreadable-local-secrets",
+      "LocalSecrets.plist is missing, too large, symlinked, or unreadable.",
+      redactedSource,
+    );
+  }
+  const plist = parseXMLPlist(localSecretsSnapshot.bytes!);
+  if (!plist) {
+    return verificationBlocked(
+      options,
+      root,
+      projectPath,
+      "malformed-local-secrets",
+      "LocalSecrets.plist must be a readable XML property-list dictionary.",
+      redactedSource,
+    );
+  }
+  const existingPublishableKey = existingValidPublishableKey(plist);
+  if (
+    !existingPublishableKey ||
+    plist[SECRET_KEY] !== existingPublishableKey ||
+    !inspection.localPublishableKey.found ||
+    inspection.localPublishableKey.conflict ||
+    inspection.localPublishableKey.source !== localSecretsRelativePath
+  ) {
+    return verificationBlocked(
+      options,
+      root,
+      projectPath,
+      "invalid-publishable-key",
+      "The proven LocalSecrets.plist runtime sink does not contain one canonical publishable key that can be verified.",
+      redactedSource,
+    );
+  }
+
+  return {
+    plan: makeVerificationPlan(options, root, projectPath, "ready", {
+      localSecretsPath: localSecretsRelativePath,
+      expectedLocalSecretsHash: localSecretsSnapshot.hash,
+    }),
+    localSecretsSnapshot,
+    existingPublishableKey,
+  };
+}
+
+export async function planIOSRuntimeKeyVerification(
+  options: IOSRuntimeKeyPlanOptions,
+): Promise<IOSRuntimeKeyVerificationPlan> {
+  return (await prepareRuntimeKeyVerification(options)).plan;
+}
+
+export async function verifyIOSRuntimeKey(
+  plan: IOSRuntimeKeyVerificationPlan,
+  linkedPublishableKey: string,
+): Promise<IOSRuntimeKeyVerificationResult> {
+  if (plan.status === "blocked") return { status: "blocked", plan };
+  if (
+    plan.schemaVersion !== 1 ||
+    plan.kind !== "clerk-ios-runtime-key-verification" ||
+    !plan.localSecretsPath ||
+    !plan.expectedLocalSecretsHash
+  ) {
+    return {
+      status: "blocked",
+      plan: {
+        ...plan,
+        status: "blocked",
+        blockers: [
+          {
+            code: "invalid-selection",
+            message: "The runtime-key verification plan is incomplete or unsupported.",
+          },
+        ],
+      },
+    };
+  }
+
+  const linkedKey = validatePublishableKey(linkedPublishableKey);
+  if (!linkedKey || linkedKey.value !== linkedPublishableKey) {
+    return {
+      status: "blocked",
+      plan: {
+        ...plan,
+        status: "blocked",
+        blockers: [
+          { code: "invalid-publishable-key", message: "A valid publishable key is required." },
+        ],
+      },
+    };
+  }
+  if (linkedKey.instanceType !== "development") {
+    return {
+      status: "blocked",
+      plan: {
+        ...plan,
+        status: "blocked",
+        blockers: [
+          {
+            code: "production-publishable-key",
+            message: "Runtime-key verification accepts a development-instance key only.",
+          },
+        ],
+      },
+    };
+  }
+
+  const prepared = await prepareRuntimeKeyVerification({
+    root: plan.root,
+    projectPath: plan.projectPath,
+    targetId: plan.targetId,
+    localSecretsPath: plan.localSecretsPath,
+  });
+  if (prepared.plan.status === "blocked") return { status: "blocked", plan: prepared.plan };
+  if (
+    prepared.plan.expectedLocalSecretsHash !== plan.expectedLocalSecretsHash ||
+    !prepared.localSecretsSnapshot ||
+    !(await snapshotMatches(prepared.localSecretsSnapshot))
+  ) {
+    return { status: "stale", plan };
+  }
+
+  return {
+    status: prepared.existingPublishableKey === linkedKey.value ? "matched" : "mismatched",
+    plan,
+  };
+}
+
+async function prepareRuntimeKeyPlan(
+  options: IOSRuntimeKeyPlanOptions,
+): Promise<PreparedRuntimeKeyPlan> {
+  const root = resolve(options.root);
+  const suppliedProjectPath = options.projectPath.replaceAll("\\", "/");
+  if (
+    !options.targetId ||
+    !suppliedProjectPath ||
+    isAbsolute(options.projectPath) ||
+    !suppliedProjectPath.endsWith(".xcodeproj") ||
+    (options.localSecretsPath != null && isAbsolute(options.localSecretsPath))
+  ) {
+    return blocked(
+      options,
+      root,
+      suppliedProjectPath,
+      "invalid-selection",
+      "A root-relative Xcode project, application target, and optional root-relative LocalSecrets path are required.",
+    );
+  }
+
+  const absoluteProjectPath = resolve(root, suppliedProjectPath);
+  const projectPath = relativeIOSPath(root, absoluteProjectPath);
+  if (!(await pathIsSafelyWithinIOSRoot(root, absoluteProjectPath))) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "external-path",
+      "The selected Xcode project resolves outside the project root.",
+    );
+  }
+
+  const inspection = await inspectIOSProject(root, { target: options.targetId });
+  if (
+    inspection.selection.state !== "selected" ||
+    inspection.selection.targetId !== options.targetId ||
+    inspection.selection.projectPath !== projectPath
+  ) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "target-not-found",
+      "The selected application target could not be verified in the selected Xcode project.",
+    );
+  }
+  const selectedTarget = inspection.appTargets.find(
+    (target) => target.id === options.targetId && target.projectPath === projectPath,
+  );
+  const generator =
+    inspection.generatedProject ?? (await generatedProjectKind(root, absoluteProjectPath));
+  if (generator) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "generated-project",
+      `This is a ${generator === "xcodegen" ? "XcodeGen" : "Tuist"} project; update its source manifest instead of generated target resources.`,
+    );
+  }
+  if (!hasProvenRuntimeKeyWiring(selectedTarget)) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "unproven-runtime-wiring",
+      "The selected target must have exactly one proven app entry point, LocalSecrets configure call, LocalSecrets runtime loader, and target-owned LocalSecrets.plist sink.",
+    );
+  }
+  if (
+    inspection.localPublishableKey.candidateSources.some((source) => source.endsWith(".xcscheme"))
+  ) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "scheme-override",
+      "The selected target has an enabled CLERK_PUBLISHABLE_KEY Run-scheme override. Disable or remove it before managing LocalSecrets.plist.",
+    );
+  }
+
+  const membership = await targetLocalSecretsPaths(root, absoluteProjectPath, options.targetId);
+  if (membership.blocker) {
+    return blocked(options, root, projectPath, membership.blocker.code, membership.blocker.message);
+  }
+  const memberPaths = membership.paths ?? [];
+  let localSecretsPath: string | undefined;
+  if (options.localSecretsPath != null) {
+    const requestedPath = resolve(root, options.localSecretsPath);
+    if (!(await pathIsSafelyWithinIOSRoot(root, requestedPath))) {
+      return blocked(
+        options,
+        root,
+        projectPath,
+        "external-path",
+        "The requested LocalSecrets.plist resolves outside the project root.",
+      );
+    }
+    localSecretsPath = memberPaths.find((path) => resolve(path) === requestedPath);
+    if (!localSecretsPath) {
+      return blocked(
+        options,
+        root,
+        projectPath,
+        "not-target-resource",
+        "The requested LocalSecrets.plist is not a proven resource of the selected target.",
+      );
+    }
+  } else if (memberPaths.length === 0) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "missing-local-secrets",
+      "The selected target does not already own a LocalSecrets.plist resource.",
+    );
+  } else if (memberPaths.length > 1) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "ambiguous-local-secrets",
+      "The selected target owns more than one LocalSecrets.plist resource; select one explicitly.",
+    );
+  } else {
+    localSecretsPath = memberPaths[0];
+  }
+
+  if (
+    !localSecretsPath ||
+    basename(localSecretsPath) !== "LocalSecrets.plist" ||
+    resolve(root, selectedTarget.runtimeKeySinks[0]!.path) !== resolve(localSecretsPath)
+  ) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "not-target-resource",
+      "A unique target-owned LocalSecrets.plist resource could not be resolved.",
+    );
+  }
+  if (
+    !(await hasExclusiveRuntimeSinkOwnership(root, projectPath, options.targetId, localSecretsPath))
+  ) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "shared-local-secrets",
+      "LocalSecrets.plist must be owned exclusively by the selected iOS application target before it can be updated automatically.",
+    );
+  }
+  const localSecretsRelativePath = relativeIOSPath(root, localSecretsPath);
+  if (containsControlCharacter(localSecretsRelativePath)) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "unsafe-gitignore",
+      "The LocalSecrets.plist path contains control characters that cannot be represented safely in .gitignore.",
+    );
+  }
+  const localSecretsSnapshot = await snapshotExistingFile(
+    localSecretsPath,
+    MAX_LOCAL_SECRETS_BYTES,
+  );
+  const redactedSource = {
+    plan: makePlan(options, root, projectPath, "ready", {
+      localSecretsPath: relativeIOSPath(root, localSecretsPath),
+    }),
+  };
+  if (!localSecretsSnapshot) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "unreadable-local-secrets",
+      "LocalSecrets.plist is missing, too large, symlinked, or unreadable.",
+      redactedSource,
+    );
+  }
+  const plist = parseXMLPlist(localSecretsSnapshot.bytes!);
+  if (!plist) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "malformed-local-secrets",
+      "LocalSecrets.plist must be a readable XML property-list dictionary.",
+      redactedSource,
+    );
+  }
+  if (plist[SECRET_KEY] != null && typeof plist[SECRET_KEY] !== "string") {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "unsupported-local-secrets",
+      "The CLERK_PUBLISHABLE_KEY entry in LocalSecrets.plist must be a string.",
+      redactedSource,
+    );
+  }
+  const existingNormalizedKey = existingValidPublishableKey(plist);
+  const plistMayNeedWrite =
+    existingNormalizedKey == null || plist[SECRET_KEY] !== existingNormalizedKey;
+
+  const resolvedGitContext = await coherentGitContext(root, [
+    absoluteProjectPath,
+    dirname(localSecretsPath),
+  ]);
+  if (resolvedGitContext.state === "unknown") {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "git-state-unknown",
+      "Git could not verify whether LocalSecrets.plist is tracked or ignored.",
+      redactedSource,
+    );
+  }
+  if (resolvedGitContext.state === "mismatch") {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "git-repository-mismatch",
+      "The selected Xcode project and LocalSecrets.plist must share the invocation root's Git repository boundary.",
+      redactedSource,
+    );
+  }
+  if (await hasDescendantGitignore(root, localSecretsPath)) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "unsafe-gitignore",
+      "A nested .gitignore can override the invocation root's LocalSecrets.plist protection. Consolidate the sink's ignore rules at the invocation root before retrying.",
+      redactedSource,
+    );
+  }
+  if (resolvedGitContext.state === "repository") {
+    const tracked = await gitPathExitCode(
+      resolvedGitContext.root,
+      ["ls-files", "--error-unmatch"],
+      localSecretsPath,
+    );
+    if (tracked == null) {
+      return blocked(
+        options,
+        root,
+        projectPath,
+        "git-state-unknown",
+        "Git could not verify whether LocalSecrets.plist is tracked.",
+        redactedSource,
+      );
+    }
+    if (tracked > 1) {
+      return blocked(
+        options,
+        root,
+        projectPath,
+        "git-state-unknown",
+        "Git could not verify whether LocalSecrets.plist is tracked.",
+        redactedSource,
+      );
+    }
+    if (tracked === 0) {
+      return blocked(
+        options,
+        root,
+        projectPath,
+        "tracked-local-secrets",
+        "LocalSecrets.plist is tracked by Git. Remove it from the index before writing a publishable key.",
+        redactedSource,
+      );
+    }
+  }
+
+  const gitignorePath = resolve(root, ".gitignore");
+  const gitignoreSnapshot = await snapshotOptionalFile(
+    root,
+    gitignorePath,
+    MAX_GITIGNORE_BYTES,
+    0o644,
+  );
+  if (!gitignoreSnapshot) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "unsafe-gitignore",
+      ".gitignore is too large, symlinked, unreadable, or resolves outside the project root.",
+      redactedSource,
+    );
+  }
+  const rule = gitignoreRule(root, localSecretsPath);
+  const gitignoreText = gitignoreSnapshot.exists ? decodeUTF8(gitignoreSnapshot.bytes!) : "";
+  if (gitignoreText == null) {
+    return blocked(
+      options,
+      root,
+      projectPath,
+      "unsafe-gitignore",
+      ".gitignore must be valid UTF-8.",
+      redactedSource,
+    );
+  }
+
+  const hasExactRule = gitignoreContainsRule(gitignoreText, rule);
+  let effectivelyIgnored = hasExactRule && gitignoreEndsWithRule(gitignoreText, rule);
+  if (resolvedGitContext.state === "repository") {
+    const ignored = await gitPathExitCode(
+      resolvedGitContext.root,
+      ["check-ignore", "--quiet", "--no-index"],
+      localSecretsPath,
+    );
+    if (ignored == null || ignored > 1) {
+      return blocked(
+        options,
+        root,
+        projectPath,
+        "git-state-unknown",
+        "Git could not verify whether LocalSecrets.plist is effectively ignored.",
+        redactedSource,
+      );
+    }
+    effectivelyIgnored = ignored === 0;
+  }
+  const gitignoreNeeded = !hasExactRule || !effectivelyIgnored;
+  const changesGitignore = gitignoreNeeded || plistMayNeedWrite;
+
+  const gitignoreRelativePath = relativeIOSPath(root, gitignorePath);
+  return {
+    plan: makePlan(options, root, projectPath, "ready", {
+      localSecretsPath: localSecretsRelativePath,
+      gitignorePath: gitignoreRelativePath,
+      gitignoreRule: rule,
+      expectedLocalSecretsHash: localSecretsSnapshot.hash,
+      expectedGitignoreHash: gitignoreSnapshot.exists ? gitignoreSnapshot.hash! : null,
+      changesGitignore,
+      actions: [
+        ...(changesGitignore
+          ? [
+              `Ensure ${localSecretsRelativePath} and its atomic-write staging file are effectively ignored by Git.`,
+            ]
+          : []),
+        `Set CLERK_PUBLISHABLE_KEY in ${localSecretsRelativePath} without exposing its value.`,
+      ],
+    }),
+    plist,
+    localSecretsSnapshot,
+    gitignoreSnapshot,
+    gitContext: resolvedGitContext,
+    gitignoreNeeded,
+  };
+}
+
+export async function planIOSRuntimeKey(
+  options: IOSRuntimeKeyPlanOptions,
+): Promise<IOSRuntimeKeyPlan> {
+  return (await prepareRuntimeKeyPlan(options)).plan;
+}
+
+function validatePublishableKey(
+  value: string,
+): { value: string; instanceType: "development" | "production" } | undefined {
+  const normalized = value.trim();
+  if (!normalized) return undefined;
+  try {
+    return { value: normalized, instanceType: decodePublishableKey(normalized).instanceType };
+  } catch {
+    return undefined;
+  }
+}
+
+function existingValidPublishableKey(plist: Record<string, unknown>): string | undefined {
+  const value = plist[SECRET_KEY];
+  if (typeof value !== "string") return undefined;
+  return validatePublishableKey(value)?.value;
+}
+
+function xmlEscape(value: string): string {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}
+
+function plistWithoutPublishableKey(plist: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(plist).filter(([key]) => key !== SECRET_KEY));
+}
+
+function replaceOrInsertPublishableKey(
+  originalBytes: Uint8Array,
+  originalPlist: Record<string, unknown>,
+  publishableKey: string,
+): Uint8Array | undefined {
+  const source = decodeUTF8(originalBytes);
+  if (!source) return undefined;
+  const keyTag = /<key>\s*CLERK_PUBLISHABLE_KEY\s*<\/key>/g;
+  const matches = [...source.matchAll(keyTag)];
+  if (matches.length > 1) return undefined;
+  if (matches.length === 0 && Object.hasOwn(originalPlist, SECRET_KEY)) return undefined;
+
+  let candidate: string;
+  if (matches.length === 1) {
+    const match = matches[0]!;
+    const keyEnd = match.index! + match[0].length;
+    const suffix = source.slice(keyEnd);
+    const stringValue = /^(\s*)<string\s*>([\s\S]*?)<\/string>/.exec(suffix);
+    const emptyStringValue = /^(\s*)<string\s*\/>/.exec(suffix);
+    if (stringValue) {
+      const replacement = `${stringValue[1]}<string>${xmlEscape(publishableKey)}</string>`;
+      candidate = `${source.slice(0, keyEnd)}${replacement}${suffix.slice(stringValue[0].length)}`;
+    } else if (emptyStringValue) {
+      const replacement = `${emptyStringValue[1]}<string>${xmlEscape(publishableKey)}</string>`;
+      candidate = `${source.slice(0, keyEnd)}${replacement}${suffix.slice(emptyStringValue[0].length)}`;
+    } else {
+      return undefined;
+    }
+  } else {
+    const closing = source.lastIndexOf("</dict>");
+    if (closing === -1) return undefined;
+    const lineEnding = source.includes("\r\n") ? "\r\n" : "\n";
+    const lineStart = source.lastIndexOf("\n", closing - 1) + 1;
+    const possibleIndent = source.slice(lineStart, closing);
+    if (/^[\t ]*$/.test(possibleIndent)) {
+      const childIndent = `${possibleIndent}${source.includes("\t<key>") ? "\t" : "  "}`;
+      const insertion = `${childIndent}<key>${SECRET_KEY}</key>${lineEnding}${childIndent}<string>${xmlEscape(publishableKey)}</string>${lineEnding}`;
+      candidate = `${source.slice(0, lineStart)}${insertion}${source.slice(lineStart)}`;
+    } else {
+      candidate = `${source.slice(0, closing)}<key>${SECRET_KEY}</key><string>${xmlEscape(publishableKey)}</string>${source.slice(closing)}`;
+    }
+  }
+
+  const candidateBytes = new TextEncoder().encode(candidate);
+  const candidatePlist = parseXMLPlist(candidateBytes);
+  if (
+    !candidatePlist ||
+    candidatePlist[SECRET_KEY] !== publishableKey ||
+    !isDeepStrictEqual(
+      plistWithoutPublishableKey(originalPlist),
+      plistWithoutPublishableKey(candidatePlist),
+    )
+  ) {
+    return undefined;
+  }
+  return candidateBytes;
+}
+
+async function snapshotMatches(snapshot: FileSnapshot): Promise<boolean> {
+  try {
+    const info = await lstat(snapshot.path);
+    if (!snapshot.exists) return false;
+    if (!info.isFile() || info.isSymbolicLink()) return false;
+    return sha256(await readFile(snapshot.path)) === snapshot.hash;
+  } catch (error) {
+    return !snapshot.exists && error instanceof Error && "code" in error && error.code === "ENOENT";
+  }
+}
+
+async function fileMatchesHash(
+  path: string,
+  maximumBytes: number,
+  expectedHash: string,
+): Promise<boolean> {
+  const snapshot = await snapshotExistingFile(path, maximumBytes);
+  return snapshot?.hash === expectedHash;
+}
+
+async function syncDirectory(path: string): Promise<void> {
+  try {
+    const directory = await open(path, "r");
+    try {
+      await directory.sync();
+    } finally {
+      await directory.close();
+    }
+  } catch {
+    // Same-directory rename/link remains atomic when directory fsync is unavailable.
+  }
+}
+
+async function stageFile(
+  snapshot: FileSnapshot,
+  content: Uint8Array,
+  options: StageFileOptions = {},
+): Promise<StagedFile> {
+  const temporaryPath = resolve(
+    dirname(snapshot.path),
+    `.${basename(snapshot.path)}.clerk-${process.pid}-${randomUUID()}.tmp`,
+  );
+  let created = false;
+  try {
+    const file = await open(temporaryPath, "wx", snapshot.mode);
+    created = true;
+    try {
+      if (options.beforeWrite && !(await options.beforeWrite(temporaryPath))) {
+        throw new Error("temporary path is not safely ignored");
+      }
+      await file.writeFile(content);
+      if (options.forceFailureAfterCreate) throw new Error("injected staging failure");
+      await file.sync();
+    } finally {
+      await file.close();
+    }
+    await chmod(temporaryPath, snapshot.mode);
+  } catch {
+    if (created) {
+      try {
+        await rm(temporaryPath, { force: true });
+      } catch {
+        throw new RuntimeKeyTemporaryFileCleanupError(
+          "A temporary runtime-key file could not be removed. Inspect the LocalSecrets.plist directory for a .clerk-*.tmp file before continuing.",
+          options.keyBearing === true,
+        );
+      }
+    }
+    throw new Error("The runtime-key update could not be staged safely.");
+  }
+  return {
+    targetPath: snapshot.path,
+    temporaryPath,
+    candidateHash: sha256(content),
+    original: snapshot,
+    committed: false,
+    cleanupFailuresRemaining: options.cleanupFailures ?? 0,
+    keyBearing: options.keyBearing === true,
+  };
+}
+
+async function removeStagedTemporaryFile(staged: StagedFile): Promise<void> {
+  if (staged.cleanupFailuresRemaining > 0) {
+    staged.cleanupFailuresRemaining -= 1;
+    throw new RuntimeKeyTemporaryFileCleanupError(
+      "A temporary runtime-key file could not be removed. Inspect the LocalSecrets.plist directory for a .clerk-*.tmp file before continuing.",
+      staged.keyBearing,
+    );
+  }
+  try {
+    await rm(staged.temporaryPath, { force: true });
+  } catch {
+    throw new RuntimeKeyTemporaryFileCleanupError(
+      "A temporary runtime-key file could not be removed. Inspect the LocalSecrets.plist directory for a .clerk-*.tmp file before continuing.",
+      staged.keyBearing,
+    );
+  }
+}
+
+async function commitStagedFile(staged: StagedFile): Promise<"written" | "stale"> {
+  if (!(await snapshotMatches(staged.original))) return "stale";
+  if (staged.original.exists) {
+    await rename(staged.temporaryPath, staged.targetPath);
+    staged.committed = true;
+  } else {
+    try {
+      await link(staged.temporaryPath, staged.targetPath);
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "EEXIST") return "stale";
+      throw error;
+    }
+    staged.committed = true;
+    await removeStagedTemporaryFile(staged);
+  }
+  await syncDirectory(dirname(staged.targetPath));
+  return "written";
+}
+
+async function cleanupStagedFile(staged: StagedFile): Promise<void> {
+  await removeStagedTemporaryFile(staged);
+}
+
+async function restoreCommittedFile(staged: StagedFile): Promise<"restored" | "stale"> {
+  const current = await snapshotExistingFile(staged.targetPath, Number.MAX_SAFE_INTEGER);
+  if (!current || current.hash !== staged.candidateHash) return "stale";
+  if (!staged.original.exists) {
+    await rm(staged.targetPath);
+    await syncDirectory(dirname(staged.targetPath));
+    staged.committed = false;
+    return "restored";
+  }
+  const rollback = await stageFile(current, staged.original.bytes!, {
+    keyBearing: staged.keyBearing,
+  });
+  try {
+    if ((await commitStagedFile(rollback)) !== "written") return "stale";
+    staged.committed = false;
+    return "restored";
+  } finally {
+    await cleanupStagedFile(rollback);
+  }
+}
+
+async function rollbackFiles(
+  stagedFiles: StagedFile[],
+  dependency: RollbackDependency,
+  preserveProtection = false,
+): Promise<boolean> {
+  let fullyRestored = true;
+  let payloadIsUnsafe = preserveProtection;
+  let cleanupFailure: RuntimeKeyTemporaryFileCleanupError | undefined;
+  for (const staged of stagedFiles) {
+    if (staged.targetPath !== dependency.payloadPath || staged.committed) continue;
+    try {
+      await cleanupStagedFile(staged);
+    } catch (error) {
+      fullyRestored = false;
+      payloadIsUnsafe = true;
+      if (error instanceof RuntimeKeyTemporaryFileCleanupError) {
+        cleanupFailure ??= error;
+      }
+    }
+  }
+  const payload = stagedFiles.find(
+    (staged) => staged.committed && staged.targetPath === dependency.payloadPath,
+  );
+  const ordered = [
+    ...(payload ? [payload] : []),
+    ...[...stagedFiles].reverse().filter((staged) => staged !== payload),
+  ];
+  for (const staged of ordered) {
+    if (!staged.committed) continue;
+    if (staged.targetPath === dependency.protectionPath && payloadIsUnsafe) {
+      fullyRestored = false;
+      continue;
+    }
+    try {
+      const restoreResult = await restoreCommittedFile(staged);
+      if (restoreResult === "restored") {
+        continue;
+      }
+      if (staged.targetPath === dependency.protectionPath && !payloadIsUnsafe) {
+        // The payload is back to a non-key-bearing state, so retain a concurrent
+        // ignore-file edit instead of overwriting it merely to restore our guard.
+        continue;
+      }
+    } catch (error) {
+      if (error instanceof RuntimeKeyTemporaryFileCleanupError) {
+        cleanupFailure ??= error;
+        if (staged.targetPath === dependency.payloadPath) payloadIsUnsafe = true;
+        if (!staged.committed) continue;
+      }
+      // Continue so independent files are still restored when it is safe to do so.
+    }
+    fullyRestored = false;
+    if (staged.targetPath === dependency.payloadPath) payloadIsUnsafe = true;
+  }
+  if (payloadIsUnsafe) {
+    const unsafeKeyBearingPaths = stagedFiles
+      .filter((staged) => staged.keyBearing)
+      .map((staged) => (staged.committed ? staged.targetPath : staged.temporaryPath));
+    if (!(await ensureRollbackProtection(dependency, unsafeKeyBearingPaths))) {
+      fullyRestored = false;
+    }
+  }
+  if (cleanupFailure) throw cleanupFailure;
+  return fullyRestored;
+}
+
+async function ensureRollbackProtection(
+  dependency: RollbackDependency,
+  keyBearingPaths: string[],
+): Promise<boolean> {
+  if (
+    keyBearingPaths.length > 0 &&
+    (
+      await Promise.all(
+        keyBearingPaths.map(async (path) =>
+          localSecretsIsIgnored(
+            dependency.root,
+            path,
+            path === dependency.payloadPath
+              ? dependency.protectionRules.at(-1)!
+              : dependency.protectionRules[0]!,
+          ),
+        ),
+      )
+    ).every(Boolean)
+  ) {
+    return true;
+  }
+
+  const current = await snapshotOptionalFile(
+    dependency.root,
+    dependency.protectionPath,
+    MAX_GITIGNORE_BYTES,
+    0o644,
+  );
+  if (!current) return false;
+  const currentText = current.exists ? decodeUTF8(current.bytes!) : "";
+  if (currentText == null) return false;
+
+  let protectedText = currentText;
+  for (const rule of dependency.protectionRules) {
+    protectedText = appendGitignoreRule(protectedText, rule);
+  }
+  const protection = await stageFile(current, new TextEncoder().encode(protectedText));
+  try {
+    if ((await commitStagedFile(protection)) !== "written") return false;
+  } finally {
+    await cleanupStagedFile(protection);
+  }
+
+  return (
+    await Promise.all(
+      keyBearingPaths.map(async (path) =>
+        localSecretsIsIgnored(
+          dependency.root,
+          path,
+          path === dependency.payloadPath
+            ? dependency.protectionRules.at(-1)!
+            : dependency.protectionRules[0]!,
+        ),
+      ),
+    )
+  ).every(Boolean);
+}
+
+async function localSecretsIsIgnored(
+  root: string,
+  localSecretsPath: string,
+  rule: string,
+): Promise<boolean> {
+  if (await hasDescendantGitignore(root, localSecretsPath)) return false;
+  const gitignore = await snapshotExistingFile(resolve(root, ".gitignore"), MAX_GITIGNORE_BYTES);
+  const gitignoreText = gitignore?.bytes ? decodeUTF8(gitignore.bytes) : undefined;
+  if (gitignoreText == null || !gitignoreContainsRule(gitignoreText, rule)) return false;
+  const context = await coherentGitContext(root, [dirname(localSecretsPath)]);
+  if (context.state === "repository") {
+    const tracked = await gitPathExitCode(
+      context.root,
+      ["ls-files", "--error-unmatch"],
+      localSecretsPath,
+    );
+    if (tracked !== 1) return false;
+    const ignored = await gitPathExitCode(
+      context.root,
+      ["check-ignore", "--quiet", "--no-index"],
+      localSecretsPath,
+    );
+    return ignored === 0;
+  }
+  return (
+    context.state === "not-repository" &&
+    gitignoreRuleIsEffectiveWithoutRepository(gitignoreText, rule)
+  );
+}
+
+async function postWriteIsValid(plan: IOSRuntimeKeyPlan, publishableKey: string): Promise<boolean> {
+  if (!plan.localSecretsPath || !plan.gitignoreRule) return false;
+  const localSecretsPath = resolve(plan.root, plan.localSecretsPath);
+  if (!(await pathIsSafelyWithinIOSRoot(plan.root, localSecretsPath))) return false;
+  const snapshot = await snapshotExistingFile(localSecretsPath, MAX_LOCAL_SECRETS_BYTES);
+  const plist = snapshot?.bytes ? parseXMLPlist(snapshot.bytes) : undefined;
+  const installedKey =
+    plist && typeof plist[SECRET_KEY] === "string"
+      ? validatePublishableKey(plist[SECRET_KEY])?.value
+      : undefined;
+  if (installedKey !== publishableKey) return false;
+  const gitBoundary = await coherentGitContext(plan.root, [
+    resolve(plan.root, plan.projectPath),
+    dirname(localSecretsPath),
+  ]);
+  if (gitBoundary.state === "unknown" || gitBoundary.state === "mismatch") return false;
+  if (!(await localSecretsIsIgnored(plan.root, localSecretsPath, plan.gitignoreRule))) {
+    return false;
+  }
+  const inspection = await inspectIOSProject(plan.root, { target: plan.targetId });
+  if (
+    inspection.selection.state !== "selected" ||
+    inspection.selection.projectPath !== plan.projectPath ||
+    inspection.selection.targetId !== plan.targetId ||
+    inspection.generatedProject != null ||
+    inspection.localPublishableKey.candidateSources.some((source) => source.endsWith(".xcscheme"))
+  ) {
+    return false;
+  }
+  if (await generatedProjectKind(plan.root, resolve(plan.root, plan.projectPath))) return false;
+  const selectedTarget = inspection.appTargets.find(
+    (target) => target.id === plan.targetId && target.projectPath === plan.projectPath,
+  );
+  if (
+    !hasProvenRuntimeKeyWiring(selectedTarget) ||
+    selectedTarget.runtimeKeySinks[0]?.path !== plan.localSecretsPath
+  ) {
+    return false;
+  }
+  if (
+    !(await hasExclusiveRuntimeSinkOwnership(
+      plan.root,
+      plan.projectPath,
+      plan.targetId,
+      localSecretsPath,
+    ))
+  ) {
+    return false;
+  }
+  const selectedSource = inspection.localPublishableKey.source;
+  return (
+    inspection.localPublishableKey.found &&
+    !inspection.localPublishableKey.conflict &&
+    selectedSource === plan.localSecretsPath
+  );
+}
+
+export async function applyIOSRuntimeKey(
+  plan: IOSRuntimeKeyPlan,
+  publishableKey: string,
+  options: IOSRuntimeKeyApplyOptions = {},
+): Promise<IOSRuntimeKeyApplyResult> {
+  if (plan.status === "blocked") return { status: "blocked", plan };
+  if (
+    plan.schemaVersion !== 1 ||
+    plan.kind !== "clerk-ios-runtime-key" ||
+    !plan.localSecretsPath ||
+    !plan.gitignorePath ||
+    !plan.gitignoreRule ||
+    !plan.expectedLocalSecretsHash ||
+    plan.expectedGitignoreHash === undefined ||
+    typeof plan.changesGitignore !== "boolean"
+  ) {
+    return {
+      status: "blocked",
+      plan,
+      message: "The runtime-key plan is incomplete or unsupported.",
+    };
+  }
+
+  const validatedKey = validatePublishableKey(publishableKey);
+  if (!validatedKey) {
+    return {
+      status: "blocked",
+      plan: {
+        ...plan,
+        status: "blocked",
+        blockers: [
+          {
+            code: "invalid-publishable-key",
+            message: "A valid Clerk publishable key is required.",
+          },
+        ],
+      },
+    };
+  }
+  if (validatedKey.instanceType !== "development") {
+    return {
+      status: "blocked",
+      plan: {
+        ...plan,
+        status: "blocked",
+        blockers: [
+          {
+            code: "production-publishable-key",
+            message:
+              "Automatic iOS runtime wiring accepts a development-instance publishable key only.",
+          },
+        ],
+      },
+    };
+  }
+  const normalizedKey = validatedKey.value;
+  const targetGitignoreRule = plan.gitignoreRule;
+
+  const prepared = await prepareRuntimeKeyPlan({
+    root: plan.root,
+    projectPath: plan.projectPath,
+    targetId: plan.targetId,
+    localSecretsPath: plan.localSecretsPath,
+  });
+  if (prepared.plan.status === "blocked") {
+    return { status: "blocked", plan: prepared.plan };
+  }
+  if (
+    prepared.plan.expectedLocalSecretsHash !== plan.expectedLocalSecretsHash ||
+    prepared.plan.expectedGitignoreHash !== plan.expectedGitignoreHash
+  ) {
+    return {
+      status: "stale",
+      plan,
+      message: "LocalSecrets.plist or .gitignore changed after the plan was created.",
+    };
+  }
+  const localSecretsSnapshot = prepared.localSecretsSnapshot!;
+  const gitignoreSnapshot = prepared.gitignoreSnapshot!;
+  const plist = prepared.plist!;
+  const existingKey = existingValidPublishableKey(plist);
+  if (existingKey && existingKey !== normalizedKey) {
+    return {
+      status: "blocked",
+      plan: {
+        ...plan,
+        status: "blocked",
+        blockers: [
+          {
+            code: "different-publishable-key",
+            message:
+              "LocalSecrets.plist already contains a different valid publishable key; it was preserved.",
+          },
+        ],
+      },
+    };
+  }
+
+  const needsPlistWrite = existingKey !== normalizedKey || plist[SECRET_KEY] !== normalizedKey;
+  const needsGitignoreWrite = prepared.gitignoreNeeded === true;
+  if (!needsPlistWrite && !needsGitignoreWrite) {
+    return { status: "satisfied", plan };
+  }
+
+  const plistCandidate = needsPlistWrite
+    ? replaceOrInsertPublishableKey(localSecretsSnapshot.bytes!, plist, normalizedKey)
+    : undefined;
+  if (needsPlistWrite && !plistCandidate) {
+    return {
+      status: "blocked",
+      plan: {
+        ...plan,
+        status: "blocked",
+        blockers: [
+          {
+            code: "unsupported-local-secrets",
+            message:
+              "The publishable-key entry could not be updated without changing unrelated plist data.",
+          },
+        ],
+      },
+    };
+  }
+
+  const gitignoreText = gitignoreSnapshot.exists ? decodeUTF8(gitignoreSnapshot.bytes!) : "";
+  if (gitignoreText == null) {
+    return {
+      status: "blocked",
+      plan,
+      message: ".gitignore is not valid UTF-8.",
+    };
+  }
+  const temporaryRule = needsPlistWrite
+    ? gitignoreTemporaryRule(plan.root, localSecretsSnapshot.path)
+    : undefined;
+  let gitignoreCandidateText = gitignoreText;
+  if (temporaryRule) {
+    // This durable guard makes a crash-safe same-filesystem atomic write possible: no key
+    // bytes are written to the staged plist until Git proves this pattern is effective.
+    gitignoreCandidateText = appendGitignoreRule(gitignoreCandidateText, temporaryRule);
+  }
+  if (needsGitignoreWrite || temporaryRule) {
+    // Keep the exact target rule last so it is portable even before a repository exists.
+    gitignoreCandidateText = appendGitignoreRule(gitignoreCandidateText, plan.gitignoreRule);
+  }
+  const gitignoreCandidate =
+    gitignoreCandidateText !== gitignoreText
+      ? new TextEncoder().encode(gitignoreCandidateText)
+      : undefined;
+  const gitignoreCandidateHash = gitignoreCandidate
+    ? sha256(gitignoreCandidate)
+    : gitignoreSnapshot.hash;
+
+  const stagedFiles: StagedFile[] = [];
+  const rollbackDependency: RollbackDependency = {
+    root: plan.root,
+    payloadPath: localSecretsSnapshot.path,
+    protectionPath: gitignoreSnapshot.path,
+    protectionRules: [...(temporaryRule ? [temporaryRule] : []), targetGitignoreRule],
+  };
+  const gitignoreCandidateIsCurrent = async (): Promise<boolean> =>
+    gitignoreCandidateHash != null &&
+    (await fileMatchesHash(gitignoreSnapshot.path, MAX_GITIGNORE_BYTES, gitignoreCandidateHash));
+  try {
+    if (gitignoreCandidate) {
+      stagedFiles.push(
+        await stageFile(gitignoreSnapshot, gitignoreCandidate, {
+          cleanupFailures: options.forceGitignoreCommitCleanupFailure === true ? 1 : 0,
+        }),
+      );
+    }
+
+    if (
+      !(await snapshotMatches(localSecretsSnapshot)) ||
+      !(await snapshotMatches(gitignoreSnapshot))
+    ) {
+      return {
+        status: "stale",
+        plan,
+        message: "LocalSecrets.plist or .gitignore changed while the update was being prepared.",
+      };
+    }
+
+    const gitignoreStaged = stagedFiles.find(
+      (staged) => staged.targetPath === gitignoreSnapshot.path,
+    );
+    if (gitignoreStaged) {
+      const result = await commitStagedFile(gitignoreStaged);
+      if (result === "stale") {
+        if (!(await rollbackFiles(stagedFiles, rollbackDependency))) {
+          throw new Error(
+            "The runtime-key update became stale and automatic rollback was incomplete. Git-ignore protection was retained when possible; inspect LocalSecrets.plist and .gitignore before retrying.",
+          );
+        }
+        return {
+          status: "stale",
+          plan,
+          message: "A target file changed while the runtime-key update was being committed.",
+        };
+      }
+    }
+
+    if (needsPlistWrite && !(await gitignoreCandidateIsCurrent())) {
+      if (!(await rollbackFiles(stagedFiles, rollbackDependency))) {
+        throw new Error(
+          "The runtime-key update became stale and automatic rollback was incomplete. Git-ignore protection was retained when possible; inspect LocalSecrets.plist and .gitignore before retrying.",
+        );
+      }
+      return {
+        status: "stale",
+        plan,
+        message: ".gitignore changed after the crash-safe guard was committed.",
+      };
+    }
+
+    const localSecretsPath = resolve(plan.root, plan.localSecretsPath);
+    if (!(await localSecretsIsIgnored(plan.root, localSecretsPath, plan.gitignoreRule))) {
+      if (!(await rollbackFiles(stagedFiles, rollbackDependency))) {
+        throw new Error(
+          "The Git-ignore safety check failed and automatic rollback was incomplete. Git-ignore protection was retained when possible; inspect LocalSecrets.plist and .gitignore before retrying.",
+        );
+      }
+      return {
+        status: "rolled-back",
+        plan,
+        message: "The Git-ignore safety check failed and the original files were restored.",
+      };
+    }
+
+    let plistStaged: StagedFile | undefined;
+    if (plistCandidate && temporaryRule) {
+      plistStaged = await stageFile(localSecretsSnapshot, plistCandidate, {
+        cleanupFailures: options.forcePlistCleanupFailureBeforeCommit === true ? 2 : 0,
+        forceFailureAfterCreate: options.forcePlistStageFailureAfterCreate === true,
+        keyBearing: true,
+        beforeWrite: async (temporaryPath) => {
+          if (!(await gitignoreCandidateIsCurrent())) return false;
+          if (!(await localSecretsIsIgnored(plan.root, temporaryPath, temporaryRule))) return false;
+          await options.beforePlistWrite?.(temporaryPath);
+          return (
+            (await gitignoreCandidateIsCurrent()) &&
+            (await localSecretsIsIgnored(plan.root, temporaryPath, temporaryRule)) &&
+            (await localSecretsIsIgnored(plan.root, localSecretsPath, targetGitignoreRule))
+          );
+        },
+      });
+      stagedFiles.push(plistStaged);
+      await options.afterPlistStage?.();
+      if (
+        !(await gitignoreCandidateIsCurrent()) ||
+        !(await snapshotMatches(localSecretsSnapshot)) ||
+        !(await localSecretsIsIgnored(plan.root, plistStaged.temporaryPath, temporaryRule)) ||
+        !(await localSecretsIsIgnored(plan.root, localSecretsPath, plan.gitignoreRule))
+      ) {
+        if (!(await rollbackFiles(stagedFiles, rollbackDependency))) {
+          throw new Error(
+            "The runtime-key update became stale and automatic rollback was incomplete. Git-ignore protection was retained when possible; inspect LocalSecrets.plist and .gitignore before retrying.",
+          );
+        }
+        return {
+          status: "stale",
+          plan,
+          message: "A target file changed while the runtime-key update was being staged.",
+        };
+      }
+      if (!(await gitignoreCandidateIsCurrent())) {
+        if (!(await rollbackFiles(stagedFiles, rollbackDependency))) {
+          throw new Error(
+            "The runtime-key update became stale and automatic rollback was incomplete. Git-ignore protection was retained when possible; inspect LocalSecrets.plist and .gitignore before retrying.",
+          );
+        }
+        return {
+          status: "stale",
+          plan,
+          message: ".gitignore changed before LocalSecrets.plist was committed.",
+        };
+      }
+      if ((await commitStagedFile(plistStaged)) === "stale") {
+        if (!(await rollbackFiles(stagedFiles, rollbackDependency))) {
+          throw new Error(
+            "The runtime-key update became stale and automatic rollback was incomplete. Git-ignore protection was retained when possible; inspect LocalSecrets.plist and .gitignore before retrying.",
+          );
+        }
+        return {
+          status: "stale",
+          plan,
+          message: "A target file changed while the runtime-key update was being committed.",
+        };
+      }
+      await options.afterPlistCommit?.();
+      if (!(await gitignoreCandidateIsCurrent())) {
+        if (!(await rollbackFiles(stagedFiles, rollbackDependency))) {
+          throw new Error(
+            "The runtime-key update became stale and automatic rollback was incomplete. Git-ignore protection was retained when possible; inspect LocalSecrets.plist and .gitignore before retrying.",
+          );
+        }
+        return {
+          status: "stale",
+          plan,
+          message: ".gitignore changed after LocalSecrets.plist was committed.",
+        };
+      }
+    }
+
+    await options.beforePostWriteValidation?.();
+    const valid =
+      options.forcePostWriteValidationFailure !== true &&
+      (!needsPlistWrite || (await gitignoreCandidateIsCurrent())) &&
+      (await postWriteIsValid(plan, normalizedKey)) &&
+      (!needsPlistWrite || (await gitignoreCandidateIsCurrent()));
+    if (valid) return { status: "applied", plan };
+
+    if (!(await rollbackFiles(stagedFiles, rollbackDependency))) {
+      throw new Error(
+        "The runtime-key update failed validation and automatic rollback was incomplete. Git-ignore protection was retained when possible; inspect LocalSecrets.plist and .gitignore before retrying.",
+      );
+    }
+    return {
+      status: "rolled-back",
+      plan,
+      message: "The runtime-key update failed validation and the original files were restored.",
+    };
+  } catch (error) {
+    if (
+      !(await rollbackFiles(
+        stagedFiles,
+        rollbackDependency,
+        error instanceof RuntimeKeyTemporaryFileCleanupError && error.keyBearing,
+      ))
+    ) {
+      throw new Error(
+        "The runtime-key update failed and automatic rollback was incomplete. Git-ignore protection was retained when possible; inspect LocalSecrets.plist and .gitignore before retrying.",
+      );
+    }
+    if (error instanceof RuntimeKeyTemporaryFileCleanupError) throw error;
+    return {
+      status: "rolled-back",
+      plan,
+      message: "The runtime-key update failed and the original files were restored.",
+    };
+  } finally {
+    await Promise.all(stagedFiles.map(cleanupStagedFile));
+  }
+}

--- a/packages/cli-core/src/commands/init/ios/swift.test.ts
+++ b/packages/cli-core/src/commands/init/ios/swift.test.ts
@@ -1,0 +1,879 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { inspectSwiftSources, sanitizeSwiftSource } from "./swift.ts";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true })));
+});
+
+describe("sanitizeSwiftSource", () => {
+  test("removes nested comments and standard, multiline, and raw strings", () => {
+    const source = `
+      // Clerk.configure(publishableKey: "fake")
+      /* outer /* @main */ AuthView() */
+      let standard = "Clerk.configure()"
+      let multiline = """.environment(Clerk.shared)"""
+      let raw = ##"AuthView()"##
+      @main struct RealApp: App {}
+    `;
+
+    const sanitized = sanitizeSwiftSource(source);
+    expect(sanitized).not.toContain("Clerk.configure");
+    expect(sanitized).not.toContain("AuthView");
+    expect(sanitized).not.toContain(".environment");
+    expect(sanitized).toContain("@main struct RealApp");
+  });
+});
+
+describe("inspectSwiftSources", () => {
+  test("records real Clerk evidence without retaining key expressions", async () => {
+    const root = await mkdtemp(join(tmpdir(), "clerk-ios-swift-"));
+    temporaryDirectories.push(root);
+    const path = join(root, "App.swift");
+    await Bun.write(
+      path,
+      `import ClerkKit
+       import ClerkKitUI
+       @main struct AppMain: App {
+         init() { Clerk.configure(publishableKey: "pk_test_must-not-leak") }
+         var body: some Scene {
+           WindowGroup {
+             AuthView()
+               .environment(Clerk.shared)
+               .onOpenURL { url in
+                 Task { try await Clerk.shared.handle(url) }
+               }
+           }
+         }
+       }`,
+    );
+
+    const inspection = await inspectSwiftSources([
+      { absolutePath: path, relativePath: "App.swift" },
+    ]);
+
+    expect(inspection.status).toBe("complete");
+    expect(inspection.configureCalls).toEqual([
+      {
+        path: "App.swift",
+        publishableKeyWiring: "inline-literal",
+        inlinePublishableKey: { state: "invalid" },
+        startupBinding: "app-init",
+      },
+    ]);
+    expect(inspection.environmentInjections).toEqual([{ path: "App.swift" }]);
+    expect(inspection.authFlowReferences).toEqual([{ path: "App.swift" }]);
+    expect(inspection.openURLHandlers).toEqual([{ path: "App.swift" }]);
+    expect(JSON.stringify(inspection)).not.toContain("must-not-leak");
+  });
+
+  test("retains only decoded metadata for a valid inline publishable key", async () => {
+    const root = await mkdtemp(join(tmpdir(), "clerk-ios-swift-"));
+    temporaryDirectories.push(root);
+    const path = join(root, "App.swift");
+    const publishableKey = `pk_test_${Buffer.from("inline.clerk.example$").toString("base64")}`;
+    await Bun.write(
+      path,
+      `import ClerkKit
+       @main struct AppMain: App {
+         init() { Clerk.configure(publishableKey: "${publishableKey}") }
+       }`,
+    );
+
+    const inspection = await inspectSwiftSources([
+      { absolutePath: path, relativePath: "App.swift" },
+    ]);
+
+    expect(inspection.configureCalls).toEqual([
+      {
+        path: "App.swift",
+        publishableKeyWiring: "inline-literal",
+        inlinePublishableKey: {
+          state: "valid",
+          frontendApiHost: "inline.clerk.example",
+          instanceType: "development",
+        },
+        startupBinding: "app-init",
+      },
+    ]);
+    expect(JSON.stringify(inspection)).not.toContain(publishableKey);
+  });
+
+  test("recognizes selective ClerkKit and ClerkKitUI imports", async () => {
+    const root = await mkdtemp(join(tmpdir(), "clerk-ios-swift-"));
+    temporaryDirectories.push(root);
+    const corePath = join(root, "Core.swift");
+    const uiPath = join(root, "UI.swift");
+    await Bun.write(corePath, "import class ClerkKit.Clerk\n");
+    await Bun.write(uiPath, "import struct ClerkKitUI.AuthView\n");
+
+    const inspection = await inspectSwiftSources([
+      { absolutePath: corePath, relativePath: "Core.swift" },
+      { absolutePath: uiPath, relativePath: "UI.swift" },
+    ]);
+
+    expect(inspection.importsClerkKit).toEqual([{ path: "Core.swift" }]);
+    expect(inspection.importsClerkKitUI).toEqual([{ path: "UI.swift" }]);
+    expect(inspection.status).toBe("partial");
+  });
+
+  test("classifies runtime key wiring without retaining expressions or values", async () => {
+    const root = await mkdtemp(join(tmpdir(), "clerk-ios-swift-"));
+    temporaryDirectories.push(root);
+    const path = join(root, "Configuration.swift");
+    await Bun.write(
+      path,
+      `import ClerkKit
+       func configureFromLoad() {
+         Clerk.configure(publishableKey: QuickstartLocalSecrets.load().publishableKey ?? "pk_test_loader-secret")
+       }
+       func configureFromProperty() {
+         Clerk.configure(publishableKey: LocalSecrets.key)
+       }
+       func configureFromEnvironment() {
+         Clerk.configure(publishableKey: ProcessInfo.processInfo.environment["CLERK_PUBLISHABLE_KEY"] ?? "pk_test_environment-secret")
+       }
+       func configureFromUnrelatedEnvironment() {
+         Clerk.configure(publishableKey: ProcessInfo.processInfo.environment["ANALYTICS_KEY"] ?? "not-a-clerk-key")
+       }
+       func configureFromUnknownSource() {
+         Clerk.configure(publishableKey: ApplicationSecrets.clerkKey)
+       }
+       func configureAfterUnicode() {
+         let note = "🔐"
+         Clerk.configure(publishableKey: ProcessInfo.processInfo.environment["CLERK_PUBLISHABLE_KEY"])
+       }
+       func configureWithUnrelatedLaterArgument() {
+         Clerk.configure(publishableKey: ApplicationSecrets.clerkKey, cache: LocalSecrets.key)
+       }`,
+    );
+
+    const inspection = await inspectSwiftSources([
+      { absolutePath: path, relativePath: "Configuration.swift" },
+    ]);
+
+    expect(inspection.configureCalls).toEqual([
+      {
+        path: "Configuration.swift",
+        publishableKeyWiring: "local-secrets-loader",
+        startupBinding: "unproven",
+        localSecretsRuntimeBinding: "unproven",
+      },
+      {
+        path: "Configuration.swift",
+        publishableKeyWiring: "local-secrets-loader",
+        startupBinding: "unproven",
+        localSecretsRuntimeBinding: "unproven",
+      },
+      {
+        path: "Configuration.swift",
+        publishableKeyWiring: "process-info-environment",
+        startupBinding: "unproven",
+      },
+      {
+        path: "Configuration.swift",
+        publishableKeyWiring: "unknown",
+        startupBinding: "unproven",
+      },
+      {
+        path: "Configuration.swift",
+        publishableKeyWiring: "unknown",
+        startupBinding: "unproven",
+      },
+      {
+        path: "Configuration.swift",
+        publishableKeyWiring: "process-info-environment",
+        startupBinding: "unproven",
+      },
+      {
+        path: "Configuration.swift",
+        publishableKeyWiring: "unknown",
+        startupBinding: "unproven",
+      },
+    ]);
+    const serialized = JSON.stringify(inspection);
+    expect(serialized).not.toContain("QuickstartLocalSecrets");
+    expect(serialized).not.toContain("ProcessInfo");
+    expect(serialized).not.toContain("loader-secret");
+    expect(serialized).not.toContain("environment-secret");
+    expect(serialized).not.toContain("ANALYTICS_KEY");
+  });
+
+  test("proves only an exact LocalSecrets plist runtime binding", async () => {
+    const root = await mkdtemp(join(tmpdir(), "clerk-ios-swift-"));
+    temporaryDirectories.push(root);
+    const provenPath = join(root, "LocalSecrets.swift");
+    const nameOnlyPath = join(root, "NameOnly.swift");
+    const configPath = join(root, "App.swift");
+    await Bun.write(
+      provenPath,
+      `import Foundation
+       struct QuickstartLocalSecrets {
+         let publishableKey: String?
+         let analyticsKey: String?
+
+         static func load(bundle: Bundle = .main) -> QuickstartLocalSecrets {
+           guard let url = bundle.url(forResource: "LocalSecrets", withExtension: "plist"),
+                 let data = try? Data(contentsOf: url),
+                 let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),
+                 let values = plist as? [String: Any]
+           else { return .init(publishableKey: nil, analyticsKey: nil) }
+           return .init(
+             publishableKey: values["CLERK_PUBLISHABLE_KEY"] as? String,
+             analyticsKey: values["ANALYTICS_KEY"] as? String
+           )
+         }
+       }
+
+       struct SameFileFakeLocalSecrets {
+         let publishableKey: String?
+         static func load(bundle: Bundle) -> SameFileFakeLocalSecrets {
+           guard let url = bundle.url(forResource: "LocalSecrets", withExtension: "plist"),
+                 let data = try? Data(contentsOf: url),
+                 let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),
+                 let values = plist as? [String: Any]
+           else { return .init(publishableKey: nil) }
+           return .init(publishableKey: values["CLERK_PUBLISHABLE_KEY"] as? String)
+         }
+         static func unrelatedDefault(bundle: Bundle = .main) {
+           _ = bundle
+         }
+       }
+
+       struct SideEffectOnlyLocalSecrets {
+         let publishableKey: String?
+         static func load() -> SideEffectOnlyLocalSecrets {
+           let values = ApplicationSecrets.values
+           _ = unusedCanonicalHelper()
+           return .init(publishableKey: values["CLERK_PUBLISHABLE_KEY"] as? String)
+         }
+         static func unusedCanonicalHelper() -> String? {
+           guard let url = Bundle.main.url(forResource: "LocalSecrets", withExtension: "plist"),
+                 let data = try? Data(contentsOf: url),
+                 let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),
+                 let values = plist as? [String: Any]
+           else { return nil }
+           return values["CLERK_PUBLISHABLE_KEY"] as? String
+         }
+       }
+
+       enum ApplicationSecrets {
+         static let values: [String: Any] = [:]
+       }
+
+       struct ShadowedLocalSecrets {
+         let publishableKey: String?
+         static func load(bundle: Bundle = .main) -> ShadowedLocalSecrets {
+           let values = ApplicationSecrets.values
+           if let url = bundle.url(forResource: "LocalSecrets", withExtension: "plist"),
+              let data = try? Data(contentsOf: url),
+              let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),
+              let values = plist as? [String: Any] {
+             _ = values
+           }
+           return .init(publishableKey: values["CLERK_PUBLISHABLE_KEY"] as? String)
+         }
+       }`,
+    );
+    await Bun.write(
+      nameOnlyPath,
+      `// Bundle.main.url(forResource: "LocalSecrets", withExtension: "plist")
+       struct FakeLocalSecrets {
+         static let key = ApplicationSecrets.clerkKey
+         static let decoy = "CLERK_PUBLISHABLE_KEY"
+       }`,
+    );
+    await Bun.write(
+      configPath,
+      `import ClerkKit
+       func configureProven() {
+         Clerk.configure(publishableKey: QuickstartLocalSecrets.load().publishableKey ?? "")
+       }
+       func configureExplicitBundle() {
+         Clerk.configure(publishableKey: QuickstartLocalSecrets.load(bundle: Bundle.module).publishableKey ?? "")
+       }
+       func configureWrongReturnedMember() {
+         Clerk.configure(publishableKey: QuickstartLocalSecrets.load().analyticsKey ?? "")
+       }
+       func configureLargerUnrelatedExpression() {
+         Clerk.configure(publishableKey: ApplicationSecrets.choose(QuickstartLocalSecrets.load().publishableKey))
+       }
+       func configureAlternateFallback() {
+         Clerk.configure(publishableKey: QuickstartLocalSecrets.load().publishableKey ?? ApplicationSecrets.key)
+       }
+       func configureSameFileDecoy() {
+         Clerk.configure(publishableKey: SameFileFakeLocalSecrets.load().publishableKey ?? "")
+       }
+       func configureSideEffectOnlyDecoy() {
+         Clerk.configure(publishableKey: SideEffectOnlyLocalSecrets.load().publishableKey ?? "")
+       }
+       func configureShadowedDecoy() {
+         Clerk.configure(publishableKey: ShadowedLocalSecrets.load().publishableKey ?? "")
+       }
+       func configureDecoy() {
+         Clerk.configure(publishableKey: FakeLocalSecrets.key)
+       }`,
+    );
+
+    const inspection = await inspectSwiftSources([
+      { absolutePath: configPath, relativePath: "App.swift" },
+      { absolutePath: nameOnlyPath, relativePath: "NameOnly.swift" },
+      { absolutePath: provenPath, relativePath: "LocalSecrets.swift" },
+    ]);
+
+    expect(inspection.localSecretsRuntimeBindings).toEqual([{ path: "LocalSecrets.swift" }]);
+    expect(inspection.configureCalls).toEqual([
+      {
+        path: "App.swift",
+        publishableKeyWiring: "local-secrets-loader",
+        startupBinding: "unproven",
+        localSecretsRuntimeBinding: "proven",
+      },
+      {
+        path: "App.swift",
+        publishableKeyWiring: "local-secrets-loader",
+        startupBinding: "unproven",
+        localSecretsRuntimeBinding: "unproven",
+      },
+      {
+        path: "App.swift",
+        publishableKeyWiring: "local-secrets-loader",
+        startupBinding: "unproven",
+        localSecretsRuntimeBinding: "unproven",
+      },
+      {
+        path: "App.swift",
+        publishableKeyWiring: "local-secrets-loader",
+        startupBinding: "unproven",
+        localSecretsRuntimeBinding: "unproven",
+      },
+      {
+        path: "App.swift",
+        publishableKeyWiring: "local-secrets-loader",
+        startupBinding: "unproven",
+        localSecretsRuntimeBinding: "unproven",
+      },
+      {
+        path: "App.swift",
+        publishableKeyWiring: "local-secrets-loader",
+        startupBinding: "unproven",
+        localSecretsRuntimeBinding: "unproven",
+      },
+      {
+        path: "App.swift",
+        publishableKeyWiring: "local-secrets-loader",
+        startupBinding: "unproven",
+        localSecretsRuntimeBinding: "unproven",
+      },
+      {
+        path: "App.swift",
+        publishableKeyWiring: "local-secrets-loader",
+        startupBinding: "unproven",
+        localSecretsRuntimeBinding: "unproven",
+      },
+      {
+        path: "App.swift",
+        publishableKeyWiring: "local-secrets-loader",
+        startupBinding: "unproven",
+        localSecretsRuntimeBinding: "unproven",
+      },
+    ]);
+    expect(JSON.stringify(inspection)).not.toContain("CLERK_PUBLISHABLE_KEY");
+  });
+
+  test("rejects unreachable, conditional, alternate, and mutable delegated resolver returns", async () => {
+    const root = await mkdtemp(join(tmpdir(), "clerk-ios-swift-"));
+    temporaryDirectories.push(root);
+    const loaderPath = join(root, "LocalSecrets.swift");
+    const configPath = join(root, "App.swift");
+    const delegatedLoader = (
+      symbol: string,
+      resolverBody: string,
+      overrides: { loadBody?: string; normalizerBody?: string; extraMethods?: string } = {},
+    ) => `
+      struct ${symbol} {
+        let publishableKey: String?
+
+        static func load(
+          bundle: Bundle = .main,
+          processInfo: ProcessInfo = .processInfo
+        ) -> ${symbol} {
+          ${
+            overrides.loadBody ??
+            `let plistValues = localSecretsPlistValues(bundle: bundle)
+            return .init(
+              publishableKey: resolveValue(
+                for: "CLERK_PUBLISHABLE_KEY",
+                processInfo: processInfo,
+                plistValues: plistValues
+              )
+            )
+          `
+          }
+        }
+
+        static func resolveValue(
+          for key: String,
+          processInfo: ProcessInfo,
+          plistValues: [String: Any]
+        ) -> String? {
+          ${resolverBody}
+        }
+
+        static func normalized(_ value: String?) -> String? {
+          ${
+            overrides.normalizerBody ??
+            `guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+              return nil
+            }
+            return value`
+          }
+        }
+
+        static func localSecretsPlistValues(bundle: Bundle) -> [String: Any] {
+          guard let url = bundle.url(forResource: "LocalSecrets", withExtension: "plist"),
+                let data = try? Data(contentsOf: url),
+                let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),
+                let values = plist as? [String: Any]
+          else { return [:] }
+          return values
+        }
+
+        ${overrides.extraMethods ?? ""}
+      }
+    `;
+
+    await Bun.write(
+      loaderPath,
+      `import Foundation
+       ${delegatedLoader(
+         "CanonicalDelegatedLocalSecrets",
+         `guard !key.isEmpty else {
+            return nil
+          }
+          if let environmentValue = normalized(processInfo.environment[key]) {
+            return environmentValue
+          }
+          return normalized(plistValues[key] as? String)`,
+       )}
+       ${delegatedLoader(
+         "UnreachableDecoyLocalSecrets",
+         `if false {
+            return normalized(plistValues[key] as? String)
+          }
+          return ApplicationSecrets.key`,
+       )}
+       ${delegatedLoader(
+         "ConditionalLookupLocalSecrets",
+         `if ApplicationSecrets.usePlist {
+            return normalized(plistValues[key] as? String)
+          }
+          return ApplicationSecrets.key`,
+       )}
+       ${delegatedLoader(
+         "AlternatePathLocalSecrets",
+         `if ApplicationSecrets.useAlternate {
+            return ApplicationSecrets.key
+          }
+          return normalized(plistValues[key] as? String)`,
+       )}
+       ${delegatedLoader(
+         "MultipleDirectReturnsLocalSecrets",
+         `return normalized(plistValues[key] as? String)
+          return ApplicationSecrets.key`,
+       )}
+       ${delegatedLoader(
+         "ShadowedDictionaryLocalSecrets",
+         `let plistValues = ApplicationSecrets.values
+          return normalized(plistValues[key] as? String)`,
+       )}
+       ${delegatedLoader(
+         "ReassignedDictionaryLocalSecrets",
+         `plistValues[key] = ApplicationSecrets.key
+          return normalized(plistValues[key] as? String)`,
+       )}
+       ${delegatedLoader(
+         "ClosureLookupLocalSecrets",
+         `let lookup = {
+            return normalized(plistValues[key] as? String)
+          }
+          return lookup()`,
+       )}
+       ${delegatedLoader(
+         "ArbitraryWrapperLocalSecrets",
+         `return alternate(plistValues[key] as? String)`,
+         {
+           extraMethods: `static func alternate(_ value: String?) -> String? {
+             ApplicationSecrets.key
+           }`,
+         },
+       )}
+       ${delegatedLoader(
+         "ReassignedHelperValueLocalSecrets",
+         `return normalized(plistValues[key] as? String)`,
+         {
+           loadBody: `var plistValues = localSecretsPlistValues(bundle: bundle)
+             plistValues = ApplicationSecrets.values
+             return .init(
+               publishableKey: resolveValue(
+                 for: "CLERK_PUBLISHABLE_KEY",
+                 processInfo: processInfo,
+                 plistValues: plistValues
+               )
+             )`,
+         },
+       )}
+       ${delegatedLoader(
+         "TrustedSideEffectModuleLocalSecrets",
+         `return normalized(plistValues[key] as? String)`,
+         {
+           loadBody: `_ = localSecretsPlistValues(bundle: bundle)
+             let plistValues = localSecretsPlistValues(bundle: .module)
+             return .init(
+               publishableKey: resolveValue(
+                 for: "CLERK_PUBLISHABLE_KEY",
+                 processInfo: processInfo,
+                 plistValues: plistValues
+               )
+             )`,
+         },
+       )}
+       ${delegatedLoader(
+         "AlternateNormalizerLocalSecrets",
+         `return normalized(plistValues[key] as? String)`,
+         {
+           normalizerBody: `guard let value else { return nil }
+             return ApplicationSecrets.key`,
+         },
+       )}`,
+    );
+    await Bun.write(
+      configPath,
+      `import ClerkKit
+       func configureCanonical() {
+         Clerk.configure(publishableKey: CanonicalDelegatedLocalSecrets.load().publishableKey ?? "")
+       }
+       func configureUnreachableDecoy() {
+         Clerk.configure(publishableKey: UnreachableDecoyLocalSecrets.load().publishableKey ?? "")
+       }
+       func configureConditionalLookup() {
+         Clerk.configure(publishableKey: ConditionalLookupLocalSecrets.load().publishableKey ?? "")
+       }
+       func configureAlternatePath() {
+         Clerk.configure(publishableKey: AlternatePathLocalSecrets.load().publishableKey ?? "")
+       }
+       func configureMultipleReturns() {
+         Clerk.configure(publishableKey: MultipleDirectReturnsLocalSecrets.load().publishableKey ?? "")
+       }
+       func configureShadowedDictionary() {
+         Clerk.configure(publishableKey: ShadowedDictionaryLocalSecrets.load().publishableKey ?? "")
+       }
+       func configureReassignedDictionary() {
+         Clerk.configure(publishableKey: ReassignedDictionaryLocalSecrets.load().publishableKey ?? "")
+       }
+       func configureClosureLookup() {
+         Clerk.configure(publishableKey: ClosureLookupLocalSecrets.load().publishableKey ?? "")
+       }
+       func configureArbitraryWrapper() {
+         Clerk.configure(publishableKey: ArbitraryWrapperLocalSecrets.load().publishableKey ?? "")
+       }
+       func configureReassignedHelperValue() {
+         Clerk.configure(publishableKey: ReassignedHelperValueLocalSecrets.load().publishableKey ?? "")
+       }
+       func configureTrustedSideEffectModule() {
+         Clerk.configure(publishableKey: TrustedSideEffectModuleLocalSecrets.load().publishableKey ?? "")
+       }
+       func configureAlternateNormalizer() {
+         Clerk.configure(publishableKey: AlternateNormalizerLocalSecrets.load().publishableKey ?? "")
+       }`,
+    );
+
+    const inspection = await inspectSwiftSources([
+      { absolutePath: configPath, relativePath: "App.swift" },
+      { absolutePath: loaderPath, relativePath: "LocalSecrets.swift" },
+    ]);
+
+    expect(inspection.configureCalls.map((call) => call.localSecretsRuntimeBinding)).toEqual([
+      "proven",
+      "unproven",
+      "unproven",
+      "unproven",
+      "unproven",
+      "unproven",
+      "unproven",
+      "unproven",
+      "unproven",
+      "unproven",
+      "unproven",
+      "unproven",
+    ]);
+    expect(inspection.localSecretsRuntimeBindings).toEqual([{ path: "LocalSecrets.swift" }]);
+  });
+
+  test("does not prove a LocalSecrets loader under conditional compilation", async () => {
+    const root = await mkdtemp(join(tmpdir(), "clerk-ios-swift-"));
+    temporaryDirectories.push(root);
+    const path = join(root, "App.swift");
+    await Bun.write(
+      path,
+      `import ClerkKit
+       import Foundation
+
+       #if DEBUG
+       struct ConditionalLocalSecrets {
+         let publishableKey: String?
+         static func load() -> ConditionalLocalSecrets {
+           guard let url = Bundle.main.url(forResource: "LocalSecrets", withExtension: "plist"),
+                 let data = try? Data(contentsOf: url),
+                 let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),
+                 let values = plist as? [String: Any]
+           else { return .init(publishableKey: nil) }
+           return .init(publishableKey: values["CLERK_PUBLISHABLE_KEY"] as? String)
+         }
+       }
+       #endif
+
+       @main struct AppMain: App {
+         init() {
+           Clerk.configure(publishableKey: ConditionalLocalSecrets.load().publishableKey ?? "")
+         }
+       }`,
+    );
+
+    const inspection = await inspectSwiftSources([
+      { absolutePath: path, relativePath: "App.swift" },
+    ]);
+
+    expect(inspection.localSecretsRuntimeBindings).toEqual([]);
+    expect(inspection.configureCalls).toEqual([
+      {
+        path: "App.swift",
+        publishableKeyWiring: "local-secrets-loader",
+        startupBinding: "app-init",
+        localSecretsRuntimeBinding: "unproven",
+      },
+    ]);
+  });
+
+  test("proves only a direct call in the @main type's init as startup-bound", async () => {
+    const root = await mkdtemp(join(tmpdir(), "clerk-ios-swift-"));
+    temporaryDirectories.push(root);
+    const path = join(root, "App.swift");
+    await Bun.write(
+      path,
+      `import ClerkKit
+       @main struct AppMain: App {
+         init() {
+           Clerk.configure(publishableKey: ApplicationSecrets.direct)
+           let deferredConfiguration = {
+             Clerk.configure(publishableKey: ApplicationSecrets.nestedClosure)
+           }
+           #if DEBUG
+           Clerk.configure(publishableKey: ApplicationSecrets.conditional)
+           #endif
+           _ = deferredConfiguration
+         }
+
+         func unusedHelper() {
+           Clerk.configure(publishableKey: ApplicationSecrets.helper)
+         }
+       }`,
+    );
+
+    const inspection = await inspectSwiftSources([
+      { absolutePath: path, relativePath: "App.swift" },
+    ]);
+
+    expect(inspection.configureCalls.map((call) => call.startupBinding)).toEqual([
+      "app-init",
+      "unproven",
+      "unproven",
+      "unproven",
+    ]);
+  });
+
+  test("only records an open URL handler when its closure forwards to Clerk", async () => {
+    const root = await mkdtemp(join(tmpdir(), "clerk-ios-swift-"));
+    temporaryDirectories.push(root);
+    const unrelatedPath = join(root, "Unrelated.swift");
+    const clerkPath = join(root, "ClerkCallback.swift");
+    await Bun.write(
+      unrelatedPath,
+      `import ClerkKit
+       struct Unrelated: View {
+         var body: some View {
+           Text("Hello")
+             .onOpenURL { url in Analytics.shared.track(url) }
+         }
+         func handleElsewhere(_ url: URL) async throws {
+           try await Clerk.shared.handle(url)
+         }
+       }`,
+    );
+    await Bun.write(
+      clerkPath,
+      `import ClerkKit
+       struct Callback: View {
+         @Environment(Clerk.self) private var clerk
+         var body: some View {
+           Text("Hello")
+             .onOpenURL { url in
+               Task { try await clerk.handle(url) }
+             }
+         }
+       }`,
+    );
+
+    const inspection = await inspectSwiftSources([
+      { absolutePath: unrelatedPath, relativePath: "Unrelated.swift" },
+      { absolutePath: clerkPath, relativePath: "ClerkCallback.swift" },
+    ]);
+
+    expect(inspection.openURLHandlers).toEqual([{ path: "ClerkCallback.swift" }]);
+  });
+
+  test("recognizes native Clerk auth calls without matching unrelated sign-in APIs", async () => {
+    const root = await mkdtemp(join(tmpdir(), "clerk-ios-swift-"));
+    temporaryDirectories.push(root);
+    const emailCodePath = join(root, "EmailCode.swift");
+    const passwordPath = join(root, "Password.swift");
+    const signUpPath = join(root, "SignUp.swift");
+    const hostedAuthPath = join(root, "HostedAuth.swift");
+    const unrelatedPath = join(root, "UnrelatedFlow.swift");
+    await Bun.write(
+      emailCodePath,
+      `import ClerkKit
+       struct EmailCodeFlow {
+         @Environment(Clerk.self) private var clerk
+         func run() async throws {
+           try await clerk.auth.signInWithEmailCode(emailAddress: "person@example.com")
+         }
+       }`,
+    );
+    await Bun.write(
+      passwordPath,
+      `import ClerkKit
+       struct PasswordFlow {
+         func run() async throws {
+           try await Clerk.shared.auth.signInWithPassword(identifier: "person@example.com", password: "secret")
+         }
+       }`,
+    );
+    await Bun.write(
+      signUpPath,
+      `import ClerkKit
+       struct SignUpFlow {
+         @Environment(Clerk.self) private var clerk
+         func run() async throws {
+           _ = try await clerk.auth.signUp(emailAddress: "person@example.com")
+         }
+       }`,
+    );
+    await Bun.write(
+      hostedAuthPath,
+      `import ClerkKit
+       struct HostedAuthFlow {
+         @Environment(Clerk.self) private var clerk
+         func run() async throws {
+           _ = try await clerk.auth.startHostedAuth()
+         }
+       }`,
+    );
+    await Bun.write(
+      unrelatedPath,
+      `struct UnrelatedFlow {
+         func run() {
+           _ = AuthView()
+           clerk.auth.signUp()
+           analytics.auth.signInWithPassword()
+           signIn.create()
+           signUp.prepare()
+         }
+       }`,
+    );
+
+    const inspection = await inspectSwiftSources([
+      { absolutePath: emailCodePath, relativePath: "EmailCode.swift" },
+      { absolutePath: passwordPath, relativePath: "Password.swift" },
+      { absolutePath: signUpPath, relativePath: "SignUp.swift" },
+      { absolutePath: hostedAuthPath, relativePath: "HostedAuth.swift" },
+      { absolutePath: unrelatedPath, relativePath: "UnrelatedFlow.swift" },
+    ]);
+
+    expect(inspection.authFlowReferences).toEqual([
+      { path: "EmailCode.swift" },
+      { path: "HostedAuth.swift" },
+      { path: "Password.swift" },
+      { path: "SignUp.swift" },
+    ]);
+  });
+
+  test("marks multiple entry points as ambiguous", async () => {
+    const root = await mkdtemp(join(tmpdir(), "clerk-ios-swift-"));
+    temporaryDirectories.push(root);
+    const paths = [join(root, "One.swift"), join(root, "Two.swift")];
+    await Promise.all(paths.map((path) => Bun.write(path, "@main struct Entry: App {}")));
+
+    const inspection = await inspectSwiftSources(
+      paths.map((absolutePath) => ({
+        absolutePath,
+        relativePath: absolutePath.endsWith("One.swift") ? "One.swift" : "Two.swift",
+      })),
+    );
+
+    expect(inspection.status).toBe("ambiguous");
+    expect(inspection.entryPoints).toHaveLength(2);
+  });
+
+  test("marks source evidence incomplete when a target member is missing", async () => {
+    const root = await mkdtemp(join(tmpdir(), "clerk-ios-swift-"));
+    temporaryDirectories.push(root);
+
+    const inspection = await inspectSwiftSources([
+      { absolutePath: join(root, "Missing.swift"), relativePath: "Missing.swift" },
+    ]);
+
+    expect(inspection.evidenceComplete).toBe(false);
+    expect(inspection.sourceFilesScanned).toBe(0);
+  });
+
+  test("marks source evidence incomplete when a target member exceeds the scan limit", async () => {
+    const root = await mkdtemp(join(tmpdir(), "clerk-ios-swift-"));
+    temporaryDirectories.push(root);
+    const path = join(root, "Oversized.swift");
+    await Bun.write(path, "x".repeat(1_000_001));
+
+    const inspection = await inspectSwiftSources([
+      { absolutePath: path, relativePath: "Oversized.swift" },
+    ]);
+
+    expect(inspection.evidenceComplete).toBe(false);
+    expect(inspection.sourceFilesScanned).toBe(0);
+  });
+
+  test("does not treat preview-only Clerk UI as a shipping authentication flow", async () => {
+    const root = await mkdtemp(join(tmpdir(), "clerk-ios-swift-"));
+    temporaryDirectories.push(root);
+    const path = join(root, "ContentView.swift");
+    await Bun.write(
+      path,
+      `import ClerkKitUI
+       import SwiftUI
+       struct ContentView: View { var body: some View { Text("Hello") } }
+       #Preview { AuthView() }
+       struct LegacyPreview: PreviewProvider {
+         static var previews: some View { SignInView() }
+       }`,
+    );
+
+    const inspection = await inspectSwiftSources([
+      { absolutePath: path, relativePath: "ContentView.swift" },
+    ]);
+
+    expect(inspection.authFlowReferences).toEqual([]);
+  });
+});

--- a/packages/cli-core/src/commands/init/ios/swift.ts
+++ b/packages/cli-core/src/commands/init/ios/swift.ts
@@ -1,0 +1,1771 @@
+import { readFile } from "node:fs/promises";
+import { decodePublishableKey } from "../../../lib/fapi.ts";
+import type {
+  IOSConfigureCallEvidence,
+  IOSInlinePublishableKeyInspection,
+  IOSPublishableKeyWiring,
+  IOSSourceEvidence,
+  IOSSwiftInspection,
+} from "./types.ts";
+
+const MAX_SWIFT_FILE_BYTES = 1_000_000;
+
+function blankRange(chars: string[], start: number, end: number): void {
+  for (let i = start; i < end; i++) {
+    if (chars[i] !== "\n" && chars[i] !== "\r") chars[i] = " ";
+  }
+}
+
+/**
+ * Removes comments and string contents while preserving offsets and newlines.
+ * This is intentionally a small lexer rather than a regex: Swift supports
+ * nested block comments, multiline strings, and arbitrary raw-string hashes.
+ */
+function sanitizeSwift(source: string, blankStrings: boolean): string {
+  // Swift source offsets below are JavaScript UTF-16 indexes. Split into code
+  // units so blanking an emoji or other astral character never shifts later
+  // slices into the original source.
+  const chars = source.split("");
+  let i = 0;
+
+  while (i < chars.length) {
+    if (chars[i] === "/" && chars[i + 1] === "/") {
+      const start = i;
+      i += 2;
+      while (i < chars.length && chars[i] !== "\n") i++;
+      blankRange(chars, start, i);
+      continue;
+    }
+
+    if (chars[i] === "/" && chars[i + 1] === "*") {
+      const start = i;
+      let depth = 1;
+      i += 2;
+      while (i < chars.length && depth > 0) {
+        if (chars[i] === "/" && chars[i + 1] === "*") {
+          depth++;
+          i += 2;
+        } else if (chars[i] === "*" && chars[i + 1] === "/") {
+          depth--;
+          i += 2;
+        } else {
+          i++;
+        }
+      }
+      blankRange(chars, start, i);
+      continue;
+    }
+
+    let hashCount = 0;
+    while (chars[i + hashCount] === "#") hashCount++;
+    const quoteIndex = i + hashCount;
+    if (chars[quoteIndex] !== '"') {
+      i++;
+      continue;
+    }
+
+    const start = i;
+    const multiline =
+      chars[quoteIndex] === '"' && chars[quoteIndex + 1] === '"' && chars[quoteIndex + 2] === '"';
+    i = quoteIndex + (multiline ? 3 : 1);
+
+    while (i < chars.length) {
+      const closesQuote = multiline
+        ? chars[i] === '"' && chars[i + 1] === '"' && chars[i + 2] === '"'
+        : chars[i] === '"';
+
+      if (closesQuote) {
+        const quoteLength = multiline ? 3 : 1;
+        let closesHashes = true;
+        for (let h = 0; h < hashCount; h++) {
+          if (chars[i + quoteLength + h] !== "#") closesHashes = false;
+        }
+        if (closesHashes) {
+          i += quoteLength + hashCount;
+          break;
+        }
+      }
+
+      // Backslash escapes apply directly in normal strings and only when
+      // followed by the matching number of hashes in raw strings.
+      if (chars[i] === "\\") {
+        let escapeHashes = 0;
+        while (chars[i + 1 + escapeHashes] === "#") escapeHashes++;
+        if (escapeHashes === hashCount) {
+          i += 2 + escapeHashes;
+          continue;
+        }
+      }
+      i++;
+    }
+
+    if (blankStrings) blankRange(chars, start, i);
+  }
+
+  return chars.join("");
+}
+
+export function sanitizeSwiftSource(source: string): string {
+  return sanitizeSwift(source, true);
+}
+
+function sourceWithoutComments(source: string): string {
+  return sanitizeSwift(source, false);
+}
+
+function has(source: string, pattern: RegExp): boolean {
+  pattern.lastIndex = 0;
+  return pattern.test(source);
+}
+
+const CLERK_URL_HANDLER = /\b(?:Clerk\s*\.\s*shared|clerk)\s*\.\s*handle\s*\(/;
+const CLERK_NATIVE_AUTH_FLOW =
+  /\b(?:Clerk\s*\.\s*shared|clerk)\s*\.\s*auth\s*\.\s*(?:signIn(?:With(?:Password|EmailCode|EmailLink|PhoneCode|OAuth|IdToken|Apple|Passkey|EnterpriseSSO|Ticket))?|signUp(?:With(?:OAuth|Apple|IdToken|EnterpriseSSO|Ticket))?|startHostedAuth)\s*\(/;
+
+function topLevelCommaSeparated(source: string): string[] {
+  const segments: string[] = [];
+  let start = 0;
+  let parenthesisDepth = 0;
+  let bracketDepth = 0;
+  let braceDepth = 0;
+  for (let index = 0; index < source.length; index++) {
+    const character = source[index];
+    if (character === "(") parenthesisDepth++;
+    if (character === ")") parenthesisDepth--;
+    if (character === "[") bracketDepth++;
+    if (character === "]") bracketDepth--;
+    if (character === "{") braceDepth++;
+    if (character === "}") braceDepth--;
+    if (character === "," && parenthesisDepth === 0 && bracketDepth === 0 && braceDepth === 0) {
+      segments.push(source.slice(start, index));
+      start = index + 1;
+    }
+  }
+  segments.push(source.slice(start));
+  return segments.map((segment) => segment.trim()).filter(Boolean);
+}
+
+interface DirectStaticMethodEvidence {
+  name: string;
+  parameters: string;
+  header: string;
+  openingBrace: number;
+  closingBrace: number;
+}
+
+interface BundleParameterEvidence {
+  externalName: string;
+  localName: string;
+  defaultsToMain: boolean;
+}
+
+function directStaticMethods(
+  source: string,
+  typeOpeningBrace: number,
+  typeClosingBrace: number,
+): DirectStaticMethodEvidence[] {
+  const methods: DirectStaticMethodEvidence[] = [];
+  const methodPattern = /\bstatic\s+func\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;
+  methodPattern.lastIndex = typeOpeningBrace + 1;
+  let method: RegExpExecArray | null;
+
+  while ((method = methodPattern.exec(source)) !== null && method.index < typeClosingBrace) {
+    const name = method[1];
+    if (!name || braceDepthAt(source, typeOpeningBrace, method.index) !== 1) continue;
+    const openingParenthesis = source.indexOf("(", method.index);
+    const closingParenthesis = matchingParenthesis(source, openingParenthesis);
+    if (closingParenthesis == null || closingParenthesis >= typeClosingBrace) continue;
+    const parameters = source.slice(openingParenthesis + 1, closingParenthesis);
+
+    const methodOpeningBrace = source.indexOf("{", closingParenthesis + 1);
+    if (methodOpeningBrace === -1 || methodOpeningBrace >= typeClosingBrace) continue;
+    const methodHeader = source.slice(closingParenthesis + 1, methodOpeningBrace);
+    if (
+      /[;}]/.test(methodHeader) ||
+      /\bfunc\b/.test(methodHeader) ||
+      braceDepthAt(source, typeOpeningBrace, methodOpeningBrace) !== 1
+    ) {
+      continue;
+    }
+    const methodClosingBrace = matchingBrace(source, methodOpeningBrace);
+    if (methodClosingBrace == null || methodClosingBrace > typeClosingBrace) continue;
+
+    methods.push({
+      name,
+      parameters,
+      header: methodHeader,
+      openingBrace: methodOpeningBrace,
+      closingBrace: methodClosingBrace,
+    });
+    methodPattern.lastIndex = methodClosingBrace + 1;
+  }
+
+  return methods;
+}
+
+function bundleParameters(parameters: string): BundleParameterEvidence[] {
+  return topLevelCommaSeparated(parameters).flatMap((parameter) => {
+    const match =
+      /^(?:(_|[A-Za-z_][A-Za-z0-9_]*)\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*:\s*Bundle\b([\s\S]*)$/.exec(
+        parameter,
+      );
+    const localName = match?.[2];
+    if (!localName) return [];
+    return [
+      {
+        externalName: match[1] ?? localName,
+        localName,
+        defaultsToMain: /=\s*(?:Bundle\s*)?\.\s*main\b/.test(match[3] ?? ""),
+      },
+    ];
+  });
+}
+
+function directZeroArgumentLoadEvidence(
+  methods: DirectStaticMethodEvidence[],
+): DirectStaticMethodEvidence | undefined {
+  const candidates = methods.filter((method) => {
+    if (method.name !== "load" || /\b(?:async|throws|rethrows)\b/.test(method.header)) {
+      return false;
+    }
+    return topLevelCommaSeparated(method.parameters).every((parameter) => parameter.includes("="));
+  });
+  return candidates.length === 1 ? candidates[0] : undefined;
+}
+
+function escapeRegularExpression(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function directCallArguments(
+  source: string,
+  caller: DirectStaticMethodEvidence,
+  typeSymbol: string,
+  calleeName: string,
+): string[] {
+  const bodyStart = caller.openingBrace + 1;
+  const body = source.slice(bodyStart, caller.closingBrace);
+  const escapedType = escapeRegularExpression(typeSymbol);
+  const escapedCallee = escapeRegularExpression(calleeName);
+  const pattern = new RegExp(
+    `(?:^|[^A-Za-z0-9_.])(?:(?:Self|${escapedType})\\s*\\.\\s*)?${escapedCallee}\\s*\\(`,
+    "g",
+  );
+  const argumentsList: string[] = [];
+  let call: RegExpExecArray | null;
+
+  while ((call = pattern.exec(body)) !== null) {
+    const localOpeningParenthesis = call.index + call[0].lastIndexOf("(");
+    const openingParenthesis = bodyStart + localOpeningParenthesis;
+    if (braceDepthAt(source, caller.openingBrace, openingParenthesis) !== 1) continue;
+    const closingParenthesis = matchingParenthesis(source, openingParenthesis);
+    if (closingParenthesis == null || closingParenthesis >= caller.closingBrace) continue;
+    argumentsList.push(source.slice(openingParenthesis + 1, closingParenthesis));
+    pattern.lastIndex = closingParenthesis - bodyStart + 1;
+  }
+
+  return argumentsList;
+}
+
+function reachableStaticMethods(
+  source: string,
+  typeSymbol: string,
+  methods: DirectStaticMethodEvidence[],
+  root: DirectStaticMethodEvidence,
+): DirectStaticMethodEvidence[] | undefined {
+  const methodsByName = new Map<string, DirectStaticMethodEvidence[]>();
+  for (const method of methods) {
+    const existing = methodsByName.get(method.name) ?? [];
+    existing.push(method);
+    methodsByName.set(method.name, existing);
+  }
+
+  const reachable = new Map<number, DirectStaticMethodEvidence>([[root.openingBrace, root]]);
+  const pending = [root];
+  while (pending.length > 0) {
+    const caller = pending.shift();
+    if (!caller) break;
+    const callerBody = source.slice(caller.openingBrace + 1, caller.closingBrace);
+    for (const [name, candidates] of methodsByName) {
+      const calls = directCallArguments(source, caller, typeSymbol, name);
+      if (calls.length === 0) continue;
+      if (
+        new RegExp(`\\b(?:let|var|func)\\s+${escapeRegularExpression(name)}\\b`).test(callerBody)
+      ) {
+        return undefined;
+      }
+      if (candidates.length !== 1) return undefined;
+      const callee = candidates[0];
+      if (callee && !reachable.has(callee.openingBrace)) {
+        reachable.set(callee.openingBrace, callee);
+        pending.push(callee);
+      }
+    }
+  }
+  return [...reachable.values()];
+}
+
+function localDeclarationPositions(
+  source: string,
+  method: DirectStaticMethodEvidence,
+  name: string,
+): number[] {
+  const bodyStart = method.openingBrace + 1;
+  const body = source.slice(bodyStart, method.closingBrace);
+  const pattern = new RegExp(`\\b(?:let|var)\\s+${escapeRegularExpression(name)}\\b`, "g");
+  return [...body.matchAll(pattern)].map((match) => bodyStart + match.index);
+}
+
+function hasUniqueDirectImmutableLocalDeclaration(
+  source: string,
+  method: DirectStaticMethodEvidence,
+  name: string,
+): boolean {
+  const bodyStart = method.openingBrace + 1;
+  const body = source.slice(bodyStart, method.closingBrace);
+  const declarationPattern = new RegExp(`\\b(let|var)\\s+${escapeRegularExpression(name)}\\b`, "g");
+  const declarations = [...body.matchAll(declarationPattern)];
+  return (
+    declarations.length === 1 &&
+    declarations[0]?.[1] === "let" &&
+    declarations[0].index != null &&
+    braceDepthAt(source, method.openingBrace, bodyStart + declarations[0].index) === 1
+  );
+}
+
+function hasUniqueImmutableInitializedLocal(
+  source: string,
+  method: DirectStaticMethodEvidence,
+  name: string,
+): boolean {
+  if (!hasUniqueDirectImmutableLocalDeclaration(source, method, name)) return false;
+  const body = source.slice(method.openingBrace + 1, method.closingBrace);
+  const escapedName = escapeRegularExpression(name);
+  const declarationsWithInitializers = [
+    ...body.matchAll(new RegExp(`\\blet\\s+${escapedName}(?:\\s*:[^=,;{}\\n\\r]+)?\\s*=`, "g")),
+  ];
+  if (declarationsWithInitializers.length !== 1) return false;
+
+  // An immutable declaration may only receive its declaration initializer.
+  // Property/subscript writes and mutating collection operations make the
+  // value reaching the key lookup impossible to prove with this scanner.
+  const writes = [
+    ...body.matchAll(
+      new RegExp(
+        `\\b${escapedName}\\s*(?:\\[[^\\]\\n\\r]*\\]|\\.[A-Za-z_][A-Za-z0-9_]*)?\\s*=(?!=)`,
+        "g",
+      ),
+    ),
+  ];
+  if (writes.length !== 1) return false;
+  return !new RegExp(
+    `\\b${escapedName}\\s*\\.\\s*(?:append|appendContentsOf|insert|remove|removeAll|removeValue|replaceSubrange|reserveCapacity|sort|swapAt|updateValue)\\s*\\(`,
+  ).test(body);
+}
+
+function hasParameterMutationOrShadowing(
+  source: string,
+  method: DirectStaticMethodEvidence,
+  parameter: string,
+): boolean {
+  if (localDeclarationPositions(source, method, parameter).length > 0) return true;
+  const body = source.slice(method.openingBrace + 1, method.closingBrace);
+  const escapedParameter = escapeRegularExpression(parameter);
+  return (
+    new RegExp(
+      `\\b${escapedParameter}\\s*(?:\\[[^\\]\\n\\r]*\\]|\\.[A-Za-z_][A-Za-z0-9_]*)?\\s*=(?!=)`,
+    ).test(body) ||
+    new RegExp(
+      `\\b${escapedParameter}\\s*\\.\\s*(?:append|appendContentsOf|insert|remove|removeAll|removeValue|replaceSubrange|reserveCapacity|sort|swapAt|updateValue)\\s*\\(`,
+    ).test(body)
+  );
+}
+
+interface ExactMainBundleResourceEvidence {
+  urlVariablesByMethod: Map<number, Set<string>>;
+}
+
+function exactMainBundleResourceEvidence(
+  structuralSource: string,
+  valueSource: string,
+  typeSymbol: string,
+  reachableMethods: DirectStaticMethodEvidence[],
+  loadMethod: DirectStaticMethodEvidence,
+): ExactMainBundleResourceEvidence {
+  const trustedBundleParameters = new Map<number, Set<string>>([
+    [
+      loadMethod.openingBrace,
+      new Set(
+        bundleParameters(loadMethod.parameters)
+          .filter((parameter) => parameter.defaultsToMain)
+          .map((parameter) => parameter.localName),
+      ),
+    ],
+  ]);
+  const methodsByName = new Map(reachableMethods.map((method) => [method.name, method]));
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const caller of reachableMethods) {
+      const trustedCallerNames = new Set(
+        [...(trustedBundleParameters.get(caller.openingBrace) ?? [])].filter(
+          (name) => localDeclarationPositions(structuralSource, caller, name).length === 0,
+        ),
+      );
+      for (const [calleeName, callee] of methodsByName) {
+        const calleeBundleParameters = bundleParameters(callee.parameters);
+        if (calleeBundleParameters.length === 0) continue;
+        for (const callArguments of directCallArguments(
+          structuralSource,
+          caller,
+          typeSymbol,
+          calleeName,
+        )) {
+          const argumentSegments = topLevelCommaSeparated(callArguments);
+          for (const parameter of calleeBundleParameters) {
+            if (parameter.externalName === "_") continue;
+            const escapedLabel = escapeRegularExpression(parameter.externalName);
+            const trustedArgument = argumentSegments.some((argument) => {
+              const label = new RegExp(`^${escapedLabel}\\s*:\\s*([A-Za-z_][A-Za-z0-9_]*)$`).exec(
+                argument,
+              );
+              return label?.[1] != null && trustedCallerNames.has(label[1]);
+            });
+            const literalMainArgument = argumentSegments.some((argument) =>
+              new RegExp(`^${escapedLabel}\\s*:\\s*(?:Bundle\\s*)?\\.\\s*main$`).test(argument),
+            );
+            if (!trustedArgument && !literalMainArgument) continue;
+            const trustedCalleeNames =
+              trustedBundleParameters.get(callee.openingBrace) ?? new Set<string>();
+            if (!trustedCalleeNames.has(parameter.localName)) {
+              trustedCalleeNames.add(parameter.localName);
+              trustedBundleParameters.set(callee.openingBrace, trustedCalleeNames);
+              changed = true;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  const urlVariablesByMethod = new Map<number, Set<string>>();
+  for (const method of reachableMethods) {
+    const body = valueSource.slice(method.openingBrace + 1, method.closingBrace);
+    const urlVariables = new Set<string>();
+    for (const match of body.matchAll(
+      /\blet\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*Bundle\s*\.\s*main\s*\.\s*url\s*\(\s*forResource\s*:\s*"LocalSecrets"\s*,\s*withExtension\s*:\s*"plist"/g,
+    )) {
+      if (match[1] && hasUniqueImmutableInitializedLocal(structuralSource, method, match[1])) {
+        urlVariables.add(match[1]);
+      }
+    }
+    for (const variable of trustedBundleParameters.get(method.openingBrace) ?? []) {
+      if (localDeclarationPositions(structuralSource, method, variable).length > 0) continue;
+      const pattern = new RegExp(
+        `\\blet\\s+([A-Za-z_][A-Za-z0-9_]*)\\s*=\\s*${escapeRegularExpression(variable)}\\s*\\.\\s*url\\s*\\(\\s*forResource\\s*:\\s*"LocalSecrets"\\s*,\\s*withExtension\\s*:\\s*"plist"`,
+        "g",
+      );
+      for (const match of body.matchAll(pattern)) {
+        if (match[1] && hasUniqueImmutableInitializedLocal(structuralSource, method, match[1])) {
+          urlVariables.add(match[1]);
+        }
+      }
+    }
+    if (urlVariables.size > 0) urlVariablesByMethod.set(method.openingBrace, urlVariables);
+  }
+  return { urlVariablesByMethod };
+}
+
+interface RedactedExpressionEvidence {
+  structural: string;
+  value: string;
+}
+
+interface NamedParameterEvidence {
+  externalName: string;
+  localName: string;
+}
+
+function namedParameters(parameters: string): NamedParameterEvidence[] {
+  return topLevelCommaSeparated(parameters).flatMap((parameter) => {
+    const match = /^(?:(_|[A-Za-z_][A-Za-z0-9_]*)\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*:/.exec(parameter);
+    const localName = match?.[2];
+    if (!localName) return [];
+    return [{ externalName: match[1] ?? localName, localName }];
+  });
+}
+
+function isTopLevelPosition(source: string, position: number): boolean {
+  let parenthesisDepth = 0;
+  let bracketDepth = 0;
+  let braceDepth = 0;
+  for (let index = 0; index < position; index++) {
+    const character = source[index];
+    if (character === "(") parenthesisDepth++;
+    if (character === ")") parenthesisDepth--;
+    if (character === "[") bracketDepth++;
+    if (character === "]") bracketDepth--;
+    if (character === "{") braceDepth++;
+    if (character === "}") braceDepth--;
+  }
+  return parenthesisDepth === 0 && bracketDepth === 0 && braceDepth === 0;
+}
+
+function topLevelLabeledExpression(
+  structuralArguments: string,
+  valueArguments: string,
+  label: string,
+): RedactedExpressionEvidence | undefined {
+  const labelPattern = new RegExp(`\\b${escapeRegularExpression(label)}\\s*:`, "g");
+  const expressions: RedactedExpressionEvidence[] = [];
+  let match: RegExpExecArray | null;
+
+  while ((match = labelPattern.exec(structuralArguments)) !== null) {
+    if (!isTopLevelPosition(structuralArguments, match.index)) continue;
+    const start = match.index + match[0].length;
+    let end = structuralArguments.length;
+    let parenthesisDepth = 0;
+    let bracketDepth = 0;
+    let braceDepth = 0;
+    for (let index = start; index < structuralArguments.length; index++) {
+      const character = structuralArguments[index];
+      if (character === "(") parenthesisDepth++;
+      if (character === ")") parenthesisDepth--;
+      if (character === "[") bracketDepth++;
+      if (character === "]") bracketDepth--;
+      if (character === "{") braceDepth++;
+      if (character === "}") braceDepth--;
+      if (character === "," && parenthesisDepth === 0 && bracketDepth === 0 && braceDepth === 0) {
+        end = index;
+        break;
+      }
+    }
+    expressions.push({
+      structural: structuralArguments.slice(start, end),
+      value: valueArguments.slice(start, end),
+    });
+  }
+
+  return expressions.length === 1 ? expressions[0] : undefined;
+}
+
+function returnedPublishableKeyExpression(
+  structuralSource: string,
+  valueSource: string,
+  typeSymbol: string,
+  loadMethod: DirectStaticMethodEvidence,
+): RedactedExpressionEvidence | undefined {
+  const bodyStart = loadMethod.openingBrace + 1;
+  const structuralBody = structuralSource.slice(bodyStart, loadMethod.closingBrace);
+  const escapedType = escapeRegularExpression(typeSymbol);
+  const returnPattern = new RegExp(`\\breturn\\s+(?:\\.\\s*init|${escapedType})\\s*\\(`, "g");
+  const expressions: RedactedExpressionEvidence[] = [];
+  let returnedInitializer: RegExpExecArray | null;
+
+  while ((returnedInitializer = returnPattern.exec(structuralBody)) !== null) {
+    const returnIndex = bodyStart + returnedInitializer.index;
+    if (braceDepthAt(structuralSource, loadMethod.openingBrace, returnIndex) !== 1) continue;
+    const openingParenthesis =
+      bodyStart + returnedInitializer.index + returnedInitializer[0].lastIndexOf("(");
+    const closingParenthesis = matchingParenthesis(structuralSource, openingParenthesis);
+    if (closingParenthesis == null || closingParenthesis >= loadMethod.closingBrace) continue;
+    const structuralArguments = structuralSource.slice(openingParenthesis + 1, closingParenthesis);
+    const valueArguments = valueSource.slice(openingParenthesis + 1, closingParenthesis);
+    const expression = topLevelLabeledExpression(
+      structuralArguments,
+      valueArguments,
+      "publishableKey",
+    );
+    if (expression) expressions.push(expression);
+    returnPattern.lastIndex = closingParenthesis - bodyStart + 1;
+  }
+
+  return expressions.length === 1 ? expressions[0] : undefined;
+}
+
+function correlatedDecodedDictionaryNames(
+  structuralSource: string,
+  valueSource: string,
+  method: DirectStaticMethodEvidence,
+  exactURLVariables: Set<string>,
+): Set<string> {
+  const body = valueSource.slice(method.openingBrace + 1, method.closingBrace);
+  const dataVariables = new Set<string>();
+  for (const urlVariable of exactURLVariables) {
+    const pattern = new RegExp(
+      `\\blet\\s+([A-Za-z_][A-Za-z0-9_]*)\\s*=\\s*(?:try\\s*[?!]?\\s*)?Data\\s*\\(\\s*contentsOf\\s*:\\s*${escapeRegularExpression(urlVariable)}\\b`,
+      "g",
+    );
+    for (const match of body.matchAll(pattern)) {
+      if (match[1] && hasUniqueImmutableInitializedLocal(structuralSource, method, match[1])) {
+        dataVariables.add(match[1]);
+      }
+    }
+  }
+
+  const propertyListVariables = new Set<string>();
+  for (const dataVariable of dataVariables) {
+    const pattern = new RegExp(
+      `\\blet\\s+([A-Za-z_][A-Za-z0-9_]*)\\s*=\\s*(?:try\\s*[?!]?\\s*)?PropertyListSerialization\\s*\\.\\s*propertyList\\s*\\(\\s*from\\s*:\\s*${escapeRegularExpression(dataVariable)}\\b`,
+      "g",
+    );
+    for (const match of body.matchAll(pattern)) {
+      if (match[1] && hasUniqueImmutableInitializedLocal(structuralSource, method, match[1])) {
+        propertyListVariables.add(match[1]);
+      }
+    }
+  }
+
+  const dictionaryVariables = new Set<string>();
+  for (const propertyListVariable of propertyListVariables) {
+    const pattern = new RegExp(
+      `\\blet\\s+([A-Za-z_][A-Za-z0-9_]*)\\s*=\\s*${escapeRegularExpression(propertyListVariable)}\\s+as\\s*\\?\\s*\\[\\s*String\\s*:\\s*Any\\s*\\]`,
+      "g",
+    );
+    for (const match of body.matchAll(pattern)) {
+      if (match[1] && hasUniqueImmutableInitializedLocal(structuralSource, method, match[1])) {
+        dictionaryVariables.add(match[1]);
+      }
+    }
+  }
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const sourceVariable of dictionaryVariables) {
+      const aliasPattern = new RegExp(
+        `(?:^|[;{}\\n\\r])\\s*let\\s+([A-Za-z_][A-Za-z0-9_]*)(?:\\s*:\\s*[^=;{}\\n\\r]+)?\\s*=\\s*${escapeRegularExpression(sourceVariable)}\\b`,
+        "g",
+      );
+      for (const match of body.matchAll(aliasPattern)) {
+        const alias = match[1];
+        if (
+          alias &&
+          !dictionaryVariables.has(alias) &&
+          hasUniqueImmutableInitializedLocal(structuralSource, method, alias)
+        ) {
+          dictionaryVariables.add(alias);
+          changed = true;
+        }
+      }
+
+      // Support the direct fixture's definite-initialization form:
+      // `let values: [String: Any]`, assigned either the decoded immutable
+      // dictionary or `[:]` in an exact if/else. These are initializations of
+      // a `let`, not later mutations.
+      const conditionalAliasPattern =
+        /\blet\s+([A-Za-z_][A-Za-z0-9_]*)\s*:\s*\[\s*String\s*:\s*Any\s*\](?!\s*=)/g;
+      for (const aliasDeclaration of body.matchAll(conditionalAliasPattern)) {
+        const alias = aliasDeclaration[1];
+        if (
+          !alias ||
+          alias === sourceVariable ||
+          dictionaryVariables.has(alias) ||
+          !hasUniqueDirectImmutableLocalDeclaration(structuralSource, method, alias)
+        ) {
+          continue;
+        }
+        const escapedAlias = escapeRegularExpression(alias);
+        const escapedSource = escapeRegularExpression(sourceVariable);
+        const assignments = [
+          ...body.matchAll(new RegExp(`\\b${escapedAlias}\\s*=\\s*([^;{}\\n\\r]+)`, "g")),
+        ].map((match) => match[1]?.replace(/\s+/g, ""));
+        if (
+          assignments.length !== 2 ||
+          assignments.filter((assignment) => assignment === sourceVariable).length !== 1 ||
+          assignments.filter((assignment) => assignment === "[:]").length !== 1 ||
+          new RegExp(
+            `\\b${escapedAlias}\\s*(?:\\[[^\\]\\n\\r]*\\]|\\.[A-Za-z_][A-Za-z0-9_]*)\\s*=(?!=)`,
+          ).test(body) ||
+          new RegExp(
+            `\\b${escapedAlias}\\s*\\.\\s*(?:append|appendContentsOf|insert|remove|removeAll|removeValue|replaceSubrange|reserveCapacity|sort|swapAt|updateValue)\\s*\\(`,
+          ).test(body)
+        ) {
+          continue;
+        }
+        const exactBranches = new RegExp(
+          `\\{\\s*${escapedAlias}\\s*=\\s*${escapedSource}\\s*\\}\\s*else\\s*\\{\\s*${escapedAlias}\\s*=\\s*\\[\\s*:\\s*\\]\\s*\\}`,
+        ).test(body);
+        if (!exactBranches) continue;
+        dictionaryVariables.add(alias);
+        changed = true;
+      }
+    }
+  }
+  return dictionaryVariables;
+}
+
+function directlyReturnedDictionaryName(
+  structuralSource: string,
+  method: DirectStaticMethodEvidence,
+  dictionaryNames: Set<string>,
+): string | undefined {
+  const bodyStart = method.openingBrace + 1;
+  const body = structuralSource.slice(bodyStart, method.closingBrace);
+  const returnedNames: string[] = [];
+  const returnPattern = /\breturn\s+([A-Za-z_][A-Za-z0-9_]*)\b/g;
+  let returned: RegExpExecArray | null;
+  while ((returned = returnPattern.exec(body)) !== null) {
+    const name = returned[1];
+    const returnIndex = bodyStart + returned.index;
+    if (
+      name &&
+      dictionaryNames.has(name) &&
+      braceDepthAt(structuralSource, method.openingBrace, returnIndex) === 1
+    ) {
+      returnedNames.push(name);
+    }
+  }
+  return returnedNames.length === 1 ? returnedNames[0] : undefined;
+}
+
+function directExactKeyLookupBase(valueExpression: string): string | undefined {
+  const subscript =
+    /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*\[\s*"CLERK_PUBLISHABLE_KEY"\s*\]\s*(?:as\s*\?\s*String)?\s*$/.exec(
+      valueExpression,
+    );
+  if (subscript?.[1]) return subscript[1];
+  return /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*\.\s*(?:value|object)\s*\(\s*forKey\s*:\s*"CLERK_PUBLISHABLE_KEY"\s*\)\s*(?:as\s*\?\s*String)?\s*$/.exec(
+    valueExpression,
+  )?.[1];
+}
+
+interface ReturnStatementEvidence {
+  index: number;
+  depth: number;
+  structuralExpression: string;
+  valueExpression: string;
+}
+
+function returnStatements(
+  structuralSource: string,
+  valueSource: string,
+  method: DirectStaticMethodEvidence,
+): ReturnStatementEvidence[] {
+  const bodyStart = method.openingBrace + 1;
+  const body = structuralSource.slice(bodyStart, method.closingBrace);
+  const statements: ReturnStatementEvidence[] = [];
+  const returnPattern = /\breturn\b/g;
+  let returned: RegExpExecArray | null;
+
+  while ((returned = returnPattern.exec(body)) !== null) {
+    const returnIndex = bodyStart + returned.index;
+    let expressionStart = returnIndex + returned[0].length;
+    while (
+      structuralSource[expressionStart] === " " ||
+      structuralSource[expressionStart] === "\t"
+    ) {
+      expressionStart++;
+    }
+
+    let expressionEnd = expressionStart;
+    let parenthesisDepth = 0;
+    let bracketDepth = 0;
+    let braceDepth = 0;
+    for (; expressionEnd < method.closingBrace; expressionEnd++) {
+      const character = structuralSource[expressionEnd];
+      if (
+        (character === "\n" || character === "\r" || character === ";") &&
+        parenthesisDepth === 0 &&
+        bracketDepth === 0 &&
+        braceDepth === 0
+      ) {
+        break;
+      }
+      if (character === "}" && parenthesisDepth === 0 && bracketDepth === 0 && braceDepth === 0) {
+        break;
+      }
+      if (character === "(") parenthesisDepth++;
+      if (character === ")") parenthesisDepth--;
+      if (character === "[") bracketDepth++;
+      if (character === "]") bracketDepth--;
+      if (character === "{") braceDepth++;
+      if (character === "}") braceDepth--;
+    }
+
+    statements.push({
+      index: returnIndex,
+      depth: braceDepthAt(structuralSource, method.openingBrace, returnIndex),
+      structuralExpression: structuralSource.slice(expressionStart, expressionEnd).trim(),
+      valueExpression: valueSource.slice(expressionStart, expressionEnd).trim(),
+    });
+    returnPattern.lastIndex = Math.max(returnPattern.lastIndex, expressionEnd - bodyStart);
+  }
+
+  return statements;
+}
+
+type ExactLookupTransform = "direct" | "normalized";
+
+function exactResolverLookupTransform(
+  expression: string,
+  plistParameter: string,
+  keyParameter: string,
+): ExactLookupTransform | undefined {
+  const lookup = `${escapeRegularExpression(plistParameter)}\\s*\\[\\s*${escapeRegularExpression(keyParameter)}\\s*\\]\\s*(?:as\\s*\\?\\s*String)?`;
+  if (new RegExp(`^${lookup}$`).test(expression)) return "direct";
+  if (new RegExp(`^normalized\\s*\\(\\s*${lookup}\\s*\\)$`).test(expression)) {
+    return "normalized";
+  }
+  return undefined;
+}
+
+function isCanonicalNormalizer(
+  structuralSource: string,
+  methods: DirectStaticMethodEvidence[],
+): boolean {
+  const candidates = methods.filter((method) => method.name === "normalized");
+  if (candidates.length !== 1) return false;
+  const normalizer = candidates[0];
+  if (!normalizer) return false;
+  const parameters = topLevelCommaSeparated(normalizer.parameters);
+  if (parameters.length !== 1) return false;
+  const parameter = /^_\s+([A-Za-z_][A-Za-z0-9_]*)\s*:\s*String\s*\?$/.exec(parameters[0] ?? "");
+  const parameterName = parameter?.[1];
+  if (!parameterName || !/^\s*->\s*String\s*\?\s*$/.test(normalizer.header)) return false;
+
+  const body = structuralSource.slice(normalizer.openingBrace + 1, normalizer.closingBrace);
+  const escapedParameter = escapeRegularExpression(parameterName);
+  const canonicalBody = new RegExp(
+    `^\\s*guard\\s+let\\s+([A-Za-z_][A-Za-z0-9_]*)\\s*=\\s*${escapedParameter}\\s*\\?\\s*\\.\\s*trimmingCharacters\\s*\\(\\s*in\\s*:\\s*\\.\\s*whitespacesAndNewlines\\s*\\)\\s*,\\s*!\\s*\\1\\s*\\.\\s*isEmpty\\s+else\\s*\\{\\s*return\\s+nil\\s*;?\\s*\\}\\s*return\\s+\\1\\s*;?\\s*$`,
+  );
+  return canonicalBody.test(body);
+}
+
+function hasResolverParameterMutation(
+  structuralSource: string,
+  method: DirectStaticMethodEvidence,
+  parameter: string,
+): boolean {
+  return hasParameterMutationOrShadowing(structuralSource, method, parameter);
+}
+
+function isExactEnvironmentOverrideReturn(
+  structuralSource: string,
+  method: DirectStaticMethodEvidence,
+  returned: ReturnStatementEvidence,
+  processInfoParameter: string,
+  keyParameter: string,
+  allowNormalized: boolean,
+): boolean {
+  const returnedName = /^([A-Za-z_][A-Za-z0-9_]*)$/.exec(returned.structuralExpression)?.[1];
+  if (!returnedName || returned.depth !== 2) return false;
+
+  const bodyStart = method.openingBrace + 1;
+  const body = structuralSource.slice(bodyStart, method.closingBrace);
+  const environmentLookup = `${escapeRegularExpression(processInfoParameter)}\\s*\\.\\s*environment\\s*\\[\\s*${escapeRegularExpression(keyParameter)}\\s*\\]`;
+  const trustedLookup = allowNormalized
+    ? `(?:${environmentLookup}|normalized\\s*\\(\\s*${environmentLookup}\\s*\\))`
+    : environmentLookup;
+  const pattern = new RegExp(
+    `\\bif\\s+let\\s+${escapeRegularExpression(returnedName)}\\s*=\\s*${trustedLookup}\\s*\\{`,
+    "g",
+  );
+  let conditional: RegExpExecArray | null;
+
+  while ((conditional = pattern.exec(body)) !== null) {
+    const openingBrace = bodyStart + conditional.index + conditional[0].lastIndexOf("{");
+    if (braceDepthAt(structuralSource, method.openingBrace, openingBrace) !== 1) continue;
+    const closingBrace = matchingBrace(structuralSource, openingBrace);
+    if (
+      closingBrace == null ||
+      returned.index <= openingBrace ||
+      returned.index >= closingBrace ||
+      braceDepthAt(structuralSource, openingBrace, returned.index) !== 1
+    ) {
+      continue;
+    }
+    const afterConditional = structuralSource.slice(closingBrace + 1, method.closingBrace);
+    if (/^\s*else\b/.test(afterConditional)) return false;
+    return true;
+  }
+
+  return false;
+}
+
+function isExactGuardNilReturn(
+  structuralSource: string,
+  method: DirectStaticMethodEvidence,
+  returned: ReturnStatementEvidence,
+): boolean {
+  if (returned.structuralExpression !== "nil" || returned.depth !== 2) return false;
+
+  const bodyStart = method.openingBrace + 1;
+  const body = structuralSource.slice(bodyStart, method.closingBrace);
+  const guardPattern = /\bguard\b[^{};]*\belse\s*\{/g;
+  let guarded: RegExpExecArray | null;
+  while ((guarded = guardPattern.exec(body)) !== null) {
+    if (braceDepthAt(structuralSource, method.openingBrace, bodyStart + guarded.index) !== 1) {
+      continue;
+    }
+    const openingBrace = bodyStart + guarded.index + guarded[0].lastIndexOf("{");
+    const closingBrace = matchingBrace(structuralSource, openingBrace);
+    if (
+      closingBrace == null ||
+      returned.index <= openingBrace ||
+      returned.index >= closingBrace ||
+      braceDepthAt(structuralSource, openingBrace, returned.index) !== 1
+    ) {
+      continue;
+    }
+    return /^\s*return\s+nil\s*;?\s*$/.test(structuralSource.slice(openingBrace + 1, closingBrace));
+  }
+
+  return false;
+}
+
+function hasExactDelegatedResolverReturnFlow(
+  structuralSource: string,
+  valueSource: string,
+  resolver: DirectStaticMethodEvidence,
+  reachableMethods: DirectStaticMethodEvidence[],
+  resolverParameters: NamedParameterEvidence[],
+  plistParameter: NamedParameterEvidence,
+  keyParameter: NamedParameterEvidence,
+): boolean {
+  if (
+    hasResolverParameterMutation(structuralSource, resolver, plistParameter.localName) ||
+    hasResolverParameterMutation(structuralSource, resolver, keyParameter.localName)
+  ) {
+    return false;
+  }
+
+  const statements = returnStatements(structuralSource, valueSource, resolver);
+  const directReturns = statements.filter((returned) => returned.depth === 1);
+  const directTransform = directReturns[0]
+    ? exactResolverLookupTransform(
+        directReturns[0].structuralExpression,
+        plistParameter.localName,
+        keyParameter.localName,
+      )
+    : undefined;
+  if (
+    directReturns.length !== 1 ||
+    !directTransform ||
+    (directTransform === "normalized" && !isCanonicalNormalizer(structuralSource, reachableMethods))
+  ) {
+    return false;
+  }
+
+  const nestedReturns = statements.filter((returned) => returned.depth !== 1);
+  if (nestedReturns.length === 0) return true;
+  const processInfoParameter = resolverParameters.find(
+    (parameter) => parameter.externalName === "processInfo",
+  );
+  if (
+    processInfoParameter &&
+    hasResolverParameterMutation(structuralSource, resolver, processInfoParameter.localName)
+  ) {
+    return false;
+  }
+  let environmentOverrideCount = 0;
+  for (const returned of nestedReturns) {
+    if (isExactGuardNilReturn(structuralSource, resolver, returned)) continue;
+    if (
+      processInfoParameter &&
+      isExactEnvironmentOverrideReturn(
+        structuralSource,
+        resolver,
+        returned,
+        processInfoParameter.localName,
+        keyParameter.localName,
+        directTransform === "normalized",
+      )
+    ) {
+      environmentOverrideCount++;
+      continue;
+    }
+    return false;
+  }
+  return environmentOverrideCount <= 1;
+}
+
+function exactDelegatedResolverFlow(
+  structuralSource: string,
+  valueSource: string,
+  typeSymbol: string,
+  loadMethod: DirectStaticMethodEvidence,
+  reachableMethods: DirectStaticMethodEvidence[],
+  resourceEvidence: ExactMainBundleResourceEvidence,
+  expression: RedactedExpressionEvidence,
+): boolean {
+  const loadParameters = topLevelCommaSeparated(loadMethod.parameters);
+  if (
+    loadParameters.length !== 2 ||
+    !loadParameters.some((parameter) =>
+      /^bundle\s*:\s*Bundle\s*=\s*(?:Bundle\s*)?\.\s*main$/.test(parameter),
+    ) ||
+    !loadParameters.some((parameter) =>
+      /^processInfo\s*:\s*ProcessInfo\s*=\s*(?:ProcessInfo\s*)?\.\s*processInfo$/.test(parameter),
+    ) ||
+    hasParameterMutationOrShadowing(structuralSource, loadMethod, "bundle") ||
+    hasParameterMutationOrShadowing(structuralSource, loadMethod, "processInfo")
+  ) {
+    return false;
+  }
+
+  const escapedType = escapeRegularExpression(typeSymbol);
+  const resolverCall = new RegExp(
+    `^\\s*(?:(?:Self|${escapedType})\\s*\\.\\s*)?([A-Za-z_][A-Za-z0-9_]*)\\s*\\(`,
+  ).exec(expression.structural);
+  const resolverName = resolverCall?.[1];
+  if (!resolverCall || !resolverName) return false;
+  const openingParenthesis = expression.structural.indexOf("(", resolverCall.index);
+  const closingParenthesis = matchingParenthesis(expression.structural, openingParenthesis);
+  if (
+    closingParenthesis == null ||
+    expression.structural.slice(closingParenthesis + 1).trim() !== ""
+  ) {
+    return false;
+  }
+  const valueArguments = expression.value.slice(openingParenthesis + 1, closingParenthesis);
+  const argumentSegments = topLevelCommaSeparated(valueArguments);
+  if (
+    argumentSegments.length !== 3 ||
+    !argumentSegments.some((argument) => /^for\s*:\s*"CLERK_PUBLISHABLE_KEY"\s*$/.test(argument))
+  ) {
+    return false;
+  }
+  const plistArgument = argumentSegments
+    .map((argument) => /^plistValues\s*:\s*([A-Za-z_][A-Za-z0-9_]*)\s*$/.exec(argument)?.[1])
+    .find((value): value is string => value != null);
+  const processInfoArgument = argumentSegments
+    .map((argument) => /^processInfo\s*:\s*([A-Za-z_][A-Za-z0-9_]*)\s*$/.exec(argument)?.[1])
+    .find((value): value is string => value != null);
+  if (!plistArgument || processInfoArgument !== "processInfo") return false;
+
+  const resolverCalls = directCallArguments(structuralSource, loadMethod, typeSymbol, resolverName);
+  if (resolverCalls.length !== 1) return false;
+
+  const resolverCandidates = reachableMethods.filter((method) => method.name === resolverName);
+  if (resolverCandidates.length !== 1) return false;
+  const resolver = resolverCandidates[0];
+  if (!resolver) return false;
+  const resolverParameters = namedParameters(resolver.parameters);
+  const keyParameter = resolverParameters.find((parameter) => parameter.externalName === "for");
+  const processInfoParameter = resolverParameters.find(
+    (parameter) => parameter.externalName === "processInfo",
+  );
+  const plistParameter = resolverParameters.find(
+    (parameter) => parameter.externalName === "plistValues",
+  );
+  const resolverParameterSegments = topLevelCommaSeparated(resolver.parameters);
+  if (
+    resolverParameterSegments.length !== 3 ||
+    !resolverParameterSegments.some((parameter) =>
+      /^for\s+[A-Za-z_][A-Za-z0-9_]*\s*:\s*String$/.test(parameter),
+    ) ||
+    !resolverParameterSegments.some((parameter) =>
+      /^processInfo\s*:\s*ProcessInfo$/.test(parameter),
+    ) ||
+    !resolverParameterSegments.some((parameter) =>
+      /^plistValues\s*:\s*\[\s*String\s*:\s*Any\s*\]$/.test(parameter),
+    ) ||
+    !keyParameter ||
+    !processInfoParameter ||
+    !plistParameter
+  ) {
+    return false;
+  }
+  if (
+    !hasExactDelegatedResolverReturnFlow(
+      structuralSource,
+      valueSource,
+      resolver,
+      reachableMethods,
+      resolverParameters,
+      plistParameter,
+      keyParameter,
+    )
+  ) {
+    return false;
+  }
+
+  const loadBodyStart = loadMethod.openingBrace + 1;
+  const structuralLoadBody = structuralSource.slice(loadBodyStart, loadMethod.closingBrace);
+  const assignmentPattern = new RegExp(
+    `\\blet\\s+${escapeRegularExpression(plistArgument)}\\s*=\\s*(?:(?:Self|${escapedType})\\s*\\.\\s*)?([A-Za-z_][A-Za-z0-9_]*)\\s*\\(`,
+    "g",
+  );
+  const resourceAssignments: Array<{
+    method: DirectStaticMethodEvidence;
+    arguments: string;
+  }> = [];
+  let assignment: RegExpExecArray | null;
+  while ((assignment = assignmentPattern.exec(structuralLoadBody)) !== null) {
+    const assignmentIndex = loadBodyStart + assignment.index;
+    if (braceDepthAt(structuralSource, loadMethod.openingBrace, assignmentIndex) !== 1) continue;
+    const resourceName = assignment[1];
+    if (!resourceName) continue;
+    const localOpeningParenthesis = assignment.index + assignment[0].lastIndexOf("(");
+    const resourceOpeningParenthesis = loadBodyStart + localOpeningParenthesis;
+    const resourceClosingParenthesis = matchingParenthesis(
+      structuralSource,
+      resourceOpeningParenthesis,
+    );
+    if (
+      resourceClosingParenthesis == null ||
+      resourceClosingParenthesis >= loadMethod.closingBrace
+    ) {
+      continue;
+    }
+    const candidates = reachableMethods.filter((method) => method.name === resourceName);
+    if (candidates.length === 1 && candidates[0]) {
+      resourceAssignments.push({
+        method: candidates[0],
+        arguments: structuralSource.slice(
+          resourceOpeningParenthesis + 1,
+          resourceClosingParenthesis,
+        ),
+      });
+    }
+  }
+  if (
+    resourceAssignments.length !== 1 ||
+    !hasUniqueImmutableInitializedLocal(structuralSource, loadMethod, plistArgument)
+  ) {
+    return false;
+  }
+  const resourceAssignment = resourceAssignments[0];
+  if (!resourceAssignment || !/^\s*bundle\s*:\s*bundle\s*$/.test(resourceAssignment.arguments)) {
+    return false;
+  }
+  const resourceMethod = resourceAssignment.method;
+  const resourceParameters = topLevelCommaSeparated(resourceMethod.parameters);
+  if (
+    resourceParameters.length !== 1 ||
+    !/^bundle\s*:\s*Bundle$/.test(resourceParameters[0] ?? "") ||
+    !/^\s*->\s*\[\s*String\s*:\s*Any\s*\]\s*$/.test(resourceMethod.header) ||
+    hasParameterMutationOrShadowing(structuralSource, resourceMethod, "bundle")
+  ) {
+    return false;
+  }
+  const resourceCalls = directCallArguments(
+    structuralSource,
+    loadMethod,
+    typeSymbol,
+    resourceMethod.name,
+  );
+  if (resourceCalls.length !== 1) return false;
+
+  const decodedDictionaries = correlatedDecodedDictionaryNames(
+    structuralSource,
+    valueSource,
+    resourceMethod,
+    resourceEvidence.urlVariablesByMethod.get(resourceMethod.openingBrace) ?? new Set(),
+  );
+  return (
+    directlyReturnedDictionaryName(structuralSource, resourceMethod, decodedDictionaries) != null
+  );
+}
+
+function loadReturnsExactPublishableKey(
+  structuralSource: string,
+  valueSource: string,
+  typeSymbol: string,
+  loadMethod: DirectStaticMethodEvidence,
+  reachableMethods: DirectStaticMethodEvidence[],
+  resourceEvidence: ExactMainBundleResourceEvidence,
+): boolean {
+  const expression = returnedPublishableKeyExpression(
+    structuralSource,
+    valueSource,
+    typeSymbol,
+    loadMethod,
+  );
+  if (!expression) return false;
+  const directLookupBase = directExactKeyLookupBase(expression.value);
+  if (directLookupBase) {
+    const decodedDictionaries = correlatedDecodedDictionaryNames(
+      structuralSource,
+      valueSource,
+      loadMethod,
+      resourceEvidence.urlVariablesByMethod.get(loadMethod.openingBrace) ?? new Set(),
+    );
+    return decodedDictionaries.has(directLookupBase);
+  }
+  return exactDelegatedResolverFlow(
+    structuralSource,
+    valueSource,
+    typeSymbol,
+    loadMethod,
+    reachableMethods,
+    resourceEvidence,
+    expression,
+  );
+}
+
+function provenLocalSecretsRuntimeSymbols(structuralSource: string, valueSource: string): string[] {
+  const symbols = new Set<string>();
+  const declarationPattern =
+    /\b(?:struct|class|enum|actor)\s+((?:[A-Za-z_][A-Za-z0-9_]*)?LocalSecrets)\b/g;
+  let declaration: RegExpExecArray | null;
+
+  while ((declaration = declarationPattern.exec(structuralSource)) !== null) {
+    const symbol = declaration[1];
+    if (
+      !symbol ||
+      braceDepthAt(structuralSource, 0, declaration.index) !== 0 ||
+      isInsideConditionalCompilation(structuralSource, declaration.index)
+    ) {
+      continue;
+    }
+    const openingBrace = structuralSource.indexOf("{", declaration.index + declaration[0].length);
+    if (openingBrace === -1) continue;
+    const headerRemainder = structuralSource.slice(
+      declaration.index + declaration[0].length,
+      openingBrace,
+    );
+    if (/[;}]/.test(headerRemainder) || /\b(?:struct|class|enum|actor)\b/.test(headerRemainder)) {
+      continue;
+    }
+    const closingBrace = matchingBrace(structuralSource, openingBrace);
+    if (closingBrace == null) continue;
+
+    const structuralBody = structuralSource.slice(openingBrace + 1, closingBrace);
+    // Any conditional member makes it ambiguous whether the loader and its
+    // resource/key path ship in the selected configuration.
+    if (/^[\t ]*#(?:if|elseif|else|endif)\b/m.test(structuralBody)) continue;
+
+    const methods = directStaticMethods(structuralSource, openingBrace, closingBrace);
+    const loadEvidence = directZeroArgumentLoadEvidence(methods);
+    if (!loadEvidence) continue;
+    const reachableMethods = reachableStaticMethods(
+      structuralSource,
+      symbol,
+      methods,
+      loadEvidence,
+    );
+    if (!reachableMethods) continue;
+
+    const resourceEvidence = exactMainBundleResourceEvidence(
+      structuralSource,
+      valueSource,
+      symbol,
+      reachableMethods,
+      loadEvidence,
+    );
+    if (
+      resourceEvidence.urlVariablesByMethod.size > 0 &&
+      loadReturnsExactPublishableKey(
+        structuralSource,
+        valueSource,
+        symbol,
+        loadEvidence,
+        reachableMethods,
+        resourceEvidence,
+      )
+    ) {
+      symbols.add(symbol);
+    }
+  }
+
+  return [...symbols].sort();
+}
+
+function matchingBrace(source: string, openingBrace: number): number | undefined {
+  let depth = 0;
+  for (let index = openingBrace; index < source.length; index++) {
+    if (source[index] === "{") depth++;
+    if (source[index] !== "}") continue;
+    depth--;
+    if (depth === 0) return index;
+  }
+  return undefined;
+}
+
+function matchingParenthesis(source: string, openingParenthesis: number): number | undefined {
+  let depth = 0;
+  for (let index = openingParenthesis; index < source.length; index++) {
+    if (source[index] === "(") depth++;
+    if (source[index] !== ")") continue;
+    depth--;
+    if (depth === 0) return index;
+  }
+  return undefined;
+}
+
+interface SourceBodyRange {
+  openingBrace: number;
+  closingBrace: number;
+}
+
+const TYPE_DECLARATION_MODIFIERS = new Set([
+  "final",
+  "fileprivate",
+  "indirect",
+  "internal",
+  "nonisolated",
+  "open",
+  "package",
+  "private",
+  "public",
+]);
+
+function skipWhitespace(source: string, start: number): number {
+  let cursor = start;
+  while (/\s/.test(source[cursor] ?? "")) cursor++;
+  return cursor;
+}
+
+function mainTypeBodies(source: string): SourceBodyRange[] {
+  const bodies: SourceBodyRange[] = [];
+  const mainPattern = /@main\b/g;
+  let mainMatch: RegExpExecArray | null;
+
+  while ((mainMatch = mainPattern.exec(source)) !== null) {
+    let cursor = mainMatch.index + mainMatch[0].length;
+
+    // Other declaration attributes and access modifiers may appear between
+    // @main and the type declaration. Anything else makes the proof fail
+    // closed rather than guessing which declaration owns the attribute.
+    while (true) {
+      cursor = skipWhitespace(source, cursor);
+      const attribute = /^@[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*/.exec(
+        source.slice(cursor),
+      );
+      if (attribute) {
+        cursor += attribute[0].length;
+        const attributeArguments = skipWhitespace(source, cursor);
+        if (source[attributeArguments] === "(") {
+          const closingParenthesis = matchingParenthesis(source, attributeArguments);
+          if (closingParenthesis == null) break;
+          cursor = closingParenthesis + 1;
+        }
+        continue;
+      }
+
+      const modifier = /^[A-Za-z_][A-Za-z0-9_]*/.exec(source.slice(cursor))?.[0];
+      if (modifier && TYPE_DECLARATION_MODIFIERS.has(modifier)) {
+        cursor += modifier.length;
+        if (modifier === "nonisolated") {
+          const modifierArguments = skipWhitespace(source, cursor);
+          if (source[modifierArguments] === "(") {
+            const closingParenthesis = matchingParenthesis(source, modifierArguments);
+            if (closingParenthesis == null) break;
+            cursor = closingParenthesis + 1;
+          }
+        }
+        continue;
+      }
+      break;
+    }
+
+    cursor = skipWhitespace(source, cursor);
+    const declaration = /^(?:struct|class|enum|actor)\s+[A-Za-z_][A-Za-z0-9_]*/.exec(
+      source.slice(cursor),
+    );
+    if (!declaration) continue;
+
+    const headerEnd = cursor + declaration[0].length;
+    const openingBrace = source.indexOf("{", headerEnd);
+    if (openingBrace === -1) continue;
+    const headerRemainder = source.slice(headerEnd, openingBrace);
+    if (/[;}]/.test(headerRemainder) || /@main\b/.test(headerRemainder)) continue;
+    const closingBrace = matchingBrace(source, openingBrace);
+    if (closingBrace == null) continue;
+    bodies.push({ openingBrace, closingBrace });
+    mainPattern.lastIndex = closingBrace + 1;
+  }
+
+  return bodies;
+}
+
+function braceDepthAt(source: string, openingBrace: number, position: number): number {
+  let depth = 0;
+  for (let index = openingBrace; index < position; index++) {
+    if (source[index] === "{") depth++;
+    if (source[index] === "}") depth--;
+  }
+  return depth;
+}
+
+function isInsideConditionalCompilation(source: string, position: number): boolean {
+  const directive = /^[\t ]*#(if|elseif|else|endif)\b/gm;
+  let depth = 0;
+  let match: RegExpExecArray | null;
+  while ((match = directive.exec(source)) !== null && match.index < position) {
+    if (match[1] === "if") depth++;
+    if (match[1] === "endif") depth = Math.max(0, depth - 1);
+  }
+  return depth > 0;
+}
+
+function mainInitializerBodies(source: string): SourceBodyRange[] {
+  const mainTypes = mainTypeBodies(source);
+  // Multiple @main declarations in one file are ambiguous even though the
+  // file-level entry-point evidence has only one path.
+  if (mainTypes.length !== 1) return [];
+
+  const typeBody = mainTypes[0];
+  if (!typeBody) return [];
+  const initializers: SourceBodyRange[] = [];
+  const initializerPattern = /\binit\s*([?!])?\s*\(/g;
+  initializerPattern.lastIndex = typeBody.openingBrace + 1;
+  let match: RegExpExecArray | null;
+
+  while (
+    (match = initializerPattern.exec(source)) !== null &&
+    match.index < typeBody.closingBrace
+  ) {
+    if (
+      match[1] != null ||
+      braceDepthAt(source, typeBody.openingBrace, match.index) !== 1 ||
+      isInsideConditionalCompilation(source, match.index)
+    ) {
+      continue;
+    }
+
+    const openingParenthesis = source.indexOf("(", match.index);
+    const closingParenthesis = matchingParenthesis(source, openingParenthesis);
+    if (closingParenthesis == null || closingParenthesis >= typeBody.closingBrace) continue;
+    if (source.slice(openingParenthesis + 1, closingParenthesis).trim() !== "") continue;
+
+    const openingBrace = skipWhitespace(source, closingParenthesis + 1);
+    if (source[openingBrace] !== "{") continue;
+    const closingBrace = matchingBrace(source, openingBrace);
+    if (closingBrace == null || closingBrace > typeBody.closingBrace) continue;
+    initializers.push({ openingBrace, closingBrace });
+    initializerPattern.lastIndex = closingBrace + 1;
+  }
+
+  return initializers;
+}
+
+function isDirectStatementInMainInitializer(
+  source: string,
+  callIndex: number,
+  initializerBodies: SourceBodyRange[],
+): boolean {
+  const initializer = initializerBodies.find(
+    (body) => callIndex > body.openingBrace && callIndex < body.closingBrace,
+  );
+  if (!initializer) return false;
+  if (braceDepthAt(source, initializer.openingBrace, callIndex) !== 1) return false;
+  if (isInsideConditionalCompilation(source, callIndex)) return false;
+
+  let cursor = callIndex - 1;
+  while (source[cursor] === " " || source[cursor] === "\t") cursor--;
+  return (
+    cursor === initializer.openingBrace ||
+    source[cursor] === "\n" ||
+    source[cursor] === "\r" ||
+    source[cursor] === ";" ||
+    source[cursor] === "}"
+  );
+}
+
+function publishableKeyWiring(
+  sanitizedCallBody: string,
+  originalCallBody: string,
+): {
+  wiring: IOSPublishableKeyWiring;
+  inlinePublishableKey?: IOSInlinePublishableKeyInspection;
+  localSecretsSymbol?: string;
+  localSecretsUsesCanonicalLoad?: boolean;
+} {
+  const label = /\bpublishableKey\s*:/.exec(sanitizedCallBody);
+  if (!label) return { wiring: "unknown" };
+  const expressionStart = label.index + label[0].length;
+  let expressionEnd = sanitizedCallBody.length;
+  let parenthesisDepth = 0;
+  let bracketDepth = 0;
+  let braceDepth = 0;
+  for (let index = expressionStart; index < sanitizedCallBody.length; index++) {
+    const character = sanitizedCallBody[index];
+    if (character === "(") parenthesisDepth++;
+    if (character === ")") parenthesisDepth--;
+    if (character === "[") bracketDepth++;
+    if (character === "]") bracketDepth--;
+    if (character === "{") braceDepth++;
+    if (character === "}") braceDepth--;
+    if (character === "," && parenthesisDepth === 0 && bracketDepth === 0 && braceDepth === 0) {
+      expressionEnd = index;
+      break;
+    }
+  }
+  const expression = sanitizedCallBody.slice(expressionStart, expressionEnd);
+  const originalExpression = originalCallBody.slice(expressionStart, expressionEnd);
+
+  // A direct ordinary string literal is the documented native iOS setup. Only
+  // retain decoded, non-secret metadata; the literal itself must never enter
+  // inspection, JSON, diagnostics, or telemetry.
+  const inlineLiteral = /^\s*"([^"\\]*)"\s*$/.exec(originalExpression);
+  if (inlineLiteral?.[1] != null && expression.trim() === "") {
+    try {
+      const decoded = decodePublishableKey(inlineLiteral[1]);
+      return {
+        wiring: "inline-literal",
+        inlinePublishableKey: {
+          state: "valid",
+          frontendApiHost: decoded.fapiHost,
+          instanceType: decoded.instanceType,
+        },
+      };
+    } catch {
+      return {
+        wiring: "inline-literal",
+        inlinePublishableKey: { state: "invalid" },
+      };
+    }
+  }
+
+  const localSecrets =
+    /\b((?:[A-Za-z_][A-Za-z0-9_]*)?LocalSecrets)\b\s*\.\s*(load\s*\(|(?:key|publishableKey)\b)/.exec(
+      expression,
+    );
+  if (localSecrets?.[1]) {
+    const canonicalLoad =
+      /^\s*((?:[A-Za-z_][A-Za-z0-9_]*)?LocalSecrets)\s*\.\s*load\s*\(\s*\)\s*\.\s*publishableKey\b([\s\S]*)$/.exec(
+        expression,
+      );
+    const remainder = canonicalLoad?.[2] ?? "";
+    const originalRemainder = originalExpression.slice(expression.length - remainder.length);
+    const canonicalRemainder =
+      remainder.trim() === "" || /^\s*\?\?\s*""\s*$/.test(originalRemainder);
+    return {
+      wiring: "local-secrets-loader",
+      localSecretsSymbol: localSecrets[1],
+      localSecretsUsesCanonicalLoad: canonicalLoad?.[1] === localSecrets[1] && canonicalRemainder,
+    };
+  }
+  if (
+    has(expression, /\bProcessInfo\s*\.\s*processInfo\s*\.\s*environment\b/) &&
+    has(
+      originalExpression,
+      /\bProcessInfo\s*\.\s*processInfo\s*\.\s*environment\s*\[\s*"CLERK_PUBLISHABLE_KEY"\s*\]/,
+    )
+  ) {
+    return { wiring: "process-info-environment" };
+  }
+  return { wiring: "unknown" };
+}
+
+interface PendingConfigureCall extends IOSConfigureCallEvidence {
+  localSecretsSymbol?: string;
+  localSecretsUsesCanonicalLoad?: boolean;
+}
+
+function configureCallEvidence(
+  sanitizedSource: string,
+  originalSource: string,
+  evidence: IOSSourceEvidence,
+): PendingConfigureCall[] {
+  const calls: PendingConfigureCall[] = [];
+  const initializerBodies = mainInitializerBodies(sanitizedSource);
+  const pattern = /\bClerk\s*\.\s*configure\s*\(/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(sanitizedSource)) !== null) {
+    const openingParenthesis = sanitizedSource.indexOf("(", match.index);
+    const closingParenthesis = matchingParenthesis(sanitizedSource, openingParenthesis);
+    if (closingParenthesis == null) {
+      calls.push({
+        ...evidence,
+        publishableKeyWiring: "unknown",
+        startupBinding: isDirectStatementInMainInitializer(
+          sanitizedSource,
+          match.index,
+          initializerBodies,
+        )
+          ? "app-init"
+          : "unproven",
+      });
+      break;
+    }
+    const classification = publishableKeyWiring(
+      sanitizedSource.slice(openingParenthesis + 1, closingParenthesis),
+      originalSource.slice(openingParenthesis + 1, closingParenthesis),
+    );
+    calls.push({
+      ...evidence,
+      publishableKeyWiring: classification.wiring,
+      inlinePublishableKey: classification.inlinePublishableKey,
+      startupBinding: isDirectStatementInMainInitializer(
+        sanitizedSource,
+        match.index,
+        initializerBodies,
+      )
+        ? "app-init"
+        : "unproven",
+      localSecretsSymbol: classification.localSecretsSymbol,
+      localSecretsUsesCanonicalLoad: classification.localSecretsUsesCanonicalLoad,
+    });
+    pattern.lastIndex = closingParenthesis + 1;
+  }
+
+  return calls;
+}
+
+function withoutPreviewOnlyRegions(source: string): string {
+  const chars = source.split("");
+  const patterns = [/#Preview\b/g, /\bstruct\s+\w+[^{}]*:\s*[^{}]*\bPreviewProvider\b/g];
+  for (const pattern of patterns) {
+    for (const match of source.matchAll(pattern)) {
+      const openingBrace = source.indexOf("{", match.index + match[0].length);
+      if (openingBrace === -1) continue;
+      const closingBrace = matchingBrace(source, openingBrace);
+      if (closingBrace == null) continue;
+      blankRange(chars, match.index, closingBrace + 1);
+    }
+  }
+  return chars.join("");
+}
+
+function hasClerkOpenURLHandler(source: string): boolean {
+  const pattern = /\.\s*onOpenURL\b/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(source)) !== null) {
+    let cursor = match.index + match[0].length;
+    while (/\s/.test(source[cursor] ?? "")) cursor++;
+
+    let openingBrace: number | undefined;
+    if (source[cursor] === "{") {
+      openingBrace = cursor;
+    } else if (source[cursor] === "(") {
+      const closingParenthesis = source.indexOf(")", cursor + 1);
+      const candidateBrace = source.indexOf("{", cursor + 1);
+      if (
+        candidateBrace !== -1 &&
+        (closingParenthesis === -1 || candidateBrace < closingParenthesis)
+      ) {
+        openingBrace = candidateBrace;
+      }
+    }
+
+    if (openingBrace == null) continue;
+    const closingBrace = matchingBrace(source, openingBrace);
+    if (closingBrace == null) continue;
+    if (has(source.slice(openingBrace + 1, closingBrace), CLERK_URL_HANDLER)) return true;
+    pattern.lastIndex = closingBrace + 1;
+  }
+
+  return false;
+}
+
+export async function inspectSwiftSources(
+  sourceFiles: Array<{ absolutePath: string; relativePath: string }>,
+  options: { membershipComplete?: boolean } = {},
+): Promise<IOSSwiftInspection> {
+  const entryPoints: IOSSourceEvidence[] = [];
+  const importsClerkKit: IOSSourceEvidence[] = [];
+  const importsClerkKitUI: IOSSourceEvidence[] = [];
+  const pendingConfigureCalls: PendingConfigureCall[] = [];
+  const localSecretsRuntimeBindings: IOSSourceEvidence[] = [];
+  const localSecretsRuntimeSymbols = new Set<string>();
+  const environmentInjections: IOSSourceEvidence[] = [];
+  const environmentConsumers: IOSSourceEvidence[] = [];
+  const authFlowReferences: IOSSourceEvidence[] = [];
+  const openURLHandlers: IOSSourceEvidence[] = [];
+  let sourceFilesScanned = 0;
+  let evidenceComplete = options.membershipComplete ?? true;
+
+  for (const file of sourceFiles.sort((a, b) => a.relativePath.localeCompare(b.relativePath))) {
+    const diskFile = Bun.file(file.absolutePath);
+    if (!(await diskFile.exists()) || diskFile.size > MAX_SWIFT_FILE_BYTES) {
+      evidenceComplete = false;
+      continue;
+    }
+
+    let source: string;
+    try {
+      source = await readFile(file.absolutePath, "utf8");
+    } catch {
+      evidenceComplete = false;
+      continue;
+    }
+
+    sourceFilesScanned++;
+    const sanitized = withoutPreviewOnlyRegions(sanitizeSwiftSource(source));
+    const uncommented = withoutPreviewOnlyRegions(sourceWithoutComments(source));
+    const evidence = { path: file.relativePath };
+    const importsKit = has(
+      sanitized,
+      /\bimport\s+(?:(?:typealias|struct|class|enum|protocol|actor|let|var|func|macro)\s+)?ClerkKit\b/,
+    );
+    const importsUI = has(
+      sanitized,
+      /\bimport\s+(?:(?:typealias|struct|class|enum|protocol|actor|let|var|func|macro)\s+)?ClerkKitUI\b/,
+    );
+    const importsClerkModule = importsKit || importsUI;
+
+    if (has(sanitized, /@main\b/)) entryPoints.push(evidence);
+    if (importsKit) importsClerkKit.push(evidence);
+    if (importsUI) importsClerkKitUI.push(evidence);
+    const runtimeSymbols = provenLocalSecretsRuntimeSymbols(sanitized, uncommented);
+    for (const symbol of runtimeSymbols) {
+      localSecretsRuntimeSymbols.add(symbol);
+      localSecretsRuntimeBindings.push(evidence);
+    }
+    if (importsClerkModule) {
+      pendingConfigureCalls.push(...configureCallEvidence(sanitized, source, evidence));
+    }
+    if (
+      importsClerkModule &&
+      has(sanitized, /\.\s*environment\s*\(\s*(?:\\?\.\s*self\s*,\s*)?Clerk\s*\.\s*shared\s*\)/)
+    ) {
+      environmentInjections.push(evidence);
+    }
+    if (importsClerkModule && has(sanitized, /@Environment\s*\(\s*Clerk\s*\.\s*self\s*\)/)) {
+      environmentConsumers.push(evidence);
+    }
+    if (
+      (importsUI && has(sanitized, /\bAuthView\s*\(/)) ||
+      (importsClerkModule && has(sanitized, CLERK_NATIVE_AUTH_FLOW))
+    ) {
+      authFlowReferences.push(evidence);
+    }
+    if (importsClerkModule && hasClerkOpenURLHandler(sanitized)) {
+      openURLHandlers.push(evidence);
+    }
+  }
+
+  const anyClerkEvidence =
+    importsClerkKit.length +
+      importsClerkKitUI.length +
+      pendingConfigureCalls.length +
+      localSecretsRuntimeBindings.length +
+      environmentInjections.length +
+      environmentConsumers.length +
+      authFlowReferences.length >
+    0;
+  const status =
+    entryPoints.length > 1
+      ? "ambiguous"
+      : pendingConfigureCalls.length > 0 && environmentInjections.length > 0
+        ? "complete"
+        : anyClerkEvidence
+          ? "partial"
+          : "absent";
+
+  const configureCalls: IOSConfigureCallEvidence[] = pendingConfigureCalls.map(
+    ({ localSecretsSymbol, localSecretsUsesCanonicalLoad, ...call }) => ({
+      ...call,
+      ...(call.publishableKeyWiring === "local-secrets-loader" && {
+        localSecretsRuntimeBinding:
+          localSecretsUsesCanonicalLoad &&
+          localSecretsSymbol &&
+          localSecretsRuntimeSymbols.has(localSecretsSymbol)
+            ? ("proven" as const)
+            : ("unproven" as const),
+      }),
+    }),
+  );
+
+  return {
+    sourceFilesScanned,
+    evidenceComplete,
+    entryPoints,
+    importsClerkKit,
+    importsClerkKitUI,
+    configureCalls,
+    localSecretsRuntimeBindings,
+    environmentInjections,
+    environmentConsumers,
+    authFlowReferences,
+    openURLHandlers,
+    status,
+  };
+}

--- a/packages/cli-core/src/commands/init/ios/test-helpers.ts
+++ b/packages/cli-core/src/commands/init/ios/test-helpers.ts
@@ -1,0 +1,342 @@
+import { lstat, mkdir, readdir, readFile, readlink, rm, writeFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { build as buildPbxProject, parse as parsePbxProject } from "@bacons/xcode/json";
+import type { PbxObjects } from "./pbx.ts";
+
+const IDS = {
+  project: "AAAAAAAAAAAAAAAAAAAAAAAA",
+  mainGroup: "BBBBBBBBBBBBBBBBBBBBBBBB",
+  appGroup: "CCCCCCCCCCCCCCCCCCCCCCCC",
+  appFile: "DDDDDDDDDDDDDDDDDDDDDDDD",
+  entitlementsFile: "EEEEEEEEEEEEEEEEEEEEEEEE",
+  appTarget: "111111111111111111111111",
+  appProduct: "121212121212121212121212",
+  projectConfigList: "131313131313131313131313",
+  projectDebug: "141414141414141414141414",
+  projectRelease: "151515151515151515151515",
+  targetConfigList: "161616161616161616161616",
+  targetDebug: "171717171717171717171717",
+  targetRelease: "181818181818181818181818",
+  sourcesPhase: "191919191919191919191919",
+  sourceBuildFile: "202020202020202020202020",
+  frameworksPhase: "212121212121212121212121",
+  clerkPackage: "222222222222222222222222",
+  clerkKit: "232323232323232323232323",
+  clerkKitUI: "242424242424242424242424",
+  clerkKitBuildFile: "252525252525252525252525",
+  clerkKitUIBuildFile: "262626262626262626262626",
+  secondTarget: "313131313131313131313131",
+  secondProduct: "323232323232323232323232",
+  secondConfigList: "333333333333333333333333",
+  secondDebug: "343434343434343434343434",
+  secondRelease: "353535353535353535353535",
+  targetXCConfig: "363636363636363636363636",
+  localSecretsFile: "373737373737373737373737",
+  resourcesPhase: "383838383838383838383838",
+  localSecretsBuildFile: "393939393939393939393939",
+  secondGroup: "404040404040404040404040",
+  secondAppFile: "414141414141414141414141",
+  secondSourcesPhase: "424242424242424242424242",
+  secondSourceBuildFile: "434343434343434343434343",
+  secondFrameworksPhase: "444444444444444444444444",
+} as const;
+
+export interface IOSFixtureOptions {
+  complete?: boolean;
+  secondTarget?: boolean | "watchos";
+  conflictingBundle?: boolean;
+  includeKey?: boolean;
+  releaseEntitlements?: boolean;
+  workspace?: boolean;
+  generated?: "xcodegen" | "tuist";
+  xcconfig?: boolean;
+  localSecrets?: boolean;
+  /** Include a fully linked clerk-ios package graph. Defaults to both products. */
+  clerkSDK?: boolean | "core-only";
+}
+
+function secondTargetObjects(platform: "ios" | "watchos"): string {
+  const isWatchOS = platform === "watchos";
+  const directoryName = isWatchOS ? "WatchApp" : "AdminApp";
+  const sourceName = isWatchOS ? "WatchAppApp.swift" : "AdminAppApp.swift";
+  const targetName = isWatchOS ? "MyApp Watch App" : "AdminApp";
+  const platformSettings = isWatchOS
+    ? 'PRODUCT_BUNDLE_IDENTIFIER = com.example.WatchApp; DEVELOPMENT_TEAM = ABCDE12345; SDKROOT = watchos; SUPPORTED_PLATFORMS = "watchos watchsimulator"; WATCHOS_DEPLOYMENT_TARGET = 10.0;'
+    : 'PRODUCT_BUNDLE_IDENTIFIER = com.example.AdminApp; DEVELOPMENT_TEAM = ABCDE12345; IPHONEOS_DEPLOYMENT_TARGET = 17.0; SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";';
+  return `
+    ${IDS.secondGroup} = { isa = PBXGroup; children = ( ${IDS.secondAppFile}, ); path = ${directoryName}; sourceTree = "<group>"; };
+    ${IDS.secondAppFile} = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ${sourceName}; sourceTree = "<group>"; };
+    ${IDS.secondTarget} = {
+      isa = PBXNativeTarget;
+      buildConfigurationList = ${IDS.secondConfigList};
+      buildPhases = ( ${IDS.secondSourcesPhase}, ${IDS.secondFrameworksPhase}, );
+      buildRules = ( );
+      dependencies = ( );
+      name = "${targetName}";
+      productName = "${targetName}";
+      productReference = ${IDS.secondProduct};
+      productType = "com.apple.product-type.application";
+      packageProductDependencies = ( );
+    };
+    ${IDS.secondProduct} = { isa = PBXFileReference; explicitFileType = wrapper.application; path = ${directoryName}.app; sourceTree = BUILT_PRODUCTS_DIR; };
+    ${IDS.secondSourcesPhase} = { isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = ( ${IDS.secondSourceBuildFile}, ); runOnlyForDeploymentPostprocessing = 0; };
+    ${IDS.secondSourceBuildFile} = { isa = PBXBuildFile; fileRef = ${IDS.secondAppFile}; };
+    ${IDS.secondFrameworksPhase} = { isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = ( ); runOnlyForDeploymentPostprocessing = 0; };
+    ${IDS.secondConfigList} = { isa = XCConfigurationList; buildConfigurations = ( ${IDS.secondDebug}, ${IDS.secondRelease}, ); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+    ${IDS.secondDebug} = { isa = XCBuildConfiguration; buildSettings = { ${platformSettings} }; name = Debug; };
+    ${IDS.secondRelease} = { isa = XCBuildConfiguration; buildSettings = { ${platformSettings} }; name = Release; };
+  `;
+}
+
+function pbxproj(options: IOSFixtureOptions): string {
+  const includeClerkSDK = options.clerkSDK !== false;
+  const includeClerkKitUI = includeClerkSDK && options.clerkSDK !== "core-only";
+  const releaseBundle = options.conflictingBundle
+    ? "com.example.MyApp.release"
+    : "com.example.MyApp";
+  const releaseEntitlements =
+    options.releaseEntitlements === false
+      ? ""
+      : "CODE_SIGN_ENTITLEMENTS = MyApp/MyApp.entitlements;";
+  const debugIdentitySettings = options.xcconfig
+    ? ""
+    : "DEVELOPMENT_TEAM = ABCDE12345; PRODUCT_BUNDLE_IDENTIFIER = com.example.MyApp;";
+  const releaseIdentitySettings = options.xcconfig
+    ? ""
+    : `DEVELOPMENT_TEAM = ABCDE12345; PRODUCT_BUNDLE_IDENTIFIER = ${releaseBundle};`;
+  const baseConfigurationReference = options.xcconfig
+    ? `baseConfigurationReference = ${IDS.targetXCConfig};`
+    : "";
+  const targetIds = options.secondTarget
+    ? `${IDS.appTarget}, ${IDS.secondTarget},`
+    : `${IDS.appTarget},`;
+  return `// !$*UTF8*$!
+{
+  archiveVersion = 1;
+  classes = { };
+  objectVersion = 56;
+  objects = {
+    ${IDS.project} = {
+      isa = PBXProject;
+      attributes = { LastUpgradeCheck = 1600; };
+      buildConfigurationList = ${IDS.projectConfigList};
+      compatibilityVersion = "Xcode 14.0";
+      developmentRegion = en;
+      knownRegions = ( en, Base, );
+      mainGroup = ${IDS.mainGroup};
+      packageReferences = ( ${includeClerkSDK ? `${IDS.clerkPackage},` : ""} );
+      projectDirPath = "";
+      projectRoot = "";
+      targets = ( ${targetIds} );
+    };
+    ${IDS.mainGroup} = { isa = PBXGroup; children = ( ${IDS.appGroup}, ${options.secondTarget ? `${IDS.secondGroup},` : ""} ${IDS.entitlementsFile}, ${options.xcconfig ? `${IDS.targetXCConfig},` : ""} ); sourceTree = "<group>"; };
+    ${IDS.appGroup} = { isa = PBXGroup; children = ( ${IDS.appFile}, ${options.localSecrets ? `${IDS.localSecretsFile},` : ""} ); path = MyApp; sourceTree = "<group>"; };
+    ${IDS.appFile} = { isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAppApp.swift; sourceTree = "<group>"; };
+    ${options.localSecrets ? `${IDS.localSecretsFile} = { isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = LocalSecrets.plist; sourceTree = "<group>"; };` : ""}
+    ${IDS.entitlementsFile} = { isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MyApp/MyApp.entitlements; sourceTree = "<group>"; };
+    ${options.xcconfig ? `${IDS.targetXCConfig} = { isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config/Target.xcconfig; sourceTree = "<group>"; };` : ""}
+    ${IDS.appTarget} = {
+      isa = PBXNativeTarget;
+      buildConfigurationList = ${IDS.targetConfigList};
+      buildPhases = ( ${IDS.sourcesPhase}, ${IDS.frameworksPhase}, ${options.localSecrets ? `${IDS.resourcesPhase},` : ""} );
+      buildRules = ( );
+      dependencies = ( );
+      name = MyApp;
+      productName = MyApp;
+      productReference = ${IDS.appProduct};
+      productType = "com.apple.product-type.application";
+      packageProductDependencies = ( ${includeClerkSDK ? `${IDS.clerkKit},` : ""} ${includeClerkKitUI ? `${IDS.clerkKitUI},` : ""} );
+    };
+    ${IDS.appProduct} = { isa = PBXFileReference; explicitFileType = wrapper.application; path = MyApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+    ${IDS.sourcesPhase} = { isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = ( ${IDS.sourceBuildFile}, ); runOnlyForDeploymentPostprocessing = 0; };
+    ${IDS.sourceBuildFile} = { isa = PBXBuildFile; fileRef = ${IDS.appFile}; };
+    ${options.localSecrets ? `${IDS.resourcesPhase} = { isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = ( ${IDS.localSecretsBuildFile}, ); runOnlyForDeploymentPostprocessing = 0; }; ${IDS.localSecretsBuildFile} = { isa = PBXBuildFile; fileRef = ${IDS.localSecretsFile}; };` : ""}
+    ${IDS.frameworksPhase} = { isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = ( ${includeClerkSDK ? `${IDS.clerkKitBuildFile},` : ""} ${includeClerkKitUI ? `${IDS.clerkKitUIBuildFile},` : ""} ); runOnlyForDeploymentPostprocessing = 0; };
+    ${includeClerkSDK ? `${IDS.clerkKitBuildFile} = { isa = PBXBuildFile; productRef = ${IDS.clerkKit}; };` : ""}
+    ${includeClerkKitUI ? `${IDS.clerkKitUIBuildFile} = { isa = PBXBuildFile; productRef = ${IDS.clerkKitUI}; };` : ""}
+    ${includeClerkSDK ? `${IDS.clerkPackage} = { isa = XCRemoteSwiftPackageReference; repositoryURL = "https://github.com/clerk/clerk-ios.git"; requirement = { kind = upToNextMajorVersion; minimumVersion = 1.0.0; }; };` : ""}
+    ${includeClerkSDK ? `${IDS.clerkKit} = { isa = XCSwiftPackageProductDependency; package = ${IDS.clerkPackage}; productName = ClerkKit; };` : ""}
+    ${includeClerkKitUI ? `${IDS.clerkKitUI} = { isa = XCSwiftPackageProductDependency; package = ${IDS.clerkPackage}; productName = ClerkKitUI; };` : ""}
+    ${IDS.projectConfigList} = { isa = XCConfigurationList; buildConfigurations = ( ${IDS.projectDebug}, ${IDS.projectRelease}, ); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+    ${IDS.projectDebug} = { isa = XCBuildConfiguration; buildSettings = { SDKROOT = iphoneos; }; name = Debug; };
+    ${IDS.projectRelease} = { isa = XCBuildConfiguration; buildSettings = { SDKROOT = iphoneos; }; name = Release; };
+    ${IDS.targetConfigList} = { isa = XCConfigurationList; buildConfigurations = ( ${IDS.targetDebug}, ${IDS.targetRelease}, ); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+    ${IDS.targetDebug} = { isa = XCBuildConfiguration; ${baseConfigurationReference} buildSettings = { CODE_SIGN_ENTITLEMENTS = MyApp/MyApp.entitlements; ${debugIdentitySettings} IPHONEOS_DEPLOYMENT_TARGET = 17.0; SUPPORTED_PLATFORMS = "iphoneos iphonesimulator"; }; name = Debug; };
+    ${IDS.targetRelease} = { isa = XCBuildConfiguration; ${baseConfigurationReference} buildSettings = { ${releaseEntitlements} ${releaseIdentitySettings} IPHONEOS_DEPLOYMENT_TARGET = 17.0; SUPPORTED_PLATFORMS = "iphoneos iphonesimulator"; }; name = Release; };
+    ${options.secondTarget ? secondTargetObjects(options.secondTarget === "watchos" ? "watchos" : "ios") : ""}
+  };
+  rootObject = ${IDS.project};
+}
+`;
+}
+
+function swiftSource(complete: boolean): string {
+  if (!complete) {
+    return `import SwiftUI
+
+@main
+struct MyApp: App {
+  var body: some Scene { WindowGroup { Text("Hello") } }
+}
+`;
+  }
+  return `import ClerkKit
+import ClerkKitUI
+import SwiftUI
+
+@main
+struct MyApp: App {
+  init() { Clerk.configure(publishableKey: QuickstartLocalSecrets.load().publishableKey ?? "") }
+  var body: some Scene {
+    WindowGroup {
+      AuthView()
+        .environment(Clerk.shared)
+        .onOpenURL { url in Task { try await Clerk.shared.handle(url) } }
+    }
+  }
+}
+
+struct QuickstartLocalSecrets {
+  let publishableKey: String?
+
+  static func load(bundle: Bundle = .main) -> QuickstartLocalSecrets {
+    let values: [String: Any]
+    if let url = bundle.url(forResource: "LocalSecrets", withExtension: "plist"),
+       let data = try? Data(contentsOf: url),
+       let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),
+       let dictionary = plist as? [String: Any] {
+      values = dictionary
+    } else {
+      values = [:]
+    }
+    return .init(publishableKey: values["CLERK_PUBLISHABLE_KEY"] as? String)
+  }
+}
+`;
+}
+
+function secondSwiftSource(platform: "ios" | "watchos"): string {
+  const appName = platform === "watchos" ? "WatchAppApp" : "AdminAppApp";
+  return `import SwiftUI
+
+@main
+struct ${appName}: App {
+  var body: some Scene { WindowGroup { Text("Hello") } }
+}
+`;
+}
+
+const ENTITLEMENTS = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>application-identifier</key><string>LEGACY1234.com.example.MyApp</string>
+<key>com.apple.developer.team-identifier</key><string>ABCDE12345</string>
+<key>com.apple.developer.associated-domains</key><array><string>webcredentials:clerk.example.test</string></array>
+</dict></plist>
+`;
+
+export async function createIOSFixture(
+  root: string,
+  options: IOSFixtureOptions = {},
+): Promise<void> {
+  const project = join(root, "MyApp.xcodeproj");
+  await mkdir(join(project), { recursive: true });
+  await mkdir(join(root, "MyApp"), { recursive: true });
+  await Bun.write(join(project, "project.pbxproj"), pbxproj(options));
+  await Bun.write(join(root, "MyApp", "MyAppApp.swift"), swiftSource(options.complete === true));
+  await Bun.write(join(root, "MyApp", "MyApp.entitlements"), ENTITLEMENTS);
+  if (options.secondTarget) {
+    const platform = options.secondTarget === "watchos" ? "watchos" : "ios";
+    const directoryName = platform === "watchos" ? "WatchApp" : "AdminApp";
+    const sourceName = platform === "watchos" ? "WatchAppApp.swift" : "AdminAppApp.swift";
+    await mkdir(join(root, directoryName), { recursive: true });
+    await Bun.write(join(root, directoryName, sourceName), secondSwiftSource(platform));
+  }
+  if (options.localSecrets) {
+    const encodedHost = Buffer.from("native.clerk.example$").toString("base64");
+    await Bun.write(
+      join(root, "MyApp", "LocalSecrets.plist"),
+      `<?xml version="1.0" encoding="UTF-8"?><plist version="1.0"><dict><key>CLERK_PUBLISHABLE_KEY</key><string>pk_live_${encodedHost}</string></dict></plist>`,
+    );
+  }
+
+  if (options.xcconfig) {
+    await mkdir(join(root, "Config"), { recursive: true });
+    await Bun.write(
+      join(root, "Config", "Base.xcconfig"),
+      "BUNDLE_BASE = com.example\nDEVELOPMENT_TEAM = ABCDE12345\n",
+    );
+    await Bun.write(
+      join(root, "Config", "Target.xcconfig"),
+      '#include "Base.xcconfig"\nPRODUCT_BUNDLE_IDENTIFIER = $(BUNDLE_BASE).MyApp\n',
+    );
+  }
+
+  if (options.includeKey !== false) {
+    const encodedHost = Buffer.from("clerk.example.test$").toString("base64");
+    await Bun.write(join(root, ".env"), `CLERK_PUBLISHABLE_KEY=pk_test_${encodedHost}\n`);
+  }
+  if (options.workspace) {
+    const workspace = join(root, "MyApp.xcworkspace");
+    await mkdir(workspace, { recursive: true });
+    await Bun.write(
+      join(workspace, "contents.xcworkspacedata"),
+      '<?xml version="1.0" encoding="UTF-8"?><Workspace version="1.0"><FileRef location="group:MyApp.xcodeproj"></FileRef></Workspace>',
+    );
+  }
+  if (options.generated === "xcodegen") await Bun.write(join(root, "project.yml"), "name: MyApp\n");
+  if (options.generated === "tuist")
+    await Bun.write(join(root, "Project.swift"), "import ProjectDescription\n");
+}
+
+/** Converts the classic fixture into the modern synchronized-root shape used by new Xcode apps. */
+export async function convertIOSFixtureToSynchronizedMissingEntitlements(
+  root: string,
+): Promise<void> {
+  const synchronizedRootId = "515151515151515151515151";
+  const projectPath = join(root, "MyApp.xcodeproj", "project.pbxproj");
+  const project = parsePbxProject(await readFile(projectPath, "utf8"));
+  const objects = (project as unknown as { objects: PbxObjects }).objects;
+  const mainGroup = objects[IDS.mainGroup]!;
+  mainGroup.children = [
+    ...(mainGroup.children as string[]).filter((id) => id !== IDS.entitlementsFile),
+    synchronizedRootId,
+  ];
+  objects[synchronizedRootId] = {
+    isa: "PBXFileSystemSynchronizedRootGroup",
+    path: "MyApp",
+    sourceTree: "<group>",
+  };
+  objects[IDS.appTarget]!.fileSystemSynchronizedGroups = [synchronizedRootId];
+  delete objects[IDS.entitlementsFile];
+  for (const id of [IDS.targetDebug, IDS.targetRelease]) {
+    const settings = objects[id]!.buildSettings as Record<string, unknown>;
+    delete settings.CODE_SIGN_ENTITLEMENTS;
+    settings["CODE_SIGN_ENTITLEMENTS[sdk=macosx*]"] = "MyApp/MyApp.mac.entitlements";
+  }
+  await writeFile(projectPath, buildPbxProject(project));
+  await rm(join(root, "MyApp", "MyApp.entitlements"), { force: true });
+}
+
+async function digestEntry(root: string, path: string): Promise<string[]> {
+  const info = await lstat(path);
+  const relativePath = relative(root, path).split("\\").join("/") || ".";
+  if (info.isSymbolicLink()) {
+    return [`l:${relativePath}:${info.mode}:${await readlink(path)}`];
+  }
+  if (info.isDirectory()) {
+    const entries = (await readdir(path)).sort();
+    const nested = await Promise.all(
+      entries.map(async (entry) => digestEntry(root, join(path, entry))),
+    );
+    return [`d:${relativePath}:${info.mode}`, ...nested.flat()];
+  }
+  const hash = new Bun.CryptoHasher("sha256").update(await readFile(path)).digest("hex");
+  return [`f:${relativePath}:${info.mode}:${hash}`];
+}
+
+export async function treeDigest(root: string): Promise<string[]> {
+  return digestEntry(root, root);
+}
+
+export { IDS as IOS_FIXTURE_IDS };

--- a/packages/cli-core/src/commands/init/ios/types.ts
+++ b/packages/cli-core/src/commands/init/ios/types.ts
@@ -1,0 +1,228 @@
+export type IOSDiagnosticSeverity = "info" | "warning" | "error";
+
+export interface IOSSourceEvidence {
+  /** Project-root-relative path. */
+  path: string;
+  objectId?: string;
+  keyPath?: string;
+}
+
+export interface IOSDiagnostic {
+  code:
+    | "xcode.no-project"
+    | "xcode.malformed-project"
+    | "xcode.missing-project-file"
+    | "xcode.dangling-reference"
+    | "xcode.no-ios-app-target"
+    | "xcode.ambiguous-app-target"
+    | "xcode.target-not-found"
+    | "xcode.unresolved-build-setting"
+    | "xcode.conflicting-build-setting"
+    | "xcode.missing-entitlements"
+    | "xcode.unreadable-entitlements"
+    | "xcode.external-path"
+    | "xcode.generated-project"
+    | "xcode.incomplete-source-membership"
+    | "clerk.package-unattributed"
+    | "clerk.invalid-publishable-key"
+    | "clerk.conflicting-publishable-keys";
+  severity: IOSDiagnosticSeverity;
+  message: string;
+  remedy?: string;
+  evidence: IOSSourceEvidence[];
+}
+
+export type IOSValueResolution =
+  | { state: "resolved"; value: string; evidence: IOSSourceEvidence[] }
+  | {
+      state: "unresolved";
+      raw: string;
+      missingVariables: string[];
+      evidence: IOSSourceEvidence[];
+    }
+  | { state: "missing"; evidence: IOSSourceEvidence[] };
+
+export interface IOSEntitlementsInspection {
+  path: string;
+  associatedDomains: string[];
+  unresolvedAssociatedDomains: string[];
+  applicationIdentifier?: string;
+  /** Literal prefix candidate from the source plist, validated against the Bundle ID. */
+  literalAppIdentifierPrefix?: string;
+  teamIdentifier?: string;
+  signInWithApple: boolean;
+}
+
+export interface IOSBuildConfiguration {
+  name: string;
+  bundleIdentifier: IOSValueResolution;
+  developmentTeam: IOSValueResolution;
+  entitlementsPath: IOSValueResolution;
+  deploymentTarget: IOSValueResolution;
+  entitlements?: IOSEntitlementsInspection;
+}
+
+export type IOSPackageReference =
+  | {
+      kind: "remote";
+      objectId: string;
+      repository: string;
+      requirement?: Record<string, string>;
+      isClerk: boolean;
+    }
+  | {
+      kind: "local";
+      objectId: string;
+      path: string;
+      isClerk: boolean;
+    };
+
+export type IOSProductLinkState = "linked" | "declared" | "absent";
+
+export interface IOSClerkPackageState {
+  package: "remote" | "local" | "unattributed" | "absent";
+  clerkKit: IOSProductLinkState;
+  clerkKitUI: IOSProductLinkState;
+}
+
+export type IOSPublishableKeyWiring =
+  | "inline-literal"
+  | "local-secrets-loader"
+  | "process-info-environment"
+  | "unknown";
+
+export type IOSInlinePublishableKeyInspection =
+  | {
+      state: "valid";
+      frontendApiHost: string;
+      instanceType: "development" | "production";
+    }
+  | { state: "invalid" };
+
+export interface IOSConfigureCallEvidence extends IOSSourceEvidence {
+  /** Redacted classification only; the key expression and value are never retained. */
+  publishableKeyWiring: IOSPublishableKeyWiring;
+  /** Decoded metadata for a plain inline literal. The literal itself is never retained. */
+  inlinePublishableKey?: IOSInlinePublishableKeyInspection;
+  /** Whether this call is a direct statement in the selected @main type's init(). */
+  startupBinding: "app-init" | "unproven";
+  /** Whether the referenced LocalSecrets symbol is the exact inspected runtime loader. */
+  localSecretsRuntimeBinding?: "proven" | "unproven";
+}
+
+export interface IOSSwiftInspection {
+  sourceFilesScanned: number;
+  /** False when target membership was truncated or a member could not be read. */
+  evidenceComplete: boolean;
+  entryPoints: IOSSourceEvidence[];
+  importsClerkKit: IOSSourceEvidence[];
+  importsClerkKitUI: IOSSourceEvidence[];
+  configureCalls: IOSConfigureCallEvidence[];
+  /** Exact target source that loads LocalSecrets.plist and CLERK_PUBLISHABLE_KEY. */
+  localSecretsRuntimeBindings: IOSSourceEvidence[];
+  environmentInjections: IOSSourceEvidence[];
+  environmentConsumers: IOSSourceEvidence[];
+  authFlowReferences: IOSSourceEvidence[];
+  openURLHandlers: IOSSourceEvidence[];
+  status: "complete" | "partial" | "absent" | "ambiguous";
+}
+
+export interface IOSRuntimeKeySink {
+  kind: "local-secrets-plist";
+  /** Project-root-relative path. The publishable-key value is never exposed. */
+  path: string;
+}
+
+export interface IOSAppTarget {
+  id: string;
+  name: string;
+  productName?: string;
+  projectPath: string;
+  configurations: IOSBuildConfiguration[];
+  packages: IOSClerkPackageState;
+  swift: IOSSwiftInspection;
+  /** Target-owned runtime destinations proven from the Xcode project graph. */
+  runtimeKeySinks: IOSRuntimeKeySink[];
+}
+
+export interface IOSProjectInspection {
+  path: string;
+  pbxprojPath: string;
+  objectVersion?: string;
+  packages: IOSPackageReference[];
+  appTargetIds: string[];
+  diagnostics: IOSDiagnostic[];
+}
+
+export interface IOSWorkspaceInspection {
+  path: string;
+  projectPaths: string[];
+}
+
+export type IOSTargetSelection =
+  | { state: "selected"; targetId: string; targetName: string; projectPath: string }
+  | {
+      state: "ambiguous";
+      candidates: Array<{ targetId: string; targetName: string; projectPath: string }>;
+    }
+  | { state: "not-found"; requested: string; candidates: string[] }
+  | { state: "none" };
+
+export interface IOSLocalPublishableKeyInspection {
+  found: boolean;
+  source?: string;
+  frontendApiHost?: string;
+  instanceType?: "development" | "production";
+  conflict: boolean;
+  candidateSources: string[];
+  invalidSources: string[];
+}
+
+export interface IOSProjectInspectionResult {
+  schemaVersion: 1;
+  platform: "ios";
+  /** Absolute invocation root. Paths nested below it are emitted relatively. */
+  root: string;
+  workspaces: IOSWorkspaceInspection[];
+  projects: IOSProjectInspection[];
+  appTargets: IOSAppTarget[];
+  selection: IOSTargetSelection;
+  localPublishableKey: IOSLocalPublishableKeyInspection;
+  generatedProject: "xcodegen" | "tuist" | null;
+  diagnostics: IOSDiagnostic[];
+}
+
+export type IOSSetupStepId =
+  | "select-target"
+  | "install-clerk-sdk"
+  | "configure-publishable-key"
+  | "inject-clerk-environment"
+  | "wire-auth-callbacks"
+  | "register-native-application"
+  | "enable-native-apple"
+  | "add-associated-domain"
+  | "add-authentication-flow"
+  | "verify-integration";
+
+export type IOSSetupStepStatus = "satisfied" | "required" | "review" | "blocked";
+
+export interface IOSSetupStep {
+  id: IOSSetupStepId;
+  title: string;
+  status: IOSSetupStepStatus;
+  automatable: boolean;
+  description: string;
+  links?: Array<{ kind: "dashboard" | "documentation"; url: string }>;
+  evidence: IOSSourceEvidence[];
+}
+
+export interface IOSSetupPlan {
+  schemaVersion: 1;
+  kind: "clerk-ios-setup";
+  root: string;
+  status: "ready" | "action-required" | "blocked";
+  selection: IOSTargetSelection;
+  summary: Record<IOSSetupStepStatus, number>;
+  steps: IOSSetupStep[];
+  diagnostics: IOSDiagnostic[];
+}


### PR DESCRIPTION
## Summary

- add deterministic mutation engines for installing ClerkKit products in Xcode projects
- add guarded Swift configuration and runtime publishable-key wiring for supported native project shapes
- add Associated Domains and entitlements project updates with byte-stable output
- compose file edits through stale-plan checks, dirty-file protection, postcondition validation, and rollback

## Stack

- PR 1: #431 — iOS project inspection foundations
- PR 2 of 4: this PR
- PR 3: #439 — init orchestration and native reconciliation
- PR 4: #432 — iOS-aware doctor diagnostics

## Review scope

This layer contains the local mutation engines only. It does not yet wire the behavior into the public init command or perform remote Clerk configuration.

## Testing

- bun run format:check
- bun run lint
- bun run typecheck
- bun run test — 2,868 passing