### PR TITLE
fix(auth): increase browser auth timeout from 2 to 15 minutes

### DIFF
--- a/.changeset/increase-auth-timeout.md
+++ b/.changeset/increase-auth-timeout.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+Increase the `clerk login` browser authentication timeout from 2 to 15 minutes, so sign-up flows with email verification don't time out.

--- a/packages/cli-core/src/lib/constants.ts
+++ b/packages/cli-core/src/lib/constants.ts
@@ -20,7 +20,7 @@ export const CREDENTIALS_FILE = join(clerkConfigDir ?? paths.data, "credentials"
 // ── Auth server ─────────────────────────────────────────────────────────────
 
 export const CALLBACK_PATH = "/callback";
-export const AUTH_TIMEOUT_MS = Number(process.env.CLERK_AUTH_TIMEOUT_MS) || 2 * 60 * 1000;
+export const AUTH_TIMEOUT_MS = Number(process.env.CLERK_AUTH_TIMEOUT_MS) || 15 * 60 * 1000;
 
 // ── OAuth client identification ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Bump `AUTH_TIMEOUT_MS` from 2 to 15 minutes. Two minutes is tight for sign-up (account creation + email verification); 15m matches CLI convention (e.g. GitHub CLI device codes).
- Still overridable via `CLERK_AUTH_TIMEOUT_MS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)