### PR TITLE
feat(mcp): add fx as a supported MCP client

### DIFF
--- a/.changeset/fx-mcp-client.md
+++ b/.changeset/fx-mcp-client.md
@@ -1,0 +1,5 @@
+---
+"clerk": minor
+---
+
+Add fx (https://fx.sh) as a supported client for `clerk mcp install`, `list`, and `uninstall`. The Clerk MCP server is written to fx's user-global `~/.fx/mcp.json` as a direct Streamable HTTP entry (`{ "type": "http", "url": … }` under top-level `mcp`) — fx connects to the URL natively, so no `clerk mcp run` bridge is involved. Detected via the presence of `~/.fx/`; target it explicitly with `--client fx`.

--- a/packages/cli-core/src/commands/mcp/README.md
+++ b/packages/cli-core/src/commands/mcp/README.md
@@ -82,18 +82,25 @@ Per-client dialect notes:
 - **Warp** ships no registration CLI (its `oz` CLI only attaches servers to
   cloud-agent runs); `~/.warp/.mcp.json` is the documented file surface behind
   `Settings → Agents → MCP servers`, standard `mcpServers` dialect.
-- **fx** loads MCP servers **only** from the user-global trusted profile
-  `~/.fx/mcp.json` (repo-local MCP files are deliberately never loaded). fx
-  does ship a non-interactive registration CLI (`fx mcp add --transport http`,
-  verified in fx 0.0.7), but we write the file directly anyway: the command is
-  newer than fx's own docs (fx.sh documents only the in-session `/mcp` form),
-  so the direct write keeps registration working on fx binaries that predate
-  it, and the entry shape is trivial and version-stable. fx speaks Streamable
-  HTTP natively, so it is the one client that skips the stdio bridge: its
-  entry is `{ "type": "http", "url": "…" }` under top-level `mcp`, with the
-  resolved URL embedded at install time. fx applies hand-edited (or
-  CLI-written) config via `/mcp reload` inside an fx session, or on next
-  start; `/mcp list` verifies.
+- **fx** is registered in the user-global trusted profile `~/.fx/mcp.json` —
+  fx 0.0.7 also loads workspace `.mcp.json` servers, but those sit behind
+  per-workspace trust approval, while the profile needs none and follows the
+  user everywhere. fx does ship a non-interactive registration CLI
+  (`fx mcp add --transport http`, verified in fx 0.0.7), but we write the
+  file directly anyway: the command is newer than fx's own docs (fx.sh
+  documents only the in-session `/mcp` form), so the direct write keeps
+  registration working on fx binaries that predate it, and the entry shape is
+  trivial and version-stable. fx speaks Streamable HTTP natively, so it is
+  the one client that skips the stdio bridge: its entry is
+  `{ "type": "http", "url": "…" }` under top-level `mcp`, with the resolved
+  URL embedded at install time. Two consequences of that: fx accepts
+  `mcpServers` as a profile alias for `mcp` (ignored whenever `mcp` exists),
+  so the client migrates an alias-only profile to canonical `mcp` before any
+  read or write — otherwise our written `mcp` would shadow every aliased
+  server; and with no bridge argv to recognize, a `--name` entry pointing at
+  a `CLERK_MCP_URL` override is recognized as ours only while that override
+  is the resolved URL. fx applies hand-edited (or CLI-written) config via
+  `/mcp reload` inside an fx session, or on next start; `/mcp list` verifies.
 - **Hermes** `mcp add` probes the server and then ends in a confirm prompt
   ("Enable all tools?" on success, "Save config anyway?" on failure) — and
   cancelling on EOF exits **0** without saving. The CLI is therefore driven

--- a/packages/cli-core/src/commands/mcp/README.md
+++ b/packages/cli-core/src/commands/mcp/README.md
@@ -6,8 +6,9 @@ These subcommands register, list, and remove the Clerk entry per client, and
 probe the server via `clerk doctor`. Clients that ship a **non-interactive** MCP
 registration CLI (Claude Code, Gemini, Codex, VS Code, OpenClaw, Hermes) are
 registered by shelling out to it — the client owns its config format and write
