### PR TITLE
docs: add telemetry opt-out to installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ brew install clerk/stable/clerk
 npm install -g clerk
 ```
 
+After installing the Clerk CLI, you can disable telemetry:
+
+```sh
+clerk telemetry disable
+```
+
 ## Usage
 
 ```


### PR DESCRIPTION
## Summary

- add the `clerk telemetry disable` command immediately after the Clerk CLI installation instructions
- keep the detailed telemetry section unchanged

## Validation

- `git diff --check`
- Not run: Bun checks (Bun is unavailable in this environment; this is a README-only change)