### PR TITLE
feat(auth): headless `auth login --ticket` with a Dashboard sign-in ticket

### DIFF
--- a/.changeset/auth-login-ticket.md
+++ b/.changeset/auth-login-ticket.md
@@ -1,0 +1,5 @@
+---
+"clerk": minor
+---
+
+Add `clerk auth login --ticket` for headless sign-in with a single-use Dashboard sign-in ticket read from stdin. The transient sign-in session is revoked on every exit path, and expired, already-used, invalid, and MFA-required tickets fail with distinct error codes instead of retrying.

--- a/packages/cli-core/src/commands/auth/index.ts
+++ b/packages/cli-core/src/commands/auth/index.ts
@@ -16,11 +16,19 @@ export function registerAuth(program: Program): void {
     .aliases(["signup", "signin", "sign-in"])
     .description("Log in to your Clerk account")
     .option("-y, --yes", "Proceed with OAuth without prompting when already logged in")
+    .option(
+      "--ticket",
+      "Log in headlessly with a single-use Dashboard sign-in ticket read from stdin (never as an argument)",
+    )
     .setExamples([
       { command: "clerk auth login", description: "Log in via browser (OAuth)" },
       {
         command: "clerk auth login -y",
         description: "Re-authenticate via OAuth without confirmation when already signed in",
+      },
+      {
+        command: "clerk auth login --ticket < ticket.txt",
+        description: "Log in without a browser using a sign-in ticket piped on stdin",
       },
     ])
     .action(async (opts) => {
@@ -38,6 +46,10 @@ export function registerAuth(program: Program): void {
     .command("login", { hidden: true })
     .description("Log in to your Clerk account")
     .option("-y, --yes", "Proceed with OAuth without prompting when already logged in")
+    .option(
+      "--ticket",
+      "Log in headlessly with a single-use Dashboard sign-in ticket read from stdin",
+    )
     .action(async (opts) => {
       await login(opts);
     });

--- a/packages/cli-core/src/commands/auth/login.ts
+++ b/packages/cli-core/src/commands/auth/login.ts
@@ -18,7 +18,7 @@ import { getAuth, setAuth, resolveProfile } from "../../lib/config.ts";
 import { AUTH_TIMEOUT_MS, CALLBACK_PATH, CLERK_CLIENT_CLI } from "../../lib/constants.ts";
 import { confirm } from "../../lib/prompts.ts";
 import { isHuman } from "../../mode.ts";
-import { errorMessage, throwUserAbort } from "../../lib/errors.ts";
+import { errorMessage, throwUsageError, throwUserAbort } from "../../lib/errors.ts";
 import { intro, outro, bar, withSpinner } from "../../lib/spinner.ts";
 import { NEXT_STEPS } from "../../lib/next-steps.ts";
 import { attemptAutoclaim, type AutoclaimResult } from "../../lib/autoclaim.ts";
@@ -27,10 +27,12 @@ import { cyan, dim } from "../../lib/color.ts";
 import { log } from "../../lib/log.ts";
 import { currentTelemetryStage, setTelemetryStage } from "../../lib/telemetry.ts";
 import { ensureFirstApplication } from "../../lib/first-application.ts";
+import { loginWithTicket } from "../../lib/ticket-auth.ts";
 
 interface LoginOptions {
   showNextSteps?: boolean;
   yes?: boolean;
+  ticket?: boolean;
 }
 
 async function getExistingSession(): Promise<UserInfo | null> {
@@ -133,6 +135,49 @@ async function performOAuthFlow(): Promise<OAuthFlowResult> {
   return { userInfo, previousSession };
 }
 
+async function performTicketFlow(yes?: boolean): Promise<OAuthFlowResult> {
+  if (process.stdin.isTTY) {
+    throwUsageError(
+      "--ticket reads the sign-in ticket from stdin. Pipe it in (for example with a heredoc); it is never accepted as an argument.",
+    );
+  }
+  const ticket = (await Bun.stdin.text()).trim();
+  if (!ticket) throwUsageError("No sign-in ticket received on stdin.");
+
+  setTelemetryStage("token_exchange");
+  const tokenResponse = await withSpinner("Redeeming sign-in ticket...", async () =>
+    loginWithTicket(ticket),
+  );
+  const userInfo = await fetchUserInfo(tokenResponse.access_token);
+
+  log.info(`Signing in as ${userInfo.email}`);
+  if (isHuman() && !yes) {
+    const proceed = await confirm({
+      message: `Save CLI credentials for ${userInfo.email}?`,
+      default: true,
+    });
+    if (!proceed) {
+      await outro();
+      throwUserAbort();
+    }
+  }
+
+  // Same snapshot point as the browser flow: read the outgoing session right
+  // before it is overwritten so it can be revoked afterwards.
+  let previousSession: OAuthSession | null = null;
+  try {
+    previousSession = await getStoredSession();
+  } catch (error) {
+    log.debug(`credentials: could not read outgoing session — ${errorMessage(error)}`);
+  }
+
+  setTelemetryStage("store");
+  await storeToken(createOAuthSession(tokenResponse));
+  await setAuth({ userId: userInfo.userId });
+
+  return { userInfo, previousSession };
+}
+
 export async function login(options: LoginOptions = {}): Promise<UserInfo> {
   // `init` and `link` call this mid-flow and share the one process-global
   // telemetry stage. Login's own markers are worth having while it runs, but
@@ -146,7 +191,7 @@ export async function login(options: LoginOptions = {}): Promise<UserInfo> {
 }
 
 async function runLogin(options: LoginOptions = {}): Promise<UserInfo> {
-  const { showNextSteps = true, yes } = options;
+  const { showNextSteps = true, yes, ticket } = options;
   intro("Signing in");
   setTelemetryStage("session_check");
   const existingSession = await withSpinner("Checking session...", async () =>
@@ -181,7 +226,9 @@ async function runLogin(options: LoginOptions = {}): Promise<UserInfo> {
   // errors are all swallowed, so a transient failure there would silently
   // orphan a live grant instead of revoking it. The store is the authority on
   // whether there is anything to revoke.
-  const { userInfo, previousSession } = await performOAuthFlow();
+  const { userInfo, previousSession } = ticket
+    ? await performTicketFlow(yes)
+    : await performOAuthFlow();
 
   // Revoked only after the replacement is safely stored: doing it up front
   // would leave the user with no session at all if the flow were abandoned.

--- a/packages/cli-core/src/lib/environment.ts
+++ b/packages/cli-core/src/lib/environment.ts
@@ -128,6 +128,7 @@ export function getOAuthConfig() {
   const env = getCurrentEnv();
   const baseUrl = process.env.CLERK_OAUTH_BASE_URL ?? env.oauthBaseUrl;
   return {
+    baseUrl,
     clientId: process.env.CLERK_OAUTH_CLIENT_ID ?? env.oauthClientId,
     // Unless scopes are explicitly set, use the default scopes
     scopes: process.env.CLERK_OAUTH_SCOPES ?? "",

--- a/packages/cli-core/src/lib/errors.ts
+++ b/packages/cli-core/src/lib/errors.ts
@@ -68,6 +68,14 @@ export const ERROR_CODE = {
   ACTOR_TOKEN_ALREADY_ACCEPTED: "actor_token_already_accepted",
   /** No active impersonation session matched the operator's actor stamp. */
   IMPERSONATION_SESSION_NOT_FOUND: "impersonation_session_not_found",
+  /** Sign-in ticket passed to `auth login --ticket` has expired; do not retry it. */
+  TICKET_EXPIRED: "ticket_expired",
+  /** Sign-in ticket was already redeemed; each ticket works once. Do not retry it. */
+  TICKET_ALREADY_USED: "ticket_already_used",
+  /** Sign-in ticket is invalid, revoked, or otherwise unusable. */
+  TICKET_INVALID: "ticket_invalid",
+  /** Account requires a second factor, which a sign-in ticket cannot satisfy. */
+  MFA_REQUIRED: "mfa_required",
   /** No MCP client detected on the system. */
   MCP_NO_CLIENT_DETECTED: "mcp_no_client_detected",
   /** Requested MCP client is not in the supported registry. */

--- a/packages/cli-core/src/lib/ticket-auth.test.ts
+++ b/packages/cli-core/src/lib/ticket-auth.test.ts
@@ -1,0 +1,188 @@
+import { test, expect, describe, beforeEach, mock } from "bun:test";
+import { CliError, ERROR_CODE, FapiError } from "./errors.ts";
+
+const mockLoggedFetch = mock<(url: URL, init: RequestInit) => Promise<Response>>();
+const mockExchangeCodeForToken = mock();
+
+mock.module("./fetch.ts", () => ({
+  loggedFetch: (url: URL, init: RequestInit) => mockLoggedFetch(url, init),
+}));
+mock.module("./token-exchange.ts", () => ({
+  exchangeCodeForToken: (...args: unknown[]) => mockExchangeCodeForToken(...args),
+}));
+mock.module("./environment.ts", () => ({
+  getOAuthConfig: () => ({
+    baseUrl: "https://clerk.example.com",
+    clientId: "test-client-id",
+    scopes: "",
+    authorizeUrl: "https://clerk.example.com/oauth/authorize",
+    tokenUrl: "https://clerk.example.com/oauth/token",
+    userinfoUrl: "https://clerk.example.com/oauth/userinfo",
+  }),
+}));
+mock.module("./pkce.ts", () => ({
+  generateCodeVerifier: () => "test-code-verifier",
+  generateCodeChallenge: () => "test-code-challenge",
+  generateState: () => "test-state",
+}));
+
+const { loginWithTicket } = await import("./ticket-auth.ts");
+
+const TOKEN_RESPONSE = {
+  access_token: "access",
+  refresh_token: "refresh",
+  expires_in: 3600,
+  token_type: "bearer",
+};
+
+function json(status: number, body: unknown, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+function redeemOk(): Response {
+  return json(
+    200,
+    { response: { status: "complete", created_session_id: "sess_1" } },
+    { authorization: "client-jwt" },
+  );
+}
+
+function consentRedirect(query: string): Response {
+  return new Response(null, {
+    status: 302,
+    headers: { location: `http://127.0.0.1:1/callback?${query}` },
+  });
+}
+
+/** Queue responses by path so the order of FAPI calls can be asserted. */
+function route(handlers: Record<string, () => Response>) {
+  mockLoggedFetch.mockImplementation(async (url) => {
+    const handler = handlers[url.pathname];
+    if (!handler) throw new Error(`unexpected fetch ${url.pathname}`);
+    return handler();
+  });
+}
+
+const calls = () => mockLoggedFetch.mock.calls.map(([url, init]) => ({ url, init }));
+const removeCall = () =>
+  calls().find((c) => c.url.pathname === "/v1/client/sessions/sess_1/remove");
+
+describe("loginWithTicket", () => {
+  beforeEach(() => {
+    mockLoggedFetch.mockReset();
+    mockExchangeCodeForToken.mockReset();
+    mockExchangeCodeForToken.mockResolvedValue(TOKEN_RESPONSE);
+  });
+
+  test("redeems, authorizes through consent with the session id, exchanges, and revokes", async () => {
+    route({
+      "/v1/client/sign_ins": redeemOk,
+      "/v1/me/oauth/consent/test-client-id": () =>
+        consentRedirect("code=auth-code&state=test-state"),
+      "/v1/client/sessions/sess_1/remove": () => json(200, {}),
+    });
+
+    const result = await loginWithTicket("ticket-jwt");
+
+    expect(result).toEqual(TOKEN_RESPONSE);
+    const [redeem, consent, remove] = calls();
+    expect(redeem!.url.searchParams.get("_is_native")).toBe("1");
+    expect(String(redeem!.init.body)).toBe("strategy=ticket&ticket=ticket-jwt");
+    expect(new Headers(consent!.init.headers).get("authorization")).toBe("client-jwt");
+    expect(new Headers(consent!.init.headers).get("clerk-session-id")).toBe("sess_1");
+    expect(consent!.init.redirect).toBe("manual");
+    const consentBody = new URLSearchParams(String(consent!.init.body));
+    expect(consentBody.get("consented")).toBe("true");
+    expect(consentBody.get("code_challenge")).toBe("test-code-challenge");
+    expect(consentBody.get("redirect_uri")).toBe("http://127.0.0.1:1/callback");
+    expect(new Headers(remove!.init.headers).get("authorization")).toBe("client-jwt");
+    expect(mockExchangeCodeForToken).toHaveBeenCalledWith({
+      code: "auth-code",
+      codeVerifier: "test-code-verifier",
+      redirectUri: "http://127.0.0.1:1/callback",
+    });
+  });
+
+  test.each([
+    ["ticket_expired_code", ERROR_CODE.TICKET_EXPIRED],
+    ["sign_in_token_already_used_code", ERROR_CODE.TICKET_ALREADY_USED],
+    ["sign_in_token_revoked_code", ERROR_CODE.TICKET_INVALID],
+    ["ticket_invalid_code", ERROR_CODE.TICKET_INVALID],
+  ])("maps FAPI %s to a non-retryable %s error", async (fapiCode, cliCode) => {
+    route({ "/v1/client/sign_ins": () => json(400, { errors: [{ code: fapiCode }] }) });
+
+    const error = await loginWithTicket("ticket-jwt").catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(CliError);
+    expect((error as CliError).code).toBe(cliCode);
+    expect(mockExchangeCodeForToken).not.toHaveBeenCalled();
+    expect(calls()).toHaveLength(1);
+  });
+
+  test("refuses to complete an MFA-protected sign-in", async () => {
+    route({
+      "/v1/client/sign_ins": () => json(200, { response: { status: "needs_second_factor" } }),
+    });
+
+    const error = await loginWithTicket("ticket-jwt").catch((e: unknown) => e);
+
+    expect((error as CliError).code).toBe(ERROR_CODE.MFA_REQUIRED);
+    expect((error as CliError).message).toContain("clerk auth login");
+  });
+
+  test("fails when FAPI returns no client token (Native API disabled)", async () => {
+    route({
+      "/v1/client/sign_ins": () =>
+        json(200, { response: { status: "complete", created_session_id: "sess_1" } }),
+    });
+
+    const error = await loginWithTicket("ticket-jwt").catch((e: unknown) => e);
+
+    expect((error as CliError).code).toBe(ERROR_CODE.FAPI_ERROR);
+    expect((error as CliError).message).toContain("Native API");
+  });
+
+  test("revokes the transient session when authorization fails", async () => {
+    route({
+      "/v1/client/sign_ins": redeemOk,
+      "/v1/me/oauth/consent/test-client-id": () =>
+        json(401, { errors: [{ code: "authentication_invalid" }] }),
+      "/v1/client/sessions/sess_1/remove": () => json(200, {}),
+    });
+
+    const error = await loginWithTicket("ticket-jwt").catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(FapiError);
+    expect(removeCall()).toBeDefined();
+    expect(mockExchangeCodeForToken).not.toHaveBeenCalled();
+  });
+
+  test("revokes the transient session on a state mismatch", async () => {
+    route({
+      "/v1/client/sign_ins": redeemOk,
+      "/v1/me/oauth/consent/test-client-id": () => consentRedirect("code=auth-code&state=wrong"),
+      "/v1/client/sessions/sess_1/remove": () => json(200, {}),
+    });
+
+    const error = await loginWithTicket("ticket-jwt").catch((e: unknown) => e);
+
+    expect((error as Error).message).toContain("Invalid state");
+    expect(removeCall()).toBeDefined();
+  });
+
+  test("revokes the transient session when the token exchange fails", async () => {
+    mockExchangeCodeForToken.mockRejectedValue(new Error("exchange down"));
+    route({
+      "/v1/client/sign_ins": redeemOk,
+      "/v1/me/oauth/consent/test-client-id": () =>
+        consentRedirect("code=auth-code&state=test-state"),
+      "/v1/client/sessions/sess_1/remove": () => json(200, {}),
+    });
+
+    await expect(loginWithTicket("ticket-jwt")).rejects.toThrow("exchange down");
+    expect(removeCall()).toBeDefined();
+  });
+});

--- a/packages/cli-core/src/lib/ticket-auth.test.ts
+++ b/packages/cli-core/src/lib/ticket-auth.test.ts
@@ -11,6 +11,7 @@ mock.module("./token-exchange.ts", () => ({
   exchangeCodeForToken: (...args: unknown[]) => mockExchangeCodeForToken(...args),
 }));
 mock.module("./environment.ts", () => ({
+  getDashboardUrl: () => "https://dashboard.example.com/",
   getOAuthConfig: () => ({
     baseUrl: "https://clerk.example.com",
     clientId: "test-client-id",
@@ -46,7 +47,7 @@ function redeemOk(): Response {
   return json(
     200,
     { response: { status: "complete", created_session_id: "sess_1" } },
-    { authorization: "client-jwt" },
+    { "set-cookie": "__client=client-jwt; Path=/; HttpOnly; Secure; SameSite=Lax" },
   );
 }
 
@@ -89,16 +90,18 @@ describe("loginWithTicket", () => {
 
     expect(result).toEqual(TOKEN_RESPONSE);
     const [redeem, consent, remove] = calls();
-    expect(redeem!.url.searchParams.get("_is_native")).toBe("1");
+    expect(redeem!.url.searchParams.has("_is_native")).toBe(false);
+    expect(new Headers(redeem!.init.headers).get("origin")).toBe("https://dashboard.example.com");
     expect(String(redeem!.init.body)).toBe("strategy=ticket&ticket=ticket-jwt");
-    expect(new Headers(consent!.init.headers).get("authorization")).toBe("client-jwt");
+    expect(new Headers(consent!.init.headers).get("cookie")).toBe("__client=client-jwt");
+    expect(new Headers(consent!.init.headers).get("origin")).toBe("https://dashboard.example.com");
     expect(new Headers(consent!.init.headers).get("clerk-session-id")).toBe("sess_1");
     expect(consent!.init.redirect).toBe("manual");
     const consentBody = new URLSearchParams(String(consent!.init.body));
     expect(consentBody.get("consented")).toBe("true");
     expect(consentBody.get("code_challenge")).toBe("test-code-challenge");
     expect(consentBody.get("redirect_uri")).toBe("http://127.0.0.1:1/callback");
-    expect(new Headers(remove!.init.headers).get("authorization")).toBe("client-jwt");
+    expect(new Headers(remove!.init.headers).get("cookie")).toBe("__client=client-jwt");
     expect(mockExchangeCodeForToken).toHaveBeenCalledWith({
       code: "auth-code",
       codeVerifier: "test-code-verifier",
@@ -133,7 +136,7 @@ describe("loginWithTicket", () => {
     expect((error as CliError).message).toContain("clerk auth login");
   });
 
-  test("fails when FAPI returns no client token (Native API disabled)", async () => {
+  test("fails when FAPI returns no client cookie", async () => {
     route({
       "/v1/client/sign_ins": () =>
         json(200, { response: { status: "complete", created_session_id: "sess_1" } }),
@@ -142,7 +145,7 @@ describe("loginWithTicket", () => {
     const error = await loginWithTicket("ticket-jwt").catch((e: unknown) => e);
 
     expect((error as CliError).code).toBe(ERROR_CODE.FAPI_ERROR);
-    expect((error as CliError).message).toContain("Native API");
+    expect((error as CliError).message).toContain("client cookie");
   });
 
   test("revokes the transient session when authorization fails", async () => {

--- a/packages/cli-core/src/lib/ticket-auth.ts
+++ b/packages/cli-core/src/lib/ticket-auth.ts
@@ -7,13 +7,13 @@
  * holding exactly the credential the browser flow yields: the role-scoped
  * OAuth access token. The FAPI session exists only inside `loginWithTicket`.
  *
- * Requires Native API on the dashboard instance: a headless client has no
- * cookies, so FAPI hands the client credential back in the `Authorization`
- * response header only for native clients (`_is_native=1`).
+ * FAPI classifies a request as a browser when it carries an `Origin` header
+ * and then identifies the client with the `__client` cookie, so this keeps a
+ * cookie jar and sends the dashboard origin. No native-client mode is needed.
  */
 
 import { CALLBACK_PATH } from "./constants.ts";
-import { getOAuthConfig } from "./environment.ts";
+import { getDashboardUrl, getOAuthConfig } from "./environment.ts";
 import { CliError, ERROR_CODE, FapiError } from "./errors.ts";
 import { loggedFetch } from "./fetch.ts";
 import { log } from "./log.ts";
@@ -57,14 +57,43 @@ const TICKET_ERROR_MESSAGES: Record<
 };
 
 interface TicketSession {
-  clientJwt: string;
+  jar: CookieJar;
   sessionId: string;
 }
 
+/** Minimal cookie jar: FAPI's `__client` cookie is the client credential. */
+class CookieJar {
+  private cookies = new Map<string, string>();
+
+  absorb(response: Response): void {
+    const lines =
+      typeof response.headers.getSetCookie === "function"
+        ? response.headers.getSetCookie()
+        : [response.headers.get("set-cookie")].filter((v): v is string => !!v);
+    for (const line of lines) {
+      const pair = line.split(";")[0] ?? "";
+      const eq = pair.indexOf("=");
+      if (eq > 0) this.cookies.set(pair.slice(0, eq).trim(), pair.slice(eq + 1).trim());
+    }
+  }
+
+  has(name: string): boolean {
+    return this.cookies.has(name);
+  }
+
+  header(): string {
+    return [...this.cookies].map(([k, v]) => `${k}=${v}`).join("; ");
+  }
+}
+
 function fapiUrl(path: string): URL {
-  const url = new URL(path, getOAuthConfig().baseUrl);
-  url.searchParams.set("_is_native", "1");
-  return url;
+  return new URL(path, getOAuthConfig().baseUrl);
+}
+
+function browserHeaders(jar?: CookieJar): Record<string, string> {
+  const headers: Record<string, string> = { Origin: new URL(getDashboardUrl()).origin };
+  if (jar) headers.Cookie = jar.header();
+  return headers;
 }
 
 async function throwTicketError(response: Response): Promise<never> {
@@ -81,13 +110,15 @@ async function throwTicketError(response: Response): Promise<never> {
 }
 
 async function redeemTicket(ticket: string): Promise<TicketSession> {
+  const jar = new CookieJar();
   const response = await loggedFetch(fapiUrl("/v1/client/sign_ins"), {
     tag: "fapi",
     method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    headers: { ...browserHeaders(), "Content-Type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams({ strategy: "ticket", ticket }).toString(),
   });
   if (!response.ok) await throwTicketError(response);
+  jar.absorb(response);
 
   const body = (await response.json()) as {
     response?: { status?: string; created_session_id?: string };
@@ -108,14 +139,15 @@ async function redeemTicket(ticket: string): Promise<TicketSession> {
     );
   }
 
-  const clientJwt = response.headers.get("authorization");
-  if (!clientJwt) {
+  if (!jar.has("__client")) {
     throw new CliError(
-      "Frontend API did not return a client token; Native API must be enabled on the dashboard instance for headless login.",
-      { code: ERROR_CODE.FAPI_ERROR },
+      "Frontend API did not return a client cookie; cannot continue the sign-in.",
+      {
+        code: ERROR_CODE.FAPI_ERROR,
+      },
     );
   }
-  return { clientJwt, sessionId: body.response.created_session_id };
+  return { jar, sessionId: body.response.created_session_id };
 }
 
 async function authorizeWithSession(
@@ -141,8 +173,8 @@ async function authorizeWithSession(
       tag: "fapi",
       method: "POST",
       headers: {
+        ...browserHeaders(session.jar),
         "Content-Type": "application/x-www-form-urlencoded",
-        Authorization: session.clientJwt,
         "Clerk-Session-Id": session.sessionId,
       },
       body: params.toString(),
@@ -175,7 +207,7 @@ async function revokeSession(session: TicketSession): Promise<void> {
     const response = await loggedFetch(fapiUrl(`/v1/client/sessions/${session.sessionId}/remove`), {
       tag: "fapi",
       method: "POST",
-      headers: { Authorization: session.clientJwt },
+      headers: browserHeaders(session.jar),
     });
     if (!response.ok)
       log.warn(`Could not revoke the transient sign-in session (${response.status}).`);

--- a/packages/cli-core/src/lib/ticket-auth.ts
+++ b/packages/cli-core/src/lib/ticket-auth.ts
@@ -1,0 +1,214 @@
+/**
+ * Headless login with a single-use Dashboard sign-in ticket.
+ *
+ * Sequence: redeem the ticket for a transient FAPI session -> drive the OAuth
+ * authorize step through the consent endpoint (consent granted in the request)
+ * -> exchange the code (PKCE) -> revoke the transient session. The CLI ends up
+ * holding exactly the credential the browser flow yields: the role-scoped
+ * OAuth access token. The FAPI session exists only inside `loginWithTicket`.
+ *
+ * Requires Native API on the dashboard instance: a headless client has no
+ * cookies, so FAPI hands the client credential back in the `Authorization`
+ * response header only for native clients (`_is_native=1`).
+ */
+
+import { CALLBACK_PATH } from "./constants.ts";
+import { getOAuthConfig } from "./environment.ts";
+import { CliError, ERROR_CODE, FapiError } from "./errors.ts";
+import { loggedFetch } from "./fetch.ts";
+import { log } from "./log.ts";
+import { generateCodeChallenge, generateCodeVerifier, generateState } from "./pkce.ts";
+import { CLI_SIGINT_HANDLER } from "./signals.ts";
+import { exchangeCodeForToken, type TokenResponse } from "./token-exchange.ts";
+
+/**
+ * Loopback redirect for the headless authorize call. FAPI accepts any port on
+ * 127.0.0.1 (RFC 8252 §7.3) and the redirect is read from the response, never followed.
+ */
+const TICKET_REDIRECT_URI = `http://127.0.0.1:1${CALLBACK_PATH}`;
+
+/** FAPI error codes that mean "do not retry this ticket". */
+const TICKET_ERROR_MESSAGES: Record<
+  string,
+  { code: (typeof ERROR_CODE)[keyof typeof ERROR_CODE]; message: string }
+> = {
+  ticket_expired_code: {
+    code: ERROR_CODE.TICKET_EXPIRED,
+    message:
+      "Sign-in ticket has expired. Copy a fresh prompt from the Clerk Dashboard, or run `clerk auth login` to sign in via the browser.",
+  },
+  sign_in_token_already_used_code: {
+    code: ERROR_CODE.TICKET_ALREADY_USED,
+    message:
+      "Sign-in ticket was already used; each ticket works exactly once. Copy a fresh prompt from the Clerk Dashboard, or run `clerk auth login` to sign in via the browser.",
+  },
+  sign_in_token_revoked_code: {
+    code: ERROR_CODE.TICKET_INVALID,
+    message: "Sign-in ticket was revoked. Run `clerk auth login` to sign in via the browser.",
+  },
+  sign_in_token_cannot_be_used_code: {
+    code: ERROR_CODE.TICKET_INVALID,
+    message: "Sign-in ticket cannot be used. Run `clerk auth login` to sign in via the browser.",
+  },
+  ticket_invalid_code: {
+    code: ERROR_CODE.TICKET_INVALID,
+    message: "Sign-in ticket is invalid. Run `clerk auth login` to sign in via the browser.",
+  },
+};
+
+interface TicketSession {
+  clientJwt: string;
+  sessionId: string;
+}
+
+function fapiUrl(path: string): URL {
+  const url = new URL(path, getOAuthConfig().baseUrl);
+  url.searchParams.set("_is_native", "1");
+  return url;
+}
+
+async function throwTicketError(response: Response): Promise<never> {
+  const body = await response.text();
+  let code: string | undefined;
+  try {
+    code = (JSON.parse(body) as { errors?: { code?: string }[] }).errors?.[0]?.code;
+  } catch {
+    // non-JSON body; fall through to the generic FAPI error
+  }
+  const known = code ? TICKET_ERROR_MESSAGES[code] : undefined;
+  if (known) throw new CliError(known.message, { code: known.code });
+  throw FapiError.fromBody(response.status, body, response.url || undefined);
+}
+
+async function redeemTicket(ticket: string): Promise<TicketSession> {
+  const response = await loggedFetch(fapiUrl("/v1/client/sign_ins"), {
+    tag: "fapi",
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ strategy: "ticket", ticket }).toString(),
+  });
+  if (!response.ok) await throwTicketError(response);
+
+  const body = (await response.json()) as {
+    response?: { status?: string; created_session_id?: string };
+  };
+  const status = body.response?.status;
+  if (status === "needs_second_factor") {
+    throw new CliError(
+      "This account requires a second factor, which a sign-in ticket cannot satisfy. Run `clerk auth login` to sign in via the browser.",
+      { code: ERROR_CODE.MFA_REQUIRED },
+    );
+  }
+  if (status !== "complete" || !body.response?.created_session_id) {
+    throw new CliError(
+      `Sign-in did not complete (status: ${status ?? "unknown"}). Run \`clerk auth login\` to sign in via the browser.`,
+      {
+        code: ERROR_CODE.TICKET_INVALID,
+      },
+    );
+  }
+
+  const clientJwt = response.headers.get("authorization");
+  if (!clientJwt) {
+    throw new CliError(
+      "Frontend API did not return a client token; Native API must be enabled on the dashboard instance for headless login.",
+      { code: ERROR_CODE.FAPI_ERROR },
+    );
+  }
+  return { clientJwt, sessionId: body.response.created_session_id };
+}
+
+async function authorizeWithSession(
+  session: TicketSession,
+  pkce: { codeChallenge: string; state: string },
+): Promise<string> {
+  const oauth = getOAuthConfig();
+  const params = new URLSearchParams({
+    consented: "true",
+    response_type: "code",
+    client_id: oauth.clientId,
+    redirect_uri: TICKET_REDIRECT_URI,
+    scope: oauth.scopes,
+    state: pkce.state,
+    code_challenge: pkce.codeChallenge,
+    code_challenge_method: "S256",
+  });
+  // The consent endpoint doubles as the authorize call when consent is
+  // granted in the request; consent stays enabled on the OAuth app.
+  const response = await loggedFetch(
+    fapiUrl(`/v1/me/oauth/consent/${encodeURIComponent(oauth.clientId)}`),
+    {
+      tag: "fapi",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Authorization: session.clientJwt,
+        "Clerk-Session-Id": session.sessionId,
+      },
+      body: params.toString(),
+      redirect: "manual",
+    },
+  );
+
+  const location = response.headers.get("location");
+  if (!location) await throwTicketError(response);
+  const redirect = new URL(location!);
+  const error = redirect.searchParams.get("error");
+  if (error) {
+    throw new CliError(
+      `Authorization failed: ${error} ${redirect.searchParams.get("error_description") ?? ""}`.trim(),
+      {
+        code: ERROR_CODE.FAPI_ERROR,
+      },
+    );
+  }
+  if (redirect.searchParams.get("state") !== pkce.state) {
+    throw new Error("Invalid state parameter. Possible CSRF attack.");
+  }
+  const code = redirect.searchParams.get("code");
+  if (!code) throw new Error("No authorization code received.");
+  return code;
+}
+
+async function revokeSession(session: TicketSession): Promise<void> {
+  try {
+    const response = await loggedFetch(fapiUrl(`/v1/client/sessions/${session.sessionId}/remove`), {
+      tag: "fapi",
+      method: "POST",
+      headers: { Authorization: session.clientJwt },
+    });
+    if (!response.ok)
+      log.warn(`Could not revoke the transient sign-in session (${response.status}).`);
+  } catch (error) {
+    log.warn(
+      `Could not revoke the transient sign-in session: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+/**
+ * Redeem a single-use sign-in ticket for an OAuth token response. The
+ * transient FAPI session is revoked on every exit path, including Ctrl+C.
+ */
+export async function loginWithTicket(ticket: string): Promise<TokenResponse> {
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = generateCodeChallenge(codeVerifier);
+  const state = generateState();
+
+  const session = await redeemTicket(ticket);
+
+  // Swap the default Ctrl+C handler for one that revokes the session first.
+  const onSigint = () => {
+    void revokeSession(session).finally(CLI_SIGINT_HANDLER);
+  };
+  process.removeListener("SIGINT", CLI_SIGINT_HANDLER);
+  process.once("SIGINT", onSigint);
+  try {
+    const code = await authorizeWithSession(session, { codeChallenge, state });
+    return await exchangeCodeForToken({ code, codeVerifier, redirectUri: TICKET_REDIRECT_URI });
+  } finally {
+    process.removeListener("SIGINT", onSigint);
+    process.on("SIGINT", CLI_SIGINT_HANDLER);
+    await revokeSession(session);
+  }
+}


### PR DESCRIPTION
Agents following the Dashboard setup prompt stall at `clerk auth login` because it needs a browser round-trip. With clerk/clerk_go#21875 the Dashboard can put a single-use sign-in ticket in the copied prompt; this is the CLI side.

`clerk auth login --ticket` reads the ticket from stdin (never argv), redeems it into a transient FAPI session, drives the OAuth authorize step through the consent endpoint with `Clerk-Session-Id`, exchanges the code with PKCE, and revokes the session before returning. The CLI ends up holding exactly what the browser flow yields: the role-scoped OAuth access token.

- Revocation runs in `finally` and from a swapped SIGINT handler, so a crash or Ctrl+C mid-flow does not orphan a live dashboard session.
- Prints the account before persisting; confirms in human mode unless `--yes` (prompts read `/dev/tty`, so piped stdin still works).
- Non-retryable, distinct errors: `ticket_expired`, `ticket_already_used`, `ticket_invalid`, `mfa_required`. MFA accounts fall back to the browser flow; no MFA-bypassing token types are used.
- No Native API requirement. The CLI sends the dashboard `Origin` header and keeps a cookie jar, so FAPI treats it as a browser client and identifies it with the `__client` cookie. Verified locally with Native API disabled on the dashboard instance: native-style calls get `native_api_disabled`, this flow still completes.

Tests: `ticket-auth.test.ts` covers the happy sequence, each error mapping, and revoke-on-failure for authorize, state mismatch, and exchange. Verified end to end on the local stack against the DAPI endpoint and `clerk apps list`.

Companion: clerk/dashboard#10167 mints the ticket on the copy click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