-safety; for the rest (Cursor, Windsurf, Warp, opencode) we write the config
-file directly. Reads (`list`, `doctor`, the uninstall picker) always parse the
+safety; for the others (Cursor, Windsurf, Warp, opencode, fx) we write the
+config file directly (fx has a registration CLI but is deliberately
+file-written — see its dialect note). Reads (`list`, `doctor`, the uninstall picker) always parse the
 config files directly. The server URL defaults to Clerk's hosted server
 (`https://mcp.clerk.com/mcp`), so `clerk mcp install` works out of the box with
 no flags or profile setup (see [Development](#development) for the override
@@ -35,6 +36,7 @@ directory you run the CLI from).
 | `openclaw`           | OpenClaw                 | `openclaw mcp add --no-probe`               | `openclaw mcp unset` | `~/.openclaw/openclaw.json` (`mcp.servers`)   |
 | `warp`               | Warp                     | direct file write (no CLI exists)           | direct file write    | `~/.warp/.mcp.json`                           |
 | `hermes`             | Hermes Agent             | `hermes mcp add`                            | `hermes mcp remove`  | `~/.hermes/config.yaml` (`mcp_servers`)       |
+| `fx`                 | fx                       | direct file write (note below)              | direct file write    | `~/.fx/mcp.json` (`mcp`)                      |
 
 For CLI-registered clients there is **no file-write fallback**: if the client's
 binary isn't on PATH (e.g. VS Code without the `code` shell command installed),
@@ -55,8 +57,8 @@ edits its `mcp.json` directly. Its user config dir is OS-specific:
 **Configs owned by a client's CLI are read-only to us.** The file layer exists
 for two different jobs: _reads_ (every client — `list`, `doctor`, and the
 presence checks parse the config files, because no client CLI offers a stable
-machine-readable listing) and _writes_ (only the clients with no usable
-registration CLI: Cursor, Windsurf, Warp, opencode — plus VS Code's
+machine-readable listing) and _writes_ (only the direct-write
+clients: Cursor, Windsurf, Warp, opencode, fx — plus VS Code's
 removal, since its CLI is add-only). For every CLI-delegated client
 (Claude Code, Gemini, Codex, OpenClaw, Hermes) the file base is built
 read-only and a write reaching it throws — Codex is the one TOML-backed
@@ -80,6 +82,18 @@ Per-client dialect notes:
 - **Warp** ships no registration CLI (its `oz` CLI only attaches servers to
   cloud-agent runs); `~/.warp/.mcp.json` is the documented file surface behind
   `Settings → Agents → MCP servers`, standard `mcpServers` dialect.
+- **fx** loads MCP servers **only** from the user-global trusted profile
+  `~/.fx/mcp.json` (repo-local MCP files are deliberately never loaded). fx
+  does ship a non-interactive registration CLI (`fx mcp add --transport http`,
+  verified in fx 0.0.7), but we write the file directly anyway: the command is
+  newer than fx's own docs (fx.sh documents only the in-session `/mcp` form),
+  so the direct write keeps registration working on fx binaries that predate
+  it, and the entry shape is trivial and version-stable. fx speaks Streamable
+  HTTP natively, so it is the one client that skips the stdio bridge: its
+  entry is `{ "type": "http", "url": "…" }` under top-level `mcp`, with the
+  resolved URL embedded at install time. fx applies hand-edited (or
+  CLI-written) config via `/mcp reload` inside an fx session, or on next
+  start; `/mcp list` verifies.
 - **Hermes** `mcp add` probes the server and then ends in a confirm prompt
   ("Enable all tools?" on success, "Save config anyway?" on failure) — and
   cancelling on EOF exits **0** without saving. The CLI is therefore driven
@@ -90,8 +104,10 @@ Per-client dialect notes:
 
 ## How clients connect (the stdio bridge)
 
-Every client installs the same stdio descriptor — it launches `clerk mcp run`
-rather than pointing the editor at the remote URL directly:
+Every client except fx installs the same stdio descriptor — it launches
+`clerk mcp run` rather than pointing the editor at the remote URL directly (fx
+connects over Streamable HTTP natively, so its entry carries the URL itself —
+see the dialect note above):
 
 ```jsonc
 { "command": "clerk", "args": ["mcp", "run"] }
@@ -144,11 +160,13 @@ output.
 **After install:** registering the entry does not connect the server on its
 own. In human mode, `install` prints per-client next steps — the server only
 goes live once you **reload the editor**, which then spawns `clerk mcp run`
-(so `clerk` must be on the editor's `PATH`).
+(so `clerk` must be on the editor's `PATH`). fx instead applies the config via
+`/mcp reload` inside a session (or on next start) and needs no `clerk` binary
+at connect time.
 
 > **Concurrent writes:** for CLI-registered clients, write safety is the
 > client's own responsibility — its CLI owns the config. The file-backed
-> clients (Cursor, Windsurf, VS Code removal) are written atomically (temp
+> clients (Cursor, Windsurf, fx, VS Code removal) are written atomically (temp
 > file + rename), which prevents a torn read but not a lost update if the
 > editor rewrites its own config concurrently — those writes are safest with
 > the target client closed.
@@ -157,8 +175,8 @@ goes live once you **reload the editor**, which then spawns `clerk mcp run`
 
 Print every Clerk MCP entry across all supported clients: any `clerk mcp run`
 bridge entry, matched by its descriptor shape regardless of its name or
-currently-resolved URL (plus, for opencode's remote dialect, entries named
-`clerk` or pointing at a `*.clerk.com` host). Entries this CLI never wrote —
+currently-resolved URL (plus, for the direct-URL dialects — opencode's remote
+entries and fx — entries named `clerk` or pointing at a `*.clerk.com` host). Entries this CLI never wrote —
 e.g. a hand-added direct-URL entry — are left alone. The `--json` (and
 agent-mode) output is `{ entries, failures }`: a client whose config exists but
 can't be read or parsed appears in `failures` (`{ client, error }`) rather than
@@ -191,7 +209,7 @@ and when the entry is present but the client's binary is missing, that client
 fails with `mcp_client_cli_not_found`. After the remove command reports
 success, the config is re-read — if the entry is somehow still present, the
 client fails with `mcp_client_cli_failed` rather than reporting a removal that
-didn't happen (the mirror of the add-side `verifyAdd` check). Cursor, Windsurf, Warp, opencode, and
+didn't happen (the mirror of the add-side `verifyAdd` check). Cursor, Windsurf, Warp, opencode, fx, and
 VS Code (add-only CLI) are removed by editing the config file directly.
 
 In human mode with no `--client`/`--all`, it prompts with a

--- a/packages/cli-core/src/commands/mcp/clients/clerk-run.ts
+++ b/packages/cli-core/src/commands/mcp/clients/clerk-run.ts
@@ -1,5 +1,6 @@
 /**
- * The stdio descriptor every client now installs: each config launches
+ * The stdio descriptor every client except fx installs (fx speaks Streamable
+ * HTTP natively and stores the URL directly): each config launches
  * `clerk mcp run`, the bridge in `../run.ts`. Centralized here so the command
  * shape and its reverse parser stay in lockstep across clients.
  *

--- a/packages/cli-core/src/commands/mcp/clients/clients.test.ts
+++ b/packages/cli-core/src/commands/mcp/clients/clients.test.ts
@@ -32,6 +32,7 @@ const { opencodeClient } = await import("./opencode.ts");
 const { openclawClient } = await import("./openclaw.ts");
 const { warpClient } = await import("./warp.ts");
 const { hermesClient } = await import("./hermes.ts");
+const { fxClient } = await import("./fx.ts");
 const { vscodeUserDir } = await import("./paths.ts");
 
 useCaptureLog();
@@ -88,6 +89,11 @@ const pathCases = [
     client: hermesClient,
     expectedPath: () => join(mockHome, ".hermes", "config.yaml"),
   },
+  {
+    name: "fx",
+    client: fxClient,
+    expectedPath: () => join(mockHome, ".fx", "mcp.json"),
+  },
 ];
 
 // File-backed clients: we write the entry ourselves (no usable registration
@@ -102,6 +108,14 @@ const fileCases = [
     topKey: "mcp",
     // opencode's stdio dialect: `type: "local"` and a single command array.
     shape: { type: "local", command: ["clerk", "mcp", "run"] },
+  },
+  {
+    name: "fx",
+    client: fxClient,
+    topKey: "mcp",
+    // fx loads servers only from `~/.fx/mcp.json` and connects over Streamable
+    // HTTP directly — no stdio bridge, so the URL is embedded at install time.
+    shape: { type: "http", url: DEFAULT_URL },
   },
 ];
 
@@ -327,6 +341,24 @@ describe("client contracts (homedir redirected)", () => {
     const entries = await opencodeClient.list("/ignored");
     expect(entries.map((e) => e.name).sort()).toEqual(["clerk", "hosted"]);
     expect(entries.every((e) => e.url === DEFAULT_URL)).toBe(true);
+  });
+
+  test("fx lists clerk-flavored direct-URL entries and ignores unrelated ones", async () => {
+    const configPath = fxClient.configPath("/ignored");
+    await mkdir(join(configPath, ".."), { recursive: true });
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        mcp: {
+          clerk: { type: "http", url: DEFAULT_URL },
+          unrelated: { type: "http", url: "https://example.com/mcp" },
+        },
+      }),
+    );
+    const entries = await fxClient.list("/ignored");
+    expect(entries).toEqual([
+      expect.objectContaining({ client: "fx", name: "clerk", url: DEFAULT_URL }),
+    ]);
   });
 
   test("`copilot` resolves to the same client as `vscode`", async () => {

--- a/packages/cli-core/src/commands/mcp/clients/clients.test.ts
+++ b/packages/cli-core/src/commands/mcp/clients/clients.test.ts
@@ -439,6 +439,50 @@ describe("client contracts (homedir redirected)", () => {
     }
   });
 
+  // Install stores `resolveUrl()`'s canonical `URL.href`; the raw override may
+  // differ in case or trailing slash and must still match.
+  test("fx matches a non-canonical but equivalent URL override", async () => {
+    const configPath = fxClient.configPath("/ignored");
+    await mkdir(join(configPath, ".."), { recursive: true });
+    await writeFile(
+      configPath,
+      JSON.stringify({ mcp: { local: { type: "http", url: "http://localhost:8787/mcp" } } }),
+    );
+    const origMcpUrl = process.env.CLERK_MCP_URL;
+    process.env.CLERK_MCP_URL = "HTTP://LOCALHOST:8787/mcp";
+    try {
+      const entries = await fxClient.list("/ignored");
+      expect(entries).toEqual([
+        expect.objectContaining({ client: "fx", name: "local", url: "http://localhost:8787/mcp" }),
+      ]);
+    } finally {
+      if (origMcpUrl === undefined) {
+        delete process.env.CLERK_MCP_URL;
+      } else {
+        process.env.CLERK_MCP_URL = origMcpUrl;
+      }
+    }
+  });
+
+  // Normalization migrates by key presence, not value shape, so a malformed
+  // profile still fails validation the way fx itself would reject it.
+  test.each([
+    ["invalid canonical key beside the alias", { mcp: null, mcpServers: { a: {} } }, "mcp"],
+    ["invalid alias key alone", { mcpServers: null }, "mcp"],
+  ])("fx rejects a profile with an %s", async (_label, profile) => {
+    const configPath = fxClient.configPath("/ignored");
+    await mkdir(join(configPath, ".."), { recursive: true });
+    await writeFile(configPath, JSON.stringify(profile));
+    await expect(
+      fxClient.upsert({ name: "clerk", url: DEFAULT_URL }, "/ignored"),
+    ).rejects.toMatchObject({
+      code: "mcp_client_config_invalid",
+    });
+    await expect(fxClient.list("/ignored")).rejects.toMatchObject({
+      code: "mcp_client_config_invalid",
+    });
+  });
+
   test("`copilot` resolves to the same client as `vscode`", async () => {
     const { resolveClients } = await import("../shared.ts");
     expect(resolveClients(["copilot"])).toEqual([vscodeClient]);

--- a/packages/cli-core/src/commands/mcp/clients/clients.test.ts
+++ b/packages/cli-core/src/commands/mcp/clients/clients.test.ts
@@ -96,8 +96,9 @@ const pathCases = [
   },
 ];
 
-// File-backed clients: we write the entry ourselves (no usable registration
-// CLI exists — opencode's `mcp add` is an interactive wizard, Warp has none).
+// File-backed clients: we write the entry ourselves (opencode's `mcp add` is
+// an interactive wizard, Warp has none, and fx's is skipped for version
+// coverage — see the README's fx note).
 const fileCases = [
   { name: "cursor", client: cursorClient, topKey: "mcpServers", shape: RUN_SHAPE },
   { name: "windsurf", client: windsurfClient, topKey: "mcpServers", shape: RUN_SHAPE },
@@ -113,8 +114,9 @@ const fileCases = [
     name: "fx",
     client: fxClient,
     topKey: "mcp",
-    // fx loads servers only from `~/.fx/mcp.json` and connects over Streamable
-    // HTTP directly — no stdio bridge, so the URL is embedded at install time.
+    // fx registers in the user-global `~/.fx/mcp.json` profile and connects
+    // over Streamable HTTP directly — no stdio bridge, so the URL is embedded
+    // at install time.
     shape: { type: "http", url: DEFAULT_URL },
   },
 ];
@@ -359,6 +361,82 @@ describe("client contracts (homedir redirected)", () => {
     expect(entries).toEqual([
       expect.objectContaining({ client: "fx", name: "clerk", url: DEFAULT_URL }),
     ]);
+  });
+
+  // fx accepts `mcpServers` as a profile alias for `mcp` and ignores the
+  // alias whenever `mcp` exists — so installing a fresh `mcp` next to an
+  // alias-form profile would shadow every aliased server. The client migrates
+  // alias-only profiles to canonical `mcp` instead.
+  test("fx install migrates an alias-form profile without dropping its servers", async () => {
+    const configPath = fxClient.configPath("/ignored");
+    await mkdir(join(configPath, ".."), { recursive: true });
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        mcpServers: { existing: { type: "http", url: "https://example.com/mcp" } },
+        theme: "dark",
+      }),
+    );
+    await fxClient.upsert({ name: "clerk", url: DEFAULT_URL }, "/ignored");
+    const parsed = JSON.parse(await readFile(configPath, "utf8")) as Record<string, unknown>;
+    expect(parsed.mcpServers).toBeUndefined();
+    expect(parsed.theme).toBe("dark");
+    expect(parsed.mcp).toEqual({
+      existing: { type: "http", url: "https://example.com/mcp" },
+      clerk: { type: "http", url: DEFAULT_URL },
+    });
+  });
+
+  test("fx list and remove see a clerk entry stored under the alias key", async () => {
+    const configPath = fxClient.configPath("/ignored");
+    await mkdir(join(configPath, ".."), { recursive: true });
+    await writeFile(
+      configPath,
+      JSON.stringify({ mcpServers: { clerk: { type: "http", url: DEFAULT_URL } } }),
+    );
+    const entries = await fxClient.list("/ignored");
+    expect(entries).toEqual([
+      expect.objectContaining({ client: "fx", name: "clerk", url: DEFAULT_URL }),
+    ]);
+    const result = await fxClient.remove("clerk", "/ignored");
+    expect(result.removed).toBe(true);
+  });
+
+  test("fx leaves the ignored alias alone when canonical `mcp` exists", async () => {
+    const configPath = fxClient.configPath("/ignored");
+    await mkdir(join(configPath, ".."), { recursive: true });
+    const shadowed = { mcpServers: { shadowed: { type: "http", url: "https://example.com/mcp" } } };
+    await writeFile(configPath, JSON.stringify({ mcp: {}, ...shadowed }));
+    await fxClient.upsert({ name: "clerk", url: DEFAULT_URL }, "/ignored");
+    const parsed = JSON.parse(await readFile(configPath, "utf8")) as Record<string, unknown>;
+    expect(parsed.mcpServers).toEqual(shadowed.mcpServers);
+    expect(parsed.mcp).toEqual({ clerk: { type: "http", url: DEFAULT_URL } });
+  });
+
+  // Direct-URL entries carry no bridge argv, so provenance rides on the URL:
+  // a custom-name entry pointing at the active `CLERK_MCP_URL` override must
+  // stay visible to list/doctor/uninstall while that override is set.
+  test("fx lists a custom-name entry matching the resolved URL override", async () => {
+    const configPath = fxClient.configPath("/ignored");
+    await mkdir(join(configPath, ".."), { recursive: true });
+    await writeFile(
+      configPath,
+      JSON.stringify({ mcp: { local: { type: "http", url: "http://localhost:8787/mcp" } } }),
+    );
+    const origMcpUrl = process.env.CLERK_MCP_URL;
+    process.env.CLERK_MCP_URL = "http://localhost:8787/mcp";
+    try {
+      const entries = await fxClient.list("/ignored");
+      expect(entries).toEqual([
+        expect.objectContaining({ client: "fx", name: "local", url: "http://localhost:8787/mcp" }),
+      ]);
+    } finally {
+      if (origMcpUrl === undefined) {
+        delete process.env.CLERK_MCP_URL;
+      } else {
+        process.env.CLERK_MCP_URL = origMcpUrl;
+      }
+    }
   });
 
   test("`copilot` resolves to the same client as `vscode`", async () => {

--- a/packages/cli-core/src/commands/mcp/clients/fx.ts
+++ b/packages/cli-core/src/commands/mcp/clients/fx.ts
@@ -1,15 +1,23 @@
 /**
- * Writes fx's user-global `~/.fx/mcp.json` directly — the only config surface
- * fx loads MCP servers from (repo-local MCP files are deliberately never
- * loaded). fx does ship `fx mcp add --transport http` (verified in 0.0.7),
- * but it is newer than fx's own docs, so the direct write keeps registration
- * working on fx binaries that predate it. fx speaks Streamable HTTP
- * natively, so unlike the bridge-backed clients the entry points straight at
- * the remote URL: entries live under top-level `mcp` as
- * `{ "type": "http", "url": … }`. The URL is therefore embedded at install
- * time rather than resolved by `clerk mcp run` at connect time.
+ * Writes fx's user-global `~/.fx/mcp.json` directly — the trusted profile fx
+ * reads on every start (fx 0.0.7 also loads workspace `.mcp.json` servers,
+ * but those sit behind per-workspace trust approval; the profile needs none
+ * and follows the user everywhere). fx does ship `fx mcp add --transport
+ * http` (verified in 0.0.7), but it is newer than fx's own docs, so the
+ * direct write keeps registration working on fx binaries that predate it.
+ * fx speaks Streamable HTTP natively, so unlike the bridge-backed clients
+ * the entry points straight at the remote URL: entries live under top-level
+ * `mcp` as `{ "type": "http", "url": … }`. The URL is therefore embedded at
+ * install time rather than resolved by `clerk mcp run` at connect time.
+ *
+ * fx accepts `mcpServers` as a profile alias for `mcp` (and ignores the
+ * alias whenever `mcp` exists), so writing a fresh `mcp` next to an
+ * alias-form profile would shadow every server in it. `normalizeConfig`
+ * folds an alias-only profile into canonical `mcp` before any read or
+ * write — the same migration fx itself performs on its own writes.
  */
 
+import { getMcpUrl } from "../../../lib/environment.ts";
 import { isRecord } from "../../../lib/objects.ts";
 import { makeJsonClient } from "./make-client.ts";
 import { pathExists, userPath } from "./paths.ts";
@@ -20,6 +28,27 @@ function extractFxUrl(descriptor: unknown): string | undefined {
   return typeof url === "string" ? url : undefined;
 }
 
+/**
+ * A direct-URL fx entry has no `clerk mcp run` argv to recognize, so
+ * provenance rides on the URL: an HTTP descriptor pointing at the currently
+ * resolved Clerk MCP URL is ours. This is what keeps a `--name` install
+ * against a `CLERK_MCP_URL` override (local worker dev) visible to
+ * `list`/`doctor`/uninstall while that override is active — the generic
+ * name/clerk-host checks in `list` already cover the default cases.
+ */
+function isOurFxEntry(descriptor: unknown): boolean {
+  if (!isRecord(descriptor) || (descriptor as { type?: unknown }).type !== "http") return false;
+  return extractFxUrl(descriptor) === getMcpUrl();
+}
+
+function normalizeFxConfig(config: Record<string, unknown>): Record<string, unknown> {
+  const { mcpServers, ...rest } = config;
+  // `mcp` present → fx ignores the alias entirely; leave the config alone
+  // rather than merging servers fx itself refuses to load.
+  if (isRecord(config.mcp) || !isRecord(mcpServers)) return config;
+  return { ...rest, mcp: mcpServers };
+}
+
 export const fxClient = makeJsonClient({
   id: "fx",
   displayName: "fx",
@@ -28,6 +57,8 @@ export const fxClient = makeJsonClient({
   topKey: "mcp",
   encode: (url) => ({ type: "http", url }),
   extractUrl: extractFxUrl,
+  isOurs: isOurFxEntry,
+  normalizeConfig: normalizeFxConfig,
   configPath: () => userPath(".fx", "mcp.json"),
   detect: async () => pathExists(userPath(".fx")),
 });

--- a/packages/cli-core/src/commands/mcp/clients/fx.ts
+++ b/packages/cli-core/src/commands/mcp/clients/fx.ts
@@ -1,0 +1,33 @@
+/**
+ * Writes fx's user-global `~/.fx/mcp.json` directly — the only config surface
+ * fx loads MCP servers from (repo-local MCP files are deliberately never
+ * loaded). fx does ship `fx mcp add --transport http` (verified in 0.0.7),
+ * but it is newer than fx's own docs, so the direct write keeps registration
+ * working on fx binaries that predate it. fx speaks Streamable HTTP
+ * natively, so unlike the bridge-backed clients the entry points straight at
+ * the remote URL: entries live under top-level `mcp` as
+ * `{ "type": "http", "url": … }`. The URL is therefore embedded at install
+ * time rather than resolved by `clerk mcp run` at connect time.
+ */
+
+import { isRecord } from "../../../lib/objects.ts";
+import { makeJsonClient } from "./make-client.ts";
+import { pathExists, userPath } from "./paths.ts";
+
+function extractFxUrl(descriptor: unknown): string | undefined {
+  if (!isRecord(descriptor)) return undefined;
+  const url = (descriptor as { url?: unknown }).url;
+  return typeof url === "string" ? url : undefined;
+}
+
+export const fxClient = makeJsonClient({
+  id: "fx",
+  displayName: "fx",
+  scope: "user",
+  activation: "Run `/mcp reload` inside an fx session (or restart fx); `/mcp list` verifies.",
+  topKey: "mcp",
+  encode: (url) => ({ type: "http", url }),
+  extractUrl: extractFxUrl,
+  configPath: () => userPath(".fx", "mcp.json"),
+  detect: async () => pathExists(userPath(".fx")),
+});

--- a/packages/cli-core/src/commands/mcp/clients/fx.ts
+++ b/packages/cli-core/src/commands/mcp/clients/fx.ts
@@ -38,14 +38,32 @@ function extractFxUrl(descriptor: unknown): string | undefined {
  */
 function isOurFxEntry(descriptor: unknown): boolean {
   if (!isRecord(descriptor) || (descriptor as { type?: unknown }).type !== "http") return false;
-  return extractFxUrl(descriptor) === getMcpUrl();
+  const url = extractFxUrl(descriptor);
+  if (url === undefined) return false;
+  // Install stores `resolveUrl()`'s normalized `URL.href`, but `getMcpUrl()`
+  // returns the raw env/profile value — canonicalize both sides so an
+  // uppercase-host or otherwise equivalent override still matches.
+  const canonical = canonicalUrl(url);
+  return canonical !== undefined && canonical === canonicalUrl(getMcpUrl());
+}
+
+function canonicalUrl(url: string): string | undefined {
+  try {
+    return new URL(url).href;
+  } catch {
+    return undefined;
+  }
 }
 
 function normalizeFxConfig(config: Record<string, unknown>): Record<string, unknown> {
+  // Presence decides, not shape — matching fx's own `mcp` orelse `mcpServers`
+  // precedence. A present canonical key of any shape stays put so the
+  // factory's validation sees it, and a present-but-malformed alias migrates
+  // so validation rejects it instead of installing alongside a profile fx
+  // itself refuses to load. (`mcp` present → fx ignores the alias entirely;
+  // leave it alone rather than merging servers fx won't read.)
+  if ("mcp" in config || !("mcpServers" in config)) return config;
   const { mcpServers, ...rest } = config;
-  // `mcp` present → fx ignores the alias entirely; leave the config alone
-  // rather than merging servers fx itself refuses to load.
-  if (isRecord(config.mcp) || !isRecord(mcpServers)) return config;
   return { ...rest, mcp: mcpServers };
 }
 

--- a/packages/cli-core/src/commands/mcp/clients/make-client.ts
+++ b/packages/cli-core/src/commands/mcp/clients/make-client.ts
@@ -47,10 +47,18 @@ interface FileClientSpec {
   /**
    * Recognize a `clerk mcp run` bridge descriptor in this client's dialect.
    * Only needed by clients whose encoding diverges from the standard
-   * `{ command, args }` shape (opencode's single argv array); the default is
-   * {@link isClerkRunEntry}.
+   * `{ command, args }` shape (opencode's single argv array, fx's direct-URL
+   * entries); the default is {@link isClerkRunEntry}.
    */
   isOurs?: (descriptor: unknown) => boolean;
+  /**
+   * Normalize a freshly-read config before the server map is walked. Lets a
+   * client fold a legacy or alias form into its canonical shape (fx accepts
+   * `mcpServers` as an alias for `mcp`) so reads see every entry and writes
+   * persist the canonical form. Must return a new object when it changes
+   * anything.
+   */
+  normalizeConfig?: (config: ConfigRecord) => ConfigRecord;
   configPath: (cwd: string) => string;
   /**
    * Omit for bases wrapped by `makeCliClient`, which replaces detection with
@@ -117,6 +125,7 @@ function makeFileClient(spec: FileClientSpec, codec: ConfigCodec): McpClient {
     typeof spec.topKey === "string" ? [spec.topKey] : spec.topKey;
 
   const isOurs = spec.isOurs ?? isClerkRunEntry;
+  const normalize = spec.normalizeConfig ?? ((config: ConfigRecord) => config);
 
   /** Walk the key path, validating each level is an object (or absent → `{}`). */
   function serversIn(config: ConfigRecord, configPath: string): Record<string, unknown> {
@@ -137,7 +146,7 @@ function makeFileClient(spec: FileClientSpec, codec: ConfigCodec): McpClient {
 
     async upsert(entry: McpServerEntry, cwd: string): Promise<UpsertResult> {
       const configPath = spec.configPath(cwd);
-      const config = await codec.read(configPath);
+      const config = normalize(await codec.read(configPath));
       const servers = serversIn(config, configPath);
 
       // Install always converges: whatever descriptor sits under this name
@@ -155,7 +164,7 @@ function makeFileClient(spec: FileClientSpec, codec: ConfigCodec): McpClient {
 
     async remove(name: string, cwd: string): Promise<RemoveResult> {
       const configPath = spec.configPath(cwd);
-      const config = await codec.read(configPath);
+      const config = normalize(await codec.read(configPath));
       const servers = serversIn(config, configPath);
       if (!Object.prototype.hasOwnProperty.call(servers, name)) {
         return { client: spec.id, configPath, removed: false };
@@ -176,7 +185,7 @@ function makeFileClient(spec: FileClientSpec, codec: ConfigCodec): McpClient {
       // uninstall's picker) settle per client, so one bad config warns there
       // without sinking the other clients — and `doctor` can tell "unreadable
       // config" apart from "no entries" instead of reporting a clean pass.
-      const config = await codec.read(configPath);
+      const config = normalize(await codec.read(configPath));
       const servers = serversIn(config, configPath);
       const entries: ListEntry[] = [];
       for (const [name, descriptor] of Object.entries(servers)) {

--- a/packages/cli-core/src/commands/mcp/clients/registry.ts
+++ b/packages/cli-core/src/commands/mcp/clients/registry.ts
@@ -6,6 +6,7 @@
 import { claudeClient } from "./claude.ts";
 import { codexClient } from "./codex.ts";
 import { cursorClient } from "./cursor.ts";
+import { fxClient } from "./fx.ts";
 import { geminiClient } from "./gemini.ts";
 import { hermesClient } from "./hermes.ts";
 import { openclawClient } from "./openclaw.ts";
@@ -26,6 +27,7 @@ export const CLIENTS: readonly McpClient[] = [
   openclawClient,
   warpClient,
   hermesClient,
+  fxClient,
 ];
 
 export const CLIENT_IDS: readonly ClientId[] = CLIENTS.map((c) => c.id);

--- a/packages/cli-core/src/commands/mcp/clients/types.ts
+++ b/packages/cli-core/src/commands/mcp/clients/types.ts
@@ -2,7 +2,7 @@
  * Shared types for MCP client integrations.
  *
  * Each supported MCP client (Claude Code, Cursor, GitHub Copilot, Windsurf,
- * Gemini, Codex, opencode, OpenClaw, Warp, Hermes) exposes an
+ * Gemini, Codex, opencode, OpenClaw, Warp, Hermes, fx) exposes an
  * {@link McpClient} that knows how to read, upsert, and remove the `clerk`
  * server entry in its own config file format.
  */
@@ -17,7 +17,8 @@ export type ClientId =
   | "opencode"
   | "openclaw"
   | "warp"
-  | "hermes";
+  | "hermes"
+  | "fx";
 
 /**
  * Per-client manual setup instructions for the Clerk MCP server. Attached as

--- a/packages/cli-core/src/commands/mcp/clients/user-scope.test.ts
+++ b/packages/cli-core/src/commands/mcp/clients/user-scope.test.ts
@@ -52,6 +52,7 @@ const ALL_CLIENT_IDS = [
   "openclaw",
   "warp",
   "hermes",
+  "fx",
 ];
 
 // The entry shape the bridge registers — no URL in args.
@@ -195,6 +196,7 @@ describe("install/uninstall across all clients (homedir + cwd redirected)", () =
       mkdir(join(mockHome, ".config", "opencode"), { recursive: true }),
       mkdir(join(mockHome, ".warp"), { recursive: true }),
       mkdir(join(mockHome, ".hermes"), { recursive: true }),
+      mkdir(join(mockHome, ".fx"), { recursive: true }),
     ]);
     // Hermes verifies its entry landed after add (its CLI can exit 0 without
     // saving); the mocked CLI writes nothing, so seed the config it would have

--- a/packages/cli-core/src/commands/mcp/install.ts
+++ b/packages/cli-core/src/commands/mcp/install.ts
@@ -2,7 +2,8 @@
  * `clerk mcp install` — register the Clerk remote MCP server in supported clients.
  *
  * URL resolution: `CLERK_MCP_URL` > active env profile `mcpUrl` > Clerk's hosted server.
- * The URL is resolved at bridge runtime, not embedded in the stored config entry.
+ * The URL is resolved at bridge runtime, not embedded in the stored config entry
+ * (except fx, which connects over HTTP directly and stores the resolved URL).
  * Target clients: `--client <id>` (repeatable) > `--all` > human picker > all detected (agent mode).
  * Install always converges: whatever entry exists under the name is replaced.
  * Clients with their own CLI (claude, gemini, codex, vscode, openclaw, hermes)


### PR DESCRIPTION
### Summary

Vercel asked us to support [fx](https://fx.sh), their open-source terminal coding agent, in `clerk mcp install`. fx speaks Streamable HTTP natively, so it's the one client whose entry points straight at the remote URL instead of going through the `clerk mcp run` stdio bridge.

### Changes

- New `fx` client: detected via `~/.fx/`, registered by writing `{ "type": "http", "url": … }` under top-level `mcp` in `~/.fx/mcp.json` — the user-global trusted profile (fx 0.0.7 also loads workspace `.mcp.json` servers, but those sit behind per-workspace trust; the profile needs none). Handles fx's `mcpServers` profile alias by migrating alias-only profiles to canonical `mcp`, and recognizes dev-override entries by URL so they stay visible to `list`/`doctor`/uninstall.
- Direct file write over fx's own `fx mcp add`: the command exists in fx 0.0.7 but is newer than fx's published docs, so the file write keeps registration working on older fx binaries. The README dialect note carries the reasoning.
- Registry, README table, tests, and changeset updated.

Verified against a real fx 0.0.7 install: our written entry matches what `fx mcp add --transport http` produces byte for byte, and `fx mcp list --connect` reports the Clerk server ready with both tools.

### Not planned

Preflight validation of the whole fx profile (malformed sibling descriptors, ambiguous root keys like `MCP-Servers`). No file-backed client validates the target client's per-entry schema, mirroring fx's parser in TypeScript would drift with every fx release, and fx already rejects and reports those profiles through its own diagnostics.

### References

- clerk/clerk#3268 — companion docs change (adds fx to the MCP page and its supported-client sentence)
- [fx MCP docs](https://fx.sh/docs/capabilities/mcp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



