### PR TITLE
fix(cli): list --help commands and options alphabetically

### DIFF
--- a/.changeset/cli-help-alphabetical.md
+++ b/.changeset/cli-help-alphabetical.md
@@ -1,0 +1,5 @@
+---
+"clerk": patch
+---
+
+List commands and options alphabetically in `--help` output so they are easier to scan.

--- a/README.md
+++ b/README.md
@@ -24,37 +24,37 @@ Usage: clerk [options] [command]
 Clerk CLI
 
 Options:
-  -v, --version        Output the version number
+  -h, --help           Display help for command
   --input-json <json>  Pass command options as a JSON string, @file.json, or -
                        for stdin
   --mode <mode>        Force interaction mode (human or agent). Defaults to
                        auto-detect based on TTY.
+  -v, --version        Output the version number
   --verbose            Show detailed output (enables debug messages)
-  -h, --help           Display help for command
 
 Commands:
-  init             [options]                      Initialize Clerk in your project
-  auth                                            Manage authentication
-  link             [options]                      Link this project to a Clerk application
-  unlink           [options]                      Unlink this project from its Clerk application
-  whoami           [options]                      Show the current logged-in user and linked application
-  open                                            Open Clerk resources in your browser
-  apps                                            Manage your Clerk applications
-  users            [options]                      Manage Clerk users
-  impersonate|imp  [options] [user]               Impersonate a Clerk user
-  env                                             Manage environment variables
-  config                                          Manage instance configuration
-  telemetry                                       Control CLI usage telemetry (status, disable, enable)
-  enable                                          Enable Clerk features on the linked instance
-  disable                                         Disable Clerk features on the linked instance
   api              [options] [endpoint] [filter]  Call any Clerk API endpoint (200+; `clerk api ls` to browse)
-  doctor           [options]                      Check your project's Clerk integration health
-  mcp                                             Manage the Clerk remote MCP server connection for AI editors and CLIs
+  apps                                            Manage your Clerk applications
+  auth                                            Manage authentication
   completion       [shell]                        Generate shell autocompletion script
-  update           [options]                      Update the Clerk CLI to the latest version
+  config                                          Manage instance configuration
   deploy                                          Deploy a Clerk application to production
-  webhooks                                        Stream webhook events to a local handler and verify their signatures
+  disable                                         Disable Clerk features on the linked instance
+  doctor           [options]                      Check your project's Clerk integration health
+  enable                                          Enable Clerk features on the linked instance
+  env                                             Manage environment variables
   help             [command]                      Display help for command
+  impersonate|imp  [options] [user]               Impersonate a Clerk user
+  init             [options]                      Initialize Clerk in your project
+  link             [options]                      Link this project to a Clerk application
+  mcp                                             Manage the Clerk remote MCP server connection for AI editors and CLIs
+  open                                            Open Clerk resources in your browser
+  telemetry                                       Control CLI usage telemetry (status, disable, enable)
+  unlink           [options]                      Unlink this project from its Clerk application
+  update           [options]                      Update the Clerk CLI to the latest version
+  users            [options]                      Manage Clerk users
+  webhooks                                        Stream webhook events to a local handler and verify their signatures
+  whoami           [options]                      Show the current logged-in user and linked application
   bird                                            Play Clerk Bird, a Flappy Bird game in your terminal
 ```
 

--- a/packages/cli-core/src/cli-program.test.ts
+++ b/packages/cli-core/src/cli-program.test.ts
@@ -146,6 +146,35 @@ test("users parent command exposes targeting flags inherited by subcommands", ()
   expect(optionNames).toEqual(expect.arrayContaining(["--secret-key", "--app", "--instance"]));
 });
 
+describe("help output ordering", () => {
+  type AnyCommand = ReturnType<typeof createProgram>["commands"][number];
+
+  function collectCommands(cmd: AnyCommand, path: string): { path: string; cmd: AnyCommand }[] {
+    return [
+      { path, cmd },
+      ...cmd.commands.flatMap((sub) => collectCommands(sub, `${path} ${sub.name()}`)),
+    ];
+  }
+
+  const allCommands = collectCommands(createProgram() as AnyCommand, "clerk");
+
+  // Commander's option sort key: short flag if present, else long flag.
+  const optionSortKey = (option: { short?: string; long?: string }): string =>
+    option.short ? option.short.replace(/^-/, "") : (option.long ?? "").replace(/^--/, "");
+
+  test.each(allCommands)("$path lists subcommands alphabetically in help", ({ cmd }) => {
+    const helper = cmd.createHelp();
+    const names = helper.visibleCommands(cmd).map((sub) => sub.name());
+    expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)));
+  });
+
+  test.each(allCommands)("$path lists options alphabetically in help", ({ cmd }) => {
+    const helper = cmd.createHelp();
+    const keys = helper.visibleOptions(cmd).map(optionSortKey);
+    expect(keys).toEqual([...keys].sort((a, b) => a.localeCompare(b)));
+  });
+});
+
 test("users create documents -d and --file for raw BAPI request bodies", () => {
   const program = createProgram();
   const users = program.commands.find((command) => command.name() === "users")!;

--- a/packages/cli-core/src/lib/help.ts
+++ b/packages/cli-core/src/lib/help.ts
@@ -40,14 +40,17 @@ Command.prototype.setExamples = function (examples: Example[]) {
 };
 
 /**
- * Custom help formatter with three improvements over Commander defaults:
+ * Custom help formatter with four improvements over Commander defaults:
  *
- * 1. Commands display in three aligned columns: name | args | description
- * 2. Each section (Arguments, Options, Commands) computes its own column width
- * 3. Examples are a first-class section with auto `$ ` prefix and aligned columns
+ * 1. Commands and options list alphabetically so users can scan for a name
+ * 2. Commands display in three aligned columns: name | args | description
+ * 3. Each section (Arguments, Options, Commands) computes its own column width
+ * 4. Examples are a first-class section with auto `$ ` prefix and aligned columns
  */
 export function clerkHelpConfig(): Partial<Help> {
   return {
+    sortSubcommands: true,
+    sortOptions: true,
     formatHelp(cmd, helper) {
       const helpWidth = helper.helpWidth ?? 80;
 

--- a/packages/cli-core/src/readme.test.ts
+++ b/packages/cli-core/src/readme.test.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "bun:test";
+import { join } from "node:path";
+import { createProgram } from "./cli-program.ts";
+
+const README_PATH = join(import.meta.dir, "../../../README.md");
+
+const ANSI_ESCAPE_PATTERN = new RegExp(String.raw`\x1b\[[0-9;]*m`, "g");
+const stripAnsi = (value: string): string => value.replace(ANSI_ESCAPE_PATTERN, "");
+
+/** The fenced code block under `## Usage` that mirrors `clerk --help`. */
+function readmeUsageBlock(readme: string): string {
+  const match = readme.match(/## Usage\n+```\n(Usage: clerk[\s\S]*?)```/);
+  if (!match) throw new Error(`No usage block found in ${README_PATH}`);
+  return match[1]!.trim();
+}
+
+test("README usage block matches `clerk --help` output", async () => {
+  const readme = await Bun.file(README_PATH).text();
+  const program = createProgram();
+  // The committed block is rendered at the 80-column non-TTY fallback width;
+  // pin it so the test doesn't depend on the local terminal size.
+  program.configureOutput({ getOutHelpWidth: () => 80 });
+  const help = stripAnsi(program.helpInformation()).trim();
+
+  expect(readmeUsageBlock(readme)).toBe(help);
+});


### PR DESCRIPTION
## Summary

Help output rendered in registration order, so finding a command meant scanning the whole list. Alphabetical listing lets users scan straight to the name they're after — same convention as Vercel's CLI.

## Changes

- Enable Commander's `sortSubcommands` and `sortOptions` in `clerkHelpConfig()`. Every subcommand inherits the root help config, so two lines cover the whole tree. The `bird` easter egg still renders last, and parse behavior is untouched.
- Add ordering tests that walk every command in the real program and assert its help lists subcommands and options alphabetically, using the same sort keys the renderer consumes. 46 commands failed before the fix.
- Sync the README usage block with live `--help` output and add a test that keeps them byte-for-byte identical, so the hand-pasted block can't drift again.

## Not Planned

- Shell completion ordering — shells sort candidates themselves.
- Sorting strictly by long-flag name. Commander sorts by short flag when one exists (`-v, --version` under "v"), which matches how the flags read in the help column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
